### PR TITLE
fix: add run summary to cut-release workflow explaining the PR banner

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -79,3 +79,19 @@ jobs:
           echo "✅ docker-publish triggered for ${BRANCH} (will publish :latest + :${NEW_VERSION})"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post run summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## ✅ Release branch created
+
+          | | |
+          |---|---|
+          | **Branch** | \`${BRANCH}\` |
+          | **Version** | \`${NEW_VERSION}\` |
+
+          ### Next steps
+          - Bugfixes targeting this release go on \`bugfixes/<name>\` branched from \`${BRANCH}\`, then PR **into** \`${BRANCH}\` (not into \`main\`).
+          - GitHub will show a **"Compare & pull request"** banner for the new branch — **dismiss it**. That banner always targets \`main\` and is not the right direction for release bugfixes.
+          - After a bugfix is merged into \`${BRANCH}\`, cherry-pick the commit to \`main\` via a separate PR so the fix is included in future feature releases.
+          EOF


### PR DESCRIPTION
## Summary

- Added a job summary step at the end of `cut-release.yml` that renders in the GitHub Actions run page
- The summary shows the branch name, version, and explicit next-step instructions
- Warns developers to **dismiss** the "Compare & pull request" banner GitHub automatically shows after any branch push — that banner always targets `main` and is not the right direction for release bugfixes

## Why

GitHub has no API to suppress the "Compare & pull request" banner. The only practical mitigation is to make the correct guidance clearly visible in the Actions run summary so the person who triggered the workflow sees it immediately.

## Test plan

- [ ] Run the Cut Release workflow for a test version
- [ ] Verify the Actions run summary page shows the branch, version, and next-step guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)