### PR TITLE
Feature/dashDashboard: full version, compose file check, graph nodes, remove lead-devboard polish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,6 +59,7 @@ jobs:
           push: false
           load: true
           tags: identity-atlas-web:qa
+          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
 
@@ -139,6 +140,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/fortigi/identity-atlas:latest
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
+          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,7 +161,7 @@ jobs:
         run: npm install -g @stoplight/spectral-cli
 
       - name: Lint openapi.yaml
-        run: spectral lint app/api/src/openapi.yaml --ruleset @stoplight/spectral-oas
+        run: spectral lint app/api/src/openapi.yaml --ruleset spectral:oas
 
   # ── Stage 6: Dependency audit ────────────────────────────────────────────
   audit:

--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -11,6 +11,13 @@ RUN npm run build
 
 # ── Stage 2: Backend runtime ──────────────────────────────────────────────────
 FROM node:20-slim AS runtime
+
+# Bake the module version into the image so /api/version returns the full
+# version string (e.g. 5.0.20260414.0900) without needing the .psd1 file.
+# Passed as a build arg by docker-publish.yml and docker-compose.yml.
+ARG MODULE_VERSION=""
+ENV MODULE_VERSION=$MODULE_VERSION
+
 WORKDIR /app/backend
 COPY api/package*.json ./
 RUN npm ci --omit=dev

--- a/app/api/src/index.js
+++ b/app/api/src/index.js
@@ -52,13 +52,19 @@ const perfEnabled = process.env.PERF_METRICS_ENABLED !== 'false';
 // Resolve module version: env var (set during deployment) → fallback to .psd1 manifest
 let moduleVersion = process.env.MODULE_VERSION || null;
 if (!moduleVersion) {
-  try {
-    const psdPath = join(__dirname, '../../../setup/IdentityAtlas.psd1');
-    const psdContent = readFileSync(psdPath, 'utf-8');
-    const match = psdContent.match(/ModuleVersion\s*=\s*'([^']+)'/);
-    if (match) moduleVersion = match[1];
-  } catch {
-    // .psd1 not available (deployed environment without env var)
+  // Try to read the version from the .psd1 manifest. Two paths:
+  //   1. /app/setup/IdentityAtlas.psd1 — mounted by docker-compose.yml for local dev
+  //   2. ../../../setup/IdentityAtlas.psd1 — works when running outside Docker (e.g. npm start)
+  const candidates = [
+    '/app/setup/IdentityAtlas.psd1',
+    join(__dirname, '../../../setup/IdentityAtlas.psd1'),
+  ];
+  for (const p of candidates) {
+    try {
+      const content = readFileSync(p, 'utf-8');
+      const match = content.match(/ModuleVersion\s*=\s*'([^']+)'/);
+      if (match) { moduleVersion = match[1]; break; }
+    } catch { /* not available at this path */ }
   }
 }
 

--- a/app/api/src/index.js
+++ b/app/api/src/index.js
@@ -152,8 +152,20 @@ app.get('/api/health', publicLimiter, (req, res) => {
   res.json({ status: 'ok' });
 });
 
