### PR TITLE
fix: reset sequences and ANALYZE tables after clean-database

### DIFF
--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -517,6 +517,37 @@ router.post('/admin/clean-database', adminDestructiveLimiter, async (req, res) =
       }
     }
 
+    // ANALYZE all wiped tables so pg_class.reltuples (used by dashboard-stats for
+    // fast estimates) resets to 0 immediately. Without this the dashboard keeps
+    // showing the old row counts after a clean until autovacuum runs.
+    for (const { table } of wiped) {
+      try { await db.query(`ANALYZE "${table}"`); } catch { /* non-critical */ }
+    }
+
+    // Reset SERIAL sequences for all wiped tables so re-inserted rows start from 1.
+    // Without this, Systems gets IDs like 10, 11, 12 after a clean, breaking
+    // demo data which hardcodes systemId references.
+    if (wiped.length > 0) {
+      try {
+        const wipedNames = wiped.map(w => w.table);
+        const seqResult = await db.query(
+          `SELECT t.relname AS table_name, s.relname AS seq_name
+           FROM pg_class t
+           JOIN pg_attribute a ON a.attrelid = t.oid
+           JOIN pg_depend d ON d.refobjid = t.oid AND d.refobjsubid = a.attnum
+           JOIN pg_class s ON s.oid = d.objid AND s.relkind = 'S'
+           WHERE t.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+             AND t.relname = ANY($1)`,
+          [wipedNames]
+        );
+        for (const row of seqResult.rows) {
+          await db.query(`SELECT setval(quote_ident($1), 1, false)`, [row.seq_name]);
+        }
+      } catch (err) {
+        console.warn('Could not reset sequences during cleanup:', err.message);
+      }
+    }
+
     // Reset lastRunAt on crawler configs so the UI shows them as "never run"
     try {
       await db.query(`UPDATE "CrawlerConfigs" SET "lastRunAt" = NULL, "lastRunStatus" = NULL`);

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -484,7 +484,7 @@ export default function App() {
           ) : page === 'performance' || page === 'crawlers' || page === 'admin' ? (
             // Crawlers and Performance now live under Admin as sub-tabs.
             // Legacy #crawlers and #performance hashes redirect to the matching sub-tab.
-            <AdminPage onNavigate={navigate} />
+            <AdminPage onNavigate={navigate} onRefresh={forceRefresh} />
           ) : loading ? (
             <div className="flex items-center justify-center h-64">
               <div className="text-gray-500">Loading permission data...</div>

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -865,7 +865,7 @@ function HistoryRetentionSection() {
 }
 
 // ─── Danger Zone — Clean Database ─────────────────────────────────────────────
-function DangerZoneSection() {
+function DangerZoneSection({ onRefresh }) {
   const { authFetch } = useAuth();
   const [confirmStep, setConfirmStep] = useState(0); // 0=idle, 1=confirm, 2=type-confirm
   const [typedConfirm, setTypedConfirm] = useState('');
@@ -886,6 +886,7 @@ function DangerZoneSection() {
       setResult(data);
       setConfirmStep(0);
       setTypedConfirm('');
+      onRefresh?.();
     } catch (err) {
       setError(err.message);
     } finally {
@@ -1490,7 +1491,7 @@ function AdminSubTabs({ activeTab, onTabChange }) {
   );
 }
 
-export default function AdminPage({ onNavigate }) {
+export default function AdminPage({ onNavigate, onRefresh }) {
   // Persist active sub-tab in URL hash like #admin?sub=crawlers so deep links work.
   // Also handles legacy #crawlers and #performance hashes by mapping them to the
   // corresponding sub-tab.
@@ -1540,7 +1541,7 @@ export default function AdminPage({ onNavigate }) {
           <>
             <CuratedDataSection />
             <HistoryRetentionSection />
-            <DangerZoneSection />
+            <DangerZoneSection onRefresh={onRefresh} />
           </>
         )}
 


### PR DESCRIPTION
Two bugs in the clean-database endpoint:

1. SERIAL sequences not reset: DELETE FROM removes rows but leaves the sequence counter at its last value, so re-inserting systems after a clean gave IDs like 10, 11, 12 instead of 1, 2, 3. Demo data hardcodes systemId references (1=EntraID, 2=HR, 3=Omada), causing a FK violation on Contexts. Fixed by looking up all dependent SERIAL sequences via pg_depend and calling setval(seq, 1, false).

2. Dashboard stats stale after clean: most dashboard counters use pg_class.reltuples (fast estimates) which only update on ANALYZE, not on DELETE. So the dashboard kept showing old row counts after a clean. Fixed by running ANALYZE on each wiped table so reltuples resets to 0 immediately.

Closes #27