### PR TITLE
Remove anthropic_api_key — use subscription via Claude Code GitHub App

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -70,7 +70,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.TRIAGE_ANTHROPIC_API_KEY }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             You are a documentation reviewer for the Identity Atlas project.

--- a/.github/workflows/issue-autofix.yml
+++ b/.github/workflows/issue-autofix.yml
@@ -113,7 +113,6 @@ jobs:
         id: claude1
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.TRIAGE_ANTHROPIC_API_KEY }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             You are fixing GitHub issue #${{ matrix.number }} for the Identity Atlas project.
@@ -273,7 +272,6 @@ jobs:
         if: steps.create-pr.outputs.pr_created == 'true' && steps.ci-check.outputs.ci_passed == 'false'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.TRIAGE_ANTHROPIC_API_KEY }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             Your previous fix for GitHub issue #${{ matrix.number }} was submitted as a PR,

--- a/.github/workflows/test-coverage-review.yml
+++ b/.github/workflows/test-coverage-review.yml
@@ -102,7 +102,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.TRIAGE_ANTHROPIC_API_KEY }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             You are a test coverage reviewer for the Identity Atlas project.


### PR DESCRIPTION
## Summary

- Remove `anthropic_api_key` from all three nightly workflows
- When both API key and OIDC are present, the action uses the API key (billed per token)
- Removing it forces auth through the Claude Code GitHub App, which uses your Claude subscription

This is why #42 failed with "Credit balance is too low" — it was charging API credits, not using the subscription.

## Test plan

- [ ] Merge, remove `cant-autofix` from #42 and #52, trigger Auto-fix
- [ ] Verify no "credit balance" errors

🤖 Generated with [Claude Code](https://claude.ai/code)