### PR TITLE
docs: documentation consistency pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ cp .env.example .env
 #   POSTGRES_PASSWORD=<strong-password>
 #   IDENTITY_ATLAS_MASTER_KEY=<random-32-char-string>
 
-# 3. Start the stack (first run: ~2 min to pull images)
-docker compose -f docker-compose.prod.yml up -d
+# 3. Start the stack (first run: ~2 min to pull images; --pull always ensures
+#    Docker fetches the newest :latest instead of reusing a cached copy)
+docker compose -f docker-compose.prod.yml up -d --pull always
 
 # 4. Open http://localhost:3001
 #    Go to Admin > Crawlers, then click "Load Demo Data" to explore with sample data, or

--- a/changes/feature-docs-consistency-pass.md
+++ b/changes/feature-docs-consistency-pass.md
@@ -1,0 +1,7 @@
+- Added branching and versioning strategy reference page under docs/architecture
+- Added `--pull always` flag to Quick Start commands in README, quickstart, docker-setup, and index docs so users always get the newest image
+- Added `.env` setup step (copy from template) to all Quick Start sections
+- Added tabbed Linux/macOS and Windows code blocks throughout docker-setup and local-dev docs
+- Fixed version pinning example in quickstart to use release format (5.2.0.0) instead of edge timestamp format
+- Fixed history.md to link to the branching strategy doc instead of referencing CLAUDE.md
+- Aligned local-dev.md with docker-setup.md: added --build note for first run, tabbed stop/reset commands

--- a/docs/architecture/branching-strategy.md
+++ b/docs/architecture/branching-strategy.md
@@ -1,6 +1,6 @@
 # Branching and Versioning Strategy
 
-This document covers branch naming, PR rules, version format, and the changelog workflow for contributors.
+This document covers branch naming, PR rules, version format, and the release workflow for contributors.
 
 ---
 
@@ -10,11 +10,13 @@ This document covers branch naming, PR rules, version format, and the changelog 
 |--------|---------|-------------|-------------------|
 | `main` | Stable trunk. Never commit directly. | Yes | Yes (at least 1) |
 | `feature/<name>` | All feature work. Created from `main`. Merged back to `main` via PR. | Yes | No |
-| `bugfixes/<name>` | Bug fixes. Created from `main`. Merged back to `main` via PR. | Yes | No |
+| `bugfixes/<name>` | Bug fixes. Branch from `main` for pre-release fixes; branch from a **release tag** for hotfixes. | Yes (to `main`) | No |
 
 **Rules:**
 
-- `feature/` and `bugfixes/` branches must be branched off `main`.
+- `feature/` branches must be branched off `main`.
+- `bugfixes/` branches branch from `main` for pre-release fixes. For hotfixes to an already-released version, branch from the release tag: `git checkout -b bugfixes/fix-foo v5.2.0`.
+- Hotfix commits must be cherry-picked back to `main` via a separate PR so the fix is included in future releases.
 - All merges to `main` go through a Pull Request — no direct pushes.
 - Branch names: lowercase, hyphens. Examples: `feature/risk-score-export`, `bugfixes/fix-login-redirect`.
 - **One issue per branch.** Each branch fixes exactly one issue or implements exactly one feature. Never combine unrelated fixes into a single branch or PR.
@@ -24,34 +26,35 @@ This document covers branch naming, PR rules, version format, and the changelog 
 ## Starting New Work
 
 ```bash
+# Feature or pre-release bugfix — branch from main
 git checkout main && git pull
 git checkout -b feature/<name>
 # or
 git checkout -b bugfixes/<name>
+
+# Hotfix to a released version — branch from the release tag, NOT from main
+git checkout -b bugfixes/<name> v5.2.0
 ```
 
 ---
 
 ## Version Number Format
 
-```
-Major.Minor.yyyyMMdd.HHmm
-```
+Two formats, both 4-part (PowerShell-compatible):
 
