### PR TITLE
feat: make sync log entry count on dashboard a link to Sync Log tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ on the upstream FortigiGraph repo.
 
 ---
 
+- **Dashboard sync log entries link to Sync Log tab** — The "N sync log entries" text at the bottom of the stats card on the Dashboard is now a clickable link that navigates directly to the Sync Log tab.
+
 - **Extract `Section` and `CollapsibleSection` to `DetailSection.jsx`** — both components were defined identically inside four detail page files (UserDetailPage, GroupDetailPage, ResourceDetailPage, AccessPackageDetailPage), causing React to recreate them on every render. Extracted to a shared `components/DetailSection.jsx`. No behavior change.
 
 - **Extract `useDebouncedValue` hook** — the `useState` + `useEffect` debounce pattern was duplicated in four places (`useEntityPage`, `AccessPackagesPage`, `IdentitiesPage`, `OrgChartPage`). Extracted to `app/ui/src/hooks/useDebouncedValue.js`. No behavior change.

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -123,7 +123,12 @@ export default function DashboardPage({ onNavigate }) {
                 <StatCard label="Relationships"  value={stats.relationships} />
               </div>
               <div className="mt-5 pt-4 border-t border-gray-100 text-xs text-gray-400 text-right">
-                {stats.syncLogEntries || 0} sync log entries
+                <button
+                  onClick={() => onNavigate?.('sync-log')}
+                  className="hover:text-lime-700 hover:underline transition-colors"
+                >
+                  {stats.syncLogEntries || 0} sync log entries
+                </button>
               </div>
             </>
           )}

--- a/setup/IdentityAtlas.psd1
+++ b/setup/IdentityAtlas.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\IdentityAtlas.psm1'
 
 # Version number of this module.
-ModuleVersion = '5.0.20260413.1830'
+ModuleVersion = '5.0.20260413.1930'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- **Dashboard sync log entries link to Sync Log tab** — The "N sync log entries" text at the bottom of the stats card on the Dashboard is now a clickable link that navigates directly to the Sync Log tab.