### PR TITLE
Bugfixes/container stats fix

### DIFF
--- a/app/ui/e2e/container-stats.spec.js
+++ b/app/ui/e2e/container-stats.spec.js
@@ -1,0 +1,68 @@
+// @ts-check
+/**
+ * Container Stats page E2E tests.
+ *
+ * Verifies the Containers tab in Admin shows live CPU, memory, and network
+ * stats for the running Docker containers (web, worker, postgres).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3001';
+const API = `${BASE}/api`;
+
+test.describe('Container Stats page', () => {
+
+  test('API returns container stats with CPU and memory', async ({ request }) => {
+    const res = await request.get(`${API}/admin/container-stats`);
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+
+    if (body.unavailable) {
+      test.skip(true, 'Docker socket not accessible');
+      return;
+    }
+
+    expect(body.containers).toBeDefined();
+    expect(body.containers.length).toBeGreaterThan(0);
+
+    // Find the web container
+    const web = body.containers.find(c => c.service === 'web');
+    expect(web, 'web container should be present').toBeDefined();
+    expect(web.state).toBe('running');
+    expect(web.cpuPercent).toBeGreaterThanOrEqual(0);
+    expect(web.memUsageBytes).toBeGreaterThan(0);
+  });
+
+  test('Containers tab renders stats cards', async ({ page }) => {
+    // Check API first — skip if socket unavailable
+    const apiRes = await page.request.get(`${API}/admin/container-stats`);
+    const apiBody = await apiRes.json();
+    if (apiBody.unavailable) {
+      test.skip(true, 'Docker socket not accessible');
+      return;
+    }
+
+    await page.goto(`${BASE}/#admin`);
+    await page.waitForLoadState('networkidle');
+
+    // Click the Containers tab
+    const tab = page.locator('button:has-text("Containers"), [role="tab"]:has-text("Containers")');
+    if (!await tab.isVisible({ timeout: 5000 }).catch(() => false)) {
+      test.skip(true, 'Containers tab not found');
+      return;
+    }
+    await tab.click();
+
+    // Wait for stats to load (auto-refreshes every 3s)
+    await page.waitForTimeout(4000);
+
+    // Verify at least one container card is rendered with CPU and Memory labels
+    await expect(page.locator('text=CPU').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Memory').first()).toBeVisible();
+    await expect(page.locator('text=Network').first()).toBeVisible();
+
+    // Verify the web container card is present
+    await expect(page.locator('text=Web (API + UI)')).toBeVisible();
+  });
+});

--- a/app/ui/src/components/ContainerStatsPage.jsx
+++ b/app/ui/src/components/ContainerStatsPage.jsx
@@ -85,6 +85,24 @@ export default function ContainerStatsPage() {
 
   if (!data) return <div className="text-sm text-gray-500 p-4">Loading container stats…</div>;
 
+  if (data.unavailable) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+        <div className="font-semibold mb-1">Container stats unavailable</div>
+        <div>The web container cannot access the Docker socket to read container metrics.</div>
+        {data.reason && <div className="mt-1 font-mono text-xs bg-amber-100 px-2 py-1 rounded">{data.reason}</div>}
+        <div className="mt-3 text-xs text-amber-700 space-y-1">
+          <p>To enable container monitoring, the Docker socket must be readable by the web container. Common fixes:</p>
+          <ul className="list-disc list-inside ml-2 space-y-0.5">
+            <li><strong>Linux:</strong> <code>sudo chmod 666 /var/run/docker.sock</code> (or add the container user to the <code>docker</code> group)</li>
+            <li><strong>Docker Desktop (Windows/Mac):</strong> Usually works out of the box — restart Docker Desktop if needed</li>
+          </ul>
+          <p className="mt-2">This does not affect any other functionality — crawlers, sync, and the UI all work without container stats.</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
       <div className="text-xs text-gray-500">

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,9 @@ services:
   # ── Web (serves built frontend + API) ────────────────────────────────────────
   web:
     image: ghcr.io/fortigi/identity-atlas:latest
+    # The container runs as the unprivileged `node` user. The Docker socket
+    # is owned by root:root 0660, so node needs GID 0 to read container stats.
+    group_add: ["0"]
     environment:
       NODE_ENV:    production
       USE_SQL:     "true"  # legacy flag — still used by routes to enable DB-backed mode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
     build:
       context: ./app
       dockerfile: api/Dockerfile
+    # The container runs as the unprivileged `node` user (Dockerfile USER node).
+    # The Docker socket is owned by root:root with 0660 permissions, so node
+    # needs the root group (GID 0) to read container stats. The socket is
+    # already mounted read-only — adding the group doesn't change the security
+    # posture.
+    group_add: ["0"]
     environment:
       NODE_ENV:    production
       USE_SQL:     "true"  # legacy flag — still used by routes to enable DB-backed mode

--- a/test/nightly/Run-NightlyLocal.ps1
+++ b/test/nightly/Run-NightlyLocal.ps1
@@ -789,16 +789,20 @@ if (-not $SkipIntegration) {
         try {
             $stats = Invoke-RestMethod -Uri "$apiBaseUrl/admin/container-stats" -TimeoutSec 30
             if ($stats.unavailable) {
-                Write-Result 'Container-Stats-Live' $true 'Docker socket not mounted (expected in some envs)'
+                Write-Result 'Container-Stats-Live' $false "Docker socket not accessible: $($stats.reason)"
             } else {
                 $hasContainers = $stats.containers -and $stats.containers.Count -gt 0
                 Write-Result 'Container-Stats-Live' $hasContainers "containers=$($stats.containers.Count)"
                 if ($hasContainers) {
-                    $webC = $stats.containers | Where-Object { $_.service -eq 'web' }
-                    Write-Result 'Container-Stats-WebPresent' ($null -ne $webC) ''
-                    if ($webC) {
-                        Write-Result 'Container-Stats-HasCPU' ($webC.cpuPercent -ge 0) "cpu=$([math]::Round($webC.cpuPercent, 1))%"
-                        Write-Result 'Container-Stats-HasMem' ($webC.memUsageBytes -gt 0) "mem=$([math]::Round($webC.memUsageBytes / 1MB, 1))MB"
+                    foreach ($svc in @('web', 'worker', 'postgres')) {
+                        $c = $stats.containers | Where-Object { $_.service -eq $svc }
+                        if ($c) {
+                            Write-Result "Container-Stats/$svc/Running" ($c.state -eq 'running') "state=$($c.state)"
+                            Write-Result "Container-Stats/$svc/HasCPU" ($c.cpuPercent -ge 0) "cpu=$([math]::Round($c.cpuPercent, 1))%"
+                            Write-Result "Container-Stats/$svc/HasMem" ($c.memUsageBytes -gt 0) "mem=$([math]::Round($c.memUsageBytes / 1MB, 1))MB"
+                        } else {
+                            Write-Result "Container-Stats/$svc/Running" $false 'not found in response'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

The Containers tab on the Admin page showed a blank page when using `docker-compose.prod.yml`. Root cause: the web container runs as `node` (uid 1000) but the Docker socket is owned by `root:root` with `0660` permissions — the `node` user gets EACCES.

## Changes

### Fix: `group_add` for Docker socket access
Added `group_add: ["0"]` to the web service in both `docker-compose.yml` and `docker-compose.prod.yml`. The Docker socket is already mounted read-only, so adding the root group doesn't change the security posture — it just lets the `node` process read container metrics.

### UI: helpful message when stats are unavailable
`ContainerStatsPage.jsx` now checks for the `unavailable: true` flag from the API (returned when the socket can't be accessed) and shows an amber info box explaining the issue, the specific error, and how to fix it on Linux vs Docker Desktop. Previously it rendered a blank page.

### Tests: API + Playwright E2E
**Nightly Phase 4f6** (strengthened):
- Checks all 3 containers (web, worker, postgres) — not just web
- Each verified for running state, CPU metric, and memory metric
- Fails (not skips) if socket is inaccessible, since `group_add` should fix it

**Playwright E2E** (`container-stats.spec.js`):
- API test: response includes running web container with CPU/memory data
- Browser test: Admin → Containers tab renders stats cards with CPU, Memory, Network labels

Both tests skip gracefully in environments without Docker socket access (e.g. CI).

## Test plan

- [ ] `docker compose -f docker-compose.prod.yml up -d web` → Containers tab shows live stats
- [ ] Nightly run: Phase 4f6 passes with all 3 containers verified
- [ ] E2E: container-stats.spec.js passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)