+// Minimum compose file version this image expects. Bump this whenever
+// docker-compose.prod.yml changes in a way that affects runtime behavior
+// (new env vars, volume mounts, group_add, etc.). Users with an older
+// compose file will see a warning on the Dashboard.
+const MIN_COMPOSE_FILE_VERSION = 1;
+
 app.get('/api/version', publicLimiter, (req, res) => {
-  res.json({ version: moduleVersion || null });
+  const composeFileVersion = parseInt(process.env.COMPOSE_FILE_VERSION || '0', 10);
+  res.json({
+    version: moduleVersion || null,
+    composeFileVersion: composeFileVersion || null,
+    minComposeFileVersion: MIN_COMPOSE_FILE_VERSION,
+    composeFileOutdated: composeFileVersion > 0 && composeFileVersion < MIN_COMPOSE_FILE_VERSION,
+  });
 });
 
 // Helper: read a feature flag override from WorkerConfig (overrides the env var)

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -645,7 +645,7 @@ router.get('/admin/dashboard-stats', async (_req, res) => {
          WHERE relname IN (
            'Systems','Resources','Principals','Identities',
            'ResourceAssignments','ResourceRelationships','Contexts',
-           'CertificationDecisions','GraphSyncLog','RiskScores'
+           'IdentityMembers','CertificationDecisions','GraphSyncLog','RiskScores'
          )
            AND relkind = 'r'
       )
@@ -659,6 +659,7 @@ router.get('/admin/dashboard-stats', async (_req, res) => {
         (SELECT COUNT(*)::int FROM "ResourceAssignments" WHERE "assignmentType" = 'Governed')  AS "governedAssignments",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'ResourceRelationships'), 0), 0)::int  AS "relationships",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'Contexts'), 0), 0)::int               AS "contexts",
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'IdentityMembers'), 0), 0)::int       AS "identityMembers",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'CertificationDecisions'), 0), 0)::int AS "certifications",
         (SELECT COUNT(*)::int FROM "GraphSyncLog")                                                         AS "syncLogEntries",
         (SELECT MAX("StartTime") FROM "GraphSyncLog")                                          AS "lastSyncAt",

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -57,7 +57,7 @@ export default function DashboardPage({ onNavigate }) {
     ]).then(([s, v]) => {
       if (cancelled) return;
       setStats(s);
-      setVersion(v?.version || null);
+      setVersion(v);
       setLoading(false);
     });
     return () => { cancelled = true; };
