### PR TITLE
feat: replace release branches with tag-based release model

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,17 +1,18 @@
 # ─── Version Bump + Changelog Merge on PR Merge ──────────────────────────────
-# On every PR merge this workflow:
+# On every PR merge to main this workflow:
 #   1. Collects all fragment files from changes/*.md and prepends them to
 #      CHANGES.md, then deletes the fragments.
-#   2. Bumps the version in setup/IdentityAtlas.psd1:
-#      - main:        increments Minor, updates timestamp  → Major.Minor.yyyyMMdd.HHmm
-#      - release/v*:  increments Patch                    → Major.Minor.Patch.0
+#   2. Increments Minor and updates the timestamp → Major.Minor.yyyyMMdd.HHmm
 #
 # Branches never touch CHANGES.md or the version file directly — each branch
 # creates a uniquely named fragment file in changes/ instead, so merge
 # conflicts on those two files are eliminated.
 #
 # After the commit lands, docker-publish.yml is triggered via workflow_run
-# so Docker images are always tagged with the new (post-bump) version.
+# so Docker images are always tagged with the new (post-bump) version (:edge).
+#
+# Releases are handled separately via git tags (Actions → Cut Release),
+# not by this workflow.
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: Bump version on PR merge
@@ -21,7 +22,6 @@ on:
     types: [closed]
     branches:
       - main
-      - 'release/**'
 
 jobs:
   bump-version:
@@ -31,27 +31,14 @@ jobs:
       contents: write
 
     steps:
