### PR TITLE
feat: move About page into Admin sub-tab

### DIFF
--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -22,7 +22,6 @@ const ContextDetailPage = lazy(() => import('./components/ContextDetailPage'));
 const IdentitiesPage = lazy(() => import('./components/IdentitiesPage'));
 const IdentityDetailPage = lazy(() => import('./components/IdentityDetailPage'));
 const AdminPage = lazy(() => import('./components/AdminPage'));
-const AboutPage = lazy(() => import('./components/AboutPage'));
 // PerfPage and CrawlersPage are lazy-loaded inside AdminPage as sub-tabs.
 // const GovernancePage = lazy(() => import('./components/GovernancePage')); // temporarily disabled
 
@@ -97,7 +96,6 @@ const ALL_NAV_TABS = [
   { key: 'identities',       label: 'Identities',   feature: 'accountCorrelation', optional: true },
   { key: 'org-chart',        label: 'Org Chart',                                    optional: true },
   { key: 'admin',            label: 'Admin' },
-  { key: 'about',            label: 'About' },
 ];
 
 export default function App() {
@@ -498,8 +496,6 @@ export default function App() {
             <IdentitiesPage onOpenDetail={openDetailTab} />
           ) : page === 'org-chart' ? (
             <OrgChartPage onOpenDetail={openDetailTab} onCacheData={onCacheData} />
-          ) : page === 'about' ? (
-            <AboutPage />
           ) : page === 'performance' || page === 'crawlers' || page === 'admin' ? (
             // Crawlers and Performance now live under Admin as sub-tabs.
             // Legacy #crawlers and #performance hashes redirect to the matching sub-tab.
@@ -535,7 +531,7 @@ export default function App() {
       {/* Footer */}
       <footer className="border-t border-gray-200 bg-white px-6 py-2 text-xs text-gray-400 text-center flex items-center justify-center gap-2">
         <button
-          onClick={() => navigate('about')}
+          onClick={() => navigate('admin?sub=about')}
           className="hover:text-gray-600 hover:underline focus:outline-none"
         >
           Identity Atlas{moduleVersion ? ` v${moduleVersion}` : ''}

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -7,6 +7,7 @@ const CrawlersPage = lazy(() => import('./CrawlersPage'));
 const ContainerStatsPage = lazy(() => import('./ContainerStatsPage'));
 const AuthSettingsPage = lazy(() => import('./AuthSettingsPage'));
 const PerfPage = lazy(() => import('./PerfPage'));
+const AboutPage = lazy(() => import('./AboutPage'));
 const RiskProfileWizard = lazy(() => import('./RiskProfileWizard'));
 const CorrelationWizard = lazy(() => import('./CorrelationWizard'));
 
@@ -1132,6 +1133,7 @@ const ADMIN_TABS = [
   { key: 'performance',  label: 'Performance',         description: 'API and SQL performance metrics' },
   { key: 'containers',   label: 'Containers',          description: 'Live CPU, memory and network for the Docker stack' },
   { key: 'auth',         label: 'Authentication',      description: 'Configure Entra ID single sign-on' },
+  { key: 'about',        label: 'About',               description: 'License, version, and software bill of materials' },
 ];
 
 // ─── LLM Settings sub-tab ────────────────────────────────────────────────────
@@ -1681,6 +1683,12 @@ export default function AdminPage({ onNavigate, onRefresh, onRiskScoresRefresh }
         {activeTab === 'auth' && (
           <Suspense fallback={<div className="text-sm text-gray-500 p-6">Loading…</div>}>
             <AuthSettingsPage />
+          </Suspense>
+        )}
+
+        {activeTab === 'about' && (
+          <Suspense fallback={<div className="text-sm text-gray-500 p-6">Loading…</div>}>
+            <AboutPage />
           </Suspense>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Removed **About** from the main navigation tab bar
- Added it as the last sub-tab under **Admin → About**
- Footer version link now navigates to `#admin?sub=about` instead of `#about`
- `AboutPage` is lazy-loaded inside `AdminPage` alongside the other sub-tabs; the lazy import in `App.jsx` is removed

## Test plan

- [ ] About tab no longer appears in the main nav bar
- [ ] Admin → About sub-tab shows the license text and SBOM
- [ ] Clicking the version string in the footer opens Admin → About
- [ ] Deep link `#admin?sub=about` works directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)