### PR TITLE
Remove dark: utility classes — app has no dark mode support

### DIFF
--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -343,7 +343,7 @@ export default function App() {
           <div className="flex items-center gap-3">
             <img src="/logo.png" alt="Identity Atlas" className="h-10 w-10" />
             <div>
-              <h1 className="text-xl font-semibold text-gray-900">Identity <span className="text-emerald-600">Atlas</span></h1>
+              <h1 className="text-xl font-semibold text-gray-900">Identity <span style={{ color: '#65b425' }}>Atlas</span></h1>
               <p className="text-xs text-gray-500">
                 Universal authorization intelligence
               </p>

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -816,16 +816,16 @@ function HistoryRetentionSection() {
   const valid = days !== '' && !isNaN(parseInt(days, 10)) && parseInt(days, 10) >= 0 && parseInt(days, 10) <= 3650;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border p-5 mb-4">
-      <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">Version History Retention</h4>
-      <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+    <div className="bg-white rounded-lg border p-5 mb-4">
+      <h4 className="font-semibold text-gray-900 mb-1">Version History Retention</h4>
+      <p className="text-sm text-gray-600 mb-4">
         How long row-level change history is kept in the audit log. Older entries are pruned automatically every 6 hours.
         Set to <code>0</code> to disable pruning and keep history forever.
       </p>
 
       <div className="flex items-end gap-3">
         <div>
-          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Retention (days)</label>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Retention (days)</label>
           <input
             type="number"
             min="0"
@@ -833,7 +833,7 @@ function HistoryRetentionSection() {
             value={days}
             onChange={e => setDays(e.target.value)}
             disabled={loading}
-            className="w-32 px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600"
+            className="w-32 px-3 py-1.5 text-sm border rounded"
           />
         </div>
         <button
@@ -846,7 +846,7 @@ function HistoryRetentionSection() {
         <button
           onClick={pruneNow}
           disabled={pruning || loading}
-          className="px-4 py-1.5 text-sm font-medium rounded border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700 disabled:opacity-50"
+          className="px-4 py-1.5 text-sm font-medium rounded border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
         >
           {pruning ? 'Pruning…' : 'Prune now'}
         </button>
@@ -1175,9 +1175,9 @@ function LLMSettingsSection() {
 
   return (
     <div className="space-y-4">
-      <div className="bg-white dark:bg-gray-800 rounded-lg border p-5">
-        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">LLM Provider</h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+      <div className="bg-white rounded-lg border p-5">
+        <h3 className="text-base font-semibold text-gray-900 mb-1">LLM Provider</h3>
+        <p className="text-sm text-gray-600 mb-4">
           Used by risk profiling, classifier generation and conversational refinement.
           The API key is encrypted at rest with envelope encryption — only the masked status is visible after saving.
         </p>
@@ -1185,11 +1185,11 @@ function LLMSettingsSection() {
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {/* Provider */}
           <div>
-            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Provider</label>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Provider</label>
             <select
               value={config.provider}
               onChange={e => setConfig(c => ({ ...c, provider: e.target.value }))}
-              className="w-full px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600"
+              className="w-full px-3 py-1.5 text-sm border rounded"
             >
               {providers.map(p => (
                 <option key={p} value={p}>{p === 'azure-openai' ? 'Azure OpenAI' : p === 'anthropic' ? 'Anthropic Claude' : 'OpenAI'}</option>
@@ -1200,7 +1200,7 @@ function LLMSettingsSection() {
           {/* Model — dropdown after discovery, otherwise free-text input */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+              <label className="block text-xs font-medium text-gray-700">
                 {isAzure ? 'Deployment' : 'Model'}
               </label>
               <button
@@ -1217,7 +1217,7 @@ function LLMSettingsSection() {
               <select
                 value={config.model || ''}
                 onChange={e => setConfig(c => ({ ...c, model: e.target.value }))}
-                className="w-full px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600"
+                className="w-full px-3 py-1.5 text-sm border rounded font-mono"
               >
                 <option value="">— select a model —</option>
                 {models.map(m => (
@@ -1230,7 +1230,7 @@ function LLMSettingsSection() {
                 value={config.model}
                 onChange={e => setConfig(c => ({ ...c, model: e.target.value }))}
                 placeholder={placeholderModel || (isAzure ? 'e.g. gpt-4o-prod' : '')}
-                className="w-full px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600"
+                className="w-full px-3 py-1.5 text-sm border rounded font-mono"
               />
             )}
             {modelsError && (
@@ -1245,33 +1245,33 @@ function LLMSettingsSection() {
           {isAzure && (
             <>
               <div className="sm:col-span-2">
-                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Azure endpoint</label>
+                <label className="block text-xs font-medium text-gray-700 mb-1">Azure endpoint</label>
                 <input
                   type="text"
                   value={config.endpoint}
                   onChange={e => setConfig(c => ({ ...c, endpoint: e.target.value }))}
                   placeholder="https://my-resource.openai.azure.com"
-                  className="w-full px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600"
+                  className="w-full px-3 py-1.5 text-sm border rounded font-mono"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Deployment</label>
+                <label className="block text-xs font-medium text-gray-700 mb-1">Deployment</label>
                 <input
                   type="text"
                   value={config.deployment}
                   onChange={e => setConfig(c => ({ ...c, deployment: e.target.value }))}
                   placeholder="gpt-4o-prod"
-                  className="w-full px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600"
+                  className="w-full px-3 py-1.5 text-sm border rounded font-mono"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">API version</label>
+                <label className="block text-xs font-medium text-gray-700 mb-1">API version</label>
                 <input
                   type="text"
                   value={config.apiVersion}
                   onChange={e => setConfig(c => ({ ...c, apiVersion: e.target.value }))}
                   placeholder="2024-08-01-preview"
-                  className="w-full px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600"
+                  className="w-full px-3 py-1.5 text-sm border rounded font-mono"
                 />
               </div>
             </>
@@ -1279,7 +1279,7 @@ function LLMSettingsSection() {
 
           {/* API key */}
           <div className="sm:col-span-2">
-            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label className="block text-xs font-medium text-gray-700 mb-1">
               API key {apiKeySet && <span className="ml-2 text-green-600">• stored</span>}
             </label>
             <input
@@ -1288,7 +1288,7 @@ function LLMSettingsSection() {
               onChange={e => setConfig(c => ({ ...c, apiKey: e.target.value }))}
               placeholder={apiKeySet ? '••••••••  (leave blank to keep existing)' : 'sk-...'}
               autoComplete="new-password"
-              className="w-full px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600"
+              className="w-full px-3 py-1.5 text-sm border rounded font-mono"
             />
           </div>
         </div>
@@ -1304,14 +1304,14 @@ function LLMSettingsSection() {
           <button
             onClick={handleTest}
             disabled={testing}
-            className="px-4 py-1.5 text-sm font-medium rounded border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700 disabled:opacity-50"
+            className="px-4 py-1.5 text-sm font-medium rounded border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
           >
             {testing ? 'Testing…' : 'Test connection'}
           </button>
           {apiKeySet && (
             <button
               onClick={handleClear}
-              className="px-4 py-1.5 text-sm font-medium rounded border border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-900"
+              className="px-4 py-1.5 text-sm font-medium rounded border border-red-300 text-red-700 hover:bg-red-50"
             >
               Clear
             </button>
@@ -1324,7 +1324,7 @@ function LLMSettingsSection() {
           </div>
         )}
         {testResult && (
-          <div className={`mt-3 text-sm rounded border p-3 ${testResult.ok ? 'bg-green-50 border-green-200 text-green-800 dark:bg-green-900 dark:border-green-700 dark:text-green-200' : 'bg-red-50 border-red-200 text-red-800 dark:bg-red-900 dark:border-red-700 dark:text-red-200'}`}>
+          <div className={`mt-3 text-sm rounded border p-3 ${testResult.ok ? 'bg-green-50 border-green-200 text-green-800' : 'bg-red-50 border-red-200 text-red-800'}`}>
             {testResult.ok ? (
               <>
                 <div className="font-medium">Connection OK</div>
@@ -1349,10 +1349,10 @@ function NewRiskProfileLauncher() {
   const [open, setOpen] = useState(false);
   const [bumpKey, setBumpKey] = useState(0);
   return (
-    <div className="bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-700 rounded-lg p-4 flex items-center justify-between">
+    <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 flex items-center justify-between">
       <div>
-        <div className="text-sm font-medium text-indigo-900 dark:text-indigo-100">Create a new risk profile</div>
-        <div className="text-xs text-indigo-700 dark:text-indigo-300 mt-0.5">
+        <div className="text-sm font-medium text-indigo-900">Create a new risk profile</div>
+        <div className="text-xs text-indigo-700 mt-0.5">
           Walks you through generating an organisational profile and classifier set with the LLM, then optionally runs a scoring pass.
         </div>
       </div>

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -816,7 +816,7 @@ function HistoryRetentionSection() {
   const valid = days !== '' && !isNaN(parseInt(days, 10)) && parseInt(days, 10) >= 0 && parseInt(days, 10) <= 3650;
 
   return (
-    <div className="bg-white rounded-lg border p-5 mb-4">
+    <div className="bg-white rounded-lg border border-gray-200 p-5 mb-4">
       <h4 className="font-semibold text-gray-900 mb-1">Version History Retention</h4>
       <p className="text-sm text-gray-600 mb-4">
         How long row-level change history is kept in the audit log. Older entries are pruned automatically every 6 hours.
@@ -1175,7 +1175,7 @@ function LLMSettingsSection() {
 
   return (
     <div className="space-y-4">
-      <div className="bg-white rounded-lg border p-5">
+      <div className="bg-white rounded-lg border border-gray-200 p-5">
         <h3 className="text-base font-semibold text-gray-900 mb-1">LLM Provider</h3>
         <p className="text-sm text-gray-600 mb-4">
           Used by risk profiling, classifier generation and conversational refinement.

--- a/app/ui/src/components/CrawlersPage.jsx
+++ b/app/ui/src/components/CrawlersPage.jsx
@@ -45,7 +45,7 @@ const CRAWLER_TYPES = [
 // ─── Step 1: Select Type ──────────────────────────────────────────────────────
 function SelectType({ onSelect, onCancel }) {
   return (
-    <div className="mb-6 p-5 bg-white dark:bg-gray-800 border rounded-lg">
+    <div className="mb-6 p-5 bg-white border rounded-lg">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold">Add Crawler — Select Type</h3>
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm">Cancel</button>
@@ -58,14 +58,14 @@ function SelectType({ onSelect, onCancel }) {
             disabled={!t.available}
             className={`flex flex-col items-start p-4 rounded-lg border-2 text-left transition-all ${
               t.available
-                ? 'border-gray-200 dark:border-gray-600 hover:border-indigo-400 hover:shadow-md cursor-pointer'
-                : 'border-gray-100 dark:border-gray-700 opacity-50 cursor-not-allowed'
+                ? 'border-gray-200 hover:border-indigo-400 hover:shadow-md cursor-pointer'
+                : 'border-gray-100 opacity-50 cursor-not-allowed'
             }`}
           >
-            <span className="font-semibold text-gray-900 dark:text-white">{t.name}</span>
-            <span className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t.description}</span>
+            <span className="font-semibold text-gray-900">{t.name}</span>
+            <span className="text-sm text-gray-500 mt-1">{t.description}</span>
             {t.comingSoon && (
-              <span className="mt-2 px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-500 text-xs rounded-full">Coming soon</span>
+              <span className="mt-2 px-2 py-0.5 bg-gray-100 text-gray-500 text-xs rounded-full">Coming soon</span>
             )}
           </button>
         ))}
@@ -92,25 +92,25 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
   return (
     <div className="mb-3">
       <div className="flex items-center justify-between mb-2">
-        <h5 className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+        <h5 className="text-xs font-semibold text-gray-700">
           {title} ({selected.length} extra + {coreAttrs.length} core)
         </h5>
         <input type="text" value={filter} onChange={e => setFilter(e.target.value)}
           placeholder="Filter..."
-          className="px-2 py-1 text-xs border rounded dark:bg-gray-700 dark:border-gray-600 w-48" />
+          className="px-2 py-1 text-xs border rounded w-48" />
       </div>
-      <div className="max-h-72 overflow-y-auto border rounded bg-white dark:bg-gray-800">
+      <div className="max-h-72 overflow-y-auto border rounded bg-white">
         {visible.length === 0 ? (
           <div className="text-xs text-gray-400 italic p-2">No attributes match filter</div>
         ) : (
-          <div className="divide-y divide-gray-100 dark:divide-gray-700">
+          <div className="divide-y divide-gray-100">
             {visible.map(attr => {
               const isCore = coreSet.has(attr);
               const isSelected = isCore || selected.includes(attr);
               return (
                 <label key={attr}
                   className={`flex items-center gap-2 text-xs px-2 py-1 ${
-                    isCore ? 'cursor-default bg-indigo-50/40 dark:bg-indigo-900/20' : 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700'
+                    isCore ? 'cursor-default bg-indigo-50/40' : 'cursor-pointer hover:bg-gray-50'
                   }`}
                   title={isCore ? 'Core attribute (always synced)' : attr}>
                   <input type="checkbox" checked={isSelected} disabled={isCore}
@@ -135,12 +135,12 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
 function ScheduleEditor({ schedule, onChange, onRemove }) {
   const update = (field, value) => onChange({ ...schedule, [field]: value });
   return (
-    <div className="p-3 bg-white dark:bg-gray-800 border rounded mb-2">
+    <div className="p-3 bg-white border rounded mb-2">
       <div className="grid grid-cols-5 gap-2 items-end">
         <div>
           <label className="block text-xs font-medium mb-1">Frequency</label>
           <select value={schedule.frequency || 'daily'} onChange={e => update('frequency', e.target.value)}
-            className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+            className="w-full p-2 border rounded text-sm">
             <option value="hourly">Hourly</option>
             <option value="daily">Daily</option>
             <option value="weekly">Weekly</option>
@@ -150,7 +150,7 @@ function ScheduleEditor({ schedule, onChange, onRemove }) {
           <div>
             <label className="block text-xs font-medium mb-1">Hour (UTC)</label>
             <select value={schedule.hour ?? 2} onChange={e => update('hour', parseInt(e.target.value, 10))}
-              className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+              className="w-full p-2 border rounded text-sm">
               {Array.from({ length: 24 }, (_, i) => <option key={i} value={i}>{String(i).padStart(2, '0')}:00</option>)}
             </select>
           </div>
@@ -158,7 +158,7 @@ function ScheduleEditor({ schedule, onChange, onRemove }) {
         <div>
           <label className="block text-xs font-medium mb-1">Minute</label>
           <select value={schedule.minute ?? 0} onChange={e => update('minute', parseInt(e.target.value, 10))}
-            className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+            className="w-full p-2 border rounded text-sm">
             {[0, 15, 30, 45].map(m => <option key={m} value={m}>:{String(m).padStart(2, '0')}</option>)}
           </select>
         </div>
@@ -166,7 +166,7 @@ function ScheduleEditor({ schedule, onChange, onRemove }) {
           <div>
             <label className="block text-xs font-medium mb-1">Day</label>
             <select value={schedule.day ?? 0} onChange={e => update('day', parseInt(e.target.value, 10))}
-              className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+              className="w-full p-2 border rounded text-sm">
               {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d, i) => <option key={i} value={i}>{d}</option>)}
             </select>
           </div>
@@ -445,10 +445,10 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           <div key={s.n} className="flex items-center gap-2">
             <div className={`w-6 h-6 rounded-full flex items-center justify-center font-semibold ${
               s.n === step ? 'bg-indigo-600 text-white' :
-              s.n < step ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300' :
-              'bg-gray-200 dark:bg-gray-700 text-gray-500'
+              s.n < step ? 'bg-indigo-100 text-indigo-700' :
+              'bg-gray-200 text-gray-500'
             }`}>{i + 1}</div>
-            <span className={s.n === step ? 'font-medium text-gray-900 dark:text-white' : 'text-gray-500'}>{s.label}</span>
+            <span className={s.n === step ? 'font-medium text-gray-900' : 'text-gray-500'}>{s.label}</span>
             {i < arr.length - 1 && <span className="text-gray-300">→</span>}
           </div>
         ))}
@@ -457,7 +457,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
   };
 
   return (
-    <div className="mb-6 p-5 bg-white dark:bg-gray-800 border rounded-lg">
+    <div className="mb-6 p-5 bg-white border rounded-lg">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold">{isEdit ? 'Edit' : 'Add'} Microsoft Graph Crawler</h3>
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm">Cancel</button>
@@ -475,20 +475,20 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
             <label className="block text-sm font-medium mb-1">Crawler Name *</label>
             <input type="text" value={crawlerName} onChange={e => setCrawlerName(e.target.value)}
               placeholder="e.g., Entra ID — Production"
-              className="w-full max-w-md p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+              className="w-full max-w-md p-2 border rounded text-sm" />
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
             <div>
               <label className="block text-sm font-medium mb-1">Tenant ID *</label>
               <input type="text" value={tenantId} onChange={e => setTenantId(e.target.value)}
                 placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 font-mono text-sm" />
+                className="w-full p-2 border rounded font-mono text-sm" />
             </div>
             <div>
               <label className="block text-sm font-medium mb-1">Client ID *</label>
               <input type="text" value={clientId} onChange={e => setClientId(e.target.value)}
                 placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 font-mono text-sm" />
+                className="w-full p-2 border rounded font-mono text-sm" />
             </div>
             <div>
               <label className="block text-sm font-medium mb-1">
@@ -496,7 +496,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
               </label>
               <input type="password" value={clientSecret} onChange={e => setClientSecret(e.target.value)}
                 placeholder={isEdit ? '••••••••' : 'Enter client secret'}
-                className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+                className="w-full p-2 border rounded text-sm" />
             </div>
           </div>
           {validationError && (
@@ -515,8 +515,8 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
       {/* ─── Step 2: Object Type Selection ──────────────────────── */}
       {step === 2 && validation && (
         <div>
-          <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded">
-            <span className="font-medium text-green-800 dark:text-green-200">
+          <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded">
+            <span className="font-medium text-green-800">
               Connected to {validation.organization || 'tenant'}
             </span>
           </div>
@@ -555,7 +555,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           </div>
 
           <div className="flex justify-between">
-            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 dark:bg-gray-600 rounded text-sm">Back</button>
+            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm">Back</button>
             <button onClick={nextStep} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">Next</button>
           </div>
         </div>
@@ -567,7 +567,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           <h4 className="text-sm font-semibold mb-3">Identity Configuration</h4>
 
           {/* Identity filter */}
-          <div className="mb-5 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+          <div className="mb-5 p-4 bg-gray-50 rounded border">
             <div className="flex items-center gap-3 mb-3">
               <input type="checkbox" checked={idFilterEnabled} onChange={e => setIdFilterEnabled(e.target.checked)} className="rounded" />
               <h5 className="text-sm font-semibold">Identity Filter</h5>
@@ -582,20 +582,20 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
                     <div className="text-xs text-gray-500">Discovering...</div>
                   ) : userAttrCatalog?.attributes?.length > 0 ? (
                     <select value={idFilterAttr} onChange={e => setIdFilterAttr(e.target.value)}
-                      className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                      className="w-full p-2 border rounded text-sm">
                       {userAttrCatalog.attributes.map(a => (
                         <option key={a} value={a}>{a}</option>
                       ))}
                     </select>
                   ) : (
                     <input type="text" value={idFilterAttr} onChange={e => setIdFilterAttr(e.target.value)}
-                      className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+                      className="w-full p-2 border rounded text-sm" />
                   )}
                 </div>
                 <div>
                   <label className="block text-xs font-medium mb-1">Condition</label>
                   <select value={idFilterCondition} onChange={e => setIdFilterCondition(e.target.value)}
-                    className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                    className="w-full p-2 border rounded text-sm">
                     <option value="isNotNull">Is not empty</option>
                     <option value="equals">Equals</option>
                     <option value="notEquals">Not equals</option>
@@ -612,14 +612,14 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
                       </label>
                       {isBool && idFilterCondition !== 'inValues' ? (
                         <select value={idFilterValue || 'true'} onChange={e => setIdFilterValue(e.target.value)}
-                          className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                          className="w-full p-2 border rounded text-sm">
                           <option value="true">true</option>
                           <option value="false">false</option>
                         </select>
                       ) : (
                         <input type="text" value={idFilterValue} onChange={e => setIdFilterValue(e.target.value)}
                           placeholder={idFilterCondition === 'inValues' ? 'a, b, c' : 'value'}
-                          className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+                          className="w-full p-2 border rounded text-sm" />
                       )}
                     </div>
                   );
@@ -629,7 +629,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           </div>
 
           {/* Identity attributes to sync */}
-          <div className="mb-5 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+          <div className="mb-5 p-4 bg-gray-50 rounded border">
             <h5 className="text-sm font-semibold mb-2">Identity Attributes to Sync</h5>
             <p className="text-xs text-gray-500 mb-3">Pick which user attributes get stored in extendedAttributes JSON for identities. Core fields (displayName, email, employeeId) are always included.</p>
             {discovering && !userAttrCatalog && <div className="text-sm text-gray-500">Discovering attributes from Microsoft Graph...</div>}
@@ -646,7 +646,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           </div>
 
           <div className="flex justify-between">
-            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 dark:bg-gray-600 rounded text-sm">Back</button>
+            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm">Back</button>
             <button onClick={nextStep} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">Next</button>
           </div>
         </div>
@@ -662,7 +662,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
             <div className="text-sm text-gray-500 mb-3">Discovering attributes from Microsoft Graph...</div>
           )}
           {userAttrCatalog?.attributes && (
-            <div className="mb-4 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+            <div className="mb-4 p-4 bg-gray-50 rounded border">
               <AttributePicker
                 title="User attributes"
                 available={userAttrCatalog.attributes}
@@ -673,7 +673,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
             </div>
           )}
           {groupAttrCatalog?.attributes && (
-            <div className="mb-4 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+            <div className="mb-4 p-4 bg-gray-50 rounded border">
               <AttributePicker
                 title="Group attributes"
                 available={groupAttrCatalog.attributes}
@@ -685,7 +685,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           )}
 
           <div className="flex justify-between">
-            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 dark:bg-gray-600 rounded text-sm">Back</button>
+            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm">Back</button>
             <button onClick={nextStep} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">Next</button>
           </div>
         </div>
@@ -698,7 +698,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           <p className="text-xs text-gray-500 mb-3">Configure when this crawler runs automatically. You can add multiple schedules (e.g., a hourly delta + a daily full sync).</p>
 
           {schedules.length === 0 && (
-            <div className="mb-3 p-4 bg-gray-50 dark:bg-gray-900 border rounded text-center text-sm text-gray-500">
+            <div className="mb-3 p-4 bg-gray-50 border rounded text-center text-sm text-gray-500">
               No schedules configured. The crawler will only run when you click "Run Now".
             </div>
           )}
@@ -712,12 +712,12 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           ))}
 
           <button onClick={() => setSchedules([...schedules, { enabled: true, frequency: 'daily', hour: 2, minute: 0 }])}
-            className="mb-4 px-3 py-1.5 text-xs bg-gray-200 dark:bg-gray-600 rounded hover:bg-gray-300">
+            className="mb-4 px-3 py-1.5 text-xs bg-gray-200 rounded hover:bg-gray-300">
             + Add Schedule
           </button>
 
           <div className="flex justify-between border-t pt-4">
-            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 dark:bg-gray-600 rounded text-sm">Back</button>
+            <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm">Back</button>
             <button onClick={handleSave} disabled={saving}
               className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
               {saving ? 'Saving...' : (isEdit ? 'Save Changes' : 'Deploy to Worker')}
@@ -807,15 +807,15 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
   const permEntries = Object.entries(validation.permissions || {}).sort(([a], [b]) => a.localeCompare(b));
 
   return (
-    <div className="mb-6 p-5 bg-white dark:bg-gray-800 border rounded-lg">
+    <div className="mb-6 p-5 bg-white border rounded-lg">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold">Microsoft Graph — Configure</h3>
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm">Cancel</button>
       </div>
 
       {/* Validation result */}
-      <div className="mb-5 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded">
-        <span className="font-medium text-green-800 dark:text-green-200">
+      <div className="mb-5 p-3 bg-green-50 border border-green-200 rounded">
+        <span className="font-medium text-green-800">
           Connected to {validation.organization || 'tenant'}
         </span>
       </div>
@@ -861,7 +861,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
 
       {/* Identity filter (shown when Identity object type is selected) */}
       {selectedObjects.identity && (
-        <div className="mb-5 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+        <div className="mb-5 p-4 bg-gray-50 rounded border">
           <div className="flex items-center gap-3 mb-3">
             <input type="checkbox" checked={idFilterEnabled} onChange={e => setIdFilterEnabled(e.target.checked)} className="rounded" />
             <h4 className="text-sm font-semibold">Identity Selection Filter</h4>
@@ -873,7 +873,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
                 <div>
                   <label className="block text-xs font-medium mb-1">Attribute</label>
                   <select value={idFilterAttr} onChange={e => setIdFilterAttr(e.target.value)}
-                    className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                    className="w-full p-2 border rounded text-sm">
                     <option value="employeeId">employeeId</option>
                     <option value="employeeType">employeeType</option>
                     <option value="companyName">companyName</option>
@@ -886,7 +886,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
                 <div>
                   <label className="block text-xs font-medium mb-1">Condition</label>
                   <select value={idFilterCondition} onChange={e => setIdFilterCondition(e.target.value)}
-                    className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                    className="w-full p-2 border rounded text-sm">
                     <option value="isNotNull">Is not empty</option>
                     <option value="equals">Equals</option>
                     <option value="notEquals">Not equals</option>
@@ -898,7 +898,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
                     <label className="block text-xs font-medium mb-1">Value</label>
                     <input type="text" value={idFilterValue} onChange={e => setIdFilterValue(e.target.value)}
                       placeholder={idFilterCondition === 'inValues' ? 'Employee, Intern, Contractor' : 'Employee'}
-                      className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+                      className="w-full p-2 border rounded text-sm" />
                   </div>
                 )}
               </div>
@@ -908,7 +908,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
       )}
 
       {/* Custom attributes */}
-      <div className="mb-5 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+      <div className="mb-5 p-4 bg-gray-50 rounded border">
         <h4 className="text-sm font-semibold mb-2">Custom Attributes (optional)</h4>
         <p className="text-xs text-gray-500 mb-3">Add extra attributes to sync from Microsoft Graph. Comma-separated. These will be stored in extendedAttributes.</p>
         <div className="grid grid-cols-2 gap-4">
@@ -916,19 +916,19 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
             <label className="block text-xs font-medium mb-1">User attributes</label>
             <input type="text" value={customUserAttrs} onChange={e => setCustomUserAttrs(e.target.value)}
               placeholder="e.g., employeeHireDate, onPremisesSyncEnabled, extension_abc123_costCenter"
-              className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+              className="w-full p-2 border rounded text-sm" />
           </div>
           <div>
             <label className="block text-xs font-medium mb-1">Group attributes</label>
             <input type="text" value={customGroupAttrs} onChange={e => setCustomGroupAttrs(e.target.value)}
               placeholder="e.g., classification, resourceBehaviorOptions"
-              className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+              className="w-full p-2 border rounded text-sm" />
           </div>
         </div>
       </div>
 
       {/* Schedule */}
-      <div className="mb-5 p-4 bg-gray-50 dark:bg-gray-900 rounded border">
+      <div className="mb-5 p-4 bg-gray-50 rounded border">
         <div className="flex items-center gap-3 mb-3">
           <input type="checkbox" checked={schedEnabled} onChange={e => setSchedEnabled(e.target.checked)} className="rounded" />
           <h4 className="text-sm font-semibold">Schedule</h4>
@@ -938,7 +938,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
             <div>
               <label className="block text-xs font-medium mb-1">Frequency</label>
               <select value={schedFrequency} onChange={e => setSchedFrequency(e.target.value)}
-                className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                className="w-full p-2 border rounded text-sm">
                 <option value="hourly">Hourly</option>
                 <option value="daily">Daily</option>
                 <option value="weekly">Weekly</option>
@@ -948,7 +948,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
               <div>
                 <label className="block text-xs font-medium mb-1">Hour (UTC)</label>
                 <select value={schedHour} onChange={e => setSchedHour(parseInt(e.target.value, 10))}
-                  className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                  className="w-full p-2 border rounded text-sm">
                   {Array.from({ length: 24 }, (_, i) => <option key={i} value={i}>{String(i).padStart(2, '0')}:00</option>)}
                 </select>
               </div>
@@ -956,7 +956,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
             <div>
               <label className="block text-xs font-medium mb-1">Minute</label>
               <select value={schedMinute} onChange={e => setSchedMinute(parseInt(e.target.value, 10))}
-                className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                className="w-full p-2 border rounded text-sm">
                 {[0, 15, 30, 45].map(m => <option key={m} value={m}>:{String(m).padStart(2, '0')}</option>)}
               </select>
             </div>
@@ -964,7 +964,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
               <div>
                 <label className="block text-xs font-medium mb-1">Day</label>
                 <select value={schedDay} onChange={e => setSchedDay(parseInt(e.target.value, 10))}
-                  className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm">
+                  className="w-full p-2 border rounded text-sm">
                   {['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'].map((d, i) => <option key={i} value={i}>{d}</option>)}
                 </select>
               </div>
@@ -978,7 +978,7 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
         <label className="block text-sm font-medium mb-1">Crawler Name</label>
         <input type="text" value={crawlerName} onChange={e => setCrawlerName(e.target.value)}
           placeholder={`Entra ID — ${validation.organization || 'Production'}`}
-          className="w-full max-w-md p-2 border rounded dark:bg-gray-700 dark:border-gray-600 text-sm" />
+          className="w-full max-w-md p-2 border rounded text-sm" />
       </div>
 
       {/* Deploy options */}
@@ -992,10 +992,10 @@ function ValidationAndDeploy({ validation, credentials, onDeploy, onCancel, load
           >
             {loading ? 'Saving...' : 'Deploy to Worker'}
           </button>
-          <button disabled className="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-400 rounded text-sm cursor-not-allowed">
+          <button disabled className="px-4 py-2 bg-gray-100 text-gray-400 rounded text-sm cursor-not-allowed">
             Azure Automation (coming soon)
           </button>
-          <button disabled className="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-400 rounded text-sm cursor-not-allowed">
+          <button disabled className="px-4 py-2 bg-gray-100 text-gray-400 rounded text-sm cursor-not-allowed">
             Download Scripts (coming soon)
           </button>
         </div>
@@ -1036,10 +1036,10 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onForceStop, ru
   };
 
   return (
-    <div className="p-4 bg-white dark:bg-gray-800 border rounded-lg">
+    <div className="p-4 bg-white border rounded-lg">
       <div className="flex items-start justify-between mb-3">
         <div>
-          <h4 className="font-semibold text-gray-900 dark:text-white">{config.displayName}</h4>
+          <h4 className="font-semibold text-gray-900">{config.displayName}</h4>
           <span className="text-xs text-gray-500">{config.crawlerType}</span>
         </div>
         <div className="flex gap-1">
@@ -1059,11 +1059,11 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onForceStop, ru
             </button>
           )}
           <button onClick={() => onEdit(config)}
-            className="px-3 py-1 text-xs bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200">
+            className="px-3 py-1 text-xs bg-gray-100 rounded hover:bg-gray-200">
             Configure
           </button>
           <button onClick={() => onRemove(config.id)}
-            className="px-3 py-1 text-xs bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded hover:bg-red-200">
+            className="px-3 py-1 text-xs bg-red-100 text-red-700 rounded hover:bg-red-200">
             Remove
           </button>
         </div>
@@ -1077,7 +1077,7 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onForceStop, ru
           <div>
             <span className="text-gray-500">Objects:</span>{' '}
             {objectLabels.length > 0
-              ? objectLabels.map(l => <span key={l} className="inline-block mr-1 px-1.5 py-0.5 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-xs rounded">{l}</span>)
+              ? objectLabels.map(l => <span key={l} className="inline-block mr-1 px-1.5 py-0.5 bg-indigo-50 text-indigo-700 text-xs rounded">{l}</span>)
               : <span className="text-gray-400 text-xs">none</span>
             }
           </div>
@@ -1097,7 +1097,7 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onForceStop, ru
         <div className="text-xs text-gray-500 mt-2 space-y-1">
           {scheduleList.map((s, i) => (
             <div key={i}>
-              <span className="px-1.5 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded">
+              <span className="px-1.5 py-0.5 bg-blue-50 text-blue-700 rounded">
                 Schedule: {formatSched(s)}
               </span>
             </div>
@@ -1107,7 +1107,7 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onForceStop, ru
       {/* Identity filter badge */}
       {cfg.identityFilter?.attribute && (
         <div className="text-xs text-gray-500 mt-1">
-          <span className="px-1.5 py-0.5 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded">
+          <span className="px-1.5 py-0.5 bg-purple-50 text-purple-700 rounded">
             Identity filter: {cfg.identityFilter.attribute} {cfg.identityFilter.condition}
             {cfg.identityFilter.value && ` "${cfg.identityFilter.value}"`}
             {cfg.identityFilter.values?.length > 0 && ` ${JSON.stringify(cfg.identityFilter.values)}`}
@@ -1118,17 +1118,17 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onForceStop, ru
       {(cfg.customUserAttributes?.length > 0 || cfg.customGroupAttributes?.length > 0 || cfg.identityAttributes?.length > 0) && (
         <div className="text-xs text-gray-500 mt-1 flex flex-wrap gap-1">
           {cfg.identityAttributes?.length > 0 && (
-            <span className="px-1.5 py-0.5 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">
+            <span className="px-1.5 py-0.5 bg-amber-50 text-amber-700 rounded">
               +{cfg.identityAttributes.length} identity attr{cfg.identityAttributes.length > 1 ? 's' : ''}
             </span>
           )}
           {cfg.customUserAttributes?.length > 0 && (
-            <span className="px-1.5 py-0.5 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">
+            <span className="px-1.5 py-0.5 bg-amber-50 text-amber-700 rounded">
               +{cfg.customUserAttributes.length} user attr{cfg.customUserAttributes.length > 1 ? 's' : ''}
             </span>
           )}
           {cfg.customGroupAttributes?.length > 0 && (
-            <span className="px-1.5 py-0.5 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">
+            <span className="px-1.5 py-0.5 bg-amber-50 text-amber-700 rounded">
               +{cfg.customGroupAttributes.length} group attr{cfg.customGroupAttributes.length > 1 ? 's' : ''}
             </span>
           )}
@@ -1172,11 +1172,11 @@ function JobProgress({ job, onNavigateToMatrix, onDismiss }) {
 
   if (job.status === 'completed') {
     return (
-      <div className="mb-6 p-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg">
+      <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg">
         <div className="flex items-center justify-between">
           <div>
-            <span className="font-semibold text-green-800 dark:text-green-200">Data loaded successfully!</span>
-            <p className="text-sm text-green-600 dark:text-green-400 mt-1">Your identity data is ready to explore.</p>
+            <span className="font-semibold text-green-800">Data loaded successfully!</span>
+            <p className="text-sm text-green-600 mt-1">Your identity data is ready to explore.</p>
           </div>
           <div className="flex gap-2">
             {onNavigateToMatrix && (
@@ -1190,11 +1190,11 @@ function JobProgress({ job, onNavigateToMatrix, onDismiss }) {
   }
   if (job.status === 'failed') {
     return (
-      <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
+      <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
         <div className="flex items-center justify-between">
           <div>
-            <span className="font-semibold text-red-800 dark:text-red-200">Job failed</span>
-            <p className="text-sm text-red-600 dark:text-red-400 mt-1">{job.errorMessage || 'Unknown error'}</p>
+            <span className="font-semibold text-red-800">Job failed</span>
+            <p className="text-sm text-red-600 mt-1">{job.errorMessage || 'Unknown error'}</p>
           </div>
           {onDismiss && <button onClick={onDismiss} className="text-red-500 hover:text-red-700 text-sm">Dismiss</button>}
         </div>
@@ -1210,17 +1210,17 @@ function JobProgress({ job, onNavigateToMatrix, onDismiss }) {
   const stalenessColor = staleness === 'stale' ? 'text-amber-600' : 'text-blue-500';
 
   return (
-    <div className="mb-6 p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg">
+    <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
       <div className="flex items-center justify-between mb-2">
-        <span className="font-semibold text-blue-800 dark:text-blue-200">{job.status === 'queued' ? 'Waiting for worker...' : step}</span>
-        <span className="text-sm text-blue-600 dark:text-blue-400">{pct}%</span>
+        <span className="font-semibold text-blue-800">{job.status === 'queued' ? 'Waiting for worker...' : step}</span>
+        <span className="text-sm text-blue-600">{pct}%</span>
       </div>
-      <div className="w-full bg-blue-200 dark:bg-blue-800 rounded-full h-2.5">
+      <div className="w-full bg-blue-200 rounded-full h-2.5">
         <div className="bg-blue-600 h-2.5 rounded-full transition-all duration-500" style={{ width: `${Math.max(pct, 2)}%` }} />
       </div>
       {(detail || secondsSince != null) && (
         <div className="flex items-center justify-between mt-2 text-xs">
-          <span className="text-blue-700 dark:text-blue-300 truncate font-mono">{detail || ''}</span>
+          <span className="text-blue-700 truncate font-mono">{detail || ''}</span>
           {secondsSince != null && (
             <span className={`ml-2 flex-shrink-0 ${stalenessColor}`} title={updatedAt?.toLocaleString()}>
               {secondsSince === 0 ? 'just now' : `${secondsSince}s ago`}
@@ -1237,18 +1237,18 @@ function JobProgress({ job, onNavigateToMatrix, onDismiss }) {
 function RecentJobs({ jobs, onForceStop }) {
   if (!jobs || jobs.length === 0) return null;
   const statusColors = {
-    queued: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
-    running: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
-    cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
+    queued: 'bg-yellow-100 text-yellow-800',
+    running: 'bg-blue-100 text-blue-800',
+    completed: 'bg-green-100 text-green-800',
+    failed: 'bg-red-100 text-red-800',
+    cancelled: 'bg-gray-100 text-gray-800',
   };
   return (
     <div className="mb-6">
       <h3 className="text-lg font-semibold mb-3">Recent Jobs</h3>
-      <div className="bg-white dark:bg-gray-800 rounded-lg border overflow-hidden">
+      <div className="bg-white rounded-lg border overflow-hidden">
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 dark:bg-gray-700">
+          <thead className="bg-gray-50">
             <tr>
               <th className="text-left p-3 font-medium">Type</th>
               <th className="text-left p-3 font-medium">Status</th>
@@ -1257,7 +1257,7 @@ function RecentJobs({ jobs, onForceStop }) {
               <th className="text-left p-3 font-medium">Error</th>
             </tr>
           </thead>
-          <tbody className="divide-y dark:divide-gray-700">
+          <tbody className="divide-y">
             {jobs.map(j => {
               const duration = j.startedAt && j.completedAt
                 ? formatDurationHMS(Math.round((new Date(j.completedAt) - new Date(j.startedAt)) / 1000))
@@ -1295,22 +1295,22 @@ function ExternalCrawlers({ crawlers, onToggle, onResetKey, onRemove, newKey, on
       <h3 className="text-lg font-semibold mb-3">External Crawlers</h3>
 
       {newKey && (
-        <div className="mb-4 p-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg">
+        <div className="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg">
           <div className="flex items-center justify-between mb-2">
-            <span className="font-semibold text-green-800 dark:text-green-200">API Key Generated</span>
+            <span className="font-semibold text-green-800">API Key Generated</span>
             <button onClick={onDismissKey} className="text-green-600 hover:text-green-800 text-sm">Dismiss</button>
           </div>
-          <p className="text-sm text-green-700 dark:text-green-300 mb-2">Store this key securely. It will not be shown again.</p>
+          <p className="text-sm text-green-700 mb-2">Store this key securely. It will not be shown again.</p>
           <div className="flex items-center gap-2">
-            <code className="flex-1 p-2 bg-white dark:bg-gray-800 border rounded font-mono text-sm break-all">{newKey}</code>
+            <code className="flex-1 p-2 bg-white border rounded font-mono text-sm break-all">{newKey}</code>
             <button onClick={() => onCopy(newKey)} className="px-3 py-2 bg-green-600 text-white rounded text-sm hover:bg-green-700">Copy</button>
           </div>
         </div>
       )}
 
-      <div className="bg-white dark:bg-gray-800 rounded-lg border overflow-hidden">
+      <div className="bg-white rounded-lg border overflow-hidden">
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 dark:bg-gray-700">
+          <thead className="bg-gray-50">
             <tr>
               <th className="text-left p-3 font-medium">Name</th>
               <th className="text-left p-3 font-medium">Key Prefix</th>
@@ -1319,7 +1319,7 @@ function ExternalCrawlers({ crawlers, onToggle, onResetKey, onRemove, newKey, on
               <th className="text-right p-3 font-medium">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y dark:divide-gray-700">
+          <tbody className="divide-y">
             {visible.map(c => (
               <tr key={c.id}>
                 <td className="p-3">
@@ -1336,7 +1336,7 @@ function ExternalCrawlers({ crawlers, onToggle, onResetKey, onRemove, newKey, on
                 <td className="p-3 text-gray-500">{formatDate(c.lastUsedAt)}</td>
                 <td className="p-3 text-right">
                   <div className="flex gap-1 justify-end">
-                    <button onClick={() => onToggleAudit(c.id)} className="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200">
+                    <button onClick={() => onToggleAudit(c.id)} className="px-2 py-1 text-xs bg-gray-100 rounded hover:bg-gray-200">
                       {expandedAudit === c.id ? 'Hide' : 'Log'}
                     </button>
                     <button onClick={() => onResetKey(c)} className="px-2 py-1 text-xs bg-amber-100 text-amber-800 rounded hover:bg-amber-200">Reset Key</button>
@@ -1355,9 +1355,9 @@ function ExternalCrawlers({ crawlers, onToggle, onResetKey, onRemove, newKey, on
 // ─── Getting Started Card ─────────────────────────────────────────────────────
 function GettingStarted({ onAddCrawler }) {
   return (
-    <div className="mb-8 p-6 bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-900/20 dark:to-teal-900/20 border border-emerald-200 dark:border-emerald-800 rounded-xl text-center">
-      <h2 className="text-xl font-bold text-emerald-900 dark:text-emerald-100 mb-2">Welcome to Identity Atlas</h2>
-      <p className="text-emerald-700 dark:text-emerald-300 mb-4">No identity data loaded yet. Add a crawler to get started.</p>
+    <div className="mb-8 p-6 bg-gradient-to-br from-emerald-50 to-teal-50 border border-emerald-200 rounded-xl text-center">
+      <h2 className="text-xl font-bold text-emerald-900 mb-2">Welcome to Identity Atlas</h2>
+      <p className="text-emerald-700 mb-4">No identity data loaded yet. Add a crawler to get started.</p>
       <button onClick={onAddCrawler} className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 font-medium">
         Add Crawler
       </button>
@@ -1542,7 +1542,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
   };
 
   return (
-    <div className="mb-6 p-5 bg-white dark:bg-gray-800 border rounded-lg">
+    <div className="mb-6 p-5 bg-white border rounded-lg">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold">{isEdit ? 'Edit CSV Crawler' : 'Add CSV Crawler'} — Step {step} of 3</h3>
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm">Cancel</button>
@@ -1997,7 +1997,7 @@ export default function CrawlersPage({ onNavigate }) {
   return (
     <div className="p-6 max-w-6xl mx-auto">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Crawlers</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Crawlers</h1>
         {!wizardStep && (
           <button onClick={() => setWizardStep('select')}
             className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 text-sm font-medium">
@@ -2007,8 +2007,8 @@ export default function CrawlersPage({ onNavigate }) {
       </div>
 
       {error && (
-        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg flex items-center justify-between">
-          <span className="text-red-700 dark:text-red-300 text-sm">{error}</span>
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center justify-between">
+          <span className="text-red-700 text-sm">{error}</span>
           <button onClick={() => setError(null)} className="text-red-500 hover:text-red-700 text-sm">Dismiss</button>
         </div>
       )}

--- a/app/ui/src/components/CrawlersPage.jsx
+++ b/app/ui/src/components/CrawlersPage.jsx
@@ -1246,7 +1246,7 @@ function RecentJobs({ jobs, onForceStop }) {
   return (
     <div className="mb-6">
       <h3 className="text-lg font-semibold mb-3">Recent Jobs</h3>
-      <div className="bg-white rounded-lg border overflow-hidden">
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
         <table className="w-full text-sm">
           <thead className="bg-gray-50">
             <tr>
@@ -1308,7 +1308,7 @@ function ExternalCrawlers({ crawlers, onToggle, onResetKey, onRemove, newKey, on
         </div>
       )}
 
-      <div className="bg-white rounded-lg border overflow-hidden">
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
         <table className="w-full text-sm">
           <thead className="bg-gray-50">
             <tr>

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -286,7 +286,7 @@ function NoDataState({ onNavigate }) {
   return (
     <div className="text-center py-8">
       <div className="text-5xl mb-3">📦</div>
-      <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+      <div className="text-sm text-gray-600 mb-4">
         No data loaded yet.
       </div>
       <button

--- a/app/ui/src/components/RiskProfileWizard.jsx
+++ b/app/ui/src/components/RiskProfileWizard.jsx
@@ -119,7 +119,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
     return (
       <Modal onClose={onClose} title="Risk Profile Wizard">
         <div className="p-6">
-          <div className="text-sm text-amber-700 dark:text-amber-300">
+          <div className="text-sm text-amber-700">
             No LLM provider is configured yet. Open <strong>Admin → LLM Settings</strong> to add credentials, then come back.
           </div>
         </div>
@@ -313,10 +313,10 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
   return (
     <Modal onClose={onClose} title="Risk Profile Wizard" wide>
       {/* Step indicator */}
-      <div className="flex items-center gap-2 px-6 py-3 border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-xs">
+      <div className="flex items-center gap-2 px-6 py-3 border-b bg-gray-50 text-xs">
         {STEPS.map((s, i) => (
-          <div key={s.key} className={`flex items-center gap-2 ${i === stepIdx ? 'font-semibold text-indigo-700 dark:text-indigo-300' : i < stepIdx ? 'text-green-700 dark:text-green-400' : 'text-gray-400'}`}>
-            <span className={`inline-flex w-5 h-5 rounded-full items-center justify-center text-[10px] ${i === stepIdx ? 'bg-indigo-600 text-white' : i < stepIdx ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>{i + 1}</span>
+          <div key={s.key} className={`flex items-center gap-2 ${i === stepIdx ? 'font-semibold text-indigo-700' : i < stepIdx ? 'text-green-700' : 'text-gray-400'}`}>
+            <span className={`inline-flex w-5 h-5 rounded-full items-center justify-center text-[10px] ${i === stepIdx ? 'bg-indigo-600 text-white' : i < stepIdx ? 'bg-green-600 text-white' : 'bg-gray-200'}`}>{i + 1}</span>
             <span>{s.label}</span>
             {i < STEPS.length - 1 && <span className="text-gray-300 mx-1">›</span>}
           </div>
@@ -331,30 +331,30 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label className="block text-xs font-medium mb-1">Domain *</label>
-                <input value={domain} onChange={e => setDomain(e.target.value)} placeholder="example.com" className="w-full px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600" />
+                <input value={domain} onChange={e => setDomain(e.target.value)} placeholder="example.com" className="w-full px-3 py-1.5 text-sm border rounded" />
               </div>
               <div>
                 <label className="block text-xs font-medium mb-1">Organisation name (optional)</label>
-                <input value={orgName} onChange={e => setOrgName(e.target.value)} placeholder="Acme Corp" className="w-full px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600" />
+                <input value={orgName} onChange={e => setOrgName(e.target.value)} placeholder="Acme Corp" className="w-full px-3 py-1.5 text-sm border rounded" />
               </div>
             </div>
             <div>
               <label className="block text-xs font-medium mb-1">Free-text hints (optional)</label>
-              <textarea value={hints} onChange={e => setHints(e.target.value)} rows={3} placeholder="e.g. We're focused on the medical-device division. Skip the consumer products business." className="w-full px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600" />
+              <textarea value={hints} onChange={e => setHints(e.target.value)} rows={3} placeholder="e.g. We're focused on the medical-device division. Skip the consumer products business." className="w-full px-3 py-1.5 text-sm border rounded" />
             </div>
 
             <div>
               <div className="flex items-center justify-between mb-2">
                 <label className="text-xs font-medium">Internal URLs to scrape (optional)</label>
-                <button onClick={addUrl} className="text-xs px-2 py-1 rounded border dark:border-gray-600">+ Add URL</button>
+                <button onClick={addUrl} className="text-xs px-2 py-1 rounded border">+ Add URL</button>
               </div>
               {urls.length === 0 && (
                 <div className="text-xs text-gray-500">Add wiki, ISMS, intranet pages here. Use credentials for auth-protected URLs (configure them on the Admin → LLM Settings page or below).</div>
               )}
               {urls.map((row, i) => (
                 <div key={i} className="flex gap-2 mb-2">
-                  <input value={row.url} onChange={e => updateUrl(i, 'url', e.target.value)} placeholder="https://wiki.internal/about" className="flex-1 px-3 py-1.5 text-sm border rounded font-mono dark:bg-gray-700 dark:border-gray-600" />
-                  <select value={row.credentialId} onChange={e => updateUrl(i, 'credentialId', e.target.value)} className="px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600">
+                  <input value={row.url} onChange={e => updateUrl(i, 'url', e.target.value)} placeholder="https://wiki.internal/about" className="flex-1 px-3 py-1.5 text-sm border rounded font-mono" />
+                  <select value={row.credentialId} onChange={e => updateUrl(i, 'credentialId', e.target.value)} className="px-3 py-1.5 text-sm border rounded">
                     <option value="">no auth</option>
                     {credList.map(c => <option key={c.id} value={c.id}>{c.label}</option>)}
                   </select>
@@ -364,22 +364,22 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             </div>
 
             <div className="flex justify-end gap-2 pt-2">
-              <button onClick={onClose} className="px-4 py-1.5 text-sm border rounded dark:border-gray-600">Cancel</button>
+              <button onClick={onClose} className="px-4 py-1.5 text-sm border rounded">Cancel</button>
               <button onClick={handleGenerate} disabled={!domain || generating} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300">
                 {generating ? `Generating… (${elapsedSec}s)` : 'Generate profile →'}
               </button>
             </div>
             {generating && (
-              <div className="mt-3 p-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded text-sm">
-                <div className="flex items-center gap-2 text-indigo-900 dark:text-indigo-200">
+              <div className="mt-3 p-3 bg-indigo-50 border border-indigo-200 rounded text-sm">
+                <div className="flex items-center gap-2 text-indigo-900">
                   <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
                     <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
                     <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" className="opacity-75" />
                   </svg>
                   <span className="font-medium">The AI is researching the organisation…</span>
-                  <span className="text-xs text-indigo-700 dark:text-indigo-300 ml-auto">{elapsedSec}s elapsed</span>
+                  <span className="text-xs text-indigo-700 ml-auto">{elapsedSec}s elapsed</span>
                 </div>
-                <div className="text-xs text-indigo-700 dark:text-indigo-300 mt-2 space-y-1">
+                <div className="text-xs text-indigo-700 mt-2 space-y-1">
                   <div>1. {urls.filter(u => u.url).length > 0 ? `Scraping ${urls.filter(u => u.url).length} URL${urls.filter(u => u.url).length === 1 ? '' : 's'}` : 'Skipping URL scraping'}</div>
                   <div>2. Calling the LLM to generate the profile JSON</div>
                   <div className="opacity-70 mt-2">This typically takes 20–60 seconds depending on the model. Opus/GPT-4 are slower but produce better industry-specific profiles.</div>
@@ -398,7 +398,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
               <span className="text-xs text-gray-500">model: <code>{llmModel}</code></span>
             </div>
             {scrapedSummary && scrapedSummary.length > 0 && (
-              <div className="text-xs bg-gray-50 dark:bg-gray-900 border rounded p-2">
+              <div className="text-xs bg-gray-50 border rounded p-2">
                 <div className="font-medium mb-1">Scraped sources:</div>
                 {scrapedSummary.map((s, i) => (
                   <div key={i} className={s.ok ? 'text-green-700' : 'text-red-700'}>
@@ -412,22 +412,22 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
               {/* Left: profile JSON */}
               <div>
                 <div className="text-xs font-medium mb-1">Current profile</div>
-                <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 border rounded p-2 overflow-auto max-h-96 font-mono">{JSON.stringify(profile, null, 2)}</pre>
+                <pre className="text-[11px] bg-gray-50 border rounded p-2 overflow-auto max-h-96 font-mono">{JSON.stringify(profile, null, 2)}</pre>
               </div>
               {/* Right: chat */}
               <div className="flex flex-col">
                 <div className="text-xs font-medium mb-1">Refinement chat</div>
-                <div className="flex-1 border rounded p-2 bg-white dark:bg-gray-900 max-h-96 overflow-auto space-y-2">
+                <div className="flex-1 border rounded p-2 bg-white max-h-96 overflow-auto space-y-2">
                   {transcript.length === 0 && (
                     <div className="text-xs text-gray-500">Ask the AI to adjust anything or ask a question: "drop NIS2 — we're US-only", "what software does this org use?", "add critical role for Customs Officer"…</div>
                   )}
                   {transcript.map((m, i) => (
-                    <div key={i} className={`text-xs ${m.role === 'user' ? 'text-gray-900 dark:text-gray-100' : 'text-indigo-700 dark:text-indigo-300'}`}>
+                    <div key={i} className={`text-xs ${m.role === 'user' ? 'text-gray-900' : 'text-indigo-700'}`}>
                       <span className="font-semibold">{m.role === 'user' ? 'You' : 'AI'}:</span> {m.content}
                     </div>
                   ))}
                   {refining && (
-                    <div className="text-xs text-indigo-700 dark:text-indigo-300 flex items-center gap-2">
+                    <div className="text-xs text-indigo-700 flex items-center gap-2">
                       <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
                         <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
                         <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" className="opacity-75" />
@@ -437,7 +437,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                   )}
                 </div>
                 <div className="flex gap-2 mt-2">
-                  <input value={chatInput} onChange={e => setChatInput(e.target.value)} onKeyDown={e => e.key === 'Enter' && handleRefine()} disabled={refining} placeholder="Ask for a change or a question…" className="flex-1 px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600" />
+                  <input value={chatInput} onChange={e => setChatInput(e.target.value)} onKeyDown={e => e.key === 'Enter' && handleRefine()} disabled={refining} placeholder="Ask for a change or a question…" className="flex-1 px-3 py-1.5 text-sm border rounded" />
                   <button onClick={handleRefine} disabled={!chatInput.trim() || refining} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300">
                     {refining ? `${elapsedSec}s` : 'Send'}
                   </button>
@@ -446,7 +446,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             </div>
 
             <div className="flex justify-between pt-2">
-              <button onClick={() => setStepIdx(0)} className="px-4 py-1.5 text-sm border rounded dark:border-gray-600">← Back</button>
+              <button onClick={() => setStepIdx(0)} className="px-4 py-1.5 text-sm border rounded">← Back</button>
               <button onClick={() => setStepIdx(2)} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">Looks good — save →</button>
             </div>
           </div>
@@ -458,14 +458,14 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             <h3 className="text-base font-semibold">Save profile</h3>
             <div>
               <label className="block text-xs font-medium mb-1">Profile name *</label>
-              <input value={profileName} onChange={e => setProfileName(e.target.value)} className="w-full px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600" />
+              <input value={profileName} onChange={e => setProfileName(e.target.value)} className="w-full px-3 py-1.5 text-sm border rounded" />
             </div>
             <label className="flex items-center gap-2 text-sm">
               <input type="checkbox" checked={makeActive} onChange={e => setMakeActive(e.target.checked)} />
               Make this the active profile
             </label>
             <div className="flex justify-between pt-2">
-              <button onClick={() => setStepIdx(1)} className="px-4 py-1.5 text-sm border rounded dark:border-gray-600">← Back</button>
+              <button onClick={() => setStepIdx(1)} className="px-4 py-1.5 text-sm border rounded">← Back</button>
               <button onClick={handleSaveProfile} disabled={!profileName || savingProfile} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300">
                 {savingProfile ? 'Saving…' : 'Save profile →'}
               </button>
@@ -477,7 +477,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
         {stepIdx === 3 && (
           <div className="space-y-4">
             <h3 className="text-base font-semibold">Generate classifiers</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
+            <p className="text-sm text-gray-600">
               Classifiers are regex patterns that detect high-risk principals by name.
               They're generated from the profile you just saved and applied during scoring.
             </p>
@@ -486,20 +486,20 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                 <button onClick={handleGenerateClassifiers} disabled={genClassifiers} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300">
                   {genClassifiers ? `Generating… (${classifierElapsedSec}s)` : 'Generate classifiers'}
                 </button>
-                <button onClick={() => { onSaved?.(); onClose(); }} disabled={genClassifiers} className="px-4 py-1.5 text-sm border rounded dark:border-gray-600 disabled:opacity-50">Skip — done for now</button>
+                <button onClick={() => { onSaved?.(); onClose(); }} disabled={genClassifiers} className="px-4 py-1.5 text-sm border rounded disabled:opacity-50">Skip — done for now</button>
               </div>
             )}
             {genClassifiers && (
-              <div className="mt-3 p-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded text-sm">
-                <div className="flex items-center gap-2 text-indigo-900 dark:text-indigo-200">
+              <div className="mt-3 p-3 bg-indigo-50 border border-indigo-200 rounded text-sm">
+                <div className="flex items-center gap-2 text-indigo-900">
                   <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
                     <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
                     <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" className="opacity-75" />
                   </svg>
                   <span className="font-medium">Generating regex classifiers from the profile…</span>
-                  <span className="text-xs text-indigo-700 dark:text-indigo-300 ml-auto">{classifierElapsedSec}s elapsed</span>
+                  <span className="text-xs text-indigo-700 ml-auto">{classifierElapsedSec}s elapsed</span>
                 </div>
-                <div className="text-xs text-indigo-700 dark:text-indigo-300 mt-2 space-y-1">
+                <div className="text-xs text-indigo-700 mt-2 space-y-1">
                   <div>The LLM is translating the profile's regulations, critical roles, and known systems into regex patterns that will match high-risk principals during scoring.</div>
                   <div className="opacity-70 mt-2">This typically takes 30–90 seconds with Opus — classifiers are larger than profiles. Switch to Sonnet or Haiku in Admin → LLM Settings for faster (but less nuanced) output.</div>
                 </div>
@@ -508,11 +508,11 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             {classifierError && <div className="text-sm text-red-700 mt-2">{classifierError}</div>}
             {classifiers && (
               <>
-                <pre className="text-[11px] bg-gray-50 dark:bg-gray-900 border rounded p-2 overflow-auto max-h-80 font-mono">{JSON.stringify(classifiers, null, 2)}</pre>
+                <pre className="text-[11px] bg-gray-50 border rounded p-2 overflow-auto max-h-80 font-mono">{JSON.stringify(classifiers, null, 2)}</pre>
                 <div className="flex items-end gap-3">
                   <div className="flex-1">
                     <label className="block text-xs font-medium mb-1">Classifier set name</label>
-                    <input value={classifierName} onChange={e => setClassifierName(e.target.value)} className="w-full px-3 py-1.5 text-sm border rounded dark:bg-gray-700 dark:border-gray-600" />
+                    <input value={classifierName} onChange={e => setClassifierName(e.target.value)} className="w-full px-3 py-1.5 text-sm border rounded" />
                   </div>
                   <label className="flex items-center gap-2 text-sm pb-1.5">
                     <input type="checkbox" checked={activateClassifier} onChange={e => setActivateClassifier(e.target.checked)} />
@@ -520,7 +520,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                   </label>
                 </div>
                 <div className="flex justify-between pt-2">
-                  <button onClick={handleGenerateClassifiers} disabled={genClassifiers} className="px-4 py-1.5 text-sm border rounded dark:border-gray-600">Regenerate</button>
+                  <button onClick={handleGenerateClassifiers} disabled={genClassifiers} className="px-4 py-1.5 text-sm border rounded">Regenerate</button>
                   <button onClick={handleSaveClassifiers} disabled={!classifierName || savingClassifiers} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300">
                     {savingClassifiers ? 'Saving…' : 'Save classifiers →'}
                   </button>
@@ -534,7 +534,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
         {stepIdx === 4 && (
           <div className="space-y-4 max-w-lg">
             <h3 className="text-base font-semibold">Run scoring</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
+            <p className="text-sm text-gray-600">
               This applies the saved classifiers to every Principal and Resource and writes the results to the RiskScores table.
               You can also run it later from the Risk Scoring page.
             </p>
@@ -543,7 +543,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                 <button onClick={handleStartScoring} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">
                   Run scoring now
                 </button>
-                <button onClick={() => { onSaved?.(); onClose(); }} className="px-4 py-1.5 text-sm border rounded dark:border-gray-600">Done</button>
+                <button onClick={() => { onSaved?.(); onClose(); }} className="px-4 py-1.5 text-sm border rounded">Done</button>
               </div>
             )}
             {scoringError && <div className="text-sm text-red-700">{scoringError}</div>}
@@ -553,7 +553,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                   Status: <span className={`font-semibold ${scoringRun.status === 'completed' ? 'text-green-700' : scoringRun.status === 'failed' ? 'text-red-700' : 'text-indigo-700'}`}>{scoringRun.status}</span>
                   {scoringRun.step && <span className="text-gray-500"> · {scoringRun.step}</span>}
                 </div>
-                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2">
+                <div className="w-full bg-gray-200 rounded h-2">
                   <div className="bg-indigo-600 h-2 rounded transition-all" style={{ width: `${scoringRun.pct || 0}%` }} />
                 </div>
                 <div className="text-xs text-gray-500">{scoringRun.scoredEntities || 0} / {scoringRun.totalEntities || '?'} entities</div>
@@ -576,8 +576,8 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
 function Modal({ children, onClose, title, wide }) {
   return (
     <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
-      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl ${wide ? 'max-w-4xl' : 'max-w-md'} w-full`}>
-        <div className="flex items-center justify-between px-6 py-3 border-b dark:border-gray-700">
+      <div className={`bg-white rounded-lg shadow-xl ${wide ? 'max-w-4xl' : 'max-w-md'} w-full`}>
+        <div className="flex items-center justify-between px-6 py-3 border-b">
           <h2 className="text-base font-semibold">{title}</h2>
           <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-xl leading-none">×</button>
         </div>

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -64,6 +64,9 @@ body,
 [data-md-color-scheme=slate] .md-main {
   background-color: #0f172a;
 }
+[data-md-color-scheme=slate] .md-content {
+  background-color: #1e293b;
+}
 
 /* ── Typography: match the UI's tight headings ─────────────────── */
 .md-typeset h1 {
@@ -236,6 +239,28 @@ body,
 }
 .md-typeset table:not([class]) tr:hover td {
   background-color: var(--ia-lime-50);
+}
+
+/* Dark mode table overrides */
+[data-md-color-scheme=slate] .md-typeset table:not([class]) {
+  border-color: #334155;
+}
+[data-md-color-scheme=slate] .md-typeset table:not([class]) th {
+  background-color: #0f172a;
+  color: var(--ia-lime-300);
+  border-bottom-color: #334155;
+}
+[data-md-color-scheme=slate] .md-typeset table:not([class]) tr:hover td {
+  background-color: #1e3a1e;
+}
+
+/* Dark mode heading colors */
+[data-md-color-scheme=slate] .md-typeset h1,
+[data-md-color-scheme=slate] .md-typeset h2 {
+  color: #f1f5f9;
+}
+[data-md-color-scheme=slate] .md-typeset h3 {
+  color: #cbd5e1;
 }
 
 /* ── Links — lime-700 with underline on hover (matches the UI) ─── */


### PR DESCRIPTION
**Fix dark mode visual glitches in Admin UI**
Users with OS dark mode enabled saw white headings on light backgrounds and dark-gray table panels. The app has no dark mode implementation, so incomplete dark: Tailwind stubs were causing isolated elements to go dark while the surrounding layout stayed light.

**Changes:**
- Remove all dark: utility classes from AdminPage, CrawlersPage, DashboardPage, and RiskProfileWizard
- Replace bare border with border-gray-200 on Version History Retention, LLM Provider, Recent Jobs, and External Crawlers panels — matching the Curated Data section
- Fix "Atlas" logo text color from emerald-600 (too dark) to #65b425 (brand green)