### PR TITLE
fix: resource assignments not showing on business role detail page

### DIFF
--- a/app/api/src/routes/details.js
+++ b/app/api/src/routes/details.js
@@ -595,18 +595,19 @@ router.get('/access-package/:id/resource-roles', async (req, res) => {
       .input('id', req.params.id)
       .query(`
       SELECT
-        rrs.roleName, rrs.roleOriginSystem,
-        r."displayName" AS scopeDisplayName, rrs."childResourceId", rrs.roleOriginSystem AS scopeOriginSystem,
-        COALESCE(r."displayName", rrs.roleName) AS groupDisplayName,
-        COALESCE(r."displayName", rrs.roleName) AS "resourceDisplayName",
+        rrs."roleName", rrs."roleOriginSystem",
+        r."displayName" AS "scopeDisplayName", rrs."childResourceId", rrs."roleOriginSystem" AS "scopeOriginSystem",
+        COALESCE(r."displayName", rrs."roleName") AS "groupDisplayName",
+        COALESCE(r."displayName", rrs."roleName") AS "resourceDisplayName",
         r."resourceType", r."systemId"
       FROM "ResourceRelationships" rrs
       LEFT JOIN "Resources" r ON rrs."childResourceId" = r.id
       WHERE rrs."parentResourceId" = @id AND rrs."relationshipType" = 'Contains'
-      ORDER BY COALESCE(r."displayName", g."displayName"), rrs.roleName
+      ORDER BY r."displayName", rrs."roleName"
     `);
     res.json(r.recordset);
   } catch (err) {
+    console.error('ap-resource-roles failed:', err.message);
     res.json([]);
   }
 });

--- a/app/ui/src/components/AccessPackageDetailPage.jsx
+++ b/app/ui/src/components/AccessPackageDetailPage.jsx
@@ -425,14 +425,14 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
                       </td>
                       <td className="px-4 py-2">
                         <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
-                          rr.roleDisplayName === 'Owner' ? 'bg-purple-100 text-purple-800'
-                          : rr.roleDisplayName === 'Member' ? 'bg-blue-100 text-blue-800'
+                          rr.roleName === 'Owner' ? 'bg-purple-100 text-purple-800'
+                          : rr.roleName === 'Member' ? 'bg-blue-100 text-blue-800'
                           : 'bg-gray-100 text-gray-600'
                         }`}>
-                          {rr.roleDisplayName || '\u2014'}
+                          {rr.roleName || '\u2014'}
                         </span>
                       </td>
-                      <td className="px-4 py-2 text-gray-500 text-xs">{rr.roleOriginSystem || '\u2014'}</td>
+                      <td className="px-4 py-2 text-gray-500 text-xs">{rr.resourceType || '\u2014'}</td>
                       <td className="px-4 py-2 text-gray-500 text-xs whitespace-nowrap">{formatDate(rr.createdDateTime)}</td>
                     </tr>
                   ))}


### PR DESCRIPTION
Two bugs in the ap-resource-roles endpoint and its frontend consumer:

1. Query referenced unquoted column names (roleName, roleOriginSystem) which postgres folds to lowercase — column not found, query fails, catch block silently returns []. Also had a stale reference to g."displayName" in ORDER BY (no g alias in query). Added proper double-quoting and error logging to the catch.

2. Frontend used rr.roleDisplayName (wrong field) instead of rr.roleName, and showed roleOriginSystem for the Type column instead of resourceType.

Closes #26 