### PR TITLE
docs: update quickstart to reflect dashboard-first flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -744,7 +744,7 @@ curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-comp
 # 2. Start the stack
 docker compose -f docker-compose.prod.yml up -d
 
-# 3. Open http://localhost:3001 → click "Load Demo Data" or "Connect Entra ID"
+# 3. Open http://localhost:3001 → go to Admin → Crawlers, then click "Load Demo Data" or "Add Crawler" to connect Entra ID
 # 4. Configure crawlers via the in-browser wizard (Admin → Crawlers → Add Crawler)
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-comp
 docker compose -f docker-compose.prod.yml up -d
 
 # 3. Open http://localhost:3001
-#    Click "Load Demo Data" to explore with sample data, or
-#    go to Admin > Crawlers > Add Crawler to connect your Entra ID tenant.
+#    Go to Admin > Crawlers, then click "Load Demo Data" to explore with sample data, or
+#    click "Add Crawler" to connect your Entra ID tenant.
 ```
 
 The in-browser crawler wizard walks you through credentials, permission validation, object type selection, and scheduling — no PowerShell or command-line setup required.

--- a/docs/architecture/docker-setup.md
+++ b/docs/architecture/docker-setup.md
@@ -19,7 +19,7 @@ docker compose -f docker-compose.prod.yml up -d
 open http://localhost:3001
 ```
 
-On first visit, the UI auto-navigates to the **Crawlers** page with a getting-started card. Click **"Load Demo Data"** to populate the system with synthetic data (~30 seconds). After that, explore the Matrix, Users, Resources, and other pages.
+On first visit, the UI opens to the Dashboard. If no data is loaded yet, click **"Configure a crawler"** to go to Admin → Crawlers, then click **"Load Demo Data"** to populate the system with synthetic data (~30 seconds). After that, explore the Matrix, Users, Resources, and other pages.
 
 To connect your own Entra ID tenant, click **"Connect Entra ID"** on the Crawlers page and enter your App Registration credentials (Tenant ID, Client ID, Client Secret).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,7 @@ Identity Atlas runs as a Docker stack — no Azure subscription, no git clone re
 !!! tip "Why `--pull always`?"
     Without `--pull always`, `docker compose up` only pulls an image if it isn't already cached locally. If you ran Identity Atlas before, Docker will happily reuse yesterday's `:latest` — even though a newer `:latest` may be on ghcr.io. Adding `--pull always` forces a registry check on every start. Requires Docker Compose v2.22 or later; on older versions, run `docker compose pull` first and then `up -d`.
 
-Open [http://localhost:3001](http://localhost:3001). The app auto-navigates to the **Crawlers** page. Click **"Load Demo Data"** to explore with synthetic data (~30 seconds).
+Open [http://localhost:3001](http://localhost:3001). The app opens to the Dashboard. If no data is loaded yet, click **"Configure a crawler"** to go to Admin → Crawlers, then click **"Load Demo Data"** to explore with synthetic data (~30 seconds).
 
 To connect your own Entra ID tenant, click **"Connect Entra ID"** and enter your App Registration credentials directly in the browser. The wizard walks you through credential validation, object type selection, identity filtering, custom attributes, and scheduling.
 


### PR DESCRIPTION
- Remove outdated auto-navigate to Crawlers page references
- Update docs to show Dashboard -> Configure crawler -> Admin -> Crawlers flow
- Updated in quickstart.md, docker-setup.md, README.md, and CLAUDE.md