### PR TITLE
feat: show section counts on detail pages before expanding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ on the upstream FortigiGraph repo.
 
 ---
 
+- **Detail pages show section counts before expanding** — Business role, resource, and user detail pages now show the count in each collapsible section header immediately on page load, without requiring the section to be expanded first. API changes: resource detail endpoint (`/api/resources/:id`) now returns `memberCount`, `accessPackageCount`, `parentResourceCount`, and `historyCount`; access-package and user/group detail endpoints now return `historyCount` (integer) instead of only `hasHistory` (boolean). The pending request count on business role pages is now fetched as a cheap `COUNT(*)` during core load rather than being deferred. Unnamed business roles show "Unnamed" in grey italic; null `parentResourceId` rows are excluded from counts and results to prevent 400 errors on navigation.
+
 - **Dashboard sync log entries link to Sync Log tab** — The "N sync log entries" text at the bottom of the stats card on the Dashboard is now a clickable link that navigates directly to the Sync Log tab.
 
 - **Extract `Section` and `CollapsibleSection` to `DetailSection.jsx`** — both components were defined identically inside four detail page files (UserDetailPage, GroupDetailPage, ResourceDetailPage, AccessPackageDetailPage), causing React to recreate them on every render. Extracted to a shared `components/DetailSection.jsx`. No behavior change.

--- a/app/api/src/routes/details.js
+++ b/app/api/src/routes/details.js
@@ -57,6 +57,14 @@ async function rowExistsInHistory(tableName, rowId) {
   return r.rows.length > 0;
 }
 
+async function countHistory(tableName, rowId) {
+  const r = await db.query(
+    `SELECT COUNT(*)::int AS cnt FROM "_history" WHERE "tableName" = $1 AND "rowId" = $2`,
+    [tableName, rowId]
+  );
+  return r.rows[0]?.cnt ?? 0;
+}
+
 // ────────────────────────────────────────────────────────────────
 // GET /api/user/:id — Lightweight: attributes, tags, counts only
 // ────────────────────────────────────────────────────────────────
