### PR TITLE
Add CODEOWNERS to restrict PR approvals to Wim and Taeke

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @taekek @wimvandenheijkant


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so that only @taekek and @wimvandenheijkant can approve pull requests to `main`

## Test plan
- [ ] Verify a PR to `main` requires approval from @taekek or @wimvandenheijkant