-      - name: Determine target branch
-        id: branch
-        run: |
-          TARGET="${{ github.event.pull_request.base.ref }}"
-          echo "name=$TARGET" >> "$GITHUB_OUTPUT"
-          if [[ "$TARGET" == release/* ]]; then
-            echo "type=release" >> "$GITHUB_OUTPUT"
-          else
-            echo "type=main" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v4
         with:
-          ref: ${{ steps.branch.outputs.name }}
+          ref: main
           token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Merge changelog fragments and bump version
         shell: pwsh
         run: |
-          $branchType = "${{ steps.branch.outputs.type }}"
-
           # ── 1. Collect changelog fragments from changes/*.md ──────────────
           $fragments = Get-ChildItem changes/*.md -ErrorAction SilentlyContinue | Sort-Object Name
           if ($fragments) {
@@ -65,39 +52,20 @@ jobs:
             Write-Host "No changelog fragments found in changes/ -- skipping CHANGES.md update"
           }
 
-          # ── 2. Bump version in setup/IdentityAtlas.psd1 ───────────────────
+          # ── 2. Increment Minor + update timestamp → Major.Minor.yyyyMMdd.HHmm
           $content = Get-Content setup/IdentityAtlas.psd1 -Raw
-
-          if ($branchType -eq 'release') {
-            # Release branch: increment Patch → Major.Minor.Patch.0
-            if ($content -match "ModuleVersion\s*=\s*'(\d+)\.(\d+)\.(\d+)\.(\d+)'") {
-              $major = $Matches[1]
-              $minor = $Matches[2]
-              $patch = [int]$Matches[3] + 1
-              $newVer = "$major.$minor.$patch.0"
-              $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
-              Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
-              Write-Host "Bumped to $newVer (release patch)"
-              "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
-            } else {
-              Write-Error "Could not find ModuleVersion in setup/IdentityAtlas.psd1"
-              exit 1
-            }
+          if ($content -match "ModuleVersion\s*=\s*'(\d+)\.(\d+)\.\d+\.\d+'") {
+            $major  = $Matches[1]
+            $minor  = [int]$Matches[2] + 1
+            $stamp  = (Get-Date -Format 'yyyyMMdd.HHmm')
+            $newVer = "$major.$minor.$stamp"
+            $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
+            Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
+            Write-Host "Bumped to $newVer"
+            "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
           } else {
-            # Main branch: increment Minor, update timestamp → Major.Minor.yyyyMMdd.HHmm
-            if ($content -match "ModuleVersion\s*=\s*'(\d+)\.(\d+)\.\d+\.\d+'") {
-              $major  = $Matches[1]
-              $minor  = [int]$Matches[2] + 1
-              $stamp  = (Get-Date -Format 'yyyyMMdd.HHmm')
-              $newVer = "$major.$minor.$stamp"
-              $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
-              Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
-              Write-Host "Bumped to $newVer (main dev build)"
-              "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
-            } else {
-              Write-Error "Could not find ModuleVersion in setup/IdentityAtlas.psd1"
-              exit 1
-            }
+            Write-Error "Could not find ModuleVersion in setup/IdentityAtlas.psd1"
+            exit 1
           }
 
       - name: Commit and push

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -1,0 +1,78 @@
+# ─── Cut a Hotfix Release ─────────────────────────────────────────────────────
+# Manually triggered. Tags the HEAD of a hotfix branch with a new patch version,
+# triggering docker-publish to build :latest + :X.Y.Z.0.
+#
+# Usage:
+#   1. git checkout -b bugfixes/fix-foo v5.2.0   ← branch from the release tag
+#   2. Fix the bug, push the branch
+#   3. Go to Actions → Cut Hotfix → Run workflow
+#   4. Enter the branch name and new version (e.g. "5.2.1")
+#   5. After the hotfix ships, open a PR to cherry-pick the fix into main
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Cut Hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Hotfix branch name (e.g. bugfixes/fix-login-crash)'
+        required: true
+      version:
+        description: 'New version (major.minor.patch, e.g. "5.2.1")'
+        required: true
+
+jobs:
+  cut-hotfix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Validate version input
+        run: |
+          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be in Major.Minor.Patch format (e.g. 5.2.1)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.VERSION_BUMP_PAT }}
+
+      - name: Create and push hotfix tag
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          TAG="v${VERSION}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Hotfix release $TAG"
+          git push origin "$TAG"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          COMMIT=$(git rev-parse --short HEAD)
+          echo "COMMIT=$COMMIT" >> "$GITHUB_ENV"
+          echo "✅ Tagged ${TAG} on ${COMMIT}"
+
+      - name: Post run summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## ✅ Hotfix tagged
+
+          | | |
+          |---|---|
+          | **Tag** | \`${TAG}\` |
+          | **Version** | \`${VERSION}.0\` |
+          | **Branch** | \`${{ github.event.inputs.branch }}\` |
+          | **Commit** | \`${COMMIT}\` |
+
+          docker-publish is now building \`:latest\` + \`:${VERSION}.0\` — check the [Actions tab](../../actions) for progress.
+
+          ### Next step — cherry-pick to main
+          \`\`\`bash
+          git checkout main && git pull
+          git cherry-pick ${COMMIT}
+          gh pr create --base main --title "fix: cherry-pick hotfix from ${TAG}"
+          \`\`\`
+          EOF

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,24 +1,26 @@
-# ─── Cut a Release Branch ─────────────────────────────────────────────────────
-# Manually triggered. Creates release/vX.Y from main, sets the version to
-# X.Y.0.0, then triggers docker-publish to build and push the initial
-# :latest image for that version.
+# ─── Cut a Release ────────────────────────────────────────────────────────────
+# Manually triggered. Tags the current main HEAD with vX.Y.Z and lets
+# docker-publish (triggered by the tag push) build and push :latest + :X.Y.Z.0.
 #
 # Usage:
-#   1. Go to Actions → Cut Release Branch → Run workflow
-#   2. Enter the version (e.g. "5.2" — major.minor only, no patch)
-#   3. The workflow creates release/v5.2, sets ModuleVersion = 5.2.0.0,
-#      and publishes ghcr.io/fortigi/identity-atlas:latest + :5.2.0.0
-#   4. Bugfixes targeting that release are PRed into release/v5.2
-#   5. Each merge bumps patch and republishes: 5.2.0.0 → 5.2.1.0 → 5.2.2.0 ...
+#   1. Go to Actions → Cut Release → Run workflow
+#   2. Enter the version (e.g. "5.2.0" — major.minor.patch)
+#   3. The workflow creates tag v5.2.0 on the current main HEAD
+#   4. docker-publish builds and pushes :latest + :5.2.0.0
+#
+# Hotfixes (shipping a bugfix without including features already on main):
+#   1. git checkout -b bugfixes/fix-foo v5.2.0   ← branch from the tag, not main
+#   2. Fix the bug, push the branch
+#   3. Run Actions → Cut Hotfix with the branch name and new version (e.g. 5.2.1)
 # ─────────────────────────────────────────────────────────────────────────────
 
-name: Cut Release Branch
+name: Cut Release
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (major.minor only, e.g. "5.2")'
+        description: 'Release version (major.minor.patch, e.g. "5.2.0")'
         required: true
 
 jobs:
@@ -26,13 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
 
     steps:
       - name: Validate version input
         run: |
-          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+$'; then
-            echo "::error::Version must be in Major.Minor format (e.g. 5.2)"
+          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be in Major.Minor.Patch format (e.g. 5.2.0)"
             exit 1
           fi
 
@@ -40,42 +41,37 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.VERSION_BUMP_PAT }}
-          fetch-depth: 0
 
-      - name: Create release branch and set version
-        shell: pwsh
+      - name: Create and push release tag
         run: |
-          $version  = "${{ github.event.inputs.version }}"
-          $branch   = "release/v$version"
-          $newVer   = "$version.0.0"
-
-          # Create and push the branch
-          git checkout -b $branch
-          Write-Host "Created branch $branch"
-
-          # Set version to Major.Minor.0.0
-          $content = Get-Content setup/IdentityAtlas.psd1 -Raw
-          $content = $content -replace "ModuleVersion\s*=\s*'\d+\.\d+\.\d+\.\d+'", "ModuleVersion = '$newVer'"
-          Set-Content setup/IdentityAtlas.psd1 $content -NoNewline
-          Write-Host "Set ModuleVersion to $newVer"
-
-          "NEW_VERSION=$newVer" | Out-File -Append $env:GITHUB_ENV
-          "BRANCH=$branch"      | Out-File -Append $env:GITHUB_ENV
-
-      - name: Commit and push
-        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          TAG="v${VERSION}"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add setup/IdentityAtlas.psd1
-          git commit -m "chore: cut release branch, set version to ${NEW_VERSION}"
-          git push origin "${BRANCH}"
-          echo "✅ Release branch ${BRANCH} created at version ${NEW_VERSION}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "✅ Tagged ${TAG} on $(git rev-parse --short HEAD)"
 
-      - name: Trigger docker-publish for initial release image
+      - name: Post run summary
         run: |
-          gh workflow run docker-publish.yml \
-            --ref main \
-            --field branch="${BRANCH}"
-          echo "✅ docker-publish triggered for ${BRANCH} (will publish :latest + :${NEW_VERSION})"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## ✅ Release tagged
+
+          | | |
+          |---|---|
+          | **Tag** | \`${TAG}\` |
+          | **Version** | \`${VERSION}.0\` |
+          | **Commit** | \`$(git rev-parse --short HEAD)\` |
+
+          docker-publish is now building \`:latest\` + \`:${VERSION}.0\` — check the [Actions tab](../../actions) for progress.
+
+          ### Hotfix workflow (if a bug is found in this release)
+          \`\`\`bash
+          git checkout -b bugfixes/fix-foo ${TAG}   # branch from the tag, not main
+          # fix the bug, commit, push
+          git push origin bugfixes/fix-foo
+          # then run Actions → Cut Hotfix
+          \`\`\`
+          EOF

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,9 +8,9 @@
 #   ghcr.io/fortigi/identity-atlas         — Node.js API + React frontend (web service)
 #   ghcr.io/fortigi/identity-atlas-worker  — PowerShell worker (crawlers, risk scoring)
 #
-# Tags pushed depend on the source branch:
-#   main:         edge  + Major.Minor.yyyyMMdd.HHmm   (dev builds, not :latest)
-#   release/v*:   latest + Major.Minor.Patch.0         (stable customer releases)
+# Tags pushed depend on the trigger:
+#   main (via bump-version):  :edge  + Major.Minor.yyyyMMdd.HHmm
+#   v* tag push:              :latest + Major.Minor.Patch.0
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: Publish Docker Images
@@ -21,11 +21,13 @@ on:
     types: [completed]
     branches:
       - main
-      - 'release/**'
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to build from (main or release/vX.Y)'
+      ref:
+        description: 'Branch or tag to build from (e.g. main, v5.2.0)'
         required: true
         default: 'main'
 
@@ -38,39 +40,55 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Determine source branch and image tags
+      - name: Determine ref and channel
         id: config
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BRANCH="${{ github.event.inputs.branch }}"
+          EVENT="${{ github.event_name }}"
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            REF="${{ github.event.inputs.ref }}"
+          elif [ "$EVENT" = "push" ]; then
+            # Tag push: github.ref_name = v5.2.0
+            REF="${{ github.ref_name }}"
           else
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            # workflow_run from bump-version on main
+            REF="${{ github.event.workflow_run.head_branch }}"
           fi
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
-          if [[ "$BRANCH" == release/* ]]; then
+          if [[ "$REF" == v* ]]; then
+            # Release tag: v5.2.0 → version 5.2.0.0
+            VERSION="${REF#v}.0"
             echo "channel=release" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "use_tag_version=true" >> "$GITHUB_OUTPUT"
           else
             echo "channel=main" >> "$GITHUB_OUTPUT"
+            echo "use_tag_version=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ steps.config.outputs.branch }}
+          ref: ${{ steps.config.outputs.ref }}
 
-      - name: Extract version from manifest
+      - name: Extract version
         id: version
         shell: bash
         run: |
-          version=$(grep -oP "ModuleVersion\s*=\s*'\K[^']+" setup/IdentityAtlas.psd1)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Module version: $version"
+          if [ "${{ steps.config.outputs.use_tag_version }}" = "true" ]; then
+            echo "version=${{ steps.config.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "Version from tag: ${{ steps.config.outputs.version }}"
+          else
+            version=$(grep -oP "ModuleVersion\s*=\s*'\K[^']+" setup/IdentityAtlas.psd1)
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "Version from psd1: $version"
+          fi
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -163,7 +181,7 @@ jobs:
         run: docker compose -f docker-compose.qa.yml down -v 2>/dev/null || true
 
       # ── Push images (only reached if smoke test passed) ─────────────
-      - name: Push web image (release → latest)
+      - name: Push web image (release tag → latest)
         if: steps.config.outputs.channel == 'release'
         uses: docker/build-push-action@v6
         with:
@@ -177,7 +195,7 @@ jobs:
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
 
-      - name: Push worker image (release → latest)
+      - name: Push worker image (release tag → latest)
         if: steps.config.outputs.channel == 'release'
         uses: docker/build-push-action@v6
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,47 +32,46 @@ Identity Atlas is a Docker-deployed application that pulls authorization data fr
 | Branch | Purpose | PR required? | Approval required? |
 |--------|---------|-------------|-------------------|
 | `main` | Integration trunk. Never commit directly. Merges push `:edge` Docker tag. | Yes | Yes (at least 1) |
-| `release/vX.Y` | Stable customer release line. Cut from `main` via `cut-release.yml`. Merges push `:latest` Docker tag. | Yes | No |
 | `feature/<name>` | All feature work. Created from `main`. Merged back to `main` via PR. | Yes (to `main`) | No |
-| `bugfixes/<name>` | Bug fixes. Branch from `release/vX.Y` for production hotfixes, or from `main` for pre-release fixes. | Yes | No |
+| `bugfixes/<name>` | Bug fixes. Branch from `main` for pre-release fixes; branch from a **release tag** for hotfixes. | Yes (to `main`) | No |
 
 **Rules:**
 - `feature/` branches must be branched off `main`.
-- `bugfixes/` branches branch from **`release/vX.Y`** when fixing a production issue (customers are affected), or from `main` when fixing something not yet released.
-- Production bugfixes merged to `release/vX.Y` must also be cherry-picked to `main` so the fix is included in future feature releases.
-- All merges go through a Pull Request — no direct pushes to `main` or `release/*` ever.
+- `bugfixes/` branches branch from `main` for pre-release fixes. For hotfixes to an already-released version, branch from the release tag: `git checkout -b bugfixes/fix-foo v5.2.0`.
+- Hotfix commits must be cherry-picked back to `main` via a separate PR so the fix is included in future releases.
+- All merges go through a Pull Request — no direct pushes to `main` ever.
 - Branch names: `feature/<short-descriptive-name>` or `bugfixes/<short-descriptive-name>` (lowercase, hyphens). Example: `feature/risk-score-export`, `bugfixes/fix-login-redirect`.
-- When starting work, always create a new branch. Never work directly on `main` or `release/*`.
+- When starting work, always create a new branch. Never work directly on `main`.
 - **One issue per branch.** Each branch must fix exactly one issue or implement exactly one feature. Never combine fixes for separate, unrelated issues into a single branch or PR. Exception: if a single code change genuinely resolves more than one issue (e.g. the same root cause), both issue numbers may be referenced in the commit and PR — but this should be rare and the connection must be explicit.
 
 ### Version Number Scheme
 
 Two formats, both 4-part (PowerShell-compatible):
 
-| Branch | Version format | Example | Docker tag pushed |
-|--------|---------------|---------|-------------------|
-| `main` | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` | `:edge` |
-| `release/vX.Y` | `Major.Minor.Patch.0` | `5.2.1.0` | `:latest` |
+| Context | Version format | Example | Docker tag pushed |
+|---------|---------------|---------|-------------------|
+| `main` dev builds | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` | `:edge` |
+| Release tags (`v*`) | `Major.Minor.Patch.0` | `5.2.1.0` | `:latest` |
 | `feature/*` / `bugfixes/*` | — | — | Nobody |
 
-The timestamp format on `main` makes dev builds instantly recognisable. The semantic `Patch.0` format on release branches gives customers a clear upgrade path.
+The timestamp format on `main` makes dev builds instantly recognisable. Release versions use `Major.Minor.Patch.0` (patch increments for each hotfix).
 
 **Who updates versions:**
 
-| Branch | Who updates it | When |
-|--------|---------------|------|
-| `main` | `bump-version.yml` (automated) | Every PR merge — increments `Minor`, updates timestamp |
-| `release/vX.Y` | `bump-version.yml` (automated) | Every PR merge — increments `Patch` (e.g. `5.2.0.0` → `5.2.1.0`) |
+| Context | Who updates it | When |
+|---------|---------------|------|
+| `main` dev builds | `bump-version.yml` (automated) | Every PR merge — increments `Minor`, updates timestamp |
+| Release tags | `cut-release.yml` / `cut-hotfix.yml` (automated) | When you run Actions → Cut Release or Cut Hotfix |
 | `feature/*` / `bugfixes/*` | **Nobody** | Never touch `setup/IdentityAtlas.psd1` on a branch |
 
 **How to apply:**
 
 1. **Starting a feature or pre-release bugfix branch**: Branch from `main`. Leave `setup/IdentityAtlas.psd1` untouched.
-2. **Starting a production hotfix branch**: Branch from `release/vX.Y`. Leave `setup/IdentityAtlas.psd1` untouched.
+2. **Starting a hotfix branch**: Branch from the release tag (`git checkout -b bugfixes/fix-foo v5.2.0`). Leave `setup/IdentityAtlas.psd1` untouched.
 3. **After any code change on a branch**: Add bullets to `changes/<branch-name>.md`. Do not edit `CHANGES.md` or `ModuleVersion`.
 4. **When merging → main via PR**: `bump-version.yml` increments Minor + timestamp. `docker-publish.yml` builds and pushes `:edge` + versioned tag.
-5. **When merging → release/vX.Y via PR**: `bump-version.yml` increments Patch. `docker-publish.yml` builds and pushes `:latest` + versioned tag.
-6. **Cutting a new release**: Run the `cut-release.yml` workflow (Actions → Cut Release Branch → enter `Major.Minor`). It creates `release/vX.Y` from `main` and sets the version to `X.Y.0.0`.
+5. **Cutting a release**: Run Actions → Cut Release, enter `Major.Minor.Patch` (e.g. `5.2.0`). Tags `v5.2.0` on current `main` HEAD; `docker-publish.yml` pushes `:latest` + `:5.2.0.0`.
+6. **Shipping a hotfix**: Run Actions → Cut Hotfix, enter the branch name and new version (e.g. `5.2.1`). Tags `v5.2.1` on the hotfix branch HEAD; `docker-publish.yml` pushes `:latest` + `:5.2.1.0`.
 7. **Major version bump**: Edit `setup/IdentityAtlas.psd1` manually on `main` (via a PR) for a breaking change. Increment `Major`, reset `Minor` to `0`.
 
 ### Changelog fragments (replaces direct CHANGES.md edits)
@@ -748,7 +747,7 @@ These steps are required once when creating or transferring the repository. They
 
 | Secret | Required scopes | Purpose |
 |--------|----------------|---------|
-| `VERSION_BUMP_PAT` | `repo` (includes `contents:write`) | Lets `bump-version.yml` and `cut-release.yml` push commits directly to protected branches (`main`, `release/**`). The PAT owner **must have the admin role** on the repository so the bypass actor rule on `release/**` applies. |
+| `VERSION_BUMP_PAT` | `repo` (includes `contents:write`) | Lets `bump-version.yml`, `cut-release.yml`, and `cut-hotfix.yml` push tags and commits to `main`. |
 
 ### Branch protection
 
@@ -760,7 +759,7 @@ bash tools/setup-branch-protection.sh Fortigi/IdentityAtlas
 
 This sets:
 - `main` — PR required (1 approval), `PR Summary` check required, admins bypass
-- `release/**` — PR required (0 approvals), `PR Summary` check required, no force-push, no deletion, admins bypass
+- Tags are immutable by default in GitHub — no extra protection needed
 
 ---
 
@@ -774,37 +773,21 @@ git checkout main && git pull
 git checkout -b feature/<name>      # e.g. feature/risk-score-export
 ```
 
-**Pre-release bugfix (bug is in main, not yet in a release):**
+**Pre-release bugfix (bug is in main, not yet released):**
 ```bash
 git checkout main && git pull
 git checkout -b bugfixes/<name>     # e.g. bugfixes/fix-login-redirect
 ```
 
-**Production hotfix (bug is in a released version, customers are affected):**
+**Hotfix (bug is in a released version — ship the fix without including unreleased features):**
 ```bash
-# Step 1 — fix on the release branch
-git checkout release/v5.2 && git pull
-git checkout -b bugfixes/<name>
-# ... make the fix, add changes/<name>.md fragment, commit ...
-gh pr create --base release/v5.2 --title "fix: ..."
-# merge the PR → bump-version bumps patch, docker-publish pushes :latest
-
-# Step 2 — bring the fix into main via its own PR (main is protected, no direct commits)
-git checkout main && git pull
-git checkout -b bugfixes/<name>-main
-git cherry-pick <fix-commit-sha>    # the fix commit only, not the version bump commit
-gh pr create --base main --title "fix: ... (cherry-pick from release/v5.2)"
-# merge the PR → bump-version bumps minor on main as normal
+# Branch from the release tag, not from main
+git checkout -b bugfixes/<name> v5.2.0
+# ... make the fix, add changes/<name>.md fragment, commit, push ...
+git push origin bugfixes/<name>
+# Then run Actions → Cut Hotfix with the branch name and new version (e.g. 5.2.1)
+# After the hotfix ships, cherry-pick the fix to main via a separate PR
 ```
-
-### Cutting a New Release
-
-When `main` is stable and ready to ship to customers:
-
-1. Go to **Actions → Cut Release Branch → Run workflow**
-2. Enter the version, e.g. `5.3` (Major.Minor only)
-3. The workflow creates `release/v5.3` from `main` and sets version to `5.3.0.0`
-4. Merges to `release/v5.3` push `:latest` to customers
 
 ### Making Changes
 
@@ -843,19 +826,35 @@ When a bottom PR merges, retarget the next one: `gh pr edit <number> --base main
 3. Requires 1 approval — merge when CI passes
 4. After merge: `bump-version.yml` increments Minor + timestamp; `docker-publish.yml` pushes `:edge`
 
-### Merging to a Release Branch (production hotfix)
+### Cutting a Release
 
-1. Open PR from `bugfixes/<name>` into `release/vX.Y`
-2. Use the fragment content from `changes/<branch-name>.md` as the PR description
-3. Merge when CI passes
-4. After merge: `bump-version.yml` increments Patch; `docker-publish.yml` pushes `:latest`
-5. Cherry-pick the fix to `main`: `git checkout main && git cherry-pick <sha>`
+When `main` is stable and ready to ship to customers:
+
+1. Go to **Actions → Cut Release → Run workflow**
+2. Enter the version: `Major.Minor.Patch` (e.g. `5.2.0`)
+3. The workflow creates tag `v5.2.0` on the current `main` HEAD
+4. `docker-publish.yml` triggers automatically and pushes `:latest` + `:5.2.0.0`
+
+### Hotfix Releases (shipping a fix without unreleased features)
+
+```bash
+# 1. Branch from the release tag — NOT from main
+git checkout -b bugfixes/fix-foo v5.2.0
+
+# 2. Fix, commit, push
+git push origin bugfixes/fix-foo
+```
+
+3. Go to **Actions → Cut Hotfix → Run workflow**
+4. Enter the branch name and new version (e.g. `5.2.1`)
+5. `docker-publish.yml` triggers on the new tag and pushes `:latest` + `:5.2.1.0`
+6. Cherry-pick the fix to `main`: open a PR from a cherry-pick branch into `main`
 
 ### Version Updates
 
 See the **Branching & Versioning Strategy** section above for the full scheme.
 - `main` merges → `Major.Minor.yyyyMMdd.HHmm` → `:edge` Docker tag
-- `release/*` merges → `Major.Minor.Patch.0` → `:latest` Docker tag
+- Release tags (`v*`) → `Major.Minor.Patch.0` → `:latest` Docker tag
 
 ## User Workflow (Getting Started)
 

--- a/changes/feature-tag-based-releases.md
+++ b/changes/feature-tag-based-releases.md
@@ -1,0 +1,4 @@
+- Replaced long-lived release branches with git tags for release management — hotfixes now ship only the fix, without features already merged to main
+- Added "Cut Release" workflow: tags vX.Y.Z on main HEAD, triggers :latest publish
+- Added "Cut Hotfix" workflow: tags a hotfix branch commit as a new patch version, triggers :latest publish
+- Removed release branch concept — no more "Compare & pull request" banner confusion after cutting a release

--- a/docs/architecture/branching-strategy.md
+++ b/docs/architecture/branching-strategy.md
@@ -1,0 +1,159 @@
+# Branching and Versioning Strategy
+
+This document covers branch naming, PR rules, version format, and the release workflow for contributors.
+
+---
+
+## Branch Model
+
+| Branch | Purpose | PR required? | Approval required? |
+|--------|---------|-------------|-------------------|
+| `main` | Stable trunk. Never commit directly. | Yes | Yes (at least 1) |
+| `feature/<name>` | All feature work. Created from `main`. Merged back to `main` via PR. | Yes | No |
+| `bugfixes/<name>` | Bug fixes. Branch from `main` for pre-release fixes; branch from a **release tag** for hotfixes. | Yes (to `main`) | No |
+
+**Rules:**
+
+- `feature/` branches must be branched off `main`.
+- `bugfixes/` branches branch from `main` for pre-release fixes. For hotfixes to an already-released version, branch from the release tag (e.g. `git checkout -b bugfixes/fix-foo v5.2.0`).
+- All merges to `main` go through a Pull Request — no direct pushes.
+- Branch names: lowercase, hyphens. Examples: `feature/risk-score-export`, `bugfixes/fix-login-redirect`.
+- **One issue per branch.** Each branch fixes exactly one issue or implements exactly one feature. Never combine unrelated fixes into a single branch or PR.
+
+---
+
+## Starting New Work
+
+```bash
+# Feature or pre-release bugfix — branch from main
+git checkout main && git pull
+git checkout -b feature/<name>
+# or
+git checkout -b bugfixes/<name>
+
+# Hotfix to a released version — branch from the release tag
+git checkout -b bugfixes/<name> v5.2.0
+```
+
+---
+
+## Version Number Format
+
+Two version formats, both PowerShell-compatible (4-part):
+
+| Context | Format | Example |
+|---------|--------|---------|
+| `main` dev builds | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` |
+| Release tags | `Major.Minor.Patch.0` | `5.2.1.0` |
+
+**Who updates what:**
+
+| Action | Who | When |
+|--------|-----|------|
+| `Minor` bump + timestamp | `bump-version.yml` GitHub Action | Automatically on every PR merge to `main` |
+| Release version | `cut-release.yml` GitHub Action | When you run Actions → Cut Release |
+| Hotfix version | `cut-hotfix.yml` GitHub Action | When you run Actions → Cut Hotfix |
+| `Major` bump | Developer, via PR to `main` | Only for breaking changes |
+| Branch work | Nobody | Never touch `setup/IdentityAtlas.psd1` on a branch |
+
+---
+
+## Changelog Fragments
+
+Every `feature/` or `bugfixes/` branch must include a changelog fragment. **Never edit `CHANGES.md` directly** — the `bump-version.yml` CI action merges all fragments on PR merge.
+
+**File:** `changes/<descriptive-name>.md` (e.g. `changes/fix-login-redirect.md`)
+
+**Format:**
+
+```markdown
+- Fixed the login redirect when auth is enabled and no session exists
+- Improved error message when tenant ID is missing
+```
+
+Write in user-facing language. One bullet per functional change. Add the file alongside the code change — don't batch at the end.
+
+---
+
+## Merging to Main (via PR)
+
+1. Open a PR from `feature/<name>` or `bugfixes/<name>` into `main`.
+2. Use the changelog fragment content as the PR description body.
+3. Requires 1 approval and passing CI.
+4. After merge, `bump-version.yml` automatically increments `Minor`, updates the timestamp, and merges all `changes/*.md` fragments into `CHANGES.md`. The `docker-publish.yml` action then builds and pushes Docker images tagged `:edge`.
+
+---
+
+## Cutting a Release
+
+When `main` is stable and ready to ship to customers:
+
+1. Go to **Actions → Cut Release → Run workflow**
+2. Enter the version: `Major.Minor.Patch` (e.g. `5.2.0`)
+3. The workflow creates tag `v5.2.0` on the current `main` HEAD
+4. `docker-publish.yml` triggers automatically on the tag push and builds `:latest` + `:5.2.0.0`
+
+Customers who track `:latest` will receive the new version automatically on their next `docker compose pull`.
+
+---
+
+## Hotfix Releases
+
+To ship a bugfix without including features that are already on `main`:
+
+```bash
+# 1. Branch from the release tag, not from main
+git checkout -b bugfixes/fix-login-crash v5.2.0
+
+# 2. Fix the bug, commit
+git add ...
+git commit -m "fix: ..."
+
+# 3. Push the branch
+git push origin bugfixes/fix-login-crash
+```
+
+Then:
+
+4. Go to **Actions → Cut Hotfix → Run workflow**
+5. Enter the branch name (`bugfixes/fix-login-crash`) and new version (`5.2.1`)
+6. The workflow creates tag `v5.2.1` on the HEAD of your branch
+7. `docker-publish.yml` builds `:latest` + `:5.2.1.0`
+
+After the hotfix ships, open a PR to cherry-pick the fix into `main`:
+
+```bash
+git checkout main && git pull
+git cherry-pick <fix-commit-sha>
+gh pr create --base main --title "fix: cherry-pick hotfix from v5.2.1"
+```
+
+---
+
+## Stacked PRs
+
+For larger features, break the work into a stack of small focused PRs. Each PR targets the previous branch in the stack:
+
+```bash
+# Step 1 — targets main
+git checkout -b feature/foo-step-1
+gh pr create --base main --title "step 1: ..."
+
+# Step 2 — stacked on step 1
+git checkout -b feature/foo-step-2
+gh pr create --base feature/foo-step-1 --title "step 2: ..."
+```
+
+When a bottom PR merges, retarget the next one: `gh pr edit <number> --base main`.
+
+---
+
+## Image Channels
+
+| Tag | Content | Who uses it |
+|-----|---------|-------------|
+| `:latest` | Last stable release (from a `v*` tag) | End users (default) |
+| `:edge` | Latest commit on `main` | Testers and developers |
+| `:5.2.1.0` | Exact pinned version | Production deployments needing controlled upgrades |
+
+See [Docker Setup](docker-setup.md) for how to select a channel via `IMAGE_TAG`.

--- a/tools/setup-branch-protection.sh
+++ b/tools/setup-branch-protection.sh
@@ -5,18 +5,15 @@
 #
 # What this configures:
 #
-#   main         (classic branch protection — already set, included here for docs)
+#   main         (classic branch protection)
 #     - Require PR with 1 approval before merging
 #     - Require "PR Summary" status check
 #     - Dismiss stale reviews on push
 #     - enforce_admins: false  ← lets VERSION_BUMP_PAT push the version bump commit
 #
-#   release/**   (GitHub Ruleset — wildcard patterns need Rulesets API)
-#     - Require PR before merging (0 approvals needed)
-#     - Require "PR Summary" status check
-#     - Block direct pushes (non-fast-forward / force push)
-#     - Block branch deletion
-#     - Bypass: repository admins (actor_id=5) ← VERSION_BUMP_PAT owner must be admin
+# Release model uses git tags (v5.2.0, v5.2.1, ...) rather than long-lived
+# release branches. Hotfix branches (bugfixes/*) are short-lived and deleted
+# after cherry-picking to main — no special protection needed.
 # ─────────────────────────────────────────────────────────────────────────────
 
 set -euo pipefail
@@ -24,7 +21,7 @@ set -euo pipefail
 REPO="${1:-Fortigi/IdentityAtlas}"
 echo "Configuring branch protection for: $REPO"
 
-# ── 1. main — classic branch protection ─────────────────────────────────────
+# ── main — classic branch protection ────────────────────────────────────────
 echo ""
 echo "Setting classic branch protection on main..."
 gh api "repos/$REPO/branches/main/protection" \
@@ -50,66 +47,23 @@ gh api "repos/$REPO/branches/main/protection" \
 JSON
 echo "✅ main branch protection set"
 
-# ── 2. release/** — GitHub Ruleset ──────────────────────────────────────────
+# ── Remove legacy release/** ruleset if it exists ───────────────────────────
 echo ""
-echo "Creating ruleset for release/** branches..."
-
-# Delete existing ruleset with the same name if it exists
+echo "Checking for legacy release/** ruleset..."
 EXISTING_ID=$(gh api "repos/$REPO/rulesets" | \
   python3 -c "import sys,json; rs=[r['id'] for r in json.load(sys.stdin) if r['name']=='Protect release branches']; print(rs[0] if rs else '')" 2>/dev/null || true)
 
 if [ -n "$EXISTING_ID" ]; then
-  echo "  Removing existing ruleset (id=$EXISTING_ID)..."
+  echo "  Removing legacy release/** ruleset (id=$EXISTING_ID)..."
   gh api "repos/$REPO/rulesets/$EXISTING_ID" --method DELETE
+  echo "  ✅ Legacy ruleset removed"
+else
+  echo "  No legacy ruleset found — nothing to remove"
 fi
-
-gh api "repos/$REPO/rulesets" --method POST --input - <<'JSON'
-{
-  "name": "Protect release branches",
-  "target": "branch",
-  "enforcement": "active",
-  "conditions": {
-    "ref_name": {
-      "include": ["refs/heads/release/**"],
-      "exclude": []
-    }
-  },
-  "bypass_actors": [
-    {
-      "actor_id": 5,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    }
-  ],
-  "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false
-      }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": false,
-        "required_status_checks": [
-          { "context": "PR Summary" }
-        ]
-      }
-    }
-  ]
-}
-JSON
-echo "✅ release/** ruleset created"
 
 echo ""
 echo "Done. Branch protection summary:"
-echo "  main         → PR required (1 approval) + PR Summary check"
-echo "  release/**   → PR required (0 approvals) + PR Summary check + no force-push + no deletion"
-echo "  Bypass       → Repository admins (the VERSION_BUMP_PAT owner must have admin role)"
+echo "  main  → PR required (1 approval) + PR Summary check + no force-push"
+echo "  tags  → No branch protection needed (tags are immutable by default)"
+echo ""
+echo "Release model: git tags (v5.2.0, v5.2.1, ...) via Actions → Cut Release / Cut Hotfix"


### PR DESCRIPTION
## Summary

- Replaced long-lived `release/vX.Y` branches with **git tags** (`v5.2.0`, `v5.2.1`, ...) for release management
- Hotfix branches now start from a release tag (`git checkout -b bugfixes/fix-foo v5.2.0`), so they contain only the fix — features already merged to `main` are not included
- No more "Compare & pull request" banner confusion after cutting a release (no branch push)

## What changed

| File | Change |
|---|---|
| `cut-release.yml` | Creates `vX.Y.Z` tag on `main` HEAD. Input is now `Major.Minor.Patch` (e.g. `5.2.0`). |
| `cut-hotfix.yml` | **New.** Tags the HEAD of a hotfix branch as a new patch version, triggering docker-publish. |
| `docker-publish.yml` | Triggers on `v*` tag pushes. Derives version from tag name (`v5.2.0` → `5.2.0.0`) instead of reading psd1. |
| `bump-version.yml` | Simplified — release branch logic removed entirely. Only handles `main`. |
| `setup-branch-protection.sh` | Removes `release/**` ruleset, adds cleanup step for any existing legacy ruleset. |
| `docs/architecture/branching-strategy.md` | Rewritten for the new model. |
| `CLAUDE.md` | Branching table, version scheme, and workflow sections updated. |

## New hotfix workflow

```bash
# 1. Branch from the release tag — NOT from main
git checkout -b bugfixes/fix-login-crash v5.2.0
# 2. Fix, commit, push
git push origin bugfixes/fix-login-crash
# 3. Actions → Cut Hotfix → enter branch + version (5.2.1)
# 4. :latest + :5.2.1.0 published
# 5. Cherry-pick to main via a separate PR
```

## Test plan

- [ ] Verify `cut-release.yml` validates `Major.Minor.Patch` format (rejects `5.2`, accepts `5.2.0`)
- [ ] Verify `cut-hotfix.yml` validates version format and creates the correct tag
- [ ] Verify `docker-publish.yml` triggers correctly on a `v*` tag push and uses the tag-derived version
- [ ] Verify `bump-version.yml` still works on `main` PR merges (no release branch logic left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)