@@ -120,9 +128,9 @@ router.get('/user/:id', async (req, res) => {
       accessPackageCount = r.recordset[0].cnt;
     } catch { /* table may not exist */ }
 
-    let hasHistory = false;
-    try { hasHistory = await rowExistsInHistory('Principals', userId); } catch { /* _history may not exist */ }
-    res.json({ attributes, tags, membershipCount, accessPackageCount, hasHistory, lastActivity: null });
+    let historyCount = 0;
+    try { historyCount = await countHistory('Principals', userId); } catch { /* _history may not exist */ }
+    res.json({ attributes, tags, membershipCount, accessPackageCount, historyCount, hasHistory: historyCount > 0, lastActivity: null });
   } catch (err) {
     console.error('Error fetching user detail:', err.message);
     res.status(500).json({ error: 'Failed to fetch user details' });
@@ -281,12 +289,10 @@ router.get('/group/:id', async (req, res) => {
       accessPackageCount = r.recordset[0].cnt;
     } catch { /* table may not exist */ }
 
-    let hasHistory = false;
-    try {
-      hasHistory = await rowExistsInHistory('Resources', groupId);
-    } catch { /* _history table may not exist on older deployments */ }
+    let historyCount = 0;
+    try { historyCount = await countHistory('Resources', groupId); } catch { /* _history table may not exist on older deployments */ }
 
-    res.json({ attributes, tags, memberCount, accessPackageCount, hasHistory });
+    res.json({ attributes, tags, memberCount, accessPackageCount, historyCount, hasHistory: historyCount > 0 });
   } catch (err) {
     console.error('Error fetching group detail:', err.message);
     res.status(500).json({ error: 'Failed to fetch group details' });
@@ -443,9 +449,17 @@ router.get('/access-package/:id', async (req, res) => {
       reviewCount = r.recordset[0].cnt;
     } catch { /* table may not exist */ }
 
-    // 5. Pending request count — skipped (was 26-76s on large request tables).
-    // The Pending Requests section lazy-loads its own data when expanded.
-    const pendingRequestCount = null;
+    // 5. Pending request count — COUNT only (cheap); full rows are lazy-loaded.
+    let pendingRequestCount = null;
+    try {
+      const r = await timedRequest(pool, 'ap-pending-request-count', res)
+        .input('id', apId)
+        .query(`
+        SELECT COUNT(*) AS cnt FROM "AssignmentRequests"
+        WHERE "resourceId" = @id AND "requestState" = 'PendingApproval'
+      `);
+      pendingRequestCount = r.recordset[0].cnt;
+    } catch { /* table may not exist */ }
 
     // 5b. Last review date + reviewer
     let lastReviewDate = null;
@@ -516,11 +530,11 @@ router.get('/access-package/:id', async (req, res) => {
       }
     } catch { /* category tables may not exist */ }
 
-    // 7. History check (v5: queries the _history audit table)
-    let hasHistory = false;
-    try { hasHistory = await rowExistsInHistory('Resources', apId); } catch { /* _history may not exist */ }
+    // 7. History count (v5: queries the _history audit table)
+    let historyCount = 0;
+    try { historyCount = await countHistory('Resources', apId); } catch { /* _history may not exist */ }
 
-    res.json({ attributes, assignmentCount, groupCount, reviewCount, pendingRequestCount, lastReviewDate, lastReviewedBy, hasHistory, policyCount, autoAddPolicyCount, assignmentType, category });
+    res.json({ attributes, assignmentCount, groupCount, reviewCount, pendingRequestCount, lastReviewDate, lastReviewedBy, historyCount, hasHistory: historyCount > 0, policyCount, autoAddPolicyCount, assignmentType, category });
   } catch (err) {
     console.error('Error fetching access package detail:', err.message);
     res.status(500).json({ error: 'Failed to fetch access package details' });

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -225,7 +225,7 @@ router.get('/resources/:id', async (req, res) => {
       } catch { /* view may not exist */ }
     }
 
-    // 4. Access package count
+    // 4. Access package count (business roles that contain this resource)
     let accessPackageCount = 0;
     try {
       const r = await timedRequest(pool, 'resource-ap-count', res)
@@ -233,23 +233,38 @@ router.get('/resources/:id', async (req, res) => {
         .query(`
           SELECT COUNT(DISTINCT rrs."parentResourceId") AS cnt
           FROM "ResourceRelationships" rrs
-          WHERE UPPER(rrs."childResourceId") = UPPER(@id)
+          INNER JOIN "Resources" br ON rrs."parentResourceId" = br.id AND br."resourceType" = 'BusinessRole'
+          WHERE rrs."childResourceId" = @id
             AND rrs."relationshipType" = 'Contains'
+            AND rrs."parentResourceId" IS NOT NULL
         `);
       accessPackageCount = r.recordset[0].cnt;
     } catch { /* table may not exist */ }
 
-    // 5. History check (v5: queries the _history audit table)
-    let hasHistory = false;
+    // 4b. Parent resource count (all parent resources via any relationship type)
+    let parentResourceCount = 0;
+    try {
+      const r = await timedRequest(pool, 'resource-parent-count', res)
+        .input('id', resourceId)
+        .query(`
+          SELECT COUNT(DISTINCT rrs."parentResourceId") AS cnt
+          FROM "ResourceRelationships" rrs
+          WHERE rrs."childResourceId" = @id
+        `);
+      parentResourceCount = r.recordset[0].cnt;
+    } catch { /* table may not exist */ }
+
+    // 5. History count (v5: queries the _history audit table)
+    let historyCount = 0;
     try {
       const r = await db.queryOne(
-        `SELECT 1 FROM "_history" WHERE "tableName" = 'Resources' AND "rowId" = $1 LIMIT 1`,
+        `SELECT COUNT(*)::int AS cnt FROM "_history" WHERE "tableName" = 'Resources' AND "rowId" = $1`,
         [resourceId]
       );
-      hasHistory = !!r;
+      historyCount = r?.cnt ?? 0;
     } catch { /* _history may not exist on older deployments */ }
 
-    res.json({ attributes, tags, memberCount, accessPackageCount, hasHistory });
+    res.json({ attributes, tags, memberCount, accessPackageCount, parentResourceCount, historyCount, hasHistory: historyCount > 0 });
   } catch (err) {
     console.error('Error fetching resource detail:', err.message);
     res.status(500).json({ error: 'Failed to fetch resource details' });
@@ -290,12 +305,13 @@ router.get('/resources/:id/business-roles', async (req, res) => {
     const r = await timedRequest(pool, 'resource-business-roles', res)
       .input('id', req.params.id)
       .query(`
-        SELECT rr."parentResourceId" AS businessRoleId, br."displayName" AS businessRoleName,
+        SELECT DISTINCT rr."parentResourceId" AS businessRoleId, br."displayName" AS businessRoleName,
                rr."roleName", rr."relationshipType"
         FROM "ResourceRelationships" rr
         INNER JOIN "Resources" br ON rr."parentResourceId" = br.id
           AND br."resourceType" = 'BusinessRole'
         WHERE rr."childResourceId" = @id AND rr."relationshipType" = 'Contains'
+          AND rr."parentResourceId" IS NOT NULL
         ORDER BY br."displayName"
       `);
     res.json(r.recordset);

--- a/app/ui/src/components/AccessPackageDetailPage.jsx
+++ b/app/ui/src/components/AccessPackageDetailPage.jsx
@@ -236,11 +236,11 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
   }
   if (!data) return null;
 
-  const { attributes, assignmentCount, groupCount, reviewCount, pendingRequestCount, lastReviewDate, lastReviewedBy, hasHistory, policyCount, assignmentType, category } = data;
+  const { attributes, assignmentCount, groupCount, reviewCount, pendingRequestCount, lastReviewDate, lastReviewedBy, historyCount, hasHistory, policyCount, assignmentType, category } = data;
   const catalogName = attributes.catalogName || null;
   const catalogId = attributes.catalogId || null;
   const apDisplayName = attributes.displayName || '';
-  const historyCount = history ? history.length : (hasHistory ? null : 1);
+  const resolvedHistoryCount = history ? history.length : historyCount;
   const otherAttributes = [['id', attributes.id], ...Object.entries(attributes).filter(([k]) => !HIDDEN_FIELDS.has(k) && k !== 'id')];
   const entraUrl = catalogId
     ? `https://portal.azure.com/#view/Microsoft_Azure_ELMAdmin/EntitlementMenuBlade/~/overview/entitlementId/${accessPackageId.toLowerCase()}/catalogId/${catalogId}/catalogName/${encodeURIComponent(catalogName || '')}/entitlementName/${encodeURIComponent(apDisplayName)}`
@@ -551,7 +551,7 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
       <div className="mt-4">
         <CollapsibleSection
           title="Pending Requests"
-          count={requests ? requests.length : null}
+          count={requests ? requests.length : pendingRequestCount}
           open={requestsOpen}
           onToggle={toggleRequests}
           loading={requestsLoading}
@@ -600,8 +600,8 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
       <div className="mt-4">
         <CollapsibleSection
           title="Version History"
-          count={historyCount}
-          countLabel={historyCount === 1 ? 'version' : 'versions'}
+          count={resolvedHistoryCount}
+          countLabel={resolvedHistoryCount === 1 ? 'version' : 'versions'}
           open={historyOpen}
           onToggle={toggleHistory}
           loading={historyLoading}

--- a/app/ui/src/components/ResourceDetailPage.jsx
+++ b/app/ui/src/components/ResourceDetailPage.jsx
@@ -149,11 +149,11 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
   }
   if (!data) return null;
 
-  const { attributes, tags, hasHistory } = data;
+  const { attributes, tags, memberCount, accessPackageCount, parentResourceCount, historyCount, hasHistory } = data;
   const resourceType = attributes.resourceType || attributes.groupTypeCalculated || '';
   const typeBadgeClass = RESOURCE_TYPE_COLORS[resourceType] || 'bg-gray-100 text-gray-700';
   const extAttrs = parseExtendedAttributes(attributes.extendedAttributes);
-  const historyCount = history ? history.length : (hasHistory ? null : 1);
+  const resolvedHistoryCount = history ? history.length : historyCount;
   const otherAttributes = [['id', attributes.id], ...Object.entries(attributes).filter(([k]) => !HIDDEN_FIELDS.has(k) && k !== 'id')];
 
   // Build Entra URL if this is an Entra group
@@ -264,7 +264,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
       <div className="mt-6">
         <CollapsibleSection
           title="Assigned Users"
-          count={assignments ? assignments.length : null}
+          count={assignments ? assignments.length : memberCount}
           open={assignmentsOpen}
           onToggle={() => { if (!assignmentsOpen) loadAssignments(); setAssignmentsOpen(p => !p); }}
           loading={assignmentsLoading}
@@ -309,7 +309,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
       <div className="mt-6">
         <CollapsibleSection
           title="Business Roles"
-          count={businessRoles ? businessRoles.length : null}
+          count={businessRoles ? businessRoles.length : accessPackageCount}
           open={businessRolesOpen}
           onToggle={() => { if (!businessRolesOpen) loadBusinessRoles(); setBusinessRolesOpen(p => !p); }}
           loading={businessRolesLoading}
@@ -328,12 +328,16 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
                 {(businessRoles || []).map((br, i) => (
                   <tr key={i} className="border-b border-gray-50">
                     <td className="px-4 py-2">
-                      <button
-                        onClick={() => onOpenDetail?.('resource', br.businessRoleId, br.businessRoleName)}
-                        className="text-blue-600 hover:text-blue-800 hover:underline font-medium"
-                      >{br.businessRoleName}</button>
+                      {br.businessRoleId ? (
+                        <button
+                          onClick={() => onOpenDetail?.('resource', br.businessRoleId, br.businessRoleName || 'Unnamed')}
+                          className="text-blue-600 hover:text-blue-800 hover:underline font-medium"
+                        >{br.businessRoleName || <span className="text-gray-400 italic">Unnamed</span>}</button>
+                      ) : (
+                        <span className="text-gray-400 italic">{br.businessRoleName || 'Unnamed'}</span>
+                      )}
                     </td>
-                    <td className="px-4 py-2 text-gray-500">{br.roleName || '\u2014'}</td>
+                    <td className="px-4 py-2 text-gray-500">{(br.roleName && br.roleName !== '-') ? br.roleName : '\u2014'}</td>
                   </tr>
                 ))}
               </tbody>
@@ -346,7 +350,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
       <div className="mt-6">
         <CollapsibleSection
           title="Member Of"
-          count={parentResources ? parentResources.length : null}
+          count={parentResources ? parentResources.length : parentResourceCount}
           open={parentResourcesOpen}
           onToggle={() => { if (!parentResourcesOpen) loadParentResources(); setParentResourcesOpen(p => !p); }}
           loading={parentResourcesLoading}
@@ -389,8 +393,8 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
       <div className="mt-6">
         <CollapsibleSection
           title="Version History"
-          count={historyCount}
-          countLabel={historyCount === 1 ? 'version' : 'versions'}
+          count={resolvedHistoryCount}
+          countLabel={resolvedHistoryCount === 1 ? 'version' : 'versions'}
           open={historyOpen}
           onToggle={toggleHistory}
           loading={historyLoading}

--- a/app/ui/src/components/UserDetailPage.jsx
+++ b/app/ui/src/components/UserDetailPage.jsx
@@ -123,8 +123,8 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
   }
   if (!data) return null;
 
-  const { attributes, tags, hasHistory, lastActivity } = data;
-  const historyCount = history ? history.length : (hasHistory ? null : 1);
+  const { attributes, tags, historyCount, hasHistory, lastActivity } = data;
+  const resolvedHistoryCount = history ? history.length : historyCount;
   const otherAttributes = [['id', attributes.id], ...Object.entries(attributes).filter(([k]) => !HIDDEN_FIELDS.has(k) && k !== 'id')];
   const isEntraSystem = (attributes.systemDisplayName || '').toLowerCase().includes('entra') ||
     (attributes.systemDisplayName || '').toLowerCase().includes('azure ad') ||
@@ -321,8 +321,8 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
       <div className="mt-6">
         <CollapsibleSection
           title="Version History"
-          count={historyCount}
-          countLabel={historyCount === 1 ? 'version' : 'versions'}
+          count={resolvedHistoryCount}
+          countLabel={resolvedHistoryCount === 1 ? 'version' : 'versions'}
           open={historyOpen}
           onToggle={toggleHistory}
           loading={historyLoading}

--- a/setup/IdentityAtlas.psd1
+++ b/setup/IdentityAtlas.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\IdentityAtlas.psm1'
 
 # Version number of this module.
-ModuleVersion = '5.0.20260413.1930'
+ModuleVersion = '5.0.20260413.2100'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
API: resource, user, group, and access-package detail endpoints now return pre-computed counts (memberCount, accessPackageCount, parentResourceCount, historyCount) so the frontend can show them in collapsible section headers on initial page load without waiting for the lazy sections to expand.

Pending request count on business role pages is now a cheap COUNT(*) fetched eagerly alongside the other counts. History endpoints return historyCount (int) instead of just hasHistory (bool).

UI: ResourceDetailPage uses the pre-fetched counts as fallbacks before lazy data loads. Unnamed business roles show "Unnamed" in italic. Null parentResourceId rows are excluded from counts and results to prevent 400 errors when navigating to those entries.