@@ -82,6 +82,20 @@ export default function DashboardPage({ onNavigate }) {
             </p>
           </div>
         </div>
+
+      {/* Compose file outdated warning */}
+      {version?.composeFileOutdated && (
+        <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm">
+          <div className="font-semibold text-amber-800 mb-1">Your docker-compose file is outdated</div>
+          <p className="text-amber-700">
+            The running image expects compose file version {version.minComposeFileVersion} but your file is version {version.composeFileVersion || 'unknown'}.
+            Re-download the latest version to get new settings (volume mounts, security fixes, etc.):
+          </p>
+          <code className="block mt-2 px-3 py-2 bg-amber-100 rounded text-xs font-mono text-amber-900">
+            curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
+          </code>
+        </div>
+      )}
 
       {/* Main 2-column layout: brain graph + stats */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
@@ -189,8 +203,8 @@ export default function DashboardPage({ onNavigate }) {
             </div>
             <h3 className="text-sm font-bold text-gray-900">Version</h3>
           </div>
-          <div className={`font-mono font-semibold text-gray-900 tabular-nums ${version && version.length > 10 ? 'text-lg' : 'text-3xl'}`}>
-            {version ? `v${version}` : 'v5.0'}
+          <div className={`font-mono font-semibold text-gray-900 tabular-nums ${version?.version?.length > 10 ? 'text-lg' : 'text-3xl'}`}>
+            {version?.version ? `v${version.version}` : 'v5.0'}
           </div>
           <div className="mt-3 text-xs">
             <a href={`${GITHUB_BASE}/blob/main/CHANGES.md`} target="_blank" rel="noopener noreferrer" className="text-lime-700 hover:text-lime-800 font-medium hover:underline inline-flex items-center gap-1">

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -338,21 +338,22 @@ function BrainGraph({ stats, loading }) {
   const GREEN_DARK = '#365314';   // text inside node body
   const GREEN_LABEL = '#4d7c0f';  // label text
 
-  // Hand-positioned to suggest the logo's brain outline:
-  // Systems at the "top of the brain", Users/Identities on the right lobe,
-  // Resources/Roles on the left lobe, Assignments in the central core,
-  // Contexts + Reviews at the bottom.
+  // Hand-positioned to suggest the logo's brain outline — a top-heavy oval
+  // with two lobes. Systems crowns the top, Assignments sits in the central
+  // core, and the remaining nodes are arranged symmetrically around them to
+  // form the brain silhouette. The two new nodes (ID Members, Relationships)
+  // are tucked into the lobes rather than dangling at the bottom.
   const NODE_DEFS = [
-    { id: 'systems',        label: 'Systems',        key: 'systems',         x: 220, y: 50  },
-    { id: 'resources',      label: 'Resources',      key: 'resources',       x: 80,  y: 120 },
-    { id: 'users',          label: 'Users',          key: 'users',           x: 360, y: 110 },
-    { id: 'roles',          label: 'Roles',          key: 'businessRoles',   x: 110, y: 215 },
-    { id: 'assignments',    label: 'Assignments',    key: 'assignments',     x: 220, y: 170 },
-    { id: 'identities',     label: 'Identities',     key: 'identities',      x: 390, y: 210 },
-    { id: 'idMembers',      label: 'ID Members',     key: 'identityMembers', x: 380, y: 300 },
-    { id: 'relationships',  label: 'Relationships',  key: 'relationships',   x: 60,  y: 300 },
-    { id: 'contexts',       label: 'Contexts',       key: 'contexts',        x: 270, y: 310 },
-    { id: 'certs',          label: 'Reviews',        key: 'certifications',  x: 150, y: 310 },
+    { id: 'systems',        label: 'Systems',        key: 'systems',         x: 220, y: 45  },
+    { id: 'resources',      label: 'Resources',      key: 'resources',       x: 75,  y: 110 },
+    { id: 'users',          label: 'Users',          key: 'users',           x: 365, y: 110 },
+    { id: 'relationships',  label: 'Relationships',  key: 'relationships',   x: 68,  y: 200 },
+    { id: 'assignments',    label: 'Assignments',    key: 'assignments',     x: 220, y: 165 },
+    { id: 'identities',     label: 'Identities',     key: 'identities',      x: 372, y: 200 },
+    { id: 'roles',          label: 'Roles',          key: 'businessRoles',   x: 110, y: 275 },
+    { id: 'idMembers',      label: 'ID Members',     key: 'identityMembers', x: 330, y: 275 },
+    { id: 'certs',          label: 'Reviews',        key: 'certifications',  x: 155, y: 335 },
+    { id: 'contexts',       label: 'Contexts',       key: 'contexts',        x: 285, y: 335 },
   ];
 
   // Edges — many more than before so the graph looks like a dense brain net.

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -119,8 +119,9 @@ export default function DashboardPage({ onNavigate }) {
                 <StatCard label="Business Roles" value={stats.businessRoles} onClick={() => onNavigate?.('access-packages')} />
                 <StatCard label="Identities"     value={stats.identities}    onClick={() => onNavigate?.('identities')} />
                 <StatCard label="Contexts"       value={stats.contexts}      onClick={() => onNavigate?.('org-chart')} />
-                <StatCard label="Assignments"    value={stats.assignments}   />
-                <StatCard label="Relationships"  value={stats.relationships} />
+                <StatCard label="Assignments"      value={stats.assignments}     />
+                <StatCard label="Relationships"    value={stats.relationships}  />
+                <StatCard label="Identity Members" value={stats.identityMembers} onClick={() => onNavigate?.('identities')} />
               </div>
               <div className="mt-5 pt-4 border-t border-gray-100 text-xs text-gray-400 text-right">
                 <button
@@ -188,7 +189,7 @@ export default function DashboardPage({ onNavigate }) {
             </div>
             <h3 className="text-sm font-bold text-gray-900">Version</h3>
           </div>
-          <div className="text-3xl font-mono font-semibold text-gray-900 tabular-nums">
+          <div className={`font-mono font-semibold text-gray-900 tabular-nums ${version && version.length > 10 ? 'text-lg' : 'text-3xl'}`}>
             {version ? `v${version}` : 'v5.0'}
           </div>
           <div className="mt-3 text-xs">
@@ -221,11 +222,6 @@ export default function DashboardPage({ onNavigate }) {
         Created by{' '}
         <a href="https://www.fortigi.nl" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-500 hover:text-lime-700 transition-colors">
           Maatschap Fortigi
-        </a>
-        {' · '}
-        Lead developer{' '}
-        <a href="https://www.linkedin.com/in/wimvdheijkant/" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-500 hover:text-lime-700 transition-colors">
-          Wim van den Heijkant
         </a>
       </div>
       </div>
@@ -333,14 +329,16 @@ function BrainGraph({ stats, loading }) {
   // Resources/Roles on the left lobe, Assignments in the central core,
   // Contexts + Reviews at the bottom.
   const NODE_DEFS = [
-    { id: 'systems',     label: 'Systems',     key: 'systems',       x: 220, y: 58  },
-    { id: 'resources',   label: 'Resources',   key: 'resources',     x: 96,  y: 130 },
-    { id: 'users',       label: 'Users',       key: 'users',         x: 340, y: 120 },
-    { id: 'roles',       label: 'Roles',       key: 'businessRoles', x: 140, y: 220 },
-    { id: 'assignments', label: 'Assignments', key: 'assignments',   x: 220, y: 180 },
-    { id: 'identities',  label: 'Identities',  key: 'identities',    x: 370, y: 220 },
-    { id: 'contexts',    label: 'Contexts',    key: 'contexts',      x: 270, y: 285 },
-    { id: 'certs',       label: 'Reviews',     key: 'certifications', x: 80,  y: 285 },
+    { id: 'systems',        label: 'Systems',        key: 'systems',         x: 220, y: 50  },
+    { id: 'resources',      label: 'Resources',      key: 'resources',       x: 80,  y: 120 },
+    { id: 'users',          label: 'Users',          key: 'users',           x: 360, y: 110 },
+    { id: 'roles',          label: 'Roles',          key: 'businessRoles',   x: 110, y: 215 },
+    { id: 'assignments',    label: 'Assignments',    key: 'assignments',     x: 220, y: 170 },
+    { id: 'identities',     label: 'Identities',     key: 'identities',      x: 390, y: 210 },
+    { id: 'idMembers',      label: 'ID Members',     key: 'identityMembers', x: 380, y: 300 },
+    { id: 'relationships',  label: 'Relationships',  key: 'relationships',   x: 60,  y: 300 },
+    { id: 'contexts',       label: 'Contexts',       key: 'contexts',        x: 270, y: 310 },
+    { id: 'certs',          label: 'Reviews',        key: 'certifications',  x: 150, y: 310 },
   ];
 
   // Edges — many more than before so the graph looks like a dense brain net.
@@ -352,14 +350,19 @@ function BrainGraph({ stats, loading }) {
     ['systems', 'contexts'],
     ['systems', 'assignments'],
     ['resources', 'assignments'],
+    ['resources', 'relationships'],
     ['users', 'assignments'],
     ['users', 'identities'],
+    ['users', 'idMembers'],
     ['users', 'contexts'],
     ['resources', 'roles'],
     ['assignments', 'roles'],
     ['assignments', 'contexts'],
     ['assignments', 'identities'],
+    ['identities', 'idMembers'],
     ['identities', 'contexts'],
+    ['relationships', 'roles'],
+    ['relationships', 'certs'],
     ['resources', 'certs'],
     ['certs', 'roles'],
     ['certs', 'assignments'],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,11 @@ services:
       DATABASE_URL: "postgres://${POSTGRES_USER:-identity_atlas}:${POSTGRES_PASSWORD:-identity_atlas_local}@postgres:5432/${POSTGRES_DB:-identity_atlas}"
       AUTH_ENABLED: "${AUTH_ENABLED:-false}"
       PORT:         "3001"
+      # Compose file version — the API checks this to warn users when their
+      # local docker-compose.prod.yml is outdated. Bump this number whenever
+      # the compose file changes in a way that affects runtime behavior
+      # (new env vars, volume mounts, group_add, etc.).
+      COMPOSE_FILE_VERSION: "1"
       # Master key for the secrets vault (LLM API keys, scraper credentials).
       # If unset, the bootstrap auto-generates one and persists it to
       # /data/uploads/.master-key inside the job_data volume. For real production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     volumes:
       - job_data:/data/uploads
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./setup/IdentityAtlas.psd1:/app/setup/IdentityAtlas.psd1:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     build:
       context: ./app
       dockerfile: api/Dockerfile
+      args:
+        MODULE_VERSION: "${MODULE_VERSION:-}"
     # The container runs as the unprivileged `node` user (Dockerfile USER node).
     # The Docker socket is owned by root:root with 0660 permissions, so node
     # needs the root group (GID 0) to read container stats. The socket is


### PR DESCRIPTION
## Summary

Four improvements to the Home/Dashboard page, triggered by real issues encountered during deployment testing.

## Changes

### 1. Full version number in the Version card
The Docker image now bakes `MODULE_VERSION` via a Dockerfile build arg. The publish workflow and `docker-compose.yml` pass it at build time. Previously `/api/version` returned `null` because `setup/IdentityAtlas.psd1` isn't inside the container image — the card showed the fallback "v5.0" instead of the full version like `v5.0.20260414.0900`. Font size adjusts automatically for the longer string.

Files: `app/api/Dockerfile`, `docker-compose.yml`, `.github/workflows/docker-publish.yml`

### 2. Compose file version check
`docker-compose.prod.yml` now carries `COMPOSE_FILE_VERSION: "1"` as an env var. The API compares it against a hardcoded `MIN_COMPOSE_FILE_VERSION` in `index.js`. When the compose file is older than the image expects, `/api/version` returns `composeFileOutdated: true` and the Dashboard shows an amber warning banner with the re-download command.

**Why:** When we added `group_add` to the compose file to fix container stats, users who pulled the new image but still had the old compose file on disk didn't get the fix — and had no way of knowing they needed to re-download the file. This makes that scenario visible.

**For maintainers:** When changing `docker-compose.prod.yml` in a way that affects runtime behavior, bump `COMPOSE_FILE_VERSION` in the file AND `MIN_COMPOSE_FILE_VERSION` in `index.js`.

Files: `docker-compose.prod.yml`, `app/api/src/index.js`, `app/ui/src/components/DashboardPage.jsx`

### 3. Identity Members + Relationships in the brain graph
The graph now has **10 nodes** (up from 8):
- **ID Members** — cross-system user-to-identity linkage count (`IdentityMembers` table)
- **Relationships** — resource-to-resource links / role nesting (`ResourceRelationships` table)

Both added to the dashboard-stats API response and the stats card grid. New edges connect them to Users, Identities, Resources, Roles, and Reviews.

Files: `app/api/src/routes/admin.js`, `app/ui/src/components/DashboardPage.jsx`

### 4. Removed "Lead developer Wim van den Heijkant"
Identity Atlas is positioned as a Fortigi product. "Created by Maatschap Fortigi" remains in the footer.

## Test plan
- [ ] Pull new image → Version card shows full version (e.g. `v5.0.20260414.0900`)
- [ ] Use an OLD `docker-compose.prod.yml` (without `COMPOSE_FILE_VERSION`) → no warning (graceful)
- [ ] Use a compose file with `COMPOSE_FILE_VERSION: "0"` → amber banner with re-download command
- [ ] Brain graph shows 10 nodes including "ID Members" and "Relationships"
- [ ] Footer shows only "Created by Maatschap Fortigi"
- [ ] `/api/admin/dashboard-stats` returns `identityMembers` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)