### PR TITLE
Fix bump-version workflow to use PAT to bypass branch protection

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Merge changelog fragments and bump version
         shell: pwsh

--- a/changes/fix-bump-version-pat.md
+++ b/changes/fix-bump-version-pat.md
@@ -1,0 +1,1 @@
+- Fixed automated version bumps failing due to branch protection requiring pull requests


### PR DESCRIPTION
## Summary
- Fixed automated version bumps failing after branch protection was tightened to require pull requests
- Workflow now uses `VERSION_BUMP_PAT` (admin PAT) instead of `GITHUB_TOKEN` to push directly to main

## Test plan
- [ ] Merge a PR to main and verify `bump-version` workflow succeeds and version is updated