### PR TITLE
feat: use GitHub App token for CI automation pushes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,10 +31,17 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.VERSION_BUMP_PAT }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Merge changelog fragments and bump version
         shell: pwsh

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -36,10 +36,17 @@ jobs:
             exit 1
           fi
 
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ secrets.VERSION_BUMP_PAT }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Create and push hotfix tag
         run: |

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -37,10 +37,17 @@ jobs:
             exit 1
           fi
 
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.VERSION_BUMP_PAT }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Create and push release tag
         run: |

--- a/changes/ci-bot-token.md
+++ b/changes/ci-bot-token.md
@@ -1,0 +1,1 @@
+- CI automation (version bumps, releases, hotfixes) now authenticates via the Fortigi CI Bot GitHub App instead of a personal access token, so repository rules apply to all human contributors without exception


### PR DESCRIPTION
## Summary

- Replaces `VERSION_BUMP_PAT` (personal access token) with short-lived tokens generated by the **Fortigi CI Bot** GitHub App in `bump-version`, `cut-release`, and `cut-hotfix`
- The app is registered as an `always` bypass actor on the Protect main ruleset — automated pushes work, but no human can push directly to `main` regardless of org role
- `BOT_APP_ID` and `BOT_PRIVATE_KEY` secrets already added to the repo

## Test plan

- [ ] PR checks pass
- [ ] After merge, verify `bump-version` completes successfully (bot token generates, push succeeds)
- [ ] Confirm you no longer see the bypass button on PRs (only Taeke/Wim see the pull_request bypass for merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)