### PR TITLE
fix: docker-publish workflow not triggering after PR merges

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,8 +19,8 @@ on:
   workflow_run:
     workflows: ["Bump version on PR merge"]
     types: [completed]
-    branches:
-      - main
+    # No branches filter: the filter matches the feature branch that triggered
+    # bump-version (via pull_request), not main — so it would never fire.
   push:
     tags:
       - 'v*'
@@ -57,8 +57,9 @@ jobs:
             # Tag push: github.ref_name = v5.2.0
             REF="${{ github.ref_name }}"
           else
-            # workflow_run from bump-version on main
-            REF="${{ github.event.workflow_run.head_branch }}"
+            # workflow_run from bump-version: always build main (bump-version
+            # only runs on PR merge to main, so the result always lands on main)
+            REF="main"
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
 

--- a/changes/fix-docker-publish-trigger.md
+++ b/changes/fix-docker-publish-trigger.md
@@ -1,0 +1,1 @@
+- Fixed Docker image publishing not triggering automatically after PR merges to main


### PR DESCRIPTION
## Summary
- Removed the `branches: [main]` filter from the `workflow_run` trigger — it matched the feature branch (from the `pull_request` event that fires `bump-version`), not `main`, causing all post-merge publish runs to be silently skipped
- Hardcoded `REF="main"` for `workflow_run` events — `head_branch` resolves to the feature branch name, which would have checked out the wrong ref

## Test plan
- [ ] Merge this PR and verify `docker-publish` fires automatically as a child of `bump-version`
- [ ] Confirm `:edge` tag on ghcr.io is updated to the new version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)