### PR TITLE
docs: add Release & Branching Strategy to MkDocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Plugin Architecture: risk-scoring/plugin-architecture.md
   - Architecture:
       - Docker Setup: architecture/docker-setup.md
+      - Release & Branching Strategy: architecture/branching-strategy.md
       - Ingest API: architecture/ingest-api.md
       - Audit History: architecture/audit-history.md
       - LLM & Risk Scoring Internals: architecture/llm-and-risk-scoring.md


### PR DESCRIPTION
## Summary

- Adds `architecture/branching-strategy.md` to the MkDocs nav under **Architecture → Release & Branching Strategy**
- The file was added to `docs/` in #112 but was missing from `mkdocs.yml`, so it wasn't visible on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)