### PR TITLE
Dashboard: Trends tab with daily snapshots + % governed over time

### DIFF
--- a/app/api/src/db/migrations/027_dashboard_snapshots.sql
+++ b/app/api/src/db/migrations/027_dashboard_snapshots.sql
@@ -1,0 +1,33 @@
+-- Identity Atlas — daily snapshot of dashboard counts.
+--
+-- One row per UTC day. Used by the new Trends tab on the Dashboard page
+-- to plot growth over time for users, resources, assignments, and the
+-- % of assignments that are governed.
+--
+-- The scheduler writes a row once per day; if today's row is already
+-- present the insert is a no-op (ON CONFLICT). Reads are a simple
+--   SELECT * FROM "DashboardSnapshots"
+--    WHERE "snapshotDate" >= CURRENT_DATE - INTERVAL 'N days'
+-- which is index-only on the primary key.
+--
+-- We deliberately do NOT backfill from `_history`. Pre-v6 history coverage
+-- was partial (composite-PK tables only got history triggers in migration
+-- 018), and a reconstructed early section would tell a misleading story.
+-- The chart starts as a single point on the day this migration applies
+-- and grows from there.
+
+CREATE TABLE IF NOT EXISTS "DashboardSnapshots" (
+    "snapshotDate"          DATE PRIMARY KEY,
+    "capturedAt"            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "systems"               INT NOT NULL DEFAULT 0,
+    "resources"             INT NOT NULL DEFAULT 0,
+    "businessRoles"         INT NOT NULL DEFAULT 0,
+    "principals"            INT NOT NULL DEFAULT 0,
+    "identities"            INT NOT NULL DEFAULT 0,
+    "assignments"           INT NOT NULL DEFAULT 0,
+    "governedAssignments"   INT NOT NULL DEFAULT 0,
+    "relationships"         INT NOT NULL DEFAULT 0,
+    "contexts"              INT NOT NULL DEFAULT 0,
+    "identityMembers"       INT NOT NULL DEFAULT 0,
+    "certifications"        INT NOT NULL DEFAULT 0
+);

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -679,6 +679,41 @@ router.get('/admin/dashboard-stats', async (_req, res) => {
   }
 });
 
+// ─── Dashboard timeseries — daily snapshot history for the Trends tab ──────
+//
+// Returns the last N days of dashboard counts, written daily by the
+// scheduler (see scheduler.js → captureDashboardSnapshotIfMissing). Used
+// by the Trends tab to plot growth over time for users, resources,
+// assignments, and the % of assignments that are governed.
+//
+// We deliberately do NOT backfill from history — the chart starts on the
+// day migration 027 applied and grows from there.
+router.get('/admin/dashboard-timeseries', async (req, res) => {
+  if (process.env.USE_SQL !== 'true') return res.status(503).json({ error: 'SQL not configured' });
+  try {
+    const days = Math.min(Math.max(parseInt(req.query.days, 10) || 90, 1), 730);
+    // Existence check — table won't exist on a fresh DB before migration 027.
+    const exists = await db.queryOne(`SELECT to_regclass('"DashboardSnapshots"') AS t`);
+    if (!exists?.t) return res.json({ days, data: [] });
+
+    const result = await db.query(
+      `SELECT
+         "snapshotDate"::text AS date,
+         "systems", "resources", "businessRoles", "principals",
+         "identities", "assignments", "governedAssignments",
+         "relationships", "contexts", "identityMembers", "certifications"
+       FROM "DashboardSnapshots"
+       WHERE "snapshotDate" >= (CURRENT_DATE - ($1 || ' days')::interval)
+       ORDER BY "snapshotDate" ASC`,
+      [String(days)],
+    );
+    res.json({ days, data: result.rows || [] });
+  } catch (err) {
+    console.error('dashboard-timeseries failed:', err.message);
+    res.status(500).json({ error: 'Failed to fetch dashboard timeseries' });
+  }
+});
+
 // ─── History retention setting ──────────────────────────────────────────────
 // Controls how long rows in the `_history` audit table are kept before being
 // pruned. Default is 180 days. Setting to 0 disables pruning entirely.

--- a/app/api/src/scheduler.js
+++ b/app/api/src/scheduler.js
@@ -163,8 +163,70 @@ async function queueScheduledScoringRun(classifierRow, scheduleIndex) {
   console.log(`Scheduler: queued risk scoring run for classifier ${classifierRow.id} (${classifierRow.displayName})`);
 }
 
