### PR TITLE
feat: stable release branch strategy with edge/latest channels

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,9 +1,10 @@
 # ─── Version Bump + Changelog Merge on PR Merge ──────────────────────────────
-# On every PR merge to main this workflow:
+# On every PR merge this workflow:
 #   1. Collects all fragment files from changes/*.md and prepends them to
 #      CHANGES.md, then deletes the fragments.
-#   2. Increments the Minor version in setup/IdentityAtlas.psd1 and updates
-#      the timestamp.
+#   2. Bumps the version in setup/IdentityAtlas.psd1:
+#      - main:        increments Minor, updates timestamp  → Major.Minor.yyyyMMdd.HHmm
+#      - release/v*:  increments Patch                    → Major.Minor.Patch.0
 #
 # Branches never touch CHANGES.md or the version file directly — each branch
 # creates a uniquely named fragment file in changes/ instead, so merge
@@ -18,7 +19,9 @@ name: Bump version on PR merge
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
 
 jobs:
   bump-version:
@@ -28,14 +31,27 @@ jobs:
       contents: write
 
     steps:
+      - name: Determine target branch
+        id: branch
+        run: |
+          TARGET="${{ github.event.pull_request.base.ref }}"
+          echo "name=$TARGET" >> "$GITHUB_OUTPUT"
+          if [[ "$TARGET" == release/* ]]; then
+            echo "type=release" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ steps.branch.outputs.name }}
           token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Merge changelog fragments and bump version
         shell: pwsh
         run: |
+          $branchType = "${{ steps.branch.outputs.type }}"
+
           # ── 1. Collect changelog fragments from changes/*.md ──────────────
           $fragments = Get-ChildItem changes/*.md -ErrorAction SilentlyContinue | Sort-Object Name
           if ($fragments) {
@@ -49,20 +65,39 @@ jobs:
             Write-Host "No changelog fragments found in changes/ -- skipping CHANGES.md update"
           }
 
-          # ── 2. Bump Minor version in setup/IdentityAtlas.psd1 ─────────────
+          # ── 2. Bump version in setup/IdentityAtlas.psd1 ───────────────────
           $content = Get-Content setup/IdentityAtlas.psd1 -Raw
-          if ($content -match "ModuleVersion\s*=\s*'(\d+)\.(\d+)\.\d+\.\d+'") {
-            $major  = $Matches[1]
-            $minor  = [int]$Matches[2] + 1
-            $stamp  = (Get-Date -Format 'yyyyMMdd.HHmm')
-            $newVer = "$major.$minor.$stamp"
-            $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
-            Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
-            Write-Host "Bumped to $newVer"
-            "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
+
+          if ($branchType -eq 'release') {
+            # Release branch: increment Patch → Major.Minor.Patch.0
+            if ($content -match "ModuleVersion\s*=\s*'(\d+)\.(\d+)\.(\d+)\.(\d+)'") {
+              $major = $Matches[1]
+              $minor = $Matches[2]
+              $patch = [int]$Matches[3] + 1
+              $newVer = "$major.$minor.$patch.0"
+              $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
+              Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
+              Write-Host "Bumped to $newVer (release patch)"
+              "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
+            } else {
+              Write-Error "Could not find ModuleVersion in setup/IdentityAtlas.psd1"
+              exit 1
+            }
           } else {
-            Write-Error "Could not find ModuleVersion in setup/IdentityAtlas.psd1"
-            exit 1
+            # Main branch: increment Minor, update timestamp → Major.Minor.yyyyMMdd.HHmm
+            if ($content -match "ModuleVersion\s*=\s*'(\d+)\.(\d+)\.\d+\.\d+'") {
+              $major  = $Matches[1]
+              $minor  = [int]$Matches[2] + 1
+              $stamp  = (Get-Date -Format 'yyyyMMdd.HHmm')
+              $newVer = "$major.$minor.$stamp"
+              $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
+              Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
+              Write-Host "Bumped to $newVer (main dev build)"
+              "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
+            } else {
+              Write-Error "Could not find ModuleVersion in setup/IdentityAtlas.psd1"
+              exit 1
+            }
           }
 
       - name: Commit and push

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,81 @@
+# ─── Cut a Release Branch ─────────────────────────────────────────────────────
+# Manually triggered. Creates release/vX.Y from main, sets the version to
+# X.Y.0.0, then triggers docker-publish to build and push the initial
+# :latest image for that version.
+#
+# Usage:
+#   1. Go to Actions → Cut Release Branch → Run workflow
+#   2. Enter the version (e.g. "5.2" — major.minor only, no patch)
+#   3. The workflow creates release/v5.2, sets ModuleVersion = 5.2.0.0,
+#      and publishes ghcr.io/fortigi/identity-atlas:latest + :5.2.0.0
+#   4. Bugfixes targeting that release are PRed into release/v5.2
+#   5. Each merge bumps patch and republishes: 5.2.0.0 → 5.2.1.0 → 5.2.2.0 ...
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Cut Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (major.minor only, e.g. "5.2")'
+        required: true
+
+jobs:
+  cut-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - name: Validate version input
+        run: |
+          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^\d+\.\d+$'; then
+            echo "::error::Version must be in Major.Minor format (e.g. 5.2)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.VERSION_BUMP_PAT }}
+          fetch-depth: 0
+
+      - name: Create release branch and set version
+        shell: pwsh
+        run: |
+          $version  = "${{ github.event.inputs.version }}"
+          $branch   = "release/v$version"
+          $newVer   = "$version.0.0"
+
+          # Create and push the branch
+          git checkout -b $branch
+          Write-Host "Created branch $branch"
+
+          # Set version to Major.Minor.0.0
+          $content = Get-Content setup/IdentityAtlas.psd1 -Raw
+          $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
+          Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
+          Write-Host "Set ModuleVersion to $newVer"
+
+          "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
+          "BRANCH=$branch"      | Out-File -Append $env:GITHUB_ENV
+
+      - name: Commit and push
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add setup/IdentityAtlas.psd1
+          git commit -m "chore: cut release branch, set version to ${NEW_VERSION}"
+          git push origin "${BRANCH}"
+          echo "✅ Release branch ${BRANCH} created at version ${NEW_VERSION}"
+
+      - name: Trigger docker-publish for initial release image
+        run: |
+          gh workflow run docker-publish.yml \
+            --ref main \
+            --field branch="${BRANCH}"
+          echo "✅ docker-publish triggered for ${BRANCH} (will publish :latest + :${NEW_VERSION})"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,6 @@
 # ─── Docker Image Publishing ─────────────────────────────────────────────────
 # Builds container images, runs a basic smoke test, then pushes to GitHub
-# Container Registry. A broken image never reaches :latest.
+# Container Registry. A broken image never reaches :latest or :edge.
 #
 # Flow:  Build (local) → Start stack → Smoke test → Push
 #
@@ -8,7 +8,9 @@
 #   ghcr.io/fortigi/identity-atlas         — Node.js API + React frontend (web service)
 #   ghcr.io/fortigi/identity-atlas-worker  — PowerShell worker (crawlers, risk scoring)
 #
-# Tags: latest + version from IdentityAtlas.psd1 (e.g., 5.0.20260413.1530)
+# Tags pushed depend on the source branch:
+#   main:         edge  + Major.Minor.yyyyMMdd.HHmm   (dev builds, not :latest)
+#   release/v*:   latest + Major.Minor.Patch.0         (stable customer releases)
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: Publish Docker Images
@@ -17,8 +19,15 @@ on:
   workflow_run:
     workflows: ["Bump version on PR merge"]
     types: [completed]
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from (main or release/vX.Y)'
+        required: true
+        default: 'main'
 
 env:
   REGISTRY: ghcr.io
@@ -35,9 +44,25 @@ jobs:
       packages: write
 
     steps:
+      - name: Determine source branch and image tags
+        id: config
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            BRANCH="${{ github.event.inputs.branch }}"
+          else
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          if [[ "$BRANCH" == release/* ]]; then
+            echo "channel=release" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ steps.config.outputs.branch }}
 
       - name: Extract version from manifest
         id: version
@@ -138,7 +163,8 @@ jobs:
         run: docker compose -f docker-compose.qa.yml down -v 2>/dev/null || true
 
       # ── Push images (only reached if smoke test passed) ─────────────
-      - name: Push web image
+      - name: Push web image (release → latest)
+        if: steps.config.outputs.channel == 'release'
         uses: docker/build-push-action@v6
         with:
           context: ./app
@@ -151,7 +177,8 @@ jobs:
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
 
-      - name: Push worker image
+      - name: Push worker image (release → latest)
+        if: steps.config.outputs.channel == 'release'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -159,6 +186,33 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:latest
+            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
+
+      - name: Push web image (main → edge)
+        if: steps.config.outputs.channel == 'main'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./app
+          file: ./app/api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/fortigi/identity-atlas:edge
+            ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
+          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
+      - name: Push worker image (main → edge)
+        if: steps.config.outputs.channel == 'main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./setup/docker/Dockerfile.powershell
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:edge
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -30,7 +30,9 @@ name: PR Integration Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
 
 env:
   DOTNET_NOLOGO: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,10 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches:
+      - main
+      - dev
+      - 'release/**'
 
 env:
   DOTNET_NOLOGO: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,32 +31,49 @@ Identity Atlas is a Docker-deployed application that pulls authorization data fr
 
 | Branch | Purpose | PR required? | Approval required? |
 |--------|---------|-------------|-------------------|
-| `main` | Stable trunk. Never commit directly. | Yes | Yes (at least 1) |
+| `main` | Integration trunk. Never commit directly. Merges push `:edge` Docker tag. | Yes | Yes (at least 1) |
+| `release/vX.Y` | Stable customer release line. Cut from `main` via `cut-release.yml`. Merges push `:latest` Docker tag. | Yes | No |
 | `feature/<name>` | All feature work. Created from `main`. Merged back to `main` via PR. | Yes (to `main`) | No |
-| `bugfixes/<name>` | Bug fixes. Created from `main`. Merged back to `main` via PR. | Yes (to `main`) | No |
+| `bugfixes/<name>` | Bug fixes. Branch from `release/vX.Y` for production hotfixes, or from `main` for pre-release fixes. | Yes | No |
 
 **Rules:**
-- `feature/` and `bugfixes/` branches must be branched off `main`.
-- All merges to `main` go through a Pull Request — no direct pushes ever.
+- `feature/` branches must be branched off `main`.
+- `bugfixes/` branches branch from **`release/vX.Y`** when fixing a production issue (customers are affected), or from `main` when fixing something not yet released.
+- Production bugfixes merged to `release/vX.Y` must also be cherry-picked to `main` so the fix is included in future feature releases.
+- All merges go through a Pull Request — no direct pushes to `main` or `release/*` ever.
 - Branch names: `feature/<short-descriptive-name>` or `bugfixes/<short-descriptive-name>` (lowercase, hyphens). Example: `feature/risk-score-export`, `bugfixes/fix-login-redirect`.
-- When starting work, always create a new `feature/` or `bugfixes/` branch. Never work directly on `main`.
+- When starting work, always create a new branch. Never work directly on `main` or `release/*`.
 - **One issue per branch.** Each branch must fix exactly one issue or implement exactly one feature. Never combine fixes for separate, unrelated issues into a single branch or PR. Exception: if a single code change genuinely resolves more than one issue (e.g. the same root cause), both issue numbers may be referenced in the commit and PR — but this should be rare and the connection must be explicit.
 
 ### Version Number Scheme
 
-Version format (4 parts, PowerShell-compatible): `Major.Minor.yyyyMMdd.HHmm`
+Two formats, both 4-part (PowerShell-compatible):
 
-| Branch | Version format | Who updates it | When |
-|--------|---------------|----------------|------|
-| `main` | `Major.Minor.yyyyMMdd.HHmm` | `bump-version.yml` GitHub Action (automated) | On every PR merge. Increments `Minor`, updates timestamp. |
-| `feature/*` / `bugfixes/*` | — | **Nobody** | Never touch `setup/IdentityAtlas.psd1` on a branch. |
+| Branch | Version format | Example | Docker tag pushed |
+|--------|---------------|---------|-------------------|
+| `main` | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` | `:edge` |
+| `release/vX.Y` | `Major.Minor.Patch.0` | `5.2.1.0` | `:latest` |
+| `feature/*` / `bugfixes/*` | — | — | Nobody |
+
+The timestamp format on `main` makes dev builds instantly recognisable. The semantic `Patch.0` format on release branches gives customers a clear upgrade path.
+
+**Who updates versions:**
+
+| Branch | Who updates it | When |
+|--------|---------------|------|
+| `main` | `bump-version.yml` (automated) | Every PR merge — increments `Minor`, updates timestamp |
+| `release/vX.Y` | `bump-version.yml` (automated) | Every PR merge — increments `Patch` (e.g. `5.2.0.0` → `5.2.1.0`) |
+| `feature/*` / `bugfixes/*` | **Nobody** | Never touch `setup/IdentityAtlas.psd1` on a branch |
 
 **How to apply:**
 
-1. **Starting a branch**: Branch from `main`. Leave `setup/IdentityAtlas.psd1` untouched.
-2. **After any code change on a branch**: Add bullets to `changes/<branch-name>.md`. Do not edit `CHANGES.md` or `ModuleVersion`.
-3. **When merging feature/bugfixes → main via PR**: The `bump-version.yml` Action runs automatically after merge and commits the Minor increment + new timestamp to `main`. The `docker-publish.yml` Action then triggers on that commit to build and push Docker images with the updated version.
-4. **Major version bump**: Edit `setup/IdentityAtlas.psd1` manually on `main` (via a PR) for a breaking change. Increment `Major`, reset `Minor` to `0`.
+1. **Starting a feature or pre-release bugfix branch**: Branch from `main`. Leave `setup/IdentityAtlas.psd1` untouched.
+2. **Starting a production hotfix branch**: Branch from `release/vX.Y`. Leave `setup/IdentityAtlas.psd1` untouched.
+3. **After any code change on a branch**: Add bullets to `changes/<branch-name>.md`. Do not edit `CHANGES.md` or `ModuleVersion`.
+4. **When merging → main via PR**: `bump-version.yml` increments Minor + timestamp. `docker-publish.yml` builds and pushes `:edge` + versioned tag.
+5. **When merging → release/vX.Y via PR**: `bump-version.yml` increments Patch. `docker-publish.yml` builds and pushes `:latest` + versioned tag.
+6. **Cutting a new release**: Run the `cut-release.yml` workflow (Actions → Cut Release Branch → enter `Major.Minor`). It creates `release/vX.Y` from `main` and sets the version to `X.Y.0.0`.
+7. **Major version bump**: Edit `setup/IdentityAtlas.psd1` manually on `main` (via a PR) for a breaking change. Increment `Major`, reset `Minor` to `0`.
 
 ### Changelog fragments (replaces direct CHANGES.md edits)
 
@@ -723,16 +740,71 @@ The Crawlers wizard validates these permissions on the App Registration during s
 - `vw_PendingRequestTimeline` - Aging pending requests
 - `vw_RequestResponseMetrics` - Aggregate approval statistics
 
+## Repository Setup (One-Time)
+
+These steps are required once when creating or transferring the repository. They are not automated by CI.
+
+### GitHub Actions secrets
+
+| Secret | Required scopes | Purpose |
+|--------|----------------|---------|
+| `VERSION_BUMP_PAT` | `repo` (includes `contents:write`) | Lets `bump-version.yml` and `cut-release.yml` push commits directly to protected branches (`main`, `release/**`). The PAT owner **must have the admin role** on the repository so the bypass actor rule on `release/**` applies. |
+
+### Branch protection
+
+Run once after repo creation (requires `gh` CLI authenticated as admin):
+
+```bash
+bash tools/setup-branch-protection.sh Fortigi/IdentityAtlas
+```
+
+This sets:
+- `main` — PR required (1 approval), `PR Summary` check required, admins bypass
+- `release/**` — PR required (0 approvals), `PR Summary` check required, no force-push, no deletion, admins bypass
+
+---
+
 ## Development Workflow
 
 ### Starting New Work
 
+**Feature (not yet released):**
 ```bash
 git checkout main && git pull
 git checkout -b feature/<name>      # e.g. feature/risk-score-export
-# or
+```
+
+**Pre-release bugfix (bug is in main, not yet in a release):**
+```bash
+git checkout main && git pull
 git checkout -b bugfixes/<name>     # e.g. bugfixes/fix-login-redirect
 ```
+
+**Production hotfix (bug is in a released version, customers are affected):**
+```bash
+# Step 1 — fix on the release branch
+git checkout release/v5.2 && git pull
+git checkout -b bugfixes/<name>
+# ... make the fix, add changes/<name>.md fragment, commit ...
+gh pr create --base release/v5.2 --title "fix: ..."
+# merge the PR → bump-version bumps patch, docker-publish pushes :latest
+
+# Step 2 — bring the fix into main via its own PR (main is protected, no direct commits)
+git checkout main && git pull
+git checkout -b bugfixes/<name>-main
+git cherry-pick <fix-commit-sha>    # the fix commit only, not the version bump commit
+gh pr create --base main --title "fix: ... (cherry-pick from release/v5.2)"
+# merge the PR → bump-version bumps minor on main as normal
+```
+
+### Cutting a New Release
+
+When `main` is stable and ready to ship to customers:
+
+1. Go to **Actions → Cut Release Branch → Run workflow**
+2. Enter the version, e.g. `5.3` (Major.Minor only)
+3. The workflow creates `release/v5.3` from `main` and sets version to `5.3.0.0`
+4. Merges to `release/v5.3` push `:latest` to customers
 
 ### Making Changes
 
@@ -764,17 +836,26 @@ gh pr create --base feature/foo-step-1 --title "step 2: ..."
 
 When a bottom PR merges, retarget the next one: `gh pr edit <number> --base main`.
 
-### Merging Feature/Bugfixes → Main (via PR)
+### Merging to Main (feature / pre-release bugfix)
 
-1. Open PR from `feature/<name>` or `bugfixes/<name>` into `main` (or into the previous stack branch)
+1. Open PR from `feature/<name>` or `bugfixes/<name>` into `main`
 2. Use the fragment content from `changes/<branch-name>.md` as the PR description
 3. Requires 1 approval — merge when CI passes
+4. After merge: `bump-version.yml` increments Minor + timestamp; `docker-publish.yml` pushes `:edge`
+
+### Merging to a Release Branch (production hotfix)
+
+1. Open PR from `bugfixes/<name>` into `release/vX.Y`
+2. Use the fragment content from `changes/<branch-name>.md` as the PR description
+3. Merge when CI passes
+4. After merge: `bump-version.yml` increments Patch; `docker-publish.yml` pushes `:latest`
+5. Cherry-pick the fix to `main`: `git checkout main && git cherry-pick <sha>`
 
 ### Version Updates
 
-Version format: `Major.Minor.yyyyMMdd.HHmm` (e.g., `2.5.20260317.1430`)
-
-See the **Branching & Versioning Strategy** section above for the full scheme. The Docker images are built and pushed by the `docker-publish.yml` GitHub Action on merge to `main`, tagged with both `latest` and the module version.
+See the **Branching & Versioning Strategy** section above for the full scheme.
+- `main` merges → `Major.Minor.yyyyMMdd.HHmm` → `:edge` Docker tag
+- `release/*` merges → `Major.Minor.Patch.0` → `:latest` Docker tag
 
 ## User Workflow (Getting Started)
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,28 @@ Permissions are scattered across identity systems, directories, and SaaS platfor
 **Prerequisites:** Docker and Docker Compose.
 
 ```bash
-# 1. Download the production compose file
+# 1. Download the compose file and environment template
 curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/setup/config/.env.example
 
-# 2. Start the stack
+# 2. Create your .env file
+cp .env.example .env
+# For a quick local evaluation the defaults are fine.
+# For any networked or production deployment, open .env and set:
+#   POSTGRES_PASSWORD=<strong-password>
+#   IDENTITY_ATLAS_MASTER_KEY=<random-32-char-string>
+
+# 3. Start the stack (first run: ~2 min to pull images)
 docker compose -f docker-compose.prod.yml up -d
 
-# 3. Open http://localhost:3001
+# 4. Open http://localhost:3001
 #    Go to Admin > Crawlers, then click "Load Demo Data" to explore with sample data, or
 #    click "Add Crawler" to connect your Entra ID tenant.
 ```
 
 The in-browser crawler wizard walks you through credentials, permission validation, object type selection, and scheduling — no PowerShell or command-line setup required.
+
+> **Image channels:** The default pulls the latest stable release (`:latest`). To run the development build instead, set `IMAGE_TAG=edge` in your `.env`. See [Docker Setup](docs/architecture/docker-setup.md) for details.
 
 ---
 

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -529,8 +529,13 @@ export default function App() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-gray-200 bg-white px-6 py-2 text-xs text-gray-400 text-center">
+      <footer className="border-t border-gray-200 bg-white px-6 py-2 text-xs text-gray-400 text-center flex items-center justify-center gap-2">
         Identity Atlas{moduleVersion ? ` v${moduleVersion}` : ''}
+        {/^\d+\.\d+\.\d{8}\.\d{4}$/.test(moduleVersion) && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold bg-amber-100 text-amber-700 border border-amber-300">
+            edge
+          </span>
+        )}
       </footer>
     </div>
     </ErrorBoundary>

--- a/changes/feature-release-branch-strategy.md
+++ b/changes/feature-release-branch-strategy.md
@@ -1,0 +1,10 @@
+- Added stable release branch model: `release/vX.Y` branches are cut from `main` and receive only bugfixes, giving customers a stable `:latest` Docker image that does not change when new features land on `main`
+- New `cut-release.yml` workflow creates a release branch and sets the initial version (e.g. `5.2.0.0`) with one click from GitHub Actions
+- Main branch builds now push the `:edge` Docker tag instead of `:latest`, so customers on `:latest` only receive intentional releases
+- Production hotfixes merged to a release branch increment the patch version (`5.2.0.0` → `5.2.1.0`) and push `:latest` automatically
+- `docker-compose.prod.yml` now supports an `IMAGE_TAG` environment variable to select the image channel (`latest`, `edge`, or a pinned version); customers get `latest` by default
+- The footer now shows the running version; edge builds display a prominent amber "edge" badge so it is immediately obvious which channel is running
+- README and Docker Setup documentation updated with step-by-step `.env` setup for both customers and developers, image channel selection guide, and a full environment variable reference
+- Fixed PR checks (lint, unit tests, integration tests) to also run on pull requests targeting `release/**` branches, so hotfixes receive the same gate as feature PRs
+- Fixed release cut workflow: the initial `X.Y.0.0` image is now published to `:latest` immediately after the release branch is created, not only after the first bugfix merges
+- `release/**` branches are now protected: direct commits are blocked, a pull request is required, and the `PR Summary` status check must pass before merging; repository admins retain bypass rights so the automated version bump can still land

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,11 @@
 #   Copy .env.example to .env and set your values, or pass them inline:
 #   GRAPH_TENANT_ID=... GRAPH_CLIENT_ID=... GRAPH_CLIENT_SECRET=... docker compose -f docker-compose.prod.yml up
 #
+# Image channel (IMAGE_TAG):
+#   latest  — stable customer release (default, omit IMAGE_TAG or leave blank)
+#   edge    — latest merged commit on main; may be unstable (set IMAGE_TAG=edge)
+#   5.2.1.0 — pin to a specific release version
+#
 # SECURITY: The default POSTGRES_PASSWORD is for local evaluation only.
 #   For any networked or production deployment, set a strong password and an
 #   explicit master key for the secrets vault:
@@ -43,7 +48,7 @@ services:
 
   # ── Web (serves built frontend + API) ────────────────────────────────────────
   web:
-    image: ghcr.io/fortigi/identity-atlas:latest
+    image: ghcr.io/fortigi/identity-atlas:${IMAGE_TAG:-latest}
     # The container runs as the unprivileged `node` user. The Docker socket
     # is owned by root:root 0660, so node needs GID 0 to read container stats.
     group_add: ["0"]
@@ -81,7 +86,7 @@ services:
   # In v5 the worker container has NO database driver. It talks to the API
   # for everything (job pickup, ingest, progress reporting).
   worker:
-    image: ghcr.io/fortigi/identity-atlas-worker:latest
+    image: ghcr.io/fortigi/identity-atlas-worker:${IMAGE_TAG:-latest}
     environment:
       WEB_API_URL: "http://web:3001/api"
       # Optional global crawler API key — overridden per-job via WorkerConfig.

--- a/docs/architecture/docker-setup.md
+++ b/docs/architecture/docker-setup.md
@@ -9,19 +9,55 @@ Running Identity Atlas locally with Docker — three containers providing the fu
 The fastest way to try Identity Atlas — pulls pre-built images, no source code needed:
 
 ```bash
-# Download the production compose file
+# 1. Download the compose file and environment template
 curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/setup/config/.env.example
 
-# Start everything (first run: ~2 min to pull images)
+# 2. Create your .env file
+cp .env.example .env
+
+# 3. Start everything (first run: ~2 min to pull images)
 docker compose -f docker-compose.prod.yml up -d
 
-# Open the UI
+# 4. Open the UI
 open http://localhost:3001
 ```
 
 On first visit, the UI opens to the Dashboard. If no data is loaded yet, click **"Configure a crawler"** to go to Admin → Crawlers, then click **"Load Demo Data"** to populate the system with synthetic data (~30 seconds). After that, explore the Matrix, Users, Resources, and other pages.
 
 To connect your own Entra ID tenant, click **"Connect Entra ID"** on the Crawlers page and enter your App Registration credentials (Tenant ID, Client ID, Client Secret).
+
+### The .env File
+
+`docker-compose.prod.yml` reads all configuration from a `.env` file in the same directory. The template has safe defaults for local evaluation — for anything networked or production, set these two variables:
+
+| Variable | Default | What to do |
+|---|---|---|
+| `POSTGRES_PASSWORD` | `identity_atlas_local` | **Change this** for any non-local deployment |
+| `IDENTITY_ATLAS_MASTER_KEY` | *(auto-generated)* | Set an explicit value so you can back it up; if left blank the container generates one and saves it to the `job_data` volume |
+
+Full variable reference: [Environment Variables](#environment-variables).
+
+### Image Channels
+
+The compose file uses the `IMAGE_TAG` variable to select which build to pull:
+
+| `IMAGE_TAG` | What you get | Who should use it |
+|---|---|---|
+| *(unset or blank)* | `:latest` — last stable release | Customers and production deployments |
+| `edge` | `:edge` — latest commit on `main`, may be unstable | Developers and testers who want the newest features |
+| `5.2.1.0` | Exact pinned version, never auto-updates | Customers who want to control upgrade timing |
+
+The running version is always visible in the footer of the UI. Edge builds show an amber **edge** badge so it is immediately obvious which channel is running.
+
+```bash
+# Run the stable release (default)
+docker compose -f docker-compose.prod.yml up -d
+
+# Run the edge build
+IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d
+# or set IMAGE_TAG=edge in your .env
+```
 
 ---
 
@@ -69,6 +105,11 @@ happens inside the web container at startup via the migrations runner
 ```powershell
 cd c:\Source\GitHub\IdentityAtlas
 
+# Create your .env file from the template
+cp setup/config/.env.example .env
+# IMAGE_TAG is ignored by the dev compose (it builds from source).
+# You can leave the other defaults as-is for local development.
+
 # Start the stack (first time takes ~3 min to build)
 docker compose up -d --build
 
@@ -82,6 +123,8 @@ Start-Process http://localhost:3001
 # Open Swagger docs
 Start-Process http://localhost:3001/api/docs
 ```
+
+> **Note:** `docker-compose.yml` (dev) builds images from source — `IMAGE_TAG` has no effect. Use `docker-compose.prod.yml` with `IMAGE_TAG=edge` if you want to run the pre-built edge image without a local build.
 
 ## Stopping
 
@@ -209,19 +252,60 @@ docker compose -f docker-compose.yml restart worker
 
 ### Environment Variables
 
-Create `.env` from the template for secrets:
+Copy the template once, then edit the values you need:
 
-```powershell
+```bash
 cp setup/config/.env.example .env
-# Edit .env with your values
 ```
 
-| Variable | Purpose |
-|---|---|
-| `POSTGRES_PASSWORD` | PostgreSQL password. Both `docker-compose.yml` and `docker-compose.prod.yml` use PostgreSQL — SQL Server was dropped in v5. |
-| `CRAWLER_API_KEY` | API key for the worker's crawler |
-| `GRAPH_TENANT_ID` / `CLIENT_ID` / `CLIENT_SECRET` | For EntraID crawler |
-| `LLM_PROVIDER` / `LLM_API_KEY` | For risk scoring (Anthropic or OpenAI) |
+Both compose files (`docker-compose.yml` and `docker-compose.prod.yml`) read from `.env` in the project root.
+
+#### Image channel (`docker-compose.prod.yml` only)
+
+| Variable | Default | Description |
+|---|---|---|
+| `IMAGE_TAG` | *(blank → `latest`)* | Docker image tag to pull. Leave blank for the stable release, set `edge` for the latest dev build, or pin to a specific version like `5.2.1.0`. |
+
+#### Database
+
+| Variable | Default | Description |
+|---|---|---|
+| `POSTGRES_PASSWORD` | `identity_atlas_local` | PostgreSQL password. Safe for local evaluation; **change for any networked deployment**. |
+| `POSTGRES_USER` | `identity_atlas` | PostgreSQL username. Rarely needs changing. |
+| `POSTGRES_DB` | `identity_atlas` | Database name. Rarely needs changing. |
+
+#### Security
+
+| Variable | Default | Description |
+|---|---|---|
+| `IDENTITY_ATLAS_MASTER_KEY` | *(auto-generated)* | Master key for the AES-256-GCM secrets vault (LLM API keys, scraper credentials). If left blank, the container generates a key on first start and persists it to the `job_data` volume. **Set an explicit value for production** so the key can be backed up alongside other root secrets. |
+
+#### Authentication (optional)
+
+Identity Atlas defaults to no-auth (any browser can access the UI). To require Entra ID login:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTH_ENABLED` | `false` | Set to `true` to require Entra ID authentication. |
+| `AUTH_TENANT_ID` | — | Your Entra ID tenant ID. |
+| `AUTH_CLIENT_ID` | — | App Registration client ID for the UI. |
+| `AUTH_REQUIRED_ROLES` | — | Optional comma-separated list of app roles required to access the UI. |
+
+#### Crawler credentials (optional — can also configure via the in-browser wizard)
+
+| Variable | Default | Description |
+|---|---|---|
+| `CRAWLER_API_KEY` | *(auto-generated)* | API key the worker uses to authenticate with the API. Auto-generated on first start; override only if you need a fixed key. |
+| `GRAPH_TENANT_ID` | — | Entra ID tenant ID for the Graph API crawler. |
+| `GRAPH_CLIENT_ID` | — | App Registration client ID. |
+| `GRAPH_CLIENT_SECRET` | — | App Registration client secret. |
+
+#### LLM / Risk Scoring (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `LLM_PROVIDER` | — | `Anthropic`, `OpenAI`, or `AzureOpenAI`. Can also be configured per-tenant via Admin → LLM Settings. |
+| `LLM_API_KEY` | — | API key for the selected LLM provider. |
 
 ---
 

--- a/setup/config/.env.example
+++ b/setup/config/.env.example
@@ -1,6 +1,12 @@
 # Identity Atlas Docker — Local Environment Variables (v5)
 # Copy to .env and fill in your values. Never commit .env to git.
 
+# Image channel — which Docker tag to pull (docker-compose.prod.yml only)
+#   latest  — stable customer release (default, leave blank)
+#   edge    — latest commit on main, may be unstable
+#   5.2.1.0 — pin to a specific version
+IMAGE_TAG=
+
 # PostgreSQL (defaults match docker-compose.yml)
 POSTGRES_DB=identity_atlas
 POSTGRES_USER=identity_atlas

--- a/tools/setup-branch-protection.sh
+++ b/tools/setup-branch-protection.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ─── Branch Protection Setup ─────────────────────────────────────────────────
+# Run once after creating or transferring the repository.
+# Requires: gh CLI authenticated as a repository admin.
+#
+# What this configures:
+#
+#   main         (classic branch protection — already set, included here for docs)
+#     - Require PR with 1 approval before merging
+#     - Require "PR Summary" status check
+#     - Dismiss stale reviews on push
+#     - enforce_admins: false  ← lets VERSION_BUMP_PAT push the version bump commit
+#
+#   release/**   (GitHub Ruleset — wildcard patterns need Rulesets API)
+#     - Require PR before merging (0 approvals needed)
+#     - Require "PR Summary" status check
+#     - Block direct pushes (non-fast-forward / force push)
+#     - Block branch deletion
+#     - Bypass: repository admins (actor_id=5) ← VERSION_BUMP_PAT owner must be admin
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+REPO="${1:-Fortigi/IdentityAtlas}"
+echo "Configuring branch protection for: $REPO"
+
+# ── 1. main — classic branch protection ─────────────────────────────────────
+echo ""
+echo "Setting classic branch protection on main..."
+gh api "repos/$REPO/branches/main/protection" \
+  --method PUT \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["PR Summary"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false
+}
+JSON
+echo "✅ main branch protection set"
+
+# ── 2. release/** — GitHub Ruleset ──────────────────────────────────────────
+echo ""
+echo "Creating ruleset for release/** branches..."
+
+# Delete existing ruleset with the same name if it exists
+EXISTING_ID=$(gh api "repos/$REPO/rulesets" | \
+  python3 -c "import sys,json; rs=[r['id'] for r in json.load(sys.stdin) if r['name']=='Protect release branches']; print(rs[0] if rs else '')" 2>/dev/null || true)
+
+if [ -n "$EXISTING_ID" ]; then
+  echo "  Removing existing ruleset (id=$EXISTING_ID)..."
+  gh api "repos/$REPO/rulesets/$EXISTING_ID" --method DELETE
+fi
+
+gh api "repos/$REPO/rulesets" --method POST --input - <<'JSON'
+{
+  "name": "Protect release branches",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/release/**"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "PR Summary" }
+        ]
+      }
+    }
+  ]
+}
+JSON
+echo "✅ release/** ruleset created"
+
+echo ""
+echo "Done. Branch protection summary:"
+echo "  main         → PR required (1 approval) + PR Summary check"
+echo "  release/**   → PR required (0 approvals) + PR Summary check + no force-push + no deletion"
+echo "  Bypass       → Repository admins (the VERSION_BUMP_PAT owner must have admin role)"


### PR DESCRIPTION
## Summary

- Introduce `release/vX.Y` branch model: merges to `main` push `:edge`, merges to release branches push `:latest` — customers on `:latest` only receive intentional releases
- Add `cut-release.yml` workflow (Actions → Cut Release Branch) to create a release branch from `main`, set version to `X.Y.0.0`, and publish the initial `:latest` image automatically
- `bump-version.yml` now increments patch (`X.Y.P.0`) on release branches and minor+timestamp on `main`
- `docker-compose.prod.yml` supports `IMAGE_TAG` env var (`latest` / `edge` / pinned version); customers get `latest` by default
- UI footer shows running version; edge builds display an amber **edge** badge
- PR checks (lint, unit tests, integration tests) now also run on `release/**` PRs
- Branch protection ruleset for `release/**` added (PR required, `PR Summary` check, no force-push, admin bypass for version bump bot)
- README and Docker Setup docs updated with `.env` setup guide and full environment variable reference

## Test plan

- [ ] Verify `bump-version.yml` increments Minor+timestamp on a `main` PR merge
- [ ] Run Actions → Cut Release Branch with a test version — confirm branch created, version set to `X.Y.0.0`, `docker-publish` triggered
- [ ] Merge a hotfix PR to the release branch — confirm patch bumped and `:latest` pushed
- [ ] Confirm direct push to `release/**` is blocked (branch protection ruleset active)
- [ ] Confirm `IMAGE_TAG=edge` in `.env` pulls the edge image
- [ ] Confirm UI footer shows amber **edge** badge on an edge build

🤖 Generated with [Claude Code](https://claude.com/claude-code)