### PR TITLE
fix: point What is new link to installed version changelog

### DIFF
--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -19,6 +19,17 @@ const GITHUB_BASE = 'https://github.com/Fortigi/IdentityAtlas';
 const DOCS_URL = 'https://fortigi.github.io/IdentityAtlas';
 const SUPPORT_EMAIL = 'support@identityatlas.io';
 
+function changesUrl(v) {
+  if (v) {
+    const parts = v.split('.');
+    // Release format: Major.Minor.Patch.0 — 3rd segment is a small patch number, not a date
+    if (parts.length === 4 && parseInt(parts[2], 10) < 10000) {
+      return `${GITHUB_BASE}/blob/v${parts[0]}.${parts[1]}.${parts[2]}/CHANGES.md`;
+    }
+  }
+  return `${GITHUB_BASE}/blob/main/CHANGES.md`;
+}
+
 function formatNumber(n) {
   if (n == null) return '—';
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
@@ -211,7 +222,7 @@ export default function DashboardPage({ onNavigate }) {
             {version?.version ? `v${version.version}` : 'v5.0'}
           </div>
           <div className="mt-3 text-xs">
-            <a href={`${GITHUB_BASE}/blob/main/CHANGES.md`} target="_blank" rel="noopener noreferrer" className="text-lime-700 hover:text-lime-800 font-medium hover:underline inline-flex items-center gap-1">
+            <a href={changesUrl(version?.version)} target="_blank" rel="noopener noreferrer" className="text-lime-700 hover:text-lime-800 font-medium hover:underline inline-flex items-center gap-1">
               What is new →
             </a>
           </div>

--- a/changes/fix-whats-new-link.md
+++ b/changes/fix-whats-new-link.md
@@ -1,0 +1,1 @@
+- Fixed "What is new" link on the dashboard — it now points to the changelog for the installed version instead of always showing the latest.


### PR DESCRIPTION
## Summary
- Cherry-pick of hotfix v5.5.2 back to main
- The "What is new" link on the dashboard now resolves to the `CHANGES.md` for the installed version (e.g. `v5.5.2`) instead of always pointing to `main`

## Test plan
- [ ] On a release build (version format `5.x.y.0`), verify the link points to `blob/v5.x.y/CHANGES.md`
- [ ] On a dev/edge build (version format `5.x.yyyyMMdd.HHmm`), verify the link still points to `blob/main/CHANGES.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)