### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize all text files to LF in the repo and working tree.
+# git's auto-detection keeps binary files untouched.
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tools/csv-templates/demodata/
 tools/csv-templates/demodataTransformed/
 .claude/settings.local.json
 Config/
+.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ tools/csv-templates/demodata/
 tools/csv-templates/demodataTransformed/
 .claude/settings.local.json
 Config/
-.aider*

--- a/changes/normalize-line-endings.md
+++ b/changes/normalize-line-endings.md
@@ -1,0 +1,1 @@
+- Added `.gitattributes` to enforce LF line endings on all text files, preventing CRLF from being introduced on Windows checkouts


### PR DESCRIPTION
## Summary

- Added `.gitattributes` with `* text=auto eol=lf` to enforce LF line endings on all text files
- Prevents CRLF from being introduced on Windows checkouts going forward

## Test plan

- [ ] Verify `.gitattributes` is present and contains `* text=auto eol=lf`
- [ ] Confirm no functional code changes (config-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)