+// Write today's row in DashboardSnapshots if it's missing. Cheap idempotent
+// check — runs every scheduler tick (60s), the COUNTs only fire once per
+// UTC day (after the first successful insert ON CONFLICT does nothing).
+// Uses the same `pg_class.reltuples` fast-path as /admin/dashboard-stats
+// for the big tables, exact COUNT(*) for the small / filtered ones.
+async function captureDashboardSnapshotIfMissing() {
+  try {
+    // Existence check via to_regclass — first install may not have the
+    // table yet if migration 027 hasn't applied (unlikely, bootstrap runs
+    // first, but cheap to check).
+    const exists = await db.queryOne(
+      `SELECT to_regclass('"DashboardSnapshots"') AS t`
+    );
+    if (!exists?.t) return;
+
+    const row = await db.queryOne(
+      `SELECT 1 FROM "DashboardSnapshots" WHERE "snapshotDate" = CURRENT_DATE`
+    );
+    if (row) return;  // already captured today
+
+    await db.query(`
+      WITH estimates AS (
+        SELECT relname, reltuples::bigint AS est
+          FROM pg_class
+         WHERE relname IN (
+           'Resources','Principals','Identities','ResourceAssignments',
+           'ResourceRelationships','Contexts','IdentityMembers',
+           'CertificationDecisions'
+         )
+           AND relkind = 'r'
+      )
+      INSERT INTO "DashboardSnapshots" (
+        "snapshotDate",
+        "systems", "resources", "businessRoles", "principals",
+        "identities", "assignments", "governedAssignments",
+        "relationships", "contexts", "identityMembers", "certifications"
+      )
+      SELECT
+        CURRENT_DATE,
+        (SELECT COUNT(*)::int FROM "Systems"),
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='Resources'), 0), 0)::int,
+        (SELECT COUNT(*)::int FROM "Resources" WHERE "resourceType" = 'BusinessRole'),
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='Principals'), 0), 0)::int,
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='Identities'), 0), 0)::int,
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='ResourceAssignments'), 0), 0)::int,
+        (SELECT COUNT(*)::int FROM "ResourceAssignments" WHERE "assignmentType" = 'Governed'),
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='ResourceRelationships'), 0), 0)::int,
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='Contexts'), 0), 0)::int,
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='IdentityMembers'), 0), 0)::int,
+        GREATEST(COALESCE((SELECT est FROM estimates WHERE relname='CertificationDecisions'), 0), 0)::int
+      ON CONFLICT ("snapshotDate") DO NOTHING
+    `);
+  } catch (err) {
+    // Never fail the tick over a snapshot — counts can wait for the next day.
+    console.warn(`Scheduler: dashboard snapshot skipped: ${err.message}`);
+  }
+}
+
 async function tick() {
   try {
+    // Daily snapshot for the dashboard trends. Idempotent; cheap check
+    // unless it's the first tick of a new day.
+    await captureDashboardSnapshotIfMissing();
+
     // Load all enabled crawler configs that have at least one schedule
     // Support both 'schedules' (array, new format) and 'schedule' (object, legacy)
     const crawlerRows = await db.query(

--- a/app/ui/CLAUDE.md
+++ b/app/ui/CLAUDE.md
@@ -74,6 +74,8 @@ If the same logic already exists in one file and you're about to write it in a s
 
 **Contexts tab (v6):** Replaces the former Org Chart tab. Manager-hierarchy trees now come from the `manager-hierarchy` context-algorithm plugin.
 
+**Dashboard Trends tab:** Daily snapshots written by the scheduler to `DashboardSnapshots`. Charts are hand-rolled SVG via `components/TimeSeriesChart.jsx` — no chart library dependency. See [`docs/architecture/dashboard-trends.md`](../../docs/architecture/dashboard-trends.md).
+
 ## Component Structure
 
 | Component | Purpose |
@@ -83,5 +85,8 @@ If the same logic already exists in one file and you're about to write it in a s
 | `components/MatrixView.jsx` | Main matrix orchestrator |
 | `components/matrix/SortableMatrixBody.jsx` | Lazy-loaded DnD + virtual scrolling wrapper |
 | `components/matrix/MatrixCell.jsx` | Individual cell (AP-colored bg, multi-type badges) |
+| `components/DashboardPage.jsx` | Landing page — Overview / Trends tabs |
+| `components/DashboardTrendsTab.jsx` | Lazy-loaded; renders the time-series charts |
+| `components/TimeSeriesChart.jsx` | Reusable hand-rolled SVG line chart (no chart lib dep) |
 | `hooks/useMatrixRowOrder.js` | Row order persistence (versioned localStorage) |
 | `hooks/useEntityPage.js` | Shared hook for Users/Resources pages |

--- a/app/ui/e2e/dashboard.spec.js
+++ b/app/ui/e2e/dashboard.spec.js
@@ -9,8 +9,8 @@ test.describe('Dashboard Page', () => {
 
   test('Overview tab renders the brain graph + stats', async ({ page }) => {
     // Tab strip should be visible
-    await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Trends',   exact: true })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Overview', exact: true })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Trends', exact: true })).toBeVisible();
 
     // Overview is the default — at least one SVG (the brain graph) must render
     const svgs = page.locator('svg');
@@ -18,7 +18,7 @@ test.describe('Dashboard Page', () => {
   });
 
   test('Trends tab switches and renders chart container', async ({ page }) => {
-    await page.getByRole('button', { name: 'Trends', exact: true }).click();
+    await page.getByRole('tab', { name: 'Trends', exact: true }).click();
 
     // The headline section heading should appear
     await expect(page.getByText(/Governed assignments — % of total/i)).toBeVisible({ timeout: 10000 });
@@ -36,7 +36,7 @@ test.describe('Dashboard Page', () => {
   });
 
   test('Trends range selector changes the days param', async ({ page }) => {
-    await page.getByRole('button', { name: 'Trends', exact: true }).click();
+    await page.getByRole('tab', { name: 'Trends', exact: true }).click();
     await expect(page.locator('select#trends-range')).toBeVisible();
 
     // Pick a different range — the chart should re-render (no crash).

--- a/app/ui/e2e/dashboard.spec.js
+++ b/app/ui/e2e/dashboard.spec.js
@@ -1,0 +1,48 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#dashboard');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('Overview tab renders the brain graph + stats', async ({ page }) => {
+    // Tab strip should be visible
+    await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Trends',   exact: true })).toBeVisible();
+
+    // Overview is the default — at least one SVG (the brain graph) must render
+    const svgs = page.locator('svg');
+    await expect(svgs.first()).toBeVisible();
+  });
+
+  test('Trends tab switches and renders chart container', async ({ page }) => {
+    await page.getByRole('button', { name: 'Trends', exact: true }).click();
+
+    // The headline section heading should appear
+    await expect(page.getByText(/Governed assignments — % of total/i)).toBeVisible({ timeout: 10000 });
+
+    // Range selector should be present
+    const rangeSelect = page.locator('select#trends-range');
+    await expect(rangeSelect).toBeVisible();
+    await expect(rangeSelect).toHaveValue('90');
+
+    // At least one chart SVG renders. The empty-state message is rendered
+    // INSIDE the SVG when no snapshots exist yet, so the SVG itself is the
+    // load-bearing assertion (not the line/path).
+    const svgs = page.locator('svg');
+    expect(await svgs.count()).toBeGreaterThan(1);
+  });
+
+  test('Trends range selector changes the days param', async ({ page }) => {
+    await page.getByRole('button', { name: 'Trends', exact: true }).click();
+    await expect(page.locator('select#trends-range')).toBeVisible();
+
+    // Pick a different range — the chart should re-render (no crash).
+    await page.locator('select#trends-range').selectOption('30');
+    await expect(page.locator('select#trends-range')).toHaveValue('30');
+    // Still on the Trends tab afterwards
+    await expect(page.getByText(/Governed assignments — % of total/i)).toBeVisible();
+  });
+});

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -11,9 +11,13 @@
 // When no data has been loaded yet, the central call-to-action becomes
 // "Configure a crawler" pointing at Admin → Crawlers.
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { useIsDark } from '../contexts/ThemeContext';
+
+// Lazy-load Trends — keeps the dashboard's first paint cheap (chart code +
+// data hook are only needed when the user clicks the tab).
+const DashboardTrendsTab = lazy(() => import('./DashboardTrendsTab'));
 
 const GITHUB_BASE = 'https://github.com/Fortigi/IdentityAtlas';
 const DOCS_URL = 'https://fortigi.github.io/IdentityAtlas';
@@ -61,6 +65,7 @@ export default function DashboardPage({ onNavigate }) {
   const [stats, setStats] = useState(null);
   const [version, setVersion] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState('overview');  // 'overview' | 'trends'
 
   useEffect(() => {
     let cancelled = false;
@@ -95,6 +100,39 @@ export default function DashboardPage({ onNavigate }) {
             </p>
           </div>
         </div>
+
+      {/* Tab strip */}
+      <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
+        <nav className="-mb-px flex gap-6">
+          {[
+            { key: 'overview', label: 'Overview' },
+            { key: 'trends',   label: 'Trends' },
+          ].map(t => {
+            const active = tab === t.key;
+            return (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={`pb-2 text-sm font-medium border-b-2 transition-colors ${
+                  active
+                    ? 'border-lime-500 text-lime-700 dark:text-lime-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                }`}
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {tab === 'trends' && (
+        <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400 py-12 text-center">Loading…</div>}>
+          <DashboardTrendsTab />
+        </Suspense>
+      )}
+
+      {tab === 'overview' && (<>
 
       {/* Compose file outdated warning */}
       {version?.composeFileOutdated && (
@@ -253,6 +291,7 @@ export default function DashboardPage({ onNavigate }) {
           Maatschap Fortigi
         </a>
       </div>
+      </>)}
       </div>
     </div>
   );

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -101,9 +101,11 @@ export default function DashboardPage({ onNavigate }) {
           </div>
         </div>
 
-      {/* Tab strip */}
+      {/* Tab strip. role="tablist" not <nav> — tabs are an internal control,
+          not site navigation, and adding a second <nav> trips strict-mode
+          selectors on existing tests that scope by `locator('nav')`. */}
       <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
-        <nav className="-mb-px flex gap-6">
+        <div role="tablist" aria-label="Dashboard sections" className="-mb-px flex gap-6">
           {[
             { key: 'overview', label: 'Overview' },
             { key: 'trends',   label: 'Trends' },
@@ -112,6 +114,8 @@ export default function DashboardPage({ onNavigate }) {
             return (
               <button
                 key={t.key}
+                role="tab"
+                aria-selected={active}
                 onClick={() => setTab(t.key)}
                 className={`pb-2 text-sm font-medium border-b-2 transition-colors ${
                   active
@@ -123,7 +127,7 @@ export default function DashboardPage({ onNavigate }) {
               </button>
             );
           })}
-        </nav>
+        </div>
       </div>
 
       {tab === 'trends' && (

--- a/app/ui/src/components/DashboardTrendsTab.jsx
+++ b/app/ui/src/components/DashboardTrendsTab.jsx
@@ -1,0 +1,165 @@
+// Dashboard → Trends tab. Plots daily snapshots written by the
+// scheduler (see scheduler.js → captureDashboardSnapshotIfMissing).
+//
+// The chart series start as a single point on the day the snapshot
+// table was introduced and grow over time. No historical backfill.
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '../auth/AuthGate';
+import TimeSeriesChart from './TimeSeriesChart';
+
+const RANGE_OPTIONS = [
+  { days: 30,  label: '30 days' },
+  { days: 90,  label: '90 days' },
+  { days: 365, label: '1 year' },
+  { days: 730, label: '2 years' },
+];
+
+export default function DashboardTrendsTab() {
+  const { authFetch } = useAuth();
+  const [days, setDays] = useState(90);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    authFetch(`/api/admin/dashboard-timeseries?days=${days}`)
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then(d => { if (!cancelled) setData(d); })
+      .catch(err => { if (!cancelled) setError(err.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [authFetch, days]);
+
+  const rows = data?.data || [];
+
+  // Derived series. Empty array if no data → the chart renders its empty state.
+  const usersSeries        = rows.map(r => ({ date: r.date, value: Number(r.principals)         || 0 }));
+  const resourcesSeries    = rows.map(r => ({ date: r.date, value: Number(r.resources)          || 0 }));
+  const assignmentsSeries  = rows.map(r => ({ date: r.date, value: Number(r.assignments)        || 0 }));
+  const governedSeries     = rows.map(r => ({ date: r.date, value: Number(r.governedAssignments) || 0 }));
+  const pctGovernedSeries  = rows.map(r => {
+    const total = Number(r.assignments) || 0;
+    const gov   = Number(r.governedAssignments) || 0;
+    return {
+      date: r.date,
+      value: total > 0 ? Math.round((gov / total) * 1000) / 10 : 0,  // 1 decimal
+    };
+  });
+
+  const latest = rows.length ? rows[rows.length - 1] : null;
+  const latestPct = latest && Number(latest.assignments) > 0
+    ? (Number(latest.governedAssignments) / Number(latest.assignments)) * 100
+    : 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xs font-bold text-lime-700 uppercase tracking-widest">Trends</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Daily snapshots. Charts start the day the feature shipped and grow as new days are captured.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="trends-range" className="text-xs text-gray-500 dark:text-gray-400">Range</label>
+          <select
+            id="trends-range"
+            value={days}
+            onChange={e => setDays(parseInt(e.target.value, 10))}
+            className="text-sm rounded border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-gray-200 px-2 py-1"
+          >
+            {RANGE_OPTIONS.map(o => (
+              <option key={o.days} value={o.days}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-rose-200 dark:border-rose-700 bg-rose-50 dark:bg-rose-900/20 p-3 text-sm text-rose-700 dark:text-rose-300">
+          Failed to load: {error}
+        </div>
+      )}
+
+      {/* % Governed — headline chart */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700">
+        <div className="flex items-start justify-between mb-2">
+          <div>
+            <div className="text-sm font-medium text-gray-800 dark:text-gray-200">Governed assignments — % of total</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">How much of your access is wrapped by an Access Package or Business Role.</div>
+          </div>
+          {latest && (
+            <div className="text-right">
+              <div className="text-3xl font-bold text-emerald-600 dark:text-emerald-400 tabular-nums">
+                {latestPct.toFixed(1)}<span className="text-base font-normal">%</span>
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">today</div>
+            </div>
+          )}
+        </div>
+        {loading ? (
+          <div className="text-sm text-gray-500 dark:text-gray-400 py-12 text-center">Loading…</div>
+        ) : (
+          <TimeSeriesChart
+            data={pctGovernedSeries}
+            color="#10b981"
+            yMin={0}
+            yMax={100}
+            yUnit="%"
+            height={240}
+          />
+        )}
+      </div>
+
+      {/* Counts — 3 small charts side by side */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700">
+          <TimeSeriesChart
+            data={usersSeries}
+            color="#3b82f6"
+            yMin={0}
+            height={180}
+            title="Users (principals)"
+            subtitle={latest ? `${(Number(latest.principals) || 0).toLocaleString()} today` : ''}
+          />
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700">
+          <TimeSeriesChart
+            data={resourcesSeries}
+            color="#8b5cf6"
+            yMin={0}
+            height={180}
+            title="Resources"
+            subtitle={latest ? `${(Number(latest.resources) || 0).toLocaleString()} today` : ''}
+          />
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700">
+          <TimeSeriesChart
+            data={assignmentsSeries}
+            color="#f59e0b"
+            yMin={0}
+            height={180}
+            title="Assignments"
+            subtitle={latest ? `${(Number(latest.assignments) || 0).toLocaleString()} today` : ''}
+          />
+        </div>
+      </div>
+
+      {/* Governed (raw count) — secondary chart */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700">
+        <TimeSeriesChart
+          data={governedSeries}
+          color="#059669"
+          yMin={0}
+          height={180}
+          title="Governed assignments (raw count)"
+          subtitle={latest ? `${(Number(latest.governedAssignments) || 0).toLocaleString()} today` : ''}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/ui/src/components/TimeSeriesChart.jsx
+++ b/app/ui/src/components/TimeSeriesChart.jsx
@@ -1,0 +1,277 @@
+// Minimal hand-rolled SVG line chart. No external dependency.
+//
+// One series per chart. Pass `data` as `[{ date: 'YYYY-MM-DD', value: number }]`
+// already sorted ascending by date. The chart auto-fits Y to [yMin, yMax],
+// rounding the axis to a sensible step.
+//
+// Two-point edge cases handled explicitly:
+//   - 0 points → renders an empty-state message
+//   - 1 point  → renders a single dot at the right edge
+//
+// Dark mode: uses CSS variables resolved at render time via the existing
+// `useIsDark` hook so colors track the theme without re-rendering.
+
+import { useMemo } from 'react';
+import { useIsDark } from '../contexts/ThemeContext';
+
+const PADDING = { top: 16, right: 16, bottom: 28, left: 44 };
+
+function formatTick(n) {
+  if (n == null) return '';
+  if (Math.abs(n) >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (Math.abs(n) >= 10_000)    return (n / 1_000).toFixed(0) + 'k';
+  if (Math.abs(n) >= 1_000)     return (n / 1_000).toFixed(1) + 'k';
+  return String(n);
+}
+
+function formatDateLabel(dateStr) {
+  // 'YYYY-MM-DD' → 'MMM d' (e.g. 'May 18')
+  if (!dateStr) return '';
+  const [, m, d] = dateStr.split('-');
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${months[parseInt(m, 10) - 1]} ${parseInt(d, 10)}`;
+}
+
+// niceStep + ceilToStep produce axis-friendly bounds (e.g. 0..120 → 0..150,
+// step 30) so the gridlines fall on round numbers.
+function niceStep(range) {
+  if (range <= 0) return 1;
+  const pow = Math.pow(10, Math.floor(Math.log10(range)));
+  const norm = range / pow;
+  if (norm < 1.5) return 0.2 * pow;
+  if (norm < 3)   return 0.5 * pow;
+  if (norm < 7)   return 1.0 * pow;
+  return 2.0 * pow;
+}
+
+export default function TimeSeriesChart({
+  data = [],
+  height = 220,
+  width = 560,
+  color = '#3b82f6',
+  yFormat = formatTick,
+  yMin = null,         // pin floor (e.g. 0 for counts, 0 for percentages)
+  yMax = null,         // pin ceiling (e.g. 100 for percentages)
+  yUnit = '',          // appended to Y tick labels (e.g. '%')
+  title = '',
+  subtitle = '',
+}) {
+  const isDark = useIsDark();
+
+  const gridColor = isDark ? '#374151' : '#e5e7eb';
+  const axisColor = isDark ? '#9ca3af' : '#6b7280';
+  const lineColor = color;
+  const fillColor = color + '20';  // 12% opacity tint
+
+  const { points, ticks, dateTicks } = useMemo(() => {
+    const w = width  - PADDING.left - PADDING.right;
+    const h = height - PADDING.top  - PADDING.bottom;
+
+    if (!data || data.length === 0) {
+      return { points: [], ticks: [], dateTicks: [] };
+    }
+
+    const values = data.map(d => Number(d.value) || 0);
+    let dataMin = Math.min(...values);
+    let dataMax = Math.max(...values);
+    if (yMin !== null) dataMin = Math.min(dataMin, yMin);
+    if (yMax !== null) dataMax = Math.max(dataMax, yMax);
+    if (yMin !== null) dataMin = yMin;  // pin
+    if (yMax !== null) dataMax = yMax;
+    if (dataMax === dataMin) dataMax = dataMin + 1;
+
+    const range = dataMax - dataMin;
+    const step  = niceStep(range);
+    const axisLo = yMin !== null ? yMin : Math.floor(dataMin / step) * step;
+    const axisHi = yMax !== null ? yMax : Math.ceil (dataMax / step) * step;
+    const axisRange = axisHi - axisLo || 1;
+
+    const xAt = (i) => data.length <= 1
+      ? PADDING.left + w
+      : PADDING.left + (i / (data.length - 1)) * w;
+    const yAt = (v) => PADDING.top + h - ((v - axisLo) / axisRange) * h;
+
+    const points = data.map((d, i) => ({
+      x: xAt(i),
+      y: yAt(Number(d.value) || 0),
+      date: d.date,
+      value: Number(d.value) || 0,
+    }));
+
+    const ticks = [];
+    for (let v = axisLo; v <= axisHi + 0.0001; v += step) {
+      ticks.push({ value: v, y: yAt(v), label: yFormat(v) + yUnit });
+    }
+
+    // Sparse X-axis labels: first, last, and ~5 in between.
+    const N = data.length;
+    const idxs = N <= 6
+      ? data.map((_, i) => i)
+      : [0, Math.floor(N * 0.25), Math.floor(N * 0.5), Math.floor(N * 0.75), N - 1];
+    const dateTicks = idxs.map(i => ({
+      x: xAt(i),
+      label: formatDateLabel(data[i].date),
+    }));
+
+    return { points, ticks, dateTicks };
+  }, [data, width, height, yMin, yMax, yFormat, yUnit]);
+
+  const pathD = useMemo(() => {
+    if (points.length === 0) return '';
+    return points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ');
+  }, [points]);
+
+  const fillD = useMemo(() => {
+    if (points.length === 0) return '';
+    const bottom = (height - PADDING.bottom).toFixed(1);
+    const first = points[0], last = points[points.length - 1];
+    return `M ${first.x.toFixed(1)} ${bottom} ` +
+      points.map(p => `L ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ') +
+      ` L ${last.x.toFixed(1)} ${bottom} Z`;
+  }, [points, height]);
+
+  const empty = data.length === 0;
+
+  return (
+    <div className="flex flex-col">
+      {(title || subtitle) && (
+        <div className="mb-1 px-1">
+          {title    && <div className="text-sm font-medium text-gray-800 dark:text-gray-200">{title}</div>}
+          {subtitle && <div className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</div>}
+        </div>
+      )}
+      <div className="relative w-full">
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          preserveAspectRatio="none"
+          className="w-full"
+          style={{ height: `${height}px` }}
+          role="img"
+          aria-label={title || 'time series chart'}
+        >
+          {/* Y-axis gridlines + labels */}
+          {ticks.map((t, i) => (
+            <g key={`y-${i}`}>
+              <line
+                x1={PADDING.left}
+                x2={width - PADDING.right}
+                y1={t.y}
+                y2={t.y}
+                stroke={gridColor}
+                strokeWidth={1}
+                strokeDasharray={i === 0 ? '' : '3 3'}
+              />
+              <text
+                x={PADDING.left - 6}
+                y={t.y + 4}
+                textAnchor="end"
+                fontSize={10}
+                fill={axisColor}
+              >
+                {t.label}
+              </text>
+            </g>
+          ))}
+
+          {/* X-axis labels */}
+          {dateTicks.map((t, i) => (
+            <text
+              key={`x-${i}`}
+              x={t.x}
+              y={height - PADDING.bottom + 14}
+              textAnchor="middle"
+              fontSize={10}
+              fill={axisColor}
+            >
+              {t.label}
+            </text>
+          ))}
+
+          {/* Empty-state */}
+          {empty && (
+            <text
+              x={width / 2}
+              y={height / 2}
+              textAnchor="middle"
+              fontSize={12}
+              fill={axisColor}
+            >
+              No data yet — first snapshot writes on the next scheduler tick.
+            </text>
+          )}
+
+          {/* Series */}
+          {!empty && (
+            <>
+              {points.length > 1 && (
+                <path d={fillD} fill={fillColor} stroke="none" />
+              )}
+              {points.length > 1 && (
+                <path
+                  d={pathD}
+                  fill="none"
+                  stroke={lineColor}
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              )}
+              {/* Dot only on the last point — full-series dots get busy fast */}
+              {points.length > 0 && (
+                <circle
+                  cx={points[points.length - 1].x}
+                  cy={points[points.length - 1].y}
+                  r={3.5}
+                  fill={lineColor}
+                  stroke={isDark ? '#0f172a' : '#fff'}
+                  strokeWidth={2}
+                />
+              )}
+            </>
+          )}
+
+          {/* Per-point hover affordance (transparent rects, tooltips via <title>) */}
+          {!empty && points.map((p, i) => {
+            const halfWidth = points.length > 1
+              ? (points[1].x - points[0].x) / 2
+              : 8;
+            const rx = Math.max(p.x - halfWidth, PADDING.left);
+            const rw = Math.min(halfWidth * 2, width - PADDING.right - rx);
+            return (
+              <g key={`hit-${i}`}>
+                <rect
+                  x={rx}
+                  y={PADDING.top}
+                  width={rw}
+                  height={height - PADDING.top - PADDING.bottom}
+                  fill="transparent"
+                >
+                  <title>{`${p.date}: ${yFormat(p.value)}${yUnit}`}</title>
+                </rect>
+              </g>
+            );
+          })}
+
+          {/* Axis lines */}
+          <line
+            x1={PADDING.left}
+            x2={PADDING.left}
+            y1={PADDING.top}
+            y2={height - PADDING.bottom}
+            stroke={gridColor}
+            strokeWidth={1}
+          />
+          <line
+            x1={PADDING.left}
+            x2={width - PADDING.right}
+            y1={height - PADDING.bottom}
+            y2={height - PADDING.bottom}
+            stroke={gridColor}
+            strokeWidth={1}
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}
+

--- a/changes/dashboard-trends-tab.md
+++ b/changes/dashboard-trends-tab.md
@@ -1,0 +1,3 @@
+- Added a **Trends** tab to the Dashboard page. Plots the % of assignments that are governed over time, plus separate charts for users, resources, and assignments growth.
+- The chart starts populated on the day this version ships and grows as new days are captured. The scheduler writes one snapshot per UTC day to the new `DashboardSnapshots` table — no historical backfill, so the early section reflects only the snapshots actually captured (not a reconstructed history).
+- Range selector switches between 30 days / 90 days / 1 year / 2 years. Charts render as hand-rolled SVG; no new frontend dependency.

--- a/changes/dashboard-trends-tests-and-docs.md
+++ b/changes/dashboard-trends-tests-and-docs.md
@@ -1,0 +1,3 @@
+- Added Playwright e2e coverage for the new Dashboard tab strip and Trends tab: verifies tab switching, chart container presence, and the range selector behaviour.
+- New `docs/architecture/dashboard-trends.md` documents the snapshot architecture, the no-backfill decision, the API surface, and the chart rendering details.
+- Pointers in `app/ui/CLAUDE.md` so future AI contributors find the new components.

--- a/docs/architecture/dashboard-trends.md
+++ b/docs/architecture/dashboard-trends.md
@@ -1,0 +1,120 @@
+# Dashboard — Trends tab
+
+> Companion to [`027_dashboard_snapshots.sql`](../../app/api/src/db/migrations/027_dashboard_snapshots.sql), [`scheduler.js`](../../app/api/src/scheduler.js), [`DashboardTrendsTab.jsx`](../../app/ui/src/components/DashboardTrendsTab.jsx), [`TimeSeriesChart.jsx`](../../app/ui/src/components/TimeSeriesChart.jsx).
+
+## What it does
+
+The Trends tab on the Dashboard plots growth over time:
+
+- **% Governed** — share of assignments wrapped by an Access Package / Business Role. The headline chart.
+- **Users / Resources / Assignments** — raw counts as separate small charts.
+- **Governed (raw)** — secondary chart, useful when total assignments are flat and the % is shifting only because governance is growing.
+
+Range selector: 30 days / 90 days / 1 year / 2 years.
+
+## Architecture
+
+```
+┌──────────────┐       60s tick       ┌──────────────────────┐
+│  scheduler   │ ─────────────────▶   │ DashboardSnapshots   │
+│   tick()     │   captureDashboard…  │  (one row per day,   │
+└──────────────┘                       │   ON CONFLICT noop)  │
+                                       └──────────────────────┘
+                                                  │
+                                                  │  SELECT … WHERE date >= today - N days
+                                                  ▼
+                              ┌─────────────────────────────────┐
+                              │  GET /api/admin/dashboard-      │
+                              │       timeseries?days=N          │
+                              └─────────────────────────────────┘
+                                                  │
+                                                  ▼
+                              ┌─────────────────────────────────┐
+                              │  DashboardTrendsTab.jsx          │
+                              │   ─► TimeSeriesChart.jsx (×4)    │
+                              └─────────────────────────────────┘
+```
+
+## Data — `DashboardSnapshots`
+
+| Column | Type | Notes |
+|---|---|---|
+| `snapshotDate` | `DATE` PK | One row per UTC day |
+| `capturedAt` | `TIMESTAMPTZ` | When the row was actually written (debugging) |
+| `systems` | `INT` | Exact count |
+| `resources` | `INT` | `pg_class.reltuples` estimate (fast on large tables) |
+| `businessRoles` | `INT` | Exact `COUNT(*) WHERE resourceType='BusinessRole'` |
+| `principals` | `INT` | Estimate |
+| `identities` | `INT` | Estimate |
+| `assignments` | `INT` | Estimate |
+| `governedAssignments` | `INT` | Exact `COUNT(*) WHERE assignmentType='Governed'` (indexed) |
+| `relationships` | `INT` | Estimate |
+| `contexts` | `INT` | Estimate |
+| `identityMembers` | `INT` | Estimate |
+| `certifications` | `INT` | Estimate |
+
+The estimate vs. exact choice mirrors the live `/admin/dashboard-stats` endpoint: estimates are good enough for a trend line (well within a couple of percent), exact counts are reserved for filtered columns that need to be on-the-nose (`Governed` for the headline %, `BusinessRole` for the bare number).
+
+## Snapshot capture — when and how
+
+`scheduler.js → captureDashboardSnapshotIfMissing()` runs on every 60-second tick. The function is structured as a cheap existence check + a one-shot INSERT:
+
+```js
+const row = await db.queryOne(
+  `SELECT 1 FROM "DashboardSnapshots" WHERE "snapshotDate" = CURRENT_DATE`
+);
+if (row) return;  // already captured today
+await db.query(/* INSERT with ON CONFLICT DO NOTHING */);
+```
+
+- **First tick of a new UTC day**: writes the row (~50–100 ms).
+- **Every other tick (so, hundreds per day)**: one tiny SELECT, no-op.
+- **Container restart mid-day**: existence check sees today's row, skips.
+- **Migration applies on an already-running stack**: scheduler writes today's row on the next tick.
+
+The INSERT uses `ON CONFLICT ("snapshotDate") DO NOTHING` for defence-in-depth: if two ticks race (e.g. across a clock skew), one wins, the other is a no-op.
+
+## No backfill — deliberate
+
+The `_history` audit table records every INSERT and DELETE per row, so reconstructing daily counts from history is technically possible. We don't, for one reason: **pre-v6 coverage was partial**. Migration 018 widened the history trigger to composite-PK tables (`ResourceAssignments`, `ResourceRelationships`, `IdentityMembers`) only as of mid-2026. A reconstructed early section would tell a misleading "we grew governance from 0%" story when the early days were simply not tracked.
+
+So the chart starts as a single point on the day migration 027 applied and grows from there. After ~2 weeks the line shape becomes informative; after a quarter, the growth narrative is real.
+
+If a future migration adds a robust backfill (e.g. by replaying `_history` insert/delete events), the chart will need a visual marker on the boundary so analysts know which range is reconstructed and which is captured live.
+
+## Frontend — `TimeSeriesChart`
+
+Hand-rolled SVG, no external chart library. The component:
+
+- Accepts `data: [{ date: 'YYYY-MM-DD', value: number }]`.
+- Auto-fits the Y axis with a `niceStep`-rounded scale, or pins it (`yMin=0, yMax=100` for percentages).
+- Renders an area fill + line + endpoint dot. Per-point hit zones via transparent rects with `<title>` tooltips.
+- Empty-state message rendered inside the SVG so the parent container's height stays consistent across data states.
+- Dark-mode aware via `useIsDark()` — grid / axis colors swap at render time.
+
+The chart is lazy-loaded — `DashboardTrendsTab` and `TimeSeriesChart` only enter the bundle when the user clicks the Trends tab.
+
+## API — `GET /api/admin/dashboard-timeseries`
+
+| Param | Default | Range | Notes |
+|---|---|---|---|
+| `days` | 90 | 1 – 730 | Caps at 2 years so the request stays bounded |
+
+Response:
+```json
+{
+  "days": 90,
+  "data": [
+    { "date": "2026-05-18", "systems": 1, "principals": 8093, "resources": 11375, "assignments": 364883, "governedAssignments": 6827, /* ... */ }
+  ]
+}
+```
+
+`data` is sorted ascending by date. Missing days (e.g. if the scheduler was down) are simply absent from the array — the chart connects across the gap. If you want to detect downtime, compare `data.length` to `days`.
+
+## Related references
+
+- Live dashboard cards endpoint: [`/admin/dashboard-stats`](../../app/api/src/routes/admin.js) — used by the Overview tab. Same fast-path technique (reltuples + targeted COUNTs).
+- Migration: [`027_dashboard_snapshots.sql`](../../app/api/src/db/migrations/027_dashboard_snapshots.sql).
+- Scheduler: [`scheduler.js`](../../app/api/src/scheduler.js) — `captureDashboardSnapshotIfMissing` is the first call in each tick.
+- Frontend entry: [`DashboardPage.jsx`](../../app/ui/src/components/DashboardPage.jsx) — tab strip between Overview and Trends.

--- a/test/nightly/Test-EntraIdCrawler.ps1
+++ b/test/nightly/Test-EntraIdCrawler.ps1
@@ -698,6 +698,22 @@ foreach ($scenario in $Scenarios) {
                     # checkbox but no phase emits rows. Remove this note when
                     # the directoryRoles phase ships.
 
+                    # Dashboard timeseries endpoint — backs the Trends tab on
+                    # the dashboard. The scheduler writes a snapshot row once
+                    # per UTC day; on a fresh CI run the snapshot may or may
+                    # not have fired yet, so we only verify the endpoint
+                    # responds with the expected `{days, data}` shape.
+                    try {
+                        $ts = Invoke-LocalApi -Path '/admin/dashboard-timeseries?days=30'
+                        if ($null -ne $ts.days -and $null -ne $ts.data) {
+                            Report-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $true "days=$($ts.days) rows=$(@($ts.data).Count)"
+                        } else {
+                            Report-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $false 'response missing days or data fields'
+                        }
+                    } catch {
+                        Report-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $false $_.Exception.Message
+                    }
+
                     # /identities/by-user smoke — the secondary query in this
                     # endpoint silently 500'd for months in 2026 because of
                     # stale column names (userId / userPrincipalName on


### PR DESCRIPTION
## Summary

Adds a **Trends** sub-tab to the Dashboard page that plots growth over time:

- **% Governed** — share of assignments wrapped by an Access Package / Business Role (headline chart, 0-100% Y axis)
- **Users / Resources / Assignments** — raw counts in three small side-by-side charts
- **Governed (raw count)** — secondary chart

Range selector switches between 30 days / 90 days / 1 year / 2 years.

## How it works

```
scheduler tick (60s) → DashboardSnapshots (one row per UTC day, ON CONFLICT noop)
                              │
                              ▼
                GET /api/admin/dashboard-timeseries?days=N
                              │
                              ▼
              DashboardTrendsTab → TimeSeriesChart × 5
```

- **Migration 027** creates `DashboardSnapshots` (date PK + 12 count columns + `capturedAt`).
- **Scheduler** picks up a new `captureDashboardSnapshotIfMissing()` step at the top of every tick. Cheap existence check; ~50-100 ms write on the first tick of a new UTC day; idempotent across container restarts / tick races (`ON CONFLICT DO NOTHING`).
- **Snapshot SQL** reuses the same `pg_class.reltuples` fast-path as `/admin/dashboard-stats` for the big tables, exact `COUNT(*)` for the filtered columns (`Governed`, `BusinessRole`).
- **Endpoint** `GET /api/admin/dashboard-timeseries?days=N` (cap 730) returns rows ASC.
- **Charts** are hand-rolled SVG (`TimeSeriesChart.jsx`) — no chart library dependency. Dark-mode aware. The Trends tab is lazy-loaded so it doesn't bloat the dashboard's first paint.

## No backfill — deliberate

Pre-v6 history coverage was partial (composite-PK history triggers landed in migration 018), so reconstructing daily counts from `_history` would silently tell a misleading "we grew governance from 0%" story for the early section. The chart starts as a single point on the day migration 027 applies and grows from there.

Documented in [`docs/architecture/dashboard-trends.md`](docs/architecture/dashboard-trends.md).

## Validation on sidekick-3

After applying migration 027 and waiting one scheduler tick, the endpoint returned the expected shape with today's snapshot for the Port of Rotterdam tenant:

| | |
|---|---|
| Users | 8,093 |
| Resources | 11,375 |
| Assignments | 364,883 |
| Governed | 6,827 (1.87%) |

## Tests added

- **Nightly** (`Test-EntraIdCrawler.ps1`) — smoke assertion that `/admin/dashboard-timeseries?days=30` returns the expected `{days, data}` shape.
- **Playwright** (`dashboard.spec.js`) — covers tab strip (Overview / Trends both clickable), Trends tab renders the chart container + range selector, range selector changes value without crashing.

## Docs

- **New** `docs/architecture/dashboard-trends.md` — snapshot architecture, the no-backfill decision, lifecycle of the capture, API surface, chart rendering details.
- Pointers added to `app/ui/CLAUDE.md` so future contributors find the new components.

## Test plan

- [x] Migration 027 applies on sidekick-3 without error
- [x] Scheduler writes today's row on first tick after deploy
- [x] `GET /api/admin/dashboard-timeseries?days=30` returns 200 with `{days:30, data:[…]}`
- [x] Repeated scheduler ticks don't write duplicate rows (idempotency)
- [x] Dashboard renders with Overview as default tab
- [x] Trends tab loads via lazy import and renders empty-state message in the chart SVG before the first snapshot, transitions to data after
- [ ] Reviewer: open the dashboard a day or two after merge, confirm the line starts forming with multiple data points

🤖 Generated with [Claude Code](https://claude.com/claude-code)