### PR TITLE
bugfix: fix cut release version validation regex (#104)

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Validate version input
         run: |
-          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^\d+\.\d+$'; then
+          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+$'; then
             echo "::error::Version must be in Major.Minor format (e.g. 5.2)"
             exit 1
           fi

--- a/changes/fix-cut-release-version-validation.md
+++ b/changes/fix-cut-release-version-validation.md
@@ -1,0 +1,1 @@
+- Fixed the Cut Release workflow rejecting valid version inputs like "5.2" due to a non-portable regex


### PR DESCRIPTION
## Summary
- The Cut Release workflow rejected valid version inputs like `5.2` because the regex used `\d`, a GNU grep extension not supported on all POSIX `grep` implementations
- Replaced `\d` with `[0-9]` for portable POSIX extended regex compatibility

## Test plan
- [ ] Run the Cut Release workflow with input `5.2` — should pass validation
- [ ] Run with invalid input like `5.2.1` or `abc` — should still be rejected

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)