-Example: `5.2.20260420.1430`
-
-| Part | Meaning |
-|------|---------|
-| `Major` | Incremented manually for breaking changes (via a PR to `main`) |
-| `Minor` | Auto-incremented by CI on every PR merge to `main` |
-| `yyyyMMdd.HHmm` | Timestamp of the merge, set by CI |
+| Context | Format | Example |
+|---------|--------|---------|
+| `main` dev builds (`:edge`) | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` |
+| Release tags (`:latest`) | `Major.Minor.Patch.0` | `5.2.1.0` |
 
 **Who updates what:**
 
 | Action | Who | When |
 |--------|-----|------|
 | `Minor` bump + timestamp | `bump-version.yml` GitHub Action | Automatically on every PR merge to `main` |
-| `Major` bump | Developer, via PR | Only for breaking changes |
+| Release version | `cut-release.yml` GitHub Action | When you run Actions → Cut Release |
+| Hotfix version | `cut-hotfix.yml` GitHub Action | When you run Actions → Cut Hotfix |
+| `Major` bump | Developer, via PR to `main` | Only for breaking changes |
 | Branch work | Nobody | Never touch `setup/IdentityAtlas.psd1` on a branch |
 
 ---
@@ -78,7 +81,47 @@ Write in user-facing language. One bullet per functional change. Add the file al
 1. Open a PR from `feature/<name>` or `bugfixes/<name>` into `main`.
 2. Use the changelog fragment content as the PR description body.
 3. Requires 1 approval and passing CI.
-4. After merge, `bump-version.yml` automatically increments `Minor`, updates the timestamp, and merges all `changes/*.md` fragments into `CHANGES.md`. The `docker-publish.yml` action then builds and pushes Docker images tagged with the new version.
+4. After merge, `bump-version.yml` automatically increments `Minor`, updates the timestamp, and merges all `changes/*.md` fragments into `CHANGES.md`. The `docker-publish.yml` action then builds and pushes Docker images tagged `:edge`.
+
+---
+
+## Cutting a Release
+
+When `main` is stable and ready to ship to customers:
+
+1. Go to **Actions → Cut Release → Run workflow**
+2. Enter the version: `Major.Minor.Patch` (e.g. `5.2.0`)
+3. The workflow creates tag `v5.2.0` on the current `main` HEAD
+4. `docker-publish.yml` triggers automatically on the tag push and builds `:latest` + `:5.2.0.0`
+
+Customers who track `:latest` will receive the new version on their next `docker compose pull`.
+
+---
+
+## Hotfix Releases
+
+To ship a bugfix without including features already on `main`:
+
+```bash
+# 1. Branch from the release tag — NOT from main
+git checkout -b bugfixes/fix-login-crash v5.2.0
+
+# 2. Fix the bug, commit, push
+git push origin bugfixes/fix-login-crash
+```
+
+3. Go to **Actions → Cut Hotfix → Run workflow**
+4. Enter the branch name (`bugfixes/fix-login-crash`) and new version (`5.2.1`)
+5. The workflow creates tag `v5.2.1` on the HEAD of your branch
+6. `docker-publish.yml` builds `:latest` + `:5.2.1.0`
+
+After the hotfix ships, open a PR to cherry-pick the fix into `main`:
+
+```bash
+git checkout main && git pull
+git cherry-pick <fix-commit-sha>
+gh pr create --base main --title "fix: cherry-pick hotfix from v5.2.1"
+```
 
 ---
 
@@ -102,12 +145,10 @@ When a bottom PR merges, retarget the next one: `gh pr edit <number> --base main
 
 ## Image Channels
 
-The CI pipeline publishes Docker images on every merge to `main`:
-
-| Tag | Content | Who uses it |
-|-----|---------|-------------|
-| `:latest` | Last stable release | End users (default) |
-| `:edge` | Latest commit on `main` | Testers and developers |
-| `:5.2.0.0` | Exact pinned version | Production deployments |
+| Tag | Published when | Who uses it |
+|-----|---------------|-------------|
+| `:latest` | A release tag (`v5.2.0`) is created via Actions → Cut Release or Cut Hotfix | Customers (default) |
+| `:edge` | Every PR merges to `main` | Developers and testers |
+| `:5.2.0.0` | Same time as `:latest` — exact pinned version | Production deployments needing controlled upgrades |
 
 See [Docker Setup](docker-setup.md) for how to select a channel via `IMAGE_TAG`.

--- a/docs/architecture/branching-strategy.md
+++ b/docs/architecture/branching-strategy.md
@@ -1,0 +1,113 @@
+# Branching and Versioning Strategy
+
+This document covers branch naming, PR rules, version format, and the changelog workflow for contributors.
+
+---
+
+## Branch Model
+
+| Branch | Purpose | PR required? | Approval required? |
+|--------|---------|-------------|-------------------|
+| `main` | Stable trunk. Never commit directly. | Yes | Yes (at least 1) |
+| `feature/<name>` | All feature work. Created from `main`. Merged back to `main` via PR. | Yes | No |
+| `bugfixes/<name>` | Bug fixes. Created from `main`. Merged back to `main` via PR. | Yes | No |
+
+**Rules:**
+
+- `feature/` and `bugfixes/` branches must be branched off `main`.
+- All merges to `main` go through a Pull Request — no direct pushes.
+- Branch names: lowercase, hyphens. Examples: `feature/risk-score-export`, `bugfixes/fix-login-redirect`.
+- **One issue per branch.** Each branch fixes exactly one issue or implements exactly one feature. Never combine unrelated fixes into a single branch or PR.
+
+---
+
+## Starting New Work
+
+```bash
+git checkout main && git pull
+git checkout -b feature/<name>
+# or
+git checkout -b bugfixes/<name>
+```
+
+---
+
+## Version Number Format
+
+```
+Major.Minor.yyyyMMdd.HHmm
+```
+
+Example: `5.2.20260420.1430`
+
+| Part | Meaning |
+|------|---------|
+| `Major` | Incremented manually for breaking changes (via a PR to `main`) |
+| `Minor` | Auto-incremented by CI on every PR merge to `main` |
+| `yyyyMMdd.HHmm` | Timestamp of the merge, set by CI |
+
+**Who updates what:**
+
+| Action | Who | When |
+|--------|-----|------|
+| `Minor` bump + timestamp | `bump-version.yml` GitHub Action | Automatically on every PR merge to `main` |
+| `Major` bump | Developer, via PR | Only for breaking changes |
+| Branch work | Nobody | Never touch `setup/IdentityAtlas.psd1` on a branch |
+
+---
+
+## Changelog Fragments
+
+Every `feature/` or `bugfixes/` branch must include a changelog fragment. **Never edit `CHANGES.md` directly** — the `bump-version.yml` CI action merges all fragments on PR merge.
+
+**File:** `changes/<descriptive-name>.md` (e.g. `changes/fix-login-redirect.md`)
+
+**Format:**
+
+```markdown
+- Fixed the login redirect when auth is enabled and no session exists
+- Improved error message when tenant ID is missing
+```
+
+Write in user-facing language. One bullet per functional change. Add the file alongside the code change — don't batch at the end.
+
+---
+
+## Merging to Main (via PR)
+
+1. Open a PR from `feature/<name>` or `bugfixes/<name>` into `main`.
+2. Use the changelog fragment content as the PR description body.
+3. Requires 1 approval and passing CI.
+4. After merge, `bump-version.yml` automatically increments `Minor`, updates the timestamp, and merges all `changes/*.md` fragments into `CHANGES.md`. The `docker-publish.yml` action then builds and pushes Docker images tagged with the new version.
+
+---
+
+## Stacked PRs
+
+For larger features, break the work into a stack of small focused PRs. Each PR targets the previous branch in the stack:
+
+```bash
+# Step 1 — targets main
+git checkout -b feature/foo-step-1
+gh pr create --base main --title "step 1: ..."
+
+# Step 2 — stacked on step 1
+git checkout -b feature/foo-step-2
+gh pr create --base feature/foo-step-1 --title "step 2: ..."
+```
+
+When a bottom PR merges, retarget the next one: `gh pr edit <number> --base main`.
+
+---
+
+## Image Channels
+
+The CI pipeline publishes Docker images on every merge to `main`:
+
+| Tag | Content | Who uses it |
+|-----|---------|-------------|
+| `:latest` | Last stable release | End users (default) |
+| `:edge` | Latest commit on `main` | Testers and developers |
+| `:5.2.0.0` | Exact pinned version | Production deployments |
+
+See [Docker Setup](docker-setup.md) for how to select a channel via `IMAGE_TAG`.

--- a/docs/architecture/docker-setup.md
+++ b/docs/architecture/docker-setup.md
@@ -67,9 +67,9 @@ The compose file uses the `IMAGE_TAG` variable to select which build to pull:
 
 | `IMAGE_TAG` | What you get | Who should use it |
 |---|---|---|
-| *(unset or blank)* | `:latest` — last stable release | Customers and production deployments |
-| `edge` | `:edge` — latest commit on `main`, may be unstable | Developers and testers who want the newest features |
-| `5.2.1.0` | Exact pinned version, never auto-updates | Customers who want to control upgrade timing |
+| *(unset or blank)* | `:latest` — last stable release, published when a release tag is cut | Customers and production deployments |
+| `edge` | `:edge` — latest commit on `main`, updated on every PR merge, may include unreleased features | Developers and testers |
+| `5.2.1.0` | Exact pinned version, never auto-updates | Production deployments needing controlled upgrade timing |
 
 The running version is always visible in the footer of the UI. Edge builds show an amber **edge** badge so it is immediately obvious which channel is running.
 
@@ -77,9 +77,12 @@ The running version is always visible in the footer of the UI. Edge builds show 
 # Run the stable release (default)
 docker compose -f docker-compose.prod.yml up -d --pull always
 
-# Run the edge build
+# Run the edge build (latest merged to main, may be unstable)
 IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d --pull always
 # or set IMAGE_TAG=edge in your .env
+
+# Run a specific pinned version
+IMAGE_TAG=5.2.0.0 docker compose -f docker-compose.prod.yml up -d --pull always
 ```
 
 ---

--- a/docs/architecture/docker-setup.md
+++ b/docs/architecture/docker-setup.md
@@ -8,20 +8,43 @@ Running Identity Atlas locally with Docker — three containers providing the fu
 
 The fastest way to try Identity Atlas — pulls pre-built images, no source code needed:
 
-```bash
-# 1. Download the compose file and environment template
-curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
-curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/setup/config/.env.example
+=== "Linux / macOS"
 
-# 2. Create your .env file
-cp .env.example .env
+    ```bash
+    # 1. Download the compose file and environment template
+    curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
+    curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/setup/config/.env.example
 
-# 3. Start everything (first run: ~2 min to pull images)
-docker compose -f docker-compose.prod.yml up -d
+    # 2. Create your .env file
+    cp .env.example .env
 
-# 4. Open the UI
-open http://localhost:3001
-```
+    # 3. Start everything (--pull always fetches the newest :latest from the registry)
+    docker compose -f docker-compose.prod.yml up -d --pull always
+
+    # 4. Open the UI
+    open http://localhost:3001
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    # 1. Download the compose file and environment template
+    Invoke-WebRequest `
+        -Uri https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml `
+        -OutFile docker-compose.prod.yml
+    Invoke-WebRequest `
+        -Uri https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/setup/config/.env.example `
+        -OutFile .env.example
+
+    # 2. Create your .env file
+    Copy-Item .env.example .env
+
+    # 3. Start everything (--pull always fetches the newest :latest from the registry)
+    docker compose -f docker-compose.prod.yml up -d --pull always
+
+    # 4. Open the UI
+    Start-Process http://localhost:3001
+    ```
 
 On first visit, the UI opens to the Dashboard. If no data is loaded yet, click **"Configure a crawler"** to go to Admin → Crawlers, then click **"Load Demo Data"** to populate the system with synthetic data (~30 seconds). After that, explore the Matrix, Users, Resources, and other pages.
 
@@ -52,10 +75,10 @@ The running version is always visible in the footer of the UI. Edge builds show 
 
 ```bash
 # Run the stable release (default)
-docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml up -d --pull always
 
 # Run the edge build
-IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d
+IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d --pull always
 # or set IMAGE_TAG=edge in your .env
 ```
 
@@ -102,27 +125,53 @@ happens inside the web container at startup via the migrations runner
 
 ## Quick Start (Developer)
 
-```powershell
-cd c:\Source\GitHub\IdentityAtlas
+=== "Linux / macOS"
 
-# Create your .env file from the template
-cp setup/config/.env.example .env
-# IMAGE_TAG is ignored by the dev compose (it builds from source).
-# You can leave the other defaults as-is for local development.
+    ```bash
+    cd /path/to/IdentityAtlas
 
-# Start the stack (first time takes ~3 min to build)
-docker compose up -d --build
+    # Create your .env file from the template
+    cp setup/config/.env.example .env
+    # IMAGE_TAG is ignored by the dev compose (it builds from source).
+    # You can leave the other defaults as-is for local development.
 
-# Verify
-docker compose ps
-# Expected: postgres (healthy), web (up), worker (up)
+    # Start the stack (first time takes ~3 min to build)
+    docker compose up -d --build
 
-# Open the UI — click "Load Demo Data" on the Crawlers page
-Start-Process http://localhost:3001
+    # Verify
+    docker compose ps
+    # Expected: postgres (healthy), web (up), worker (up)
 
-# Open Swagger docs
-Start-Process http://localhost:3001/api/docs
-```
+    # Open the UI — click "Load Demo Data" on the Crawlers page
+    open http://localhost:3001
+
+    # Open Swagger docs
+    open http://localhost:3001/api/docs
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    cd C:\path\to\IdentityAtlas
+
+    # Create your .env file from the template
+    Copy-Item setup/config/.env.example .env
+    # IMAGE_TAG is ignored by the dev compose (it builds from source).
+    # You can leave the other defaults as-is for local development.
+
+    # Start the stack (first time takes ~3 min to build)
+    docker compose up -d --build
+
+    # Verify
+    docker compose ps
+    # Expected: postgres (healthy), web (up), worker (up)
+
+    # Open the UI — click "Load Demo Data" on the Crawlers page
+    Start-Process http://localhost:3001
+
+    # Open Swagger docs
+    Start-Process http://localhost:3001/api/docs
+    ```
 
 > **Note:** `docker-compose.yml` (dev) builds images from source — `IMAGE_TAG` has no effect. Use `docker-compose.prod.yml` with `IMAGE_TAG=edge` if you want to run the pre-built edge image without a local build.
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -89,7 +89,7 @@ The v5 rewrite was executed in a single ~2-week feature branch (`feature/univers
 
 ## Version numbers
 
-v5 resets the major version. `ModuleVersion` follows `Major.Minor.yyyyMMdd.HHmm` per the branching strategy in CLAUDE.md. The `CHANGELOG.md` at the repo root is the authoritative per-release history; this document is the narrative.
+v5 resets the major version. `ModuleVersion` follows `Major.Minor.yyyyMMdd.HHmm` per the [branching and versioning strategy](architecture/branching-strategy.md). The `CHANGELOG.md` at the repo root is the authoritative per-release history; this document is the narrative.
 
 ## Acknowledgements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,11 +60,15 @@ A 4-layer scoring engine that classifies principals by risk without sending sens
 **Prerequisite:** Docker.
 
 ```bash
-# Download the production compose file
+# Download the compose file and environment template
 curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/setup/config/.env.example
 
-# Start the stack
-docker compose -f docker-compose.prod.yml up -d
+# Create your .env file (defaults are fine for local evaluation)
+cp .env.example .env
+
+# Start the stack (--pull always fetches the newest :latest from the registry)
+docker compose -f docker-compose.prod.yml up -d --pull always
 ```
 
 Open [http://localhost:3001](http://localhost:3001) → click **"Load Demo Data"** for instant gratification, or **"Connect Entra ID"** to wire up your own tenant via the in-browser wizard.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -116,8 +116,8 @@ image: ghcr.io/fortigi/identity-atlas-worker:latest
 with the explicit version tag:
 
 ```yaml
-image: ghcr.io/fortigi/identity-atlas:5.0.20260411.1955
-image: ghcr.io/fortigi/identity-atlas-worker:5.0.20260411.1955
+image: ghcr.io/fortigi/identity-atlas:5.2.0.0
+image: ghcr.io/fortigi/identity-atlas-worker:5.2.0.0
 ```
 
 Both images are always published with the same version tag, so they'll stay in sync.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,11 +74,30 @@ Open the UI at [http://localhost:3001](http://localhost:3001) and the Admin → 
 
 ---
 
+## Image channels
+
+Identity Atlas publishes two channels:
+
+| Channel | Tag | Updated when | Use it for |
+|---------|-----|-------------|-----------|
+| **Stable** | `:latest` | A new release is cut (e.g. `v5.2.0`) | Customers and production — default |
+| **Edge** | `:edge` | Every PR merges to `main` | Developers and testers who want unreleased features |
+
+Both channels also publish an exact version tag (`:5.2.0.0`, `:5.2.1.0`) at the same time as `:latest`, so you can pin to a specific build.
+
+```bash
+# Default: pull the latest stable release
+docker compose -f docker-compose.prod.yml up -d --pull always
+
+# Edge: latest commit on main (may include unreleased features)
+IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d --pull always
+```
+
+---
+
 ## Upgrading to a new version
 
-Identity Atlas publishes new images to `ghcr.io/fortigi/identity-atlas{,-worker}` on every push to `main`. The `:latest` tag always points at the newest build, and each build also gets a version-stamped tag (`5.0.yyyyMMdd.HHmm`) for reproducible deployments.
-
-To upgrade an existing deployment to the newest version:
+To upgrade an existing deployment to the newest stable release:
 
 === "Linux / macOS"
 
@@ -98,8 +117,8 @@ The database volume is preserved across upgrades — any data you have loaded st
 
 Three ways to see which version is currently deployed:
 
-1. **Dashboard** — open [http://localhost:3001](http://localhost:3001); the Version card on the right shows `v5.0.yyyyMMdd.HHmm`.
-2. **API endpoint** — `Invoke-RestMethod http://localhost:3001/api/version` (or `curl` on Linux/macOS). Returns `{ "version": "5.0.yyyyMMdd.HHmm" }`.
+1. **Dashboard** — open [http://localhost:3001](http://localhost:3001); the Version card in the footer shows the version. Stable releases show `v5.2.0.0`; edge builds show `v5.3.20260419.1430` with an amber **edge** badge.
+2. **API endpoint** — `Invoke-RestMethod http://localhost:3001/api/version` (or `curl` on Linux/macOS). Returns `{ "version": "5.2.0.0" }`.
 3. **Docker directly** — `docker compose -f docker-compose.prod.yml images` lists the image tag each container is running.
 
 Compare that against the newest tag on [ghcr.io/fortigi/identity-atlas](https://github.com/Fortigi/IdentityAtlas/pkgs/container/identity-atlas) to see whether an upgrade is available.

--- a/docs/ui/local-dev.md
+++ b/docs/ui/local-dev.md
@@ -21,9 +21,41 @@ The PostgreSQL port `5432` is exposed to the host for direct database access dur
 
 ## Start the Stack
 
-```bash
-docker compose up -d
-```
+First, create your `.env` file from the template (only needed once):
+
+=== "Linux / macOS"
+
+    ```bash
+    cp setup/config/.env.example .env
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    Copy-Item setup/config/.env.example .env
+    ```
+
+Then start the stack. Use `--build` on the first run (or after pulling new commits) to build the images from source:
+
+=== "Linux / macOS"
+
+    ```bash
+    # First run or after code changes — builds images from source (~3 min)
+    docker compose up -d --build
+
+    # Subsequent runs (images already built)
+    docker compose up -d
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    # First run or after code changes — builds images from source (~3 min)
+    docker compose up -d --build
+
+    # Subsequent runs (images already built)
+    docker compose up -d
+    ```
 
 This starts:
 
@@ -52,13 +84,25 @@ The worker runs every minute and picks up queued jobs. Live progress is shown on
 
 ## Stopping and Resetting
 
-```bash
-# Stop the stack (data persists in the postgres_data volume)
-docker compose down
+=== "Linux / macOS"
 
-# Stop and delete all data (full reset)
-docker compose down -v
-```
+    ```bash
+    # Stop the stack (data persists in the postgres_data volume)
+    docker compose down
+
+    # Stop and delete all data (full reset)
+    docker compose down -v
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    # Stop the stack (data persists in the postgres_data volume)
+    docker compose down
+
+    # Stop and delete all data (full reset)
+    docker compose down -v
+    ```
 
 ## Building the Image Manually
 


### PR DESCRIPTION
## Summary

- Added `docs/architecture/branching-strategy.md` — full branching model, version format, changelog fragment instructions, release and hotfix workflows, stacked PRs pattern, and image channels table
- Added `--pull always` to all Quick Start commands (README, quickstart.md, docker-setup.md, index.md) so users always get the newest image from the registry
- Added `.env` setup step (copy from template) to all Quick Start sections that were missing it
- Added tabbed Linux/macOS vs Windows code blocks throughout docker-setup.md and local-dev.md
- Fixed version pinning example to use release format (`5.2.0.0`) instead of edge timestamp format
- Fixed history.md to link to the new branching-strategy.md doc instead of CLAUDE.md
- Aligned local-dev.md with docker-setup.md: added `--build` note for first run, tabbed stop/reset commands
- Updated branching-strategy.md, docker-setup.md, and quickstart.md to reflect the tag-based release model from #112: `:latest` is published when a release tag is cut, `:edge` on every PR merge to `main`; added Image Channels section to quickstart.md

## Dependency

> ⚠️ **Merge after #112.** This PR documents the tag-based release model introduced in #112. If merged first, the branching strategy and channel descriptions will be slightly ahead of the actual CI behaviour.

## Test plan

- [ ] Verify `docs/architecture/branching-strategy.md` renders correctly in MkDocs (tabs, tables, code blocks)
- [ ] Verify tabbed blocks in docker-setup.md and local-dev.md render as tabs in MkDocs Material
- [ ] Confirm README.md Quick Start command includes `--pull always`
- [ ] Confirm Image Channels section in quickstart.md correctly describes `:latest` vs `:edge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)