### PR TITLE
Use Claude subscription for nightly workflows instead of API credits

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -70,6 +70,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             You are a documentation reviewer for the Identity Atlas project.

--- a/.github/workflows/issue-autofix.yml
+++ b/.github/workflows/issue-autofix.yml
@@ -113,6 +113,7 @@ jobs:
         id: claude1
         uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             You are fixing GitHub issue #${{ matrix.number }} for the Identity Atlas project.
@@ -272,6 +273,7 @@ jobs:
         if: steps.create-pr.outputs.pr_created == 'true' && steps.ci-check.outputs.ci_passed == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             Your previous fix for GitHub issue #${{ matrix.number }} was submitted as a PR,

--- a/.github/workflows/test-coverage-review.yml
+++ b/.github/workflows/test-coverage-review.yml
@@ -102,6 +102,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model ${{ secrets.TRIAGE_LLM_MODEL }} --allowedTools Bash,Read,Write,Edit,Glob,Grep,Agent"
           prompt: |
             You are a test coverage reviewer for the Identity Atlas project.


### PR DESCRIPTION
## Summary

- Switch from `anthropic_api_key` to `claude_code_oauth_token` in all three nightly workflows
- This uses your Claude Max/Pro subscription instead of per-token API billing
- Token generated via `claude setup-token`, stored as `CLAUDE_CODE_OAUTH_TOKEN` secret

## Test plan

- [ ] Merge, remove `cant-autofix` from #42 and #52, trigger Auto-fix
- [ ] Verify no "credit balance too low" or "ANTHROPIC_API_KEY required" errors

🤖 Generated with [Claude Code](https://claude.ai/code)