### PR TITLE
Fix auto-fix git push: re-authenticate with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/issue-autofix.yml
+++ b/.github/workflows/issue-autofix.yml
@@ -203,6 +203,10 @@ jobs:
           echo "Changes detected — creating branch and PR"
           git log origin/main..HEAD --oneline
 
+          # Re-authenticate git remote with GITHUB_TOKEN (the OIDC token from
+          # claude-code-action may have replaced the default credentials)
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
           SLUG=$(echo "${{ matrix.title }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 40)
           BRANCH="bugfixes/autofix-issue-${{ matrix.number }}-${SLUG}"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
@@ -333,6 +337,7 @@ jobs:
             echo "No additional changes from retry"
             echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
             git push origin "${{ steps.create-pr.outputs.branch }}"
             echo "Pushed CI fixes"
             echo "pushed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Claude IS making changes now (the change detection fix worked!) but `git push` fails with "Authentication failed" because the OIDC token from claude-code-action replaces the git credentials and doesn't have push permissions.

Fix: re-set the remote URL with `GITHUB_TOKEN` before pushing.

```
Changes detected — creating branch and PR
fatal: Authentication failed for 'https://github.com/Fortigi/IdentityAtlas.git/'
```

## Test plan

- [ ] Merge, remove `cant-autofix` from #42 and #52, trigger workflow
- [ ] Verify branch is pushed and PR is created

🤖 Generated with [Claude Code](https://claude.ai/code)