### PR TITLE
fix: enforce WCAG 2.0 AA contrast across all UI components

### DIFF
--- a/app/ui/CLAUDE.md
+++ b/app/ui/CLAUDE.md
@@ -14,6 +14,16 @@ The UI supports a light/dark theme toggle via Tailwind v4's class-based dark mod
 
 **Rule: all light-theme colors must meet WCAG 2.0 AA contrast.** Any hardcoded color used as text, icon, or border on a light background must achieve ≥4.5:1 contrast ratio against that background (≥3:1 for large text ≥18pt / bold ≥14pt). Use Tailwind 700–800 tier values for colored text on white — mid-tone 400–500 values consistently fail. Check new color constants with a contrast tool before committing. The `TAG_COLORS` array in `src/utils/colors.js` is the reference example of compliant values.
 
+**Enforced by lint:** The ESLint rule `local/no-low-contrast-text` (defined in `eslint-rules/no-low-contrast-text.js`) flags any bare (light-mode) Tailwind `text-{color}-300` or `text-{color}-400` class in JSX `className` attributes and blocks the build. Fix by raising to `-600` and pairing with a `dark:` override:
+```jsx
+// ✗ FAILS lint (and WCAG)
+className="text-gray-400 dark:text-gray-500"
+
+// ✓ Passes lint
+className="text-gray-600 dark:text-gray-400"
+```
+Exception: shades 100–200 are not flagged because they are routinely used as near-white text on dark/colored button backgrounds (`bg-gray-900 text-gray-100`). Use them only in that context.
+
 **Common patterns:**
 ```jsx
 // Container cards

--- a/app/ui/eslint-rules/no-low-contrast-text.js
+++ b/app/ui/eslint-rules/no-low-contrast-text.js
@@ -1,0 +1,126 @@
+// ESLint rule: no-low-contrast-text
+//
+// Flags Tailwind text color classes whose light-mode shade (100–400) fails
+// WCAG 2.0 AA contrast (≥4.5:1) on white/near-white backgrounds.
+//
+// Checks className string literals, template literal static parts, and
+// conditional expression branches — the three main patterns in this codebase.
+// Skips any token prefixed with a Tailwind variant (dark:, hover:, focus:,
+// etc.) since those apply only in specific contexts.
+//
+// Rule: use text-{color}-600 or above for light-mode text; always pair with a
+// dark: override. See app/ui/CLAUDE.md § Dark Mode.
+
+// 100–200 are near-white and commonly used on dark/colored button backgrounds
+// where contrast is fine — they can't be safely flagged without background context.
+// 300 (≈1.5:1) and 400 (≈2.6:1) are the shades that appear as "subtle secondary
+// text" on light backgrounds and reliably fail WCAG 2.0 AA.
+const FAIL_SHADES = new Set(['300', '400']);
+
+const TAILWIND_COLORS = new Set([
+  'gray', 'slate', 'zinc', 'neutral', 'stone',
+  'red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald',
+  'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple',
+  'fuchsia', 'pink', 'rose',
+]);
+
+function findBadClasses(str) {
+  const bad = [];
+  for (const token of str.split(/\s+/)) {
+    if (!token) continue;
+    if (token.includes(':')) continue; // skip dark:/hover:/focus:/etc. variants
+    const m = /^text-([a-z]+)-(\d{3})$/.exec(token);
+    if (m && TAILWIND_COLORS.has(m[1]) && FAIL_SHADES.has(m[2])) {
+      bad.push(token);
+    }
+  }
+  return bad;
+}
+
+function reportBad(node, bad, context) {
+  for (const cls of bad) {
+    context.report({
+      node,
+      messageId: 'lowContrast',
+      data: { cls },
+    });
+  }
+}
+
+function checkStringValue(node, value, context) {
+  reportBad(node, findBadClasses(value), context);
+}
+
+// Recursively walks expression nodes that can appear inside className={...}
+// to find string literals and template literal static parts.
+function walkExpr(node, context) {
+  if (!node) return;
+  switch (node.type) {
+    case 'Literal':
+      if (typeof node.value === 'string') checkStringValue(node, node.value, context);
+      break;
+    case 'TemplateLiteral':
+      for (const quasi of node.quasis) {
+        checkStringValue(quasi, quasi.value.cooked || '', context);
+      }
+      for (const expr of node.expressions) {
+        walkExpr(expr, context);
+      }
+      break;
+    case 'ConditionalExpression':
+      walkExpr(node.consequent, context);
+      walkExpr(node.alternate, context);
+      break;
+    case 'LogicalExpression':
+      walkExpr(node.left, context);
+      walkExpr(node.right, context);
+      break;
+    case 'BinaryExpression':
+      if (node.operator === '+') {
+        walkExpr(node.left, context);
+        walkExpr(node.right, context);
+      }
+      break;
+    case 'CallExpression':
+      // e.g. clsx('text-gray-400', ...) — check string args
+      for (const arg of node.arguments) {
+        walkExpr(arg, context);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Tailwind text color classes that fail WCAG 2.0 AA contrast (≥4.5:1) on light backgrounds.',
+      url: 'app/ui/CLAUDE.md',
+    },
+    schema: [],
+    messages: {
+      lowContrast:
+        'Text class "{{cls}}" fails WCAG 2.0 AA on light backgrounds. ' +
+        'Use -600 or above (e.g. text-gray-600), paired with a dark: variant (e.g. dark:text-gray-400).',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name?.name !== 'className') return;
+        const val = node.value;
+        if (!val) return;
+
+        if (val.type === 'Literal') {
+          checkStringValue(val, val.value ?? '', context);
+        } else if (val.type === 'JSXExpressionContainer') {
+          walkExpr(val.expression, context);
+        }
+      },
+    };
+  },
+};

--- a/app/ui/eslint.config.js
+++ b/app/ui/eslint.config.js
@@ -1,6 +1,7 @@
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import noLowContrastText from './eslint-rules/no-low-contrast-text.js';
 
 export default [
   { ignores: ['dist', 'playwright-report', 'test-results'] },
@@ -18,9 +19,11 @@ export default [
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'local': { rules: { 'no-low-contrast-text': noLowContrastText } },
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      'local/no-low-contrast-text': 'error',
       // React Compiler strict rules — downgrade to warnings until data-fetching
       // patterns are refactored to avoid setState-in-effect (requires Suspense or
       // useTransition migration across all detail pages).

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
+﻿import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { useMatrix } from './hooks/useMatrix';
 import { useAuth } from './auth/AuthGate';
 import { useTheme } from './hooks/useTheme';
@@ -381,7 +381,7 @@ export default function App() {
                 {(account?.name || account?.username || '?')[0].toUpperCase()}
               </div>
               <span className="hidden sm:inline">{account?.name || account?.username || 'User'}</span>
-              <svg className={`w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform ${settingsOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className={`w-3.5 h-3.5 text-gray-600 dark:text-gray-500 transition-transform ${settingsOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </button>
@@ -515,7 +515,7 @@ export default function App() {
                 <span className="truncate max-w-[140px]">{tab.displayName}</span>
                 <span
                   onClick={(e) => { e.stopPropagation(); closeDetailTab(tab.type, tab.id); }}
-                  className="ml-0.5 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                  className="ml-0.5 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
                   title="Close"
                 >
                   <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -601,7 +601,7 @@ export default function App() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-2 text-xs text-gray-400 dark:text-gray-500 text-center flex items-center justify-center gap-2">
+      <footer className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-2 text-xs text-gray-600 dark:text-gray-500 text-center flex items-center justify-center gap-2">
         <button
           onClick={() => navigate('admin?sub=about')}
           className="hover:text-gray-600 dark:hover:text-gray-300 hover:underline focus:outline-none"

--- a/app/ui/src/components/AccessPackageDetailPage.jsx
+++ b/app/ui/src/components/AccessPackageDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+﻿import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import RiskScoreSection from './RiskScoreSection';
 import { formatDate, computeHistoryDiffs, friendlyLabel } from '../utils/formatters';
@@ -161,7 +161,7 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
           )}
         </div>
         <button onClick={onClose}
-          className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
           title="Close tab">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -182,7 +182,7 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
                 onNodeClick={graph.handleNodeClick}
               />
               {graph.pathDepth > 0 && (
-                <div className="text-xs text-gray-400 dark:text-gray-500 text-center pb-2">
+                <div className="text-xs text-gray-600 dark:text-gray-500 text-center pb-2">
                   <span className="font-medium text-gray-600 dark:text-gray-300">{graph.activeListLabel}</span>
                   {' — '}
                   <button onClick={graph.reset} className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline">collapse</button>
@@ -199,7 +199,7 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
               />
             ) : (
               <div className="bg-white dark:bg-gray-800 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg p-6 text-center">
-                <p className="text-sm text-gray-400 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
+                <p className="text-sm text-gray-600 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
               </div>
             )}
           </div>
@@ -225,7 +225,7 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
           loading={historyLoading}
         >
           {historyDiffs.length === 0 ? (
-            <p className="text-sm text-gray-400 dark:text-gray-500 italic p-4">No changes recorded</p>
+            <p className="text-sm text-gray-600 dark:text-gray-500 italic p-4">No changes recorded</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
@@ -243,9 +243,9 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
                         {diff.changes.map((c, j) => (
                           <div key={j} className="text-xs">
                             <span className="font-medium text-gray-700 dark:text-gray-300">{friendlyLabel(c.field)}</span>
-                            <span className="text-gray-400 dark:text-gray-500 mx-1">:</span>
+                            <span className="text-gray-600 dark:text-gray-500 mx-1">:</span>
                             <span className="text-red-500 dark:text-red-400 line-through mr-1">{c.from}</span>
-                            <span className="text-gray-400 dark:text-gray-500 mr-1">&rarr;</span>
+                            <span className="text-gray-600 dark:text-gray-500 mr-1">&rarr;</span>
                             <span className="text-green-600 dark:text-green-400">{c.to}</span>
                           </div>
                         ))}

--- a/app/ui/src/components/AccessPackagesPage.jsx
+++ b/app/ui/src/components/AccessPackagesPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+﻿import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { TAG_COLORS } from '../utils/colors';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
@@ -454,7 +454,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                       {sortCol === col.key ? (
                         <span className="text-blue-600 text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>
                       ) : (
-                        <span className="text-gray-300 dark:text-gray-500 text-[10px]">{'▴'}</span>
+                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
                       )}
                     </span>
                   </th>
@@ -468,7 +468,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                     {sortCol === 'category' ? (
                       <span className="text-blue-600 text-[10px]">{sortDir === 'asc' ? '▲' : '▼'}</span>
                     ) : (
-                      <span className="text-gray-300 dark:text-gray-500 text-[10px]">{'▴'}</span>
+                      <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
                     )}
                   </span>
                 </th>
@@ -526,7 +526,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                         </span>
                         {ap.reviewerInfo && (ap.complianceStatus === 'Missed' || ap.complianceStatus === 'In Progress') && (
                           <div className="mt-0.5 text-gray-500 dark:text-gray-400 text-[11px] leading-tight" title={`Reviewer: ${ap.reviewerInfo}`}>
-                            <span className="text-gray-400 dark:text-gray-500">Reviewer: </span>{ap.reviewerInfo}
+                            <span className="text-gray-600 dark:text-gray-500">Reviewer: </span>{ap.reviewerInfo}
                           </div>
                         )}
                         {ap.missedReviewsCount > 0 && (
@@ -540,7 +540,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                       </div>
                     ) : ap.totalAssignments === 0 ? (
                       <span
-                        className="text-gray-400 dark:text-gray-500 text-xs"
+                        className="text-gray-600 dark:text-gray-500 text-xs"
                         title={ap.hasReviewConfigured
                           ? 'Review is configured but there are no active assignments — nothing to review'
                           : 'No active assignments'}
@@ -557,7 +557,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                         </span>
                         {ap.reviewerInfo && (
                           <div className="mt-0.5 text-gray-500 dark:text-gray-400 text-[11px] leading-tight" title={`Reviewer: ${ap.reviewerInfo}`}>
-                            <span className="text-gray-400 dark:text-gray-500">Reviewer: </span>{ap.reviewerInfo}
+                            <span className="text-gray-600 dark:text-gray-500">Reviewer: </span>{ap.reviewerInfo}
                           </div>
                         )}
                         {ap.missedReviewsCount > 0 && (
@@ -571,7 +571,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                       </div>
                     ) : (
                       <span
-                        className="text-gray-400 dark:text-gray-500 text-xs"
+                        className="text-gray-600 dark:text-gray-500 text-xs"
                         title="No certification is configured on any assignment policy for this business role"
                       >
                         Not required
@@ -579,7 +579,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                     )}
                   </td>
                   <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs whitespace-nowrap">
-                    {ap.lastReviewDate ? formatDate(ap.lastReviewDate) : <span className="text-gray-300 dark:text-gray-500">-</span>}
+                    {ap.lastReviewDate ? formatDate(ap.lastReviewDate) : <span className="text-gray-500 dark:text-gray-500">-</span>}
                   </td>
                   <td className="px-3 py-2 text-gray-500 dark:text-gray-400 text-xs">
                     {ap.lastReviewedBy ? (
@@ -595,7 +595,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
                         ap.lastReviewedBy
                       )
                     ) : (
-                      <span className="text-gray-300 dark:text-gray-500">-</span>
+                      <span className="text-gray-500 dark:text-gray-500">-</span>
                     )}
                   </td>
                   <td className="px-3 py-2" onClick={e => e.stopPropagation()}>

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
+﻿import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import ScheduleEditor from './ScheduleEditor';
 
@@ -26,7 +26,7 @@ function MetaBadge({ label, value }) {
   if (!value) return null;
   return (
     <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs">
-      <span className="text-gray-400 dark:text-gray-500">{label}:</span>
+      <span className="text-gray-600 dark:text-gray-500">{label}:</span>
       <span className="font-medium">{value}</span>
     </span>
   );
@@ -66,7 +66,7 @@ function Section({ title, icon, children, defaultOpen = false }) {
           <span className="text-lg">{icon}</span>
           <span className="font-medium text-gray-900 dark:text-white">{title}</span>
         </div>
-        <svg className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className={`w-4 h-4 text-gray-600 dark:text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
@@ -77,7 +77,7 @@ function Section({ title, icon, children, defaultOpen = false }) {
 
 function NotConfigured({ message }) {
   return (
-    <div className="mt-4 flex items-center gap-2 text-sm text-gray-400 dark:text-gray-500">
+    <div className="mt-4 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-500">
       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
@@ -108,7 +108,7 @@ function RiskProfileSection() {
   }, [authFetch]);
 
   const content = () => {
-    if (loading) return <p className="mt-4 text-sm text-gray-400 dark:text-gray-500">Loading...</p>;
+    if (loading) return <p className="mt-4 text-sm text-gray-600 dark:text-gray-500">Loading...</p>;
     if (!data?.available) {
       return (
         <div className="mt-4">
@@ -252,7 +252,7 @@ const TIER_STYLES_SMALL = {
 };
 
 function ClassifierTable({ rules, emptyMsg }) {
-  if (!rules?.length) return <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">{emptyMsg}</p>;
+  if (!rules?.length) return <p className="text-xs text-gray-600 dark:text-gray-500 mt-2">{emptyMsg}</p>;
   return (
     <div className="mt-2 overflow-x-auto rounded border border-gray-200 dark:border-gray-700">
       <table className="w-full text-xs">
@@ -274,7 +274,7 @@ function ClassifierTable({ rules, emptyMsg }) {
                 <td className="px-3 py-2 font-medium text-gray-800 dark:text-gray-200">
                   {rule.label || rule.id || '—'}
                   {rule.description && (
-                    <p className="text-gray-400 dark:text-gray-500 font-normal mt-0.5 leading-relaxed">{rule.description}</p>
+                    <p className="text-gray-600 dark:text-gray-500 font-normal mt-0.5 leading-relaxed">{rule.description}</p>
                   )}
                 </td>
                 <td className="px-3 py-2 text-gray-600 dark:text-gray-400 font-mono">
@@ -351,7 +351,7 @@ function ClassifiersSection() {
   };
 
   const content = () => {
-    if (loading) return <p className="mt-4 text-sm text-gray-400 dark:text-gray-500">Loading...</p>;
+    if (loading) return <p className="mt-4 text-sm text-gray-600 dark:text-gray-500">Loading...</p>;
     if (!data?.available) {
       return (
         <div className="mt-4">
@@ -507,7 +507,7 @@ function CorrelationSection() {
   }, [authFetch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const content = () => {
-    if (loading) return <p className="mt-4 text-sm text-gray-400 dark:text-gray-500">Loading...</p>;
+    if (loading) return <p className="mt-4 text-sm text-gray-600 dark:text-gray-500">Loading...</p>;
     if (!data?.available) {
       return (
         <div className="mt-4">
@@ -557,7 +557,7 @@ function CorrelationSection() {
 
         {activeTab === 'signals' && (
           signals.length === 0
-            ? <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">No correlation signals defined.</p>
+            ? <p className="text-xs text-gray-600 dark:text-gray-500 mt-2">No correlation signals defined.</p>
             : <div className="mt-2 overflow-x-auto rounded border border-gray-200 dark:border-gray-700">
                 <table className="w-full text-xs">
                   <thead>
@@ -590,14 +590,14 @@ function CorrelationSection() {
 
         {activeTab === 'accountTypes' && (
           accountTypeRules.length === 0
-            ? <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">No account type rules defined.</p>
+            ? <p className="text-xs text-gray-600 dark:text-gray-500 mt-2">No account type rules defined.</p>
             : <div className="mt-2 space-y-2">
                 {accountTypeRules.map((rule, i) => (
                   <div key={i} className="p-3 bg-gray-50 dark:bg-gray-700/50 rounded border border-gray-200 dark:border-gray-600">
                     <div className="flex items-center gap-2 mb-1">
                       <span className="font-medium text-sm text-gray-800 dark:text-gray-200">{rule.accountType || rule.type || `Rule ${i + 1}`}</span>
                       {rule.priority !== undefined && (
-                        <span className="text-xs text-gray-400 dark:text-gray-500">priority {rule.priority}</span>
+                        <span className="text-xs text-gray-600 dark:text-gray-500">priority {rule.priority}</span>
                       )}
                     </div>
                     {rule.patterns?.length > 0 && (

--- a/app/ui/src/components/AuthSettingsPage.jsx
+++ b/app/ui/src/components/AuthSettingsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+﻿import { useEffect, useState } from 'react';
 import { useAuth } from '../auth/AuthGate';
 
 function CopyableCommand({ command }) {
@@ -92,15 +92,15 @@ export default function AuthSettingsPage() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm bg-white/60 dark:bg-gray-800/60 rounded p-3 border border-gray-200 dark:border-gray-600">
           <div>
             <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Tenant ID</div>
-            <div className="font-mono text-xs mt-0.5 break-all dark:text-gray-200">{tenantId || <span className="text-gray-400 dark:text-gray-500">— not set —</span>}</div>
+            <div className="font-mono text-xs mt-0.5 break-all dark:text-gray-200">{tenantId || <span className="text-gray-600 dark:text-gray-500">— not set —</span>}</div>
           </div>
           <div>
             <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Client ID</div>
-            <div className="font-mono text-xs mt-0.5 break-all dark:text-gray-200">{clientId || <span className="text-gray-400 dark:text-gray-500">— not set —</span>}</div>
+            <div className="font-mono text-xs mt-0.5 break-all dark:text-gray-200">{clientId || <span className="text-gray-600 dark:text-gray-500">— not set —</span>}</div>
           </div>
           <div>
             <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Required roles</div>
-            <div className="text-xs mt-0.5 dark:text-gray-200">{requiredRoles.length ? requiredRoles.join(', ') : <span className="text-gray-400 dark:text-gray-500">— any signed-in user —</span>}</div>
+            <div className="text-xs mt-0.5 dark:text-gray-200">{requiredRoles.length ? requiredRoles.join(', ') : <span className="text-gray-600 dark:text-gray-500">— any signed-in user —</span>}</div>
           </div>
         </div>
 

--- a/app/ui/src/components/ConfidenceBar.jsx
+++ b/app/ui/src/components/ConfidenceBar.jsx
@@ -1,11 +1,11 @@
-const CONFIDENCE_TOOLTIP = 'Correlation confidence — how certain the system is that the linked accounts belong to the same person.';
+﻿const CONFIDENCE_TOOLTIP = 'Correlation confidence — how certain the system is that the linked accounts belong to the same person.';
 
 export default function ConfidenceBar({ confidence }) {
   if (confidence == null) {
     return (
       <div className="flex items-center gap-2" title={`${CONFIDENCE_TOOLTIP} Not yet calculated.`}>
         <div className="w-20 h-2 bg-gray-200 dark:bg-gray-700 rounded-full" />
-        <span className="text-xs font-mono text-gray-400 dark:text-gray-500 w-8 text-right">—%</span>
+        <span className="text-xs font-mono text-gray-600 dark:text-gray-500 w-8 text-right">—%</span>
       </div>
     );
   }

--- a/app/ui/src/components/ContainerStatsPage.jsx
+++ b/app/ui/src/components/ContainerStatsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+﻿import { useEffect, useState, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 
 function fmtBytes(n) {
@@ -21,7 +21,7 @@ function Bar({ percent, color }) {
 function LineChart({ data, maxValue, color, height = 60, label }) {
   if (!data || data.length === 0) {
     return (
-      <div className="text-xs text-gray-400 dark:text-gray-500 text-center py-4">
+      <div className="text-xs text-gray-600 dark:text-gray-500 text-center py-4">
         Collecting data...
       </div>
     );
@@ -264,10 +264,10 @@ export default function ContainerStatsPage() {
                   <div>
                     <div className="text-xs text-gray-600 dark:text-gray-400 mb-1">Network</div>
                     <div className="font-mono text-xs text-gray-900 dark:text-white">
-                      ↓ {rate.rxRate != null ? `${fmtBytes(rate.rxRate)}/s` : '—'} <span className="text-gray-400 dark:text-gray-500">({fmtBytes(c.netRxBytes)} total)</span>
+                      ↓ {rate.rxRate != null ? `${fmtBytes(rate.rxRate)}/s` : '—'} <span className="text-gray-600 dark:text-gray-500">({fmtBytes(c.netRxBytes)} total)</span>
                     </div>
                     <div className="font-mono text-xs text-gray-900 dark:text-white">
-                      ↑ {rate.txRate != null ? `${fmtBytes(rate.txRate)}/s` : '—'} <span className="text-gray-400 dark:text-gray-500">({fmtBytes(c.netTxBytes)} total)</span>
+                      ↑ {rate.txRate != null ? `${fmtBytes(rate.txRate)}/s` : '—'} <span className="text-gray-600 dark:text-gray-500">({fmtBytes(c.netTxBytes)} total)</span>
                     </div>
                   </div>
                 </div>

--- a/app/ui/src/components/ContextDetailPage.jsx
+++ b/app/ui/src/components/ContextDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+﻿import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import RiskScoreSection from './RiskScoreSection';
 import ManualContextEditor from './contexts/ManualContextEditor';
@@ -129,7 +129,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
 
   if (!detail || !detail.attributes) {
     return (
-      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center text-gray-400 dark:text-gray-500 text-sm">
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center text-gray-600 dark:text-gray-500 text-sm">
         Context not found.
         <button onClick={onClose} className="ml-2 text-blue-500 dark:text-blue-400 underline hover:text-blue-700 dark:text-blue-300">Close</button>
       </div>
@@ -209,7 +209,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                   <span className="text-sm text-gray-900 dark:text-white group-hover:text-sky-700 dark:text-sky-300">{sc.displayName}</span>
                 </div>
                 {sc.memberCount != null && (
-                  <span className="text-xs text-gray-400 dark:text-gray-500">{sc.memberCount} members</span>
+                  <span className="text-xs text-gray-600 dark:text-gray-500">{sc.memberCount} members</span>
                 )}
               </button>
             ))}
@@ -282,9 +282,9 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
         )}
 
         {membersLoading ? (
-          <div className="text-center text-gray-400 dark:text-gray-500 py-8 text-sm">Loading members...</div>
+          <div className="text-center text-gray-600 dark:text-gray-500 py-8 text-sm">Loading members...</div>
         ) : members.length === 0 ? (
-          <div className="text-center text-gray-400 dark:text-gray-500 py-8 text-sm">No members found.</div>
+          <div className="text-center text-gray-600 dark:text-gray-500 py-8 text-sm">No members found.</div>
         ) : (
           <>
             <table className="w-full text-sm">
@@ -323,7 +323,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                     {canEditMembers && (
                       <td className="py-1.5 text-right">
                         {includeDescendants ? (
-                          <span className="text-[11px] text-gray-400 dark:text-gray-500" title="Turn off sub-context view to remove members">—</span>
+                          <span className="text-[11px] text-gray-600 dark:text-gray-500" title="Turn off sub-context view to remove members">—</span>
                         ) : (
                           <RemoveMemberButton
                             memberRow={m}
@@ -348,7 +348,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                 >
                   Previous
                 </button>
-                <span className="text-xs text-gray-400 dark:text-gray-500">
+                <span className="text-xs text-gray-600 dark:text-gray-500">
                   Page {memberPage + 1} of {totalPages}
                 </span>
                 <button
@@ -405,7 +405,7 @@ function ContextHeader({ attrs, onClose }) {
             <p className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-1">Parent: {attrs.parentDisplayName}</p>
           )}
         </div>
-        <button onClick={onClose} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 p-1" title="Close">
+        <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 p-1" title="Close">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>

--- a/app/ui/src/components/CorrelationWizard.jsx
+++ b/app/ui/src/components/CorrelationWizard.jsx
@@ -1,4 +1,4 @@
-// Identity Atlas v5 — Account Correlation Ruleset wizard.
+﻿// Identity Atlas v5 — Account Correlation Ruleset wizard.
 //
 // Multi-step UX for creating account correlation rulesets via LLM. Steps:
 //   1. Sources   — domain, org name, hints, connected systems
@@ -182,7 +182,7 @@ export default function CorrelationWizard({ onClose, onSaved }) {
             const active = i === stepIdx;
             return (
               <div key={s.key} className="flex-1 flex items-center">
-                <div className={`flex items-center gap-2 ${active ? 'font-semibold text-indigo-700 dark:text-indigo-400' : done ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}`}>
+                <div className={`flex items-center gap-2 ${active ? 'font-semibold text-indigo-700 dark:text-indigo-400' : done ? 'text-gray-700 dark:text-gray-300' : 'text-gray-600 dark:text-gray-500'}`}>
                   <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs ${active ? 'bg-indigo-600 text-white' : done ? 'bg-green-500 text-white' : 'bg-gray-200 dark:bg-gray-600'}`}>
                     {done ? '✓' : i + 1}
                   </div>
@@ -469,7 +469,7 @@ function Modal({ onClose, title, children }) {
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 px-6 py-4">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
-          <button onClick={onClose} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/app/ui/src/components/CrawlersPage.jsx
+++ b/app/ui/src/components/CrawlersPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+﻿import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import ScheduleEditor from './ScheduleEditor';
 
@@ -51,7 +51,7 @@ function StepIndicator({ steps, step, onStepClick, allowAll }) {
             ) : (
               <div className="flex items-center gap-2">{content}</div>
             )}
-            {i < arr.length - 1 && <span className="text-gray-300 dark:text-gray-600">→</span>}
+            {i < arr.length - 1 && <span className="text-gray-500 dark:text-gray-600">→</span>}
           </div>
         );
       })}
@@ -177,7 +177,7 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
       </div>
       <div className="max-h-72 overflow-y-auto border border-gray-200 rounded bg-white dark:border-gray-600 dark:bg-gray-800">
         {visible.length === 0 ? (
-          <div className="text-xs text-gray-400 italic p-2 dark:text-gray-500">No attributes match filter</div>
+          <div className="text-xs text-gray-600 italic p-2 dark:text-gray-500">No attributes match filter</div>
         ) : (
           <div className="divide-y divide-gray-100 dark:divide-gray-700">
             {visible.map(attr => {
@@ -199,7 +199,7 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
           </div>
         )}
       </div>
-      <p className="text-xs text-gray-400 mt-1 dark:text-gray-500">
+      <p className="text-xs text-gray-600 mt-1 dark:text-gray-500">
         <span className="text-indigo-500 dark:text-indigo-400">core</span> = always synced.
         Extras go into the extendedAttributes JSON column.
       </p>
@@ -561,8 +561,8 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
             <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
               {Object.entries(validation.permissions || {}).sort(([a], [b]) => a.localeCompare(b)).map(([perm, granted]) => (
                 <div key={perm} className="flex items-center gap-2 text-sm py-1">
-                  <span className={granted ? 'text-green-600 dark:text-green-400' : 'text-red-400 dark:text-red-400'}>{granted ? '✓' : '✗'}</span>
-                  <span className={granted ? 'dark:text-gray-200' : 'text-gray-400 line-through dark:text-gray-500'}>{perm}</span>
+                  <span className={granted ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>{granted ? '✓' : '✗'}</span>
+                  <span className={granted ? 'dark:text-gray-200' : 'text-gray-600 line-through dark:text-gray-500'}>{perm}</span>
                 </div>
               ))}
             </div>
@@ -643,7 +643,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
                   return (
                     <div>
                       <label className="block text-xs font-medium mb-1 dark:text-gray-300">
-                        Value{filterType && <span className="ml-1 text-gray-400 dark:text-gray-500">({filterType})</span>}
+                        Value{filterType && <span className="ml-1 text-gray-600 dark:text-gray-500">({filterType})</span>}
                       </label>
                       {isBool && idFilterCondition !== 'inValues' ? (
                         <select value={idFilterValue || 'true'} onChange={e => setIdFilterValue(e.target.value)}
@@ -899,12 +899,12 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onExport, onFor
         <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm mb-3">
           <div><span className="text-gray-500 dark:text-gray-400">Tenant ID:</span> <span className="font-mono text-xs dark:text-gray-300">{cfg.tenantId || '—'}</span></div>
           <div><span className="text-gray-500 dark:text-gray-400">Client ID:</span> <span className="font-mono text-xs dark:text-gray-300">{cfg.clientId || '—'}</span></div>
-          <div><span className="text-gray-500 dark:text-gray-400">Secret:</span> <span className="text-gray-400 dark:text-gray-500">{SECRET_MASK}</span></div>
+          <div><span className="text-gray-500 dark:text-gray-400">Secret:</span> <span className="text-gray-600 dark:text-gray-500">{SECRET_MASK}</span></div>
           <div>
             <span className="text-gray-500 dark:text-gray-400">Objects:</span>{' '}
             {objectLabels.length > 0
               ? objectLabels.map(l => <span key={l} className="inline-block mr-1 px-1.5 py-0.5 bg-indigo-50 text-indigo-700 text-xs rounded dark:bg-indigo-900/30 dark:text-indigo-300">{l}</span>)
-              : <span className="text-gray-400 text-xs dark:text-gray-500">none</span>
+              : <span className="text-gray-600 text-xs dark:text-gray-500">none</span>
             }
           </div>
         </div>
@@ -1330,7 +1330,7 @@ function RecentJobs({ jobs, onForceStop }) {
                 ? <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300" title="Full: re-fetches everything from the source, ignores any stored delta tokens.">full</span>
                 : jobSyncMode === 'delta'
                   ? <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 dark:bg-slate-700/40 dark:text-slate-300" title="Delta: fetches only what changed since the last successful run.">delta</span>
-                  : <span className="text-gray-400 text-xs">—</span>;
+                  : <span className="text-gray-600 text-xs">—</span>;
               return (
                 <tr key={j.id}>
                   <td className="p-3 font-medium dark:text-gray-200">{j.jobType}</td>

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -1,4 +1,4 @@
-// Identity Atlas — Dashboard / landing page.
+﻿// Identity Atlas — Dashboard / landing page.
 //
 // One-shot overview showing:
 //   - A brain-like SVG force-graph that echoes the logo
@@ -171,7 +171,7 @@ export default function DashboardPage({ onNavigate }) {
           <div className="flex items-center justify-between mb-5">
             <h2 className="text-xs font-bold text-lime-700 uppercase tracking-widest">Loaded data</h2>
             {hasData && (
-              <span className="text-xs text-gray-400 dark:text-gray-500">
+              <span className="text-xs text-gray-600 dark:text-gray-500">
                 Last sync <span className="text-gray-700 dark:text-gray-300">{formatRelativeTime(stats.lastSyncAt)}</span>
               </span>
             )}
@@ -194,7 +194,7 @@ export default function DashboardPage({ onNavigate }) {
                 <StatCard label="Relationships"    value={stats.relationships}  />
                 <StatCard label="Identity Members" value={stats.identityMembers} onClick={() => onNavigate?.('identities')} />
               </div>
-              <div className="mt-5 pt-4 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400 dark:text-gray-500 text-right">
+              <div className="mt-5 pt-4 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-500 text-right">
                 <button
                   onClick={() => onNavigate?.('sync-log')}
                   className="hover:text-lime-700 hover:underline transition-colors"
@@ -289,7 +289,7 @@ export default function DashboardPage({ onNavigate }) {
       </div>
 
       {/* Footer */}
-      <div className="text-center text-xs text-gray-400 dark:text-gray-500 pb-6">
+      <div className="text-center text-xs text-gray-600 dark:text-gray-500 pb-6">
         Created by{' '}
         <a href="https://www.fortigi.nl" target="_blank" rel="noopener noreferrer" className="hover:underline text-gray-500 dark:text-gray-400 hover:text-lime-700 transition-colors">
           Maatschap Fortigi
@@ -316,10 +316,10 @@ function StatCard({ label, value, onClick }) {
             : 'bg-gradient-to-br from-lime-50 to-white dark:from-lime-900/25 dark:to-gray-800 ring-1 ring-lime-200 dark:ring-lime-700/50'
       }`}
     >
-      <div className={`text-2xl font-bold tabular-nums ${empty ? 'text-gray-400 dark:text-gray-500' : 'text-gray-900 dark:text-white'}`}>
+      <div className={`text-2xl font-bold tabular-nums ${empty ? 'text-gray-600 dark:text-gray-500' : 'text-gray-900 dark:text-white'}`}>
         {formatNumber(value)}
       </div>
-      <div className={`text-xs mt-0.5 font-medium ${empty ? 'text-gray-400 dark:text-gray-500' : 'text-lime-700'}`}>
+      <div className={`text-xs mt-0.5 font-medium ${empty ? 'text-gray-600 dark:text-gray-500' : 'text-lime-700'}`}>
         {label}
       </div>
     </div>
@@ -368,7 +368,7 @@ function NoDataState({ onNavigate }) {
       >
         Configure a crawler →
       </button>
-      <div className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+      <div className="mt-3 text-xs text-gray-600 dark:text-gray-500">
         Connect Entra ID, upload CSV exports, or click "Load Demo Data" in Admin → Crawlers.
       </div>
     </div>

--- a/app/ui/src/components/DepartmentDetailPage.jsx
+++ b/app/ui/src/components/DepartmentDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+﻿import { useState, useEffect, useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { TIER_STYLES } from '../utils/tierStyles';
 
@@ -268,7 +268,7 @@ function RiskSummary({ directMembers, allMembers, directRisk, allRisk, subDepts,
                 { label: 'Scored', value: `${scored.length} / ${allMembers.length}` },
               ].map(s => (
                 <div key={s.label} className="flex justify-between text-xs py-0.5">
-                  <span className="text-gray-400 dark:text-gray-500">{s.label}</span>
+                  <span className="text-gray-600 dark:text-gray-500">{s.label}</span>
                   <span className="font-mono text-gray-700 dark:text-gray-300">{s.value}</span>
                 </div>
               ))}
@@ -287,7 +287,7 @@ function RiskSummary({ directMembers, allMembers, directRisk, allRisk, subDepts,
                   >
                     {user.displayName}
                   </button>
-                  <span className="ml-auto font-mono text-gray-400 dark:text-gray-500 shrink-0">{user.riskScore}</span>
+                  <span className="ml-auto font-mono text-gray-600 dark:text-gray-500 shrink-0">{user.riskScore}</span>
                   <TierBadge tier={user.riskTier} />
                 </div>
               ))}
@@ -405,7 +405,7 @@ export default function DepartmentDetailPage({ departmentName, cachedData, onCac
               <TierBadge tier={directRisk.maxTier} showAll />
               <button
                 onClick={onClose}
-                className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
                 title="Close"
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -436,8 +436,8 @@ export default function DepartmentDetailPage({ departmentName, cachedData, onCac
             <div className="flex flex-wrap gap-1.5">
               {subDepts.map((d, i) => (
                 <span key={i} className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 px-2 py-0.5 rounded-full">
-                  {d.depth > 0 && <span className="text-gray-300 dark:text-gray-500">{'  '.repeat(d.depth)}</span>}
-                  {d.name} <span className="text-gray-400 dark:text-gray-500">({d.directCount})</span>
+                  {d.depth > 0 && <span className="text-gray-500 dark:text-gray-500">{'  '.repeat(d.depth)}</span>}
+                  {d.name} <span className="text-gray-600 dark:text-gray-500">({d.directCount})</span>
                 </span>
               ))}
             </div>
@@ -485,8 +485,8 @@ export default function DepartmentDetailPage({ departmentName, cachedData, onCac
 
         {TIER_DISPLAY.some(t => displayRisk.tierCounts[t] > 0) && (
           <div className="flex gap-2 px-6 py-2 border-b border-gray-100 dark:border-gray-700">
-            <span className="text-xs text-gray-400 dark:text-gray-500 mr-1 self-center">Avg. score: {displayRisk.avgScore}</span>
-            <span className="text-gray-200 dark:text-gray-600 self-center">|</span>
+            <span className="text-xs text-gray-600 dark:text-gray-500 mr-1 self-center">Avg. score: {displayRisk.avgScore}</span>
+            <span className="text-gray-500 dark:text-gray-500 self-center">|</span>
             {TIER_DISPLAY.filter(t => displayRisk.tierCounts[t] > 0).map(t => {
               const s = TIER_STYLES[t];
               return (
@@ -509,21 +509,21 @@ export default function DepartmentDetailPage({ departmentName, cachedData, onCac
                 >
                   {user.displayName}
                 </button>
-                <div className="text-xs text-gray-400 dark:text-gray-500 truncate">
+                <div className="text-xs text-gray-600 dark:text-gray-500 truncate">
                   {user.jobTitle || '—'}
                   {tab !== 'direct' && user._dept && (
-                    <span className="ml-1.5 text-gray-300 dark:text-gray-600">({user._dept})</span>
+                    <span className="ml-1.5 text-gray-500 dark:text-gray-600">({user._dept})</span>
                   )}
                 </div>
               </div>
               <TierBadge tier={user.riskTier} />
               {user.riskScore != null && (
-                <span className="text-xs font-mono text-gray-400 dark:text-gray-500 w-8 text-right shrink-0">{user.riskScore}</span>
+                <span className="text-xs font-mono text-gray-600 dark:text-gray-500 w-8 text-right shrink-0">{user.riskScore}</span>
               )}
             </div>
           ))}
           {sortedMembers.length === 0 && (
-            <div className="px-6 py-8 text-center text-sm text-gray-400 dark:text-gray-500">No members found.</div>
+            <div className="px-6 py-8 text-center text-sm text-gray-600 dark:text-gray-500">No members found.</div>
           )}
         </div>
       </div>

--- a/app/ui/src/components/DetailSection.jsx
+++ b/app/ui/src/components/DetailSection.jsx
@@ -1,9 +1,9 @@
-export function Section({ title, count, children }) {
+﻿export function Section({ title, count, children }) {
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
       <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
         {title}
-        {count != null && <span className="text-xs font-normal text-gray-400 dark:text-gray-500">({count})</span>}
+        {count != null && <span className="text-xs font-normal text-gray-600 dark:text-gray-500">({count})</span>}
       </h3>
       {children}
     </div>
@@ -20,11 +20,11 @@ export function CollapsibleSection({ title, count, countLabel, open, onToggle, l
         <span className="text-xs">{open ? '\u25BC' : '\u25B6'}</span>
         {title}
         {count != null && (
-          <span className="text-xs font-normal text-gray-400 dark:text-gray-500">
+          <span className="text-xs font-normal text-gray-600 dark:text-gray-500">
             ({count}{countLabel ? ` ${countLabel}` : ''})
           </span>
         )}
-        {loading && <span className="text-xs text-gray-400 dark:text-gray-500 animate-pulse">Loading...</span>}
+        {loading && <span className="text-xs text-gray-600 dark:text-gray-500 animate-pulse">Loading...</span>}
       </button>
       {open && !loading && (
         <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">

--- a/app/ui/src/components/EntityDetailLayout.jsx
+++ b/app/ui/src/components/EntityDetailLayout.jsx
@@ -1,4 +1,4 @@
-import { friendlyLabel } from '../utils/formatters';
+﻿import { friendlyLabel } from '../utils/formatters';
 import { renderAttributeValue } from '../utils/renderAttribute';
 
 // ─── EntityDetailLayout ────────────────────────────────────────────────
@@ -38,7 +38,7 @@ export function AttributesTable({ title = 'Attributes', entries }) {
         <span className="text-xs text-gray-500 dark:text-gray-400">{visible.length}</span>
       </div>
       {visible.length === 0 ? (
-        <p className="text-sm text-gray-400 dark:text-gray-500 italic p-4">No attributes</p>
+        <p className="text-sm text-gray-600 dark:text-gray-500 italic p-4">No attributes</p>
       ) : (
         <div>
           {/* table-fixed + a hard column width on the label keeps a long
@@ -60,7 +60,7 @@ export function AttributesTable({ title = 'Attributes', entries }) {
                     <span className="inline-flex items-start gap-1.5">
                       <span className="break-all">{friendlyLabel(key)}</span>
                       {meta?.extended && (
-                        <span className="inline-block px-1 py-0 rounded text-[9px] font-mono text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 shrink-0" title="From extendedAttributes">ext</span>
+                        <span className="inline-block px-1 py-0 rounded text-[9px] font-mono text-gray-600 dark:text-gray-500 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 shrink-0" title="From extendedAttributes">ext</span>
                       )}
                     </span>
                   </td>

--- a/app/ui/src/components/EntityGraph.jsx
+++ b/app/ui/src/components/EntityGraph.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef } from 'react';
+﻿import { useMemo, useState, useRef } from 'react';
 
 // ─── EntityGraph ──────────────────────────────────────────────────────
 // Radial graph: the current entity sits in the middle, relationship nodes
@@ -224,7 +224,7 @@ export default function EntityGraph({
           title="Reset graph view to default position and zoom"
         >Reset view</button>
       )}
-      <span className="absolute bottom-2 left-2 z-10 text-[10px] text-gray-400 dark:text-gray-500 select-none pointer-events-none">
+      <span className="absolute bottom-2 left-2 z-10 text-[10px] text-gray-600 dark:text-gray-500 select-none pointer-events-none">
         drag to pan · wheel to zoom{scale !== 1 ? ` · ${Math.round(scale * 100)}%` : ''}
       </span>
       <svg

--- a/app/ui/src/components/ExpandedItemsList.jsx
+++ b/app/ui/src/components/ExpandedItemsList.jsx
@@ -1,4 +1,4 @@
-// ─── ExpandedItemsList ───────────────────────────────────────────────
+﻿// ─── ExpandedItemsList ───────────────────────────────────────────────
 // Generic list shown below the entity graph when a category has been
 // drilled into. Every item the shape helper returns has the same
 // shape — { key, label, kind: 'item', entityKind, entityId } — so one
@@ -36,7 +36,7 @@ export default function ExpandedItemsList({ label, items, loading, onOpenDetail 
   }
   if (!items || items.length === 0) {
     return (
-      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 text-center text-sm text-gray-400 dark:text-gray-500 italic">
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 text-center text-sm text-gray-600 dark:text-gray-500 italic">
         Nothing to show for this relationship.
       </div>
     );

--- a/app/ui/src/components/FilterBar.jsx
+++ b/app/ui/src/components/FilterBar.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+﻿import { useState, useMemo } from 'react';
 
 /**
  * Reusable pill-based filter bar.
@@ -77,7 +77,7 @@ export default function FilterBar({
             </select>
             <button
               onClick={() => onRemoveFilter(af.field)}
-              className="text-blue-400 dark:text-blue-500 hover:text-blue-700 dark:hover:text-blue-300 font-bold ml-0.5"
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-bold ml-0.5"
               title="Remove filter"
             >
               &times;
@@ -102,7 +102,7 @@ export default function FilterBar({
           </select>
           {selectedField && (
             <>
-              <span className="text-gray-400 dark:text-gray-500">=</span>
+              <span className="text-gray-600 dark:text-gray-500">=</span>
               <select
                 value=""
                 onChange={e => handleAddValue(e.target.value)}
@@ -117,13 +117,13 @@ export default function FilterBar({
           )}
           <button
             onClick={() => { setAdding(false); setSelectedField(''); }}
-            className="text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 font-bold"
+            className="text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 font-bold"
           >
             &times;
           </button>
         </span>
       ) : loading && filterFields.length === 0 ? (
-        <span className="inline-flex items-center gap-1.5 px-2 py-1 text-xs text-gray-400 dark:text-gray-500">
+        <span className="inline-flex items-center gap-1.5 px-2 py-1 text-xs text-gray-600 dark:text-gray-500">
           <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />

--- a/app/ui/src/components/GovernancePage.jsx
+++ b/app/ui/src/components/GovernancePage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+﻿import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { formatDate } from '../utils/formatters';
 
@@ -37,7 +37,7 @@ function StatCard({ label, value, sub, color = 'gray', onClick }) {
       <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</div>
       <div className={`text-2xl font-bold mt-1 ${textMap[color] || textMap.gray}`}>{value}</div>
       {sub && <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{sub}</div>}
-      {clickable && <div className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">Click to view details</div>}
+      {clickable && <div className="text-[10px] text-gray-600 dark:text-gray-500 mt-1">Click to view details</div>}
     </div>
   );
 }
@@ -55,7 +55,7 @@ function CollapsibleSection({ title, count, children, open: controlledOpen, onTo
       >
         <span className="text-xs">{isOpen ? '▼' : '▶'}</span>
         {title}
-        {count != null && <span className="text-xs font-normal text-gray-400 dark:text-gray-500">({count})</span>}
+        {count != null && <span className="text-xs font-normal text-gray-600 dark:text-gray-500">({count})</span>}
       </button>
       {isOpen && <div className="px-5 pb-5">{children}</div>}
     </div>
@@ -238,8 +238,8 @@ export default function GovernancePage() {
 // ─── Drill-down table ────────────────────────────────────────
 
 function DrilldownTable({ data: drilldown }) {
-  if (drilldown.loading) return <div className="text-sm text-gray-400 dark:text-gray-500 animate-pulse">Loading...</div>;
-  if (!drilldown.data || drilldown.data.length === 0) return <p className="text-sm text-gray-400 dark:text-gray-500 italic">No business roles found</p>;
+  if (drilldown.loading) return <div className="text-sm text-gray-600 dark:text-gray-500 animate-pulse">Loading...</div>;
+  if (!drilldown.data || drilldown.data.length === 0) return <p className="text-sm text-gray-600 dark:text-gray-500 italic">No business roles found</p>;
 
   const rows = drilldown.data;
 
@@ -267,12 +267,12 @@ function DrilldownTable({ data: drilldown }) {
             }`}>
               <td className="px-3 py-2">
                 <div className="text-gray-900 dark:text-white font-medium">{r.accessPackageName}</div>
-                {r.catalogName && <div className="text-xs text-gray-400 dark:text-gray-500">{r.catalogName}</div>}
+                {r.catalogName && <div className="text-xs text-gray-600 dark:text-gray-500">{r.catalogName}</div>}
               </td>
               <td className="px-3 py-2">
                 {r.categoryName
                   ? <CategoryBadge name={r.categoryName} color={r.categoryColor} />
-                  : <span className="text-gray-400 dark:text-gray-500 text-xs">{'—'}</span>
+                  : <span className="text-gray-600 dark:text-gray-500 text-xs">{'—'}</span>
                 }
               </td>
               <td className="px-3 py-2">
@@ -285,14 +285,14 @@ function DrilldownTable({ data: drilldown }) {
                 {r.daysOverdue > 0 ? (
                   <span className="text-red-600 dark:text-red-400 font-semibold">{r.daysOverdue}d</span>
                 ) : (
-                  <span className="text-gray-400 dark:text-gray-500">{'—'}</span>
+                  <span className="text-gray-600 dark:text-gray-500">{'—'}</span>
                 )}
               </td>
               <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">{r.totalDecisions}</td>
               <td className="px-3 py-2 text-right">
                 {r.notReviewed > 0
                   ? <span className="text-red-600 dark:text-red-400 font-medium">{r.notReviewed}</span>
-                  : <span className="text-gray-400 dark:text-gray-500">0</span>
+                  : <span className="text-gray-600 dark:text-gray-500">0</span>
                 }
               </td>
               <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{r.lastReviewedBy || '—'}</td>

--- a/app/ui/src/components/GroupsPage.jsx
+++ b/app/ui/src/components/GroupsPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+﻿import { useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import useEntityPage from '../hooks/useEntityPage';
 import FilterBar from './FilterBar';
@@ -244,7 +244,7 @@ export default function ResourcesPage({ onOpenDetail }) {
                       {ep.sortCol === col.key ? (
                         <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
                       ) : (
-                        <span className="text-gray-300 dark:text-gray-500 text-[10px]">{'▴'}</span>
+                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
                       )}
                     </span>
                   </th>

--- a/app/ui/src/components/IdentitiesPage.jsx
+++ b/app/ui/src/components/IdentitiesPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+﻿import { useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import useEntityPage from '../hooks/useEntityPage';
 import FilterBar from './FilterBar';
@@ -246,7 +246,7 @@ export default function IdentitiesPage({ onOpenDetail }) {
                       {ep.sortCol === col.key ? (
                         <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
                       ) : (
-                        <span className="text-gray-300 dark:text-gray-500 text-[10px]">{'▴'}</span>
+                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
                       )}
                     </span>
                   </th>

--- a/app/ui/src/components/IdentityDetailPage.jsx
+++ b/app/ui/src/components/IdentityDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+﻿import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import RiskScoreSection from './RiskScoreSection';
 import ConfidenceBar from './ConfidenceBar';
@@ -165,7 +165,7 @@ export default function IdentityDetailPage({ identityId, cachedData, onCacheData
               }`}>
               {identity.analystVerified ? 'Remove Verification' : 'Verify Identity'}
             </button>
-            <button onClick={onClose} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1" title="Close">
+            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1" title="Close">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
@@ -187,7 +187,7 @@ export default function IdentityDetailPage({ identityId, cachedData, onCacheData
                 onNodeClick={graph.handleNodeClick}
               />
               {graph.pathDepth > 0 && (
-                <div className="text-xs text-gray-400 dark:text-gray-500 text-center pb-2">
+                <div className="text-xs text-gray-600 dark:text-gray-500 text-center pb-2">
                   <span className="font-medium text-gray-600 dark:text-gray-300">{graph.activeListLabel}</span>
                   {' — '}
                   <button onClick={graph.reset} className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline">collapse</button>
@@ -204,7 +204,7 @@ export default function IdentityDetailPage({ identityId, cachedData, onCacheData
               />
             ) : (
               <div className="bg-white dark:bg-gray-800 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg p-6 text-center">
-                <p className="text-sm text-gray-400 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
+                <p className="text-sm text-gray-600 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
               </div>
             )}
           </div>

--- a/app/ui/src/components/JsonViewer.jsx
+++ b/app/ui/src/components/JsonViewer.jsx
@@ -1,4 +1,4 @@
-// JsonViewer — Syntax-highlighted, collapsible JSON display
+﻿// JsonViewer — Syntax-highlighted, collapsible JSON display
 // Used in RiskProfileWizard for profile and classifier JSON
 
 import { useState } from 'react';
@@ -32,11 +32,11 @@ function JsonNode({ data, depth = 0, label = null }) {
         onClick={() => setCollapsed(!collapsed)}
         className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 rounded px-1 -mx-1 inline-block select-none"
       >
-        <span className="text-gray-400 dark:text-gray-500 mr-1">{collapsed ? '▶' : '▼'}</span>
+        <span className="text-gray-600 dark:text-gray-500 mr-1">{collapsed ? '▶' : '▼'}</span>
         {label && <span className="text-blue-600 dark:text-blue-400">{JSON.stringify(label)}: </span>}
         <span className="text-gray-500 dark:text-gray-400">{bracket[0]}</span>
         {collapsed && (
-          <span className="text-gray-400 dark:text-gray-500 text-xs ml-1">{preview}</span>
+          <span className="text-gray-600 dark:text-gray-500 text-xs ml-1">{preview}</span>
         )}
         {collapsed && <span className="text-gray-500 dark:text-gray-400 ml-1">{bracket[1]}</span>}
       </div>
@@ -45,7 +45,7 @@ function JsonNode({ data, depth = 0, label = null }) {
           {entries.map(([k, v]) => (
             <div key={k}>
               <JsonNode data={v} depth={depth + 1} label={isArray ? null : k} />
-              {isArray || <span className="text-gray-400 dark:text-gray-500">,</span>}
+              {isArray || <span className="text-gray-600 dark:text-gray-500">,</span>}
             </div>
           ))}
         </div>

--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -2,10 +2,8 @@ import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { useMatrixRowOrder } from '../hooks/useMatrixRowOrder';
 import MatrixToolbar from './matrix/MatrixToolbar';
-import MatrixFilterSummary from './matrix/MatrixFilterSummary';
-import MatrixColumnHeaders from './matrix/MatrixColumnHeaders';
+import MatrixColumnHeaders, { BLANK_TAG } from './matrix/MatrixColumnHeaders';
 import MatrixGroupRow from './matrix/MatrixGroupRow';
-import { filterHasAnyCondition } from './matrix/MatrixFilterWizard';
 
 // Inline arrayMove so MatrixView doesn't depend on @dnd-kit
 function arrayMove(arr, from, to) {
@@ -15,36 +13,48 @@ function arrayMove(arr, from, to) {
   return result;
 }
 
-// Empty state shown when the user hasn't created a matrix yet.
-function EmptyFilterState({ onAdjustFilter }) {
-  return (
-    <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
-      <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">Pick a slice to inspect</h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xl mx-auto mb-4">
-        The Matrix tab always operates on a defined sub-selection of subjects (users or
-        identities) and resources. Open the wizard to set up which slice to compare.
-      </p>
-      <button
-        onClick={onAdjustFilter}
-        className="px-4 py-2 rounded text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
-      >
-        Create matrix
-      </button>
-    </div>
-  );
-}
+// Fields to exclude from filter (IDs, display names used as labels, not useful for filtering)
+const EXCLUDE_FIELDS = new Set(['groupId', 'resourceId', 'memberId', 'memberDisplayName', 'memberUPN', 'memberType', 'managedByAccessPackage', 'systemId', 'systemName', 'resourceDisplayName', 'groupDisplayName', 'resourceType', 'groupTypeCalculated', 'resourceDescription', 'groupDescription']);
+// Friendly labels for known fields
+const FIELD_LABELS = {
+  // User columns
+  department: 'Department',
+  jobTitle: 'Job Title',
+  companyName: 'Company',
+  accountEnabled: 'Account Enabled',
+  userType: 'User Type',
+  employeeType: 'Employee Type',
+  officeLocation: 'Office Location',
+  city: 'City',
+  country: 'Country',
+  state: 'State',
+  usageLocation: 'Usage Location',
+  mail: 'Mail',
+  manager: 'Manager',
+  onPremisesSamAccountName: 'SAM Account',
+  onPremisesSyncEnabled: 'On-Prem Sync',
+  __userTag: 'User Tag',
+  // Relationship fields
+  membershipType: 'Membership Type',
+};
 
 export default function MatrixView({
-  data, accessPackageGroups = [], managedByPackages = [],
-  filter,
-  counts,
+  data, accessPackageGroups = [], managedByPackages = [], totalUsers: serverTotalUsers,
+  userLimit, setUserLimit,
+  activeFilters, setActiveFilters,
   managedFilter, setManagedFilter,
+  filterText, setFilterText,
+  contextFilters, setContextFilters,
+  userColumns,
   groupTagMap,
   refreshing,
   shareUrl,
   onOpenDetail,
-  onAdjustFilter,
 }) {
+  const [groupTypeFilter, setGroupTypeFilter] = useState(null); // null = all, Set = selected types
+  const [groupTagFilter, setGroupTagFilter] = useState(null); // null = all, Set = selected tag names
+  const [systemNameFilter] = useState(null); // null = all, Set = selected system names
+
   // ─── Nested group expansion ─────────────────────────────────────
   const { authFetch } = useAuth();
   const [groupsWithNested, setGroupsWithNested] = useState(new Set());
@@ -85,25 +95,144 @@ export default function MatrixView({
     setExpandedGroups(prev => new Set(prev).add(groupId));
   }, [expandedGroups, nestedDataCache, authFetch]);
 
-  // Build a stable storage key from the filter (matches per-filter row order)
+  // Build a stable storage key from all active filters (sorted for consistency)
   const storageKey = useMemo(() => {
-    if (!filter) return '';
-    return JSON.stringify(filter);
-  }, [filter]);
+    if (activeFilters.length === 0) return '';
+    return activeFilters
+      .map(f => `${f.field}:${f.value}`)
+      .sort()
+      .join('|');
+  }, [activeFilters]);
 
   const rowOrderHook = useMatrixRowOrder(storageKey);
 
-  // Apply CLIENT-SIDE managed-state toggle. Subject and resource filters are
-  // already applied by the backend so the matrix data is "the right subset".
+  // Sets of column names (for knowing which filters are server-side)
+  const userColumnNames = useMemo(() => {
+    if (!userColumns) return new Set();
+    return new Set(userColumns.map(c => c.column));
+  }, [userColumns]);
+
+  // Auto-discover filterable fields from data + merge server-provided user columns.
+  // Data-derived fields appear even if not in server columns (e.g., membershipType).
+  // Server-provided columns appear even if all values are null in the current page.
+  const filterFields = useMemo(() => {
+    const fieldMap = new Map(); // key -> { key, label, dataKey }
+
+    // 1. Discover from data (current page)
+    if (data && data.length > 0) {
+      const sample = data[0];
+      for (const key of Object.keys(sample)) {
+        if (EXCLUDE_FIELDS.has(key)) continue;
+        const values = new Set();
+        for (const d of data) {
+          const val = d[key];
+          if (val != null && val !== '') values.add(String(val));
+          if (values.size > 500) break;
+        }
+        if (values.size >= 1 && values.size <= 500) {
+          fieldMap.set(key, {
+            key,
+            label: FIELD_LABELS[key] || key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim(),
+            dataKey: key,
+          });
+        }
+      }
+    }
+
+    // 2. Add server-provided user columns that aren't already discovered
+    if (userColumns) {
+      for (const col of userColumns) {
+        if (EXCLUDE_FIELDS.has(col.column)) continue;
+        if (!fieldMap.has(col.column) && col.values && col.values.length > 0) {
+          fieldMap.set(col.column, {
+            key: col.column,
+            label: FIELD_LABELS[col.column] || col.column.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim(),
+            dataKey: col.column,
+          });
+        }
+      }
+    }
+
+    return [...fieldMap.values()].sort((a, b) => a.label.localeCompare(b.label));
+  }, [data, userColumns]);
+
+  // User filter fields = columns known to the server from GraphUsers table + __userTag.
+  // __userTag is always included when the backend supports it, even if no tags exist yet
+  // (col.values.length > 0 guard in filterFields step 2 would otherwise drop it).
+  const userFilterFields = useMemo(() => {
+    const fields = filterFields.filter(f => userColumnNames.has(f.key));
+    if (userColumnNames.has('__userTag') && !fields.some(f => f.key === '__userTag')) {
+      fields.push({ key: '__userTag', label: 'User Tag', dataKey: '__userTag' });
+    }
+    return fields;
+  }, [filterFields, userColumnNames]);
+
+  // Get available values for a specific field.
+  // Server-provided columns: use server values (full dataset, not just current page).
+  // Other fields: derive from loaded data with cross-filter logic.
+  const getOptionsForField = useCallback((fieldKey) => {
+    // For user columns, return server-provided values (from full dataset)
+    if (userColumns) {
+      const serverCol = userColumns.find(c => c.column === fieldKey);
+      if (serverCol && serverCol.values && serverCol.values.length > 0) {
+        return serverCol.values;
+      }
+    }
+    // For non-server columns (membershipType, etc.), derive from loaded data
+    const field = filterFields.find(f => f.key === fieldKey);
+    if (!field) return [];
+    // Apply all OTHER active filters first to show contextual values
+    let filtered = data;
+    for (const af of activeFilters) {
+      if (af.field === fieldKey) continue;
+      const f = filterFields.find(ff => ff.key === af.field);
+      if (f) {
+        filtered = filtered.filter(d => String(d[f.dataKey] ?? '') === af.value);
+      }
+    }
+    const values = new Set();
+    filtered.forEach(d => {
+      const val = d[field.dataKey];
+      if (val != null && val !== '') values.add(String(val));
+    });
+    return [...values].sort();
+  }, [data, activeFilters, filterFields, userColumns]);
+
+  const addFilter = useCallback((field, value) => {
+    setActiveFilters(prev => [...prev.filter(f => f.field !== field), { field, value }]);
+  }, [setActiveFilters]);
+
+  const removeFilter = useCallback((field) => {
+    setActiveFilters(prev => prev.filter(f => f.field !== field));
+  }, [setActiveFilters]);
+
+  // Apply CLIENT-SIDE filters only (server-side user & group attribute filters already applied by backend).
+  // Client-side: text search, managed toggle, non-server-column structured filters (e.g., membershipType).
   const filteredData = useMemo(() => {
     let result = data;
+    // Only apply non-server filters client-side
+    for (const af of activeFilters) {
+      if (userColumnNames.has(af.field)) continue; // already applied server-side
+      const field = filterFields.find(f => f.key === af.field);
+      if (field) {
+        result = result.filter(d => String(d[field.dataKey] ?? '') === af.value);
+      }
+    }
+    if (filterText) {
+      const lower = filterText.toLowerCase();
+      result = result.filter(d =>
+        (d.memberDisplayName || '').toLowerCase().includes(lower) ||
+        (d.resourceDisplayName || d.groupDisplayName || '').toLowerCase().includes(lower) ||
+        (d.memberUPN || '').toLowerCase().includes(lower)
+      );
+    }
     if (managedFilter === 'managed') {
       result = result.filter(d => !!d.managedByAccessPackage);
     } else if (managedFilter === 'unmanaged') {
       result = result.filter(d => !d.managedByAccessPackage);
     }
     return result;
-  }, [data, managedFilter]);
+  }, [data, activeFilters, filterFields, filterText, managedFilter, userColumnNames]);
 
   // Build matrix data structures
   // Owner memberships are split into separate synthetic rows (id: "groupId__owner",
@@ -308,6 +437,39 @@ export default function MatrixView({
     return map;
   }, [accessPackages]);
 
+  // Unique group types for filter dropdown
+  const uniqueGroupTypes = useMemo(() => {
+    const types = new Set();
+    groups.forEach(g => { if (g.groupType) types.add(g.groupType); });
+    return [...types].sort();
+  }, [groups]);
+
+
+  // Unique group tags for filter dropdown (derived from groups which already have tags attached)
+  const uniqueGroupTags = useMemo(() => {
+    const tagMap = new Map(); // name -> { name, color }
+    groups.forEach(g => {
+      (g.tags || []).forEach(t => {
+        if (!tagMap.has(t.name)) tagMap.set(t.name, { name: t.name, color: t.color });
+      });
+    });
+    return [...tagMap.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [groups]);
+
+  const hasGroupsWithoutTags = useMemo(() => groups.some(g => !g.tags || g.tags.length === 0), [groups]);
+
+  // Default: exclude Distribution and Dynamic group types (user can change)
+  const groupTypeDefaultsApplied = useRef(false);
+  useEffect(() => {
+    if (groupTypeDefaultsApplied.current || uniqueGroupTypes.length === 0) return;
+    groupTypeDefaultsApplied.current = true;
+    const excluded = /distribution|dynamic/i;
+    const defaults = new Set(uniqueGroupTypes.filter(t => !excluded.test(t)));
+    if (defaults.size > 0 && defaults.size < uniqueGroupTypes.length) {
+      setGroupTypeFilter(defaults);
+    }
+  }, [uniqueGroupTypes]);
+
   // Default sort: AP staircase pattern.
   // All groups in the leftmost AP first, then next AP, etc. Unmanaged at the bottom.
   const apSortedGroups = useMemo(() => {
@@ -349,12 +511,25 @@ export default function MatrixView({
     });
   }, [groups, accessPackages, apGroupMap]);
 
-  // Apply custom drag-row order on top of the default AP staircase sort. All
-  // subject/resource selection happens through the filter wizard, so there
-  // are no per-column filters to apply here any more.
+  // Apply custom row order (drag), then filter by group type, tags, and system
   const orderedGroups = useMemo(() => {
-    return rowOrderHook.getOrderedGroups(apSortedGroups);
-  }, [apSortedGroups, rowOrderHook.getOrderedGroups]);
+    let result = rowOrderHook.getOrderedGroups(apSortedGroups);
+    if (groupTypeFilter && groupTypeFilter.size > 0) {
+      result = result.filter(g => groupTypeFilter.has(g.groupType));
+    }
+    if (groupTagFilter && groupTagFilter.size > 0) {
+      const wantBlank = groupTagFilter.has(BLANK_TAG);
+      result = result.filter(g => {
+        const tags = g.tags || [];
+        if (tags.length === 0) return wantBlank;
+        return tags.some(t => groupTagFilter.has(t.name));
+      });
+    }
+    if (systemNameFilter && systemNameFilter.size > 0) {
+      result = result.filter(g => systemNameFilter.has(g.systemName));
+    }
+    return result;
+  }, [apSortedGroups, rowOrderHook.getOrderedGroups, groupTypeFilter, groupTagFilter, systemNameFilter]);
 
   const groupIds = useMemo(() => orderedGroups.map(g => g.id), [orderedGroups]);
 
@@ -547,13 +722,13 @@ export default function MatrixView({
       memberships,
       managedApMap,
       apIdToIndex,
-      activeFilters: [],
-      filterFields: [],
+      activeFilters,
+      filterFields,
       accessPackages,
       apGroupMap,
       shareUrl,
     });
-  }, [users, orderedGroups, memberships, managedApMap, apIdToIndex, accessPackages, apGroupMap, shareUrl]);
+  }, [users, orderedGroups, memberships, managedApMap, apIdToIndex, activeFilters, filterFields, accessPackages, apGroupMap, shareUrl]);
 
   // Share: copy URL to clipboard
   const handleShare = useCallback(async () => {
@@ -565,6 +740,13 @@ export default function MatrixView({
     }
   }, [shareUrl]);
 
+  const stats = {
+    users: users.length,
+    totalUsers: serverTotalUsers,
+    groups: orderedGroups.length,
+    memberships: memberships.size,
+  };
+
   // Number of info columns on the left (drag handle + resource name + type)
   const infoColumnCount = 3;
 
@@ -575,6 +757,13 @@ export default function MatrixView({
       infoColumnCount={infoColumnCount}
       onSortByCount={handleSortByCount}
       accessPackages={accessPackages}
+      uniqueGroupTypes={uniqueGroupTypes}
+      groupTypeFilter={groupTypeFilter}
+      onGroupTypeFilterChange={setGroupTypeFilter}
+      uniqueGroupTags={uniqueGroupTags}
+      groupTagFilter={groupTagFilter}
+      onGroupTagFilterChange={setGroupTagFilter}
+      hasGroupsWithoutTags={hasGroupsWithoutTags}
       onOpenDetail={onOpenDetail}
     />
   );
@@ -582,36 +771,39 @@ export default function MatrixView({
   // Ref for the scroll container (needed by virtualizer)
   const scrollRef = useRef(null);
 
-  const filterIsApplied = filterHasAnyCondition(filter);
-
   return (
     <div className="flex flex-col gap-3">
-      {filterIsApplied && (
-        <MatrixFilterSummary
-          filter={filter}
-          preview={counts}
-          onAdjust={onAdjustFilter}
-        />
-      )}
-
       <MatrixToolbar
+        filterFields={filterFields}
+        userFilterFields={userFilterFields}
+        activeFilters={activeFilters}
+        getOptionsForField={getOptionsForField}
+        onAddFilter={addFilter}
+        onRemoveFilter={removeFilter}
+        filterText={filterText}
+        setFilterText={setFilterText}
+        contextFilters={contextFilters}
+        setContextFilters={setContextFilters}
         managedFilter={managedFilter}
         setManagedFilter={setManagedFilter}
+        userLimit={userLimit}
+        setUserLimit={setUserLimit}
         onExportExcel={handleExportExcel}
         onShare={handleShare}
         onResetRowOrder={rowOrderHook.resetOrder}
         hasCustomRowOrder={rowOrderHook.hasCustomOrder}
+        stats={stats}
         hasExpandableGroups={groupsWithNested.size > 0}
         hasExpandedGroups={expandedGroups.size > 0}
         onExpandAll={expandAll}
         onCollapseAll={collapseAll}
       />
 
-      {!filterIsApplied ? (
-        <EmptyFilterState onAdjustFilter={onAdjustFilter} />
-      ) : users.length === 0 || orderedGroups.length === 0 ? (
+      {users.length === 0 || orderedGroups.length === 0 ? (
         <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          No assignments match the current filter. Adjust the subjects or resources to widen the view.
+          {activeFilters.length > 0
+            ? 'No data found for the current filters. Try removing some filters.'
+            : 'No permission data available. Add a filter to narrow down the view.'}
         </div>
       ) : (
         <div ref={scrollRef} className="relative border border-gray-200 dark:border-gray-700 rounded-lg overflow-auto max-h-[calc(100vh-280px)]">

--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -2,8 +2,10 @@ import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { useMatrixRowOrder } from '../hooks/useMatrixRowOrder';
 import MatrixToolbar from './matrix/MatrixToolbar';
-import MatrixColumnHeaders, { BLANK_TAG } from './matrix/MatrixColumnHeaders';
+import MatrixFilterSummary from './matrix/MatrixFilterSummary';
+import MatrixColumnHeaders from './matrix/MatrixColumnHeaders';
 import MatrixGroupRow from './matrix/MatrixGroupRow';
+import { filterHasAnyCondition } from './matrix/MatrixFilterWizard';
 
 // Inline arrayMove so MatrixView doesn't depend on @dnd-kit
 function arrayMove(arr, from, to) {
@@ -13,48 +15,36 @@ function arrayMove(arr, from, to) {
   return result;
 }
 
-// Fields to exclude from filter (IDs, display names used as labels, not useful for filtering)
-const EXCLUDE_FIELDS = new Set(['groupId', 'resourceId', 'memberId', 'memberDisplayName', 'memberUPN', 'memberType', 'managedByAccessPackage', 'systemId', 'systemName', 'resourceDisplayName', 'groupDisplayName', 'resourceType', 'groupTypeCalculated', 'resourceDescription', 'groupDescription']);
-// Friendly labels for known fields
-const FIELD_LABELS = {
-  // User columns
-  department: 'Department',
-  jobTitle: 'Job Title',
-  companyName: 'Company',
-  accountEnabled: 'Account Enabled',
-  userType: 'User Type',
-  employeeType: 'Employee Type',
-  officeLocation: 'Office Location',
-  city: 'City',
-  country: 'Country',
-  state: 'State',
-  usageLocation: 'Usage Location',
-  mail: 'Mail',
-  manager: 'Manager',
-  onPremisesSamAccountName: 'SAM Account',
-  onPremisesSyncEnabled: 'On-Prem Sync',
-  __userTag: 'User Tag',
-  // Relationship fields
-  membershipType: 'Membership Type',
-};
+// Empty state shown when the user hasn't created a matrix yet.
+function EmptyFilterState({ onAdjustFilter }) {
+  return (
+    <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
+      <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">Pick a slice to inspect</h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xl mx-auto mb-4">
+        The Matrix tab always operates on a defined sub-selection of subjects (users or
+        identities) and resources. Open the wizard to set up which slice to compare.
+      </p>
+      <button
+        onClick={onAdjustFilter}
+        className="px-4 py-2 rounded text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
+      >
+        Create matrix
+      </button>
+    </div>
+  );
+}
 
 export default function MatrixView({
-  data, accessPackageGroups = [], managedByPackages = [], totalUsers: serverTotalUsers,
-  userLimit, setUserLimit,
-  activeFilters, setActiveFilters,
+  data, accessPackageGroups = [], managedByPackages = [],
+  filter,
+  counts,
   managedFilter, setManagedFilter,
-  filterText, setFilterText,
-  contextFilters, setContextFilters,
-  userColumns,
   groupTagMap,
   refreshing,
   shareUrl,
   onOpenDetail,
+  onAdjustFilter,
 }) {
-  const [groupTypeFilter, setGroupTypeFilter] = useState(null); // null = all, Set = selected types
-  const [groupTagFilter, setGroupTagFilter] = useState(null); // null = all, Set = selected tag names
-  const [systemNameFilter] = useState(null); // null = all, Set = selected system names
-
   // ─── Nested group expansion ─────────────────────────────────────
   const { authFetch } = useAuth();
   const [groupsWithNested, setGroupsWithNested] = useState(new Set());
@@ -95,144 +85,25 @@ export default function MatrixView({
     setExpandedGroups(prev => new Set(prev).add(groupId));
   }, [expandedGroups, nestedDataCache, authFetch]);
 
-  // Build a stable storage key from all active filters (sorted for consistency)
+  // Build a stable storage key from the filter (matches per-filter row order)
   const storageKey = useMemo(() => {
-    if (activeFilters.length === 0) return '';
-    return activeFilters
-      .map(f => `${f.field}:${f.value}`)
-      .sort()
-      .join('|');
-  }, [activeFilters]);
+    if (!filter) return '';
+    return JSON.stringify(filter);
+  }, [filter]);
 
   const rowOrderHook = useMatrixRowOrder(storageKey);
 
-  // Sets of column names (for knowing which filters are server-side)
-  const userColumnNames = useMemo(() => {
-    if (!userColumns) return new Set();
-    return new Set(userColumns.map(c => c.column));
-  }, [userColumns]);
-
-  // Auto-discover filterable fields from data + merge server-provided user columns.
-  // Data-derived fields appear even if not in server columns (e.g., membershipType).
-  // Server-provided columns appear even if all values are null in the current page.
-  const filterFields = useMemo(() => {
-    const fieldMap = new Map(); // key -> { key, label, dataKey }
-
-    // 1. Discover from data (current page)
-    if (data && data.length > 0) {
-      const sample = data[0];
-      for (const key of Object.keys(sample)) {
-        if (EXCLUDE_FIELDS.has(key)) continue;
-        const values = new Set();
-        for (const d of data) {
-          const val = d[key];
-          if (val != null && val !== '') values.add(String(val));
-          if (values.size > 500) break;
-        }
-        if (values.size >= 1 && values.size <= 500) {
-          fieldMap.set(key, {
-            key,
-            label: FIELD_LABELS[key] || key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim(),
-            dataKey: key,
-          });
-        }
-      }
-    }
-
-    // 2. Add server-provided user columns that aren't already discovered
-    if (userColumns) {
-      for (const col of userColumns) {
-        if (EXCLUDE_FIELDS.has(col.column)) continue;
-        if (!fieldMap.has(col.column) && col.values && col.values.length > 0) {
-          fieldMap.set(col.column, {
-            key: col.column,
-            label: FIELD_LABELS[col.column] || col.column.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim(),
-            dataKey: col.column,
-          });
-        }
-      }
-    }
-
-    return [...fieldMap.values()].sort((a, b) => a.label.localeCompare(b.label));
-  }, [data, userColumns]);
-
-  // User filter fields = columns known to the server from GraphUsers table + __userTag.
-  // __userTag is always included when the backend supports it, even if no tags exist yet
-  // (col.values.length > 0 guard in filterFields step 2 would otherwise drop it).
-  const userFilterFields = useMemo(() => {
-    const fields = filterFields.filter(f => userColumnNames.has(f.key));
-    if (userColumnNames.has('__userTag') && !fields.some(f => f.key === '__userTag')) {
-      fields.push({ key: '__userTag', label: 'User Tag', dataKey: '__userTag' });
-    }
-    return fields;
-  }, [filterFields, userColumnNames]);
-
-  // Get available values for a specific field.
-  // Server-provided columns: use server values (full dataset, not just current page).
-  // Other fields: derive from loaded data with cross-filter logic.
-  const getOptionsForField = useCallback((fieldKey) => {
-    // For user columns, return server-provided values (from full dataset)
-    if (userColumns) {
-      const serverCol = userColumns.find(c => c.column === fieldKey);
-      if (serverCol && serverCol.values && serverCol.values.length > 0) {
-        return serverCol.values;
-      }
-    }
-    // For non-server columns (membershipType, etc.), derive from loaded data
-    const field = filterFields.find(f => f.key === fieldKey);
-    if (!field) return [];
-    // Apply all OTHER active filters first to show contextual values
-    let filtered = data;
-    for (const af of activeFilters) {
-      if (af.field === fieldKey) continue;
-      const f = filterFields.find(ff => ff.key === af.field);
-      if (f) {
-        filtered = filtered.filter(d => String(d[f.dataKey] ?? '') === af.value);
-      }
-    }
-    const values = new Set();
-    filtered.forEach(d => {
-      const val = d[field.dataKey];
-      if (val != null && val !== '') values.add(String(val));
-    });
-    return [...values].sort();
-  }, [data, activeFilters, filterFields, userColumns]);
-
-  const addFilter = useCallback((field, value) => {
-    setActiveFilters(prev => [...prev.filter(f => f.field !== field), { field, value }]);
-  }, [setActiveFilters]);
-
-  const removeFilter = useCallback((field) => {
-    setActiveFilters(prev => prev.filter(f => f.field !== field));
-  }, [setActiveFilters]);
-
-  // Apply CLIENT-SIDE filters only (server-side user & group attribute filters already applied by backend).
-  // Client-side: text search, managed toggle, non-server-column structured filters (e.g., membershipType).
+  // Apply CLIENT-SIDE managed-state toggle. Subject and resource filters are
+  // already applied by the backend so the matrix data is "the right subset".
   const filteredData = useMemo(() => {
     let result = data;
-    // Only apply non-server filters client-side
-    for (const af of activeFilters) {
-      if (userColumnNames.has(af.field)) continue; // already applied server-side
-      const field = filterFields.find(f => f.key === af.field);
-      if (field) {
-        result = result.filter(d => String(d[field.dataKey] ?? '') === af.value);
-      }
-    }
-    if (filterText) {
-      const lower = filterText.toLowerCase();
-      result = result.filter(d =>
-        (d.memberDisplayName || '').toLowerCase().includes(lower) ||
-        (d.resourceDisplayName || d.groupDisplayName || '').toLowerCase().includes(lower) ||
-        (d.memberUPN || '').toLowerCase().includes(lower)
-      );
-    }
     if (managedFilter === 'managed') {
       result = result.filter(d => !!d.managedByAccessPackage);
     } else if (managedFilter === 'unmanaged') {
       result = result.filter(d => !d.managedByAccessPackage);
     }
     return result;
-  }, [data, activeFilters, filterFields, filterText, managedFilter, userColumnNames]);
+  }, [data, managedFilter]);
 
   // Build matrix data structures
   // Owner memberships are split into separate synthetic rows (id: "groupId__owner",
@@ -437,39 +308,6 @@ export default function MatrixView({
     return map;
   }, [accessPackages]);
 
-  // Unique group types for filter dropdown
-  const uniqueGroupTypes = useMemo(() => {
-    const types = new Set();
-    groups.forEach(g => { if (g.groupType) types.add(g.groupType); });
-    return [...types].sort();
-  }, [groups]);
-
-
-  // Unique group tags for filter dropdown (derived from groups which already have tags attached)
-  const uniqueGroupTags = useMemo(() => {
-    const tagMap = new Map(); // name -> { name, color }
-    groups.forEach(g => {
-      (g.tags || []).forEach(t => {
-        if (!tagMap.has(t.name)) tagMap.set(t.name, { name: t.name, color: t.color });
-      });
-    });
-    return [...tagMap.values()].sort((a, b) => a.name.localeCompare(b.name));
-  }, [groups]);
-
-  const hasGroupsWithoutTags = useMemo(() => groups.some(g => !g.tags || g.tags.length === 0), [groups]);
-
-  // Default: exclude Distribution and Dynamic group types (user can change)
-  const groupTypeDefaultsApplied = useRef(false);
-  useEffect(() => {
-    if (groupTypeDefaultsApplied.current || uniqueGroupTypes.length === 0) return;
-    groupTypeDefaultsApplied.current = true;
-    const excluded = /distribution|dynamic/i;
-    const defaults = new Set(uniqueGroupTypes.filter(t => !excluded.test(t)));
-    if (defaults.size > 0 && defaults.size < uniqueGroupTypes.length) {
-      setGroupTypeFilter(defaults);
-    }
-  }, [uniqueGroupTypes]);
-
   // Default sort: AP staircase pattern.
   // All groups in the leftmost AP first, then next AP, etc. Unmanaged at the bottom.
   const apSortedGroups = useMemo(() => {
@@ -511,25 +349,12 @@ export default function MatrixView({
     });
   }, [groups, accessPackages, apGroupMap]);
 
-  // Apply custom row order (drag), then filter by group type, tags, and system
+  // Apply custom drag-row order on top of the default AP staircase sort. All
+  // subject/resource selection happens through the filter wizard, so there
+  // are no per-column filters to apply here any more.
   const orderedGroups = useMemo(() => {
-    let result = rowOrderHook.getOrderedGroups(apSortedGroups);
-    if (groupTypeFilter && groupTypeFilter.size > 0) {
-      result = result.filter(g => groupTypeFilter.has(g.groupType));
-    }
-    if (groupTagFilter && groupTagFilter.size > 0) {
-      const wantBlank = groupTagFilter.has(BLANK_TAG);
-      result = result.filter(g => {
-        const tags = g.tags || [];
-        if (tags.length === 0) return wantBlank;
-        return tags.some(t => groupTagFilter.has(t.name));
-      });
-    }
-    if (systemNameFilter && systemNameFilter.size > 0) {
-      result = result.filter(g => systemNameFilter.has(g.systemName));
-    }
-    return result;
-  }, [apSortedGroups, rowOrderHook.getOrderedGroups, groupTypeFilter, groupTagFilter, systemNameFilter]);
+    return rowOrderHook.getOrderedGroups(apSortedGroups);
+  }, [apSortedGroups, rowOrderHook.getOrderedGroups]);
 
   const groupIds = useMemo(() => orderedGroups.map(g => g.id), [orderedGroups]);
 
@@ -722,13 +547,13 @@ export default function MatrixView({
       memberships,
       managedApMap,
       apIdToIndex,
-      activeFilters,
-      filterFields,
+      activeFilters: [],
+      filterFields: [],
       accessPackages,
       apGroupMap,
       shareUrl,
     });
-  }, [users, orderedGroups, memberships, managedApMap, apIdToIndex, activeFilters, filterFields, accessPackages, apGroupMap, shareUrl]);
+  }, [users, orderedGroups, memberships, managedApMap, apIdToIndex, accessPackages, apGroupMap, shareUrl]);
 
   // Share: copy URL to clipboard
   const handleShare = useCallback(async () => {
@@ -740,13 +565,6 @@ export default function MatrixView({
     }
   }, [shareUrl]);
 
-  const stats = {
-    users: users.length,
-    totalUsers: serverTotalUsers,
-    groups: orderedGroups.length,
-    memberships: memberships.size,
-  };
-
   // Number of info columns on the left (drag handle + resource name + type)
   const infoColumnCount = 3;
 
@@ -757,13 +575,6 @@ export default function MatrixView({
       infoColumnCount={infoColumnCount}
       onSortByCount={handleSortByCount}
       accessPackages={accessPackages}
-      uniqueGroupTypes={uniqueGroupTypes}
-      groupTypeFilter={groupTypeFilter}
-      onGroupTypeFilterChange={setGroupTypeFilter}
-      uniqueGroupTags={uniqueGroupTags}
-      groupTagFilter={groupTagFilter}
-      onGroupTagFilterChange={setGroupTagFilter}
-      hasGroupsWithoutTags={hasGroupsWithoutTags}
       onOpenDetail={onOpenDetail}
     />
   );
@@ -771,39 +582,36 @@ export default function MatrixView({
   // Ref for the scroll container (needed by virtualizer)
   const scrollRef = useRef(null);
 
+  const filterIsApplied = filterHasAnyCondition(filter);
+
   return (
     <div className="flex flex-col gap-3">
+      {filterIsApplied && (
+        <MatrixFilterSummary
+          filter={filter}
+          preview={counts}
+          onAdjust={onAdjustFilter}
+        />
+      )}
+
       <MatrixToolbar
-        filterFields={filterFields}
-        userFilterFields={userFilterFields}
-        activeFilters={activeFilters}
-        getOptionsForField={getOptionsForField}
-        onAddFilter={addFilter}
-        onRemoveFilter={removeFilter}
-        filterText={filterText}
-        setFilterText={setFilterText}
-        contextFilters={contextFilters}
-        setContextFilters={setContextFilters}
         managedFilter={managedFilter}
         setManagedFilter={setManagedFilter}
-        userLimit={userLimit}
-        setUserLimit={setUserLimit}
         onExportExcel={handleExportExcel}
         onShare={handleShare}
         onResetRowOrder={rowOrderHook.resetOrder}
         hasCustomRowOrder={rowOrderHook.hasCustomOrder}
-        stats={stats}
         hasExpandableGroups={groupsWithNested.size > 0}
         hasExpandedGroups={expandedGroups.size > 0}
         onExpandAll={expandAll}
         onCollapseAll={collapseAll}
       />
 
-      {users.length === 0 || orderedGroups.length === 0 ? (
+      {!filterIsApplied ? (
+        <EmptyFilterState onAdjustFilter={onAdjustFilter} />
+      ) : users.length === 0 || orderedGroups.length === 0 ? (
         <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          {activeFilters.length > 0
-            ? 'No data found for the current filters. Try removing some filters.'
-            : 'No permission data available. Add a filter to narrow down the view.'}
+          No assignments match the current filter. Adjust the subjects or resources to widen the view.
         </div>
       ) : (
         <div ref={scrollRef} className="relative border border-gray-200 dark:border-gray-700 rounded-lg overflow-auto max-h-[calc(100vh-280px)]">

--- a/app/ui/src/components/PerfPage.jsx
+++ b/app/ui/src/components/PerfPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+﻿import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../auth/AuthGate';
 
 function formatMs(ms) {
@@ -200,7 +200,7 @@ function EndpointSummary({ endpoints }) {
   };
 
   if (!endpoints?.length) {
-    return <p className="text-sm text-gray-400 dark:text-gray-500 italic">No requests recorded yet. Use the application to generate metrics.</p>;
+    return <p className="text-sm text-gray-600 dark:text-gray-500 italic">No requests recorded yet. Use the application to generate metrics.</p>;
   }
 
   return (
@@ -230,11 +230,11 @@ function EndpointSummary({ endpoints }) {
                 className={`border-b border-gray-100 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 ${durationBg(ep.p95)}`}
                 onClick={() => hasSql && toggle(key)}
               >
-                <td className="px-3 py-2 w-6 text-gray-400 dark:text-gray-500 text-xs">
+                <td className="px-3 py-2 w-6 text-gray-600 dark:text-gray-500 text-xs">
                   {hasSql ? (isOpen ? '▼' : '▶') : ''}
                 </td>
                 <td className="px-3 py-2 font-mono text-xs">
-                  <span className="text-gray-400 dark:text-gray-500 mr-1">{ep.method}</span>
+                  <span className="text-gray-600 dark:text-gray-500 mr-1">{ep.method}</span>
                   <span className="text-gray-800 dark:text-gray-100">{ep.route}</span>
                 </td>
                 <td className="px-3 py-2 text-right text-gray-600 dark:text-gray-400">{ep.count}</td>
@@ -281,7 +281,7 @@ function RequestList({ entries }) {
   };
 
   if (!entries?.length) {
-    return <p className="text-sm text-gray-400 dark:text-gray-500 italic">No requests recorded yet.</p>;
+    return <p className="text-sm text-gray-600 dark:text-gray-500 italic">No requests recorded yet.</p>;
   }
 
   return (
@@ -308,14 +308,14 @@ function RequestList({ entries }) {
                 className={`border-b border-gray-100 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 ${durationBg(entry.totalMs)}`}
                 onClick={() => hasSql && toggle(idx)}
               >
-                <td className="px-3 py-2 w-6 text-gray-400 dark:text-gray-500 text-xs">
+                <td className="px-3 py-2 w-6 text-gray-600 dark:text-gray-500 text-xs">
                   {hasSql ? (isOpen ? '▼' : '▶') : ''}
                 </td>
                 <td className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
                   {new Date(entry.timestamp).toLocaleTimeString()}
                 </td>
                 <td className="px-3 py-2 font-mono text-xs">
-                  <span className="text-gray-400 dark:text-gray-500 mr-1">{entry.method}</span>
+                  <span className="text-gray-600 dark:text-gray-500 mr-1">{entry.method}</span>
                   <span className="text-gray-800 dark:text-gray-100 break-all">{entry.url || entry.route}</span>
                 </td>
                 <td className="px-3 py-2 text-right">
@@ -339,7 +339,7 @@ function RequestList({ entries }) {
                   <td className="px-3 py-1"></td>
                   <td className="px-3 py-1 font-mono text-xs text-blue-700 dark:text-blue-300 pl-8">
                     {sq.label}
-                    {sq.rows != null && <span className="text-gray-400 dark:text-gray-500 ml-2">({sq.rows} rows)</span>}
+                    {sq.rows != null && <span className="text-gray-600 dark:text-gray-500 ml-2">({sq.rows} rows)</span>}
                     {sq.error && <span className="text-red-500 ml-2">{sq.error}</span>}
                   </td>
                   <td className="px-3 py-1"></td>

--- a/app/ui/src/components/RecentChangesSection.jsx
+++ b/app/ui/src/components/RecentChangesSection.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+﻿import { useState } from 'react';
 import { formatDate } from '../utils/formatters';
 
 // ─── RecentChangesSection ────────────────────────────────────────────
@@ -42,9 +42,9 @@ export default function RecentChangesSection({
         className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700/50"
       >
         <div className="flex items-center gap-2">
-          <span className="text-gray-400 dark:text-gray-500 text-xs">{open ? '▼' : '▶'}</span>
+          <span className="text-gray-600 dark:text-gray-500 text-xs">{open ? '▼' : '▶'}</span>
           <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Recent Changes</h3>
-          {sinceDays && <span className="text-xs text-gray-400 dark:text-gray-500">last {sinceDays} days</span>}
+          {sinceDays && <span className="text-xs text-gray-600 dark:text-gray-500">last {sinceDays} days</span>}
         </div>
         <div className="flex items-center gap-2 text-xs">
           {addedCount > 0 && (
@@ -58,7 +58,7 @@ export default function RecentChangesSection({
             </span>
           )}
           {!hasData && !loading && (
-            <span className="text-gray-400 dark:text-gray-500">No changes</span>
+            <span className="text-gray-600 dark:text-gray-500">No changes</span>
           )}
         </div>
       </button>
@@ -68,7 +68,7 @@ export default function RecentChangesSection({
           {loading ? (
             <div className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">Loading…</div>
           ) : !hasData ? (
-            <p className="p-4 text-sm text-gray-400 dark:text-gray-500 italic">
+            <p className="p-4 text-sm text-gray-600 dark:text-gray-500 italic">
               No relationship changes recorded in the last {sinceDays || 30} days.
             </p>
           ) : (

--- a/app/ui/src/components/ResourceDetailPage.jsx
+++ b/app/ui/src/components/ResourceDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+﻿import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import RiskScoreSection, { RISK_FIELDS } from './RiskScoreSection';
 import { formatDate, computeHistoryDiffs, friendlyLabel } from '../utils/formatters';
@@ -148,7 +148,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
                   </span>
                 )}
                 {attributes.systemId && (
-                  <span className="text-xs text-gray-400 dark:text-gray-500">System: {attributes.systemId}</span>
+                  <span className="text-xs text-gray-600 dark:text-gray-500">System: {attributes.systemId}</span>
                 )}
               </div>
             </div>
@@ -168,7 +168,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
           )}
         </div>
         <button onClick={onClose}
-          className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
           title="Close tab">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -189,7 +189,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
                 onNodeClick={graph.handleNodeClick}
               />
               {graph.pathDepth > 0 && (
-                <div className="text-xs text-gray-400 dark:text-gray-500 text-center pb-2">
+                <div className="text-xs text-gray-600 dark:text-gray-500 text-center pb-2">
                   <span className="font-medium text-gray-600 dark:text-gray-300">{graph.activeListLabel}</span>
                   {' — '}
                   <button onClick={graph.reset} className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline">collapse</button>
@@ -206,7 +206,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
               />
             ) : (
               <div className="bg-white dark:bg-gray-800 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg p-6 text-center">
-                <p className="text-sm text-gray-400 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
+                <p className="text-sm text-gray-600 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
               </div>
             )}
           </div>
@@ -232,7 +232,7 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
           loading={historyLoading}
         >
           {historyDiffs.length === 0 ? (
-            <p className="text-sm text-gray-400 dark:text-gray-500 italic p-4">No changes recorded</p>
+            <p className="text-sm text-gray-600 dark:text-gray-500 italic p-4">No changes recorded</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
@@ -250,9 +250,9 @@ export default function ResourceDetailPage({ resourceId, cachedData, onCacheData
                         {diff.changes.map((c, j) => (
                           <div key={j} className="text-xs">
                             <span className="font-medium text-gray-700 dark:text-gray-300">{friendlyLabel(c.field)}</span>
-                            <span className="text-gray-400 dark:text-gray-500 mx-1">:</span>
+                            <span className="text-gray-600 dark:text-gray-500 mx-1">:</span>
                             <span className="text-red-500 dark:text-red-400 line-through mr-1">{c.from}</span>
-                            <span className="text-gray-400 dark:text-gray-500 mr-1">&rarr;</span>
+                            <span className="text-gray-600 dark:text-gray-500 mr-1">&rarr;</span>
                             <span className="text-green-600 dark:text-green-400">{c.to}</span>
                           </div>
                         ))}

--- a/app/ui/src/components/RiskProfileWizard.jsx
+++ b/app/ui/src/components/RiskProfileWizard.jsx
@@ -1,4 +1,4 @@
-// Identity Atlas v5 — Risk Profile wizard.
+﻿// Identity Atlas v5 — Risk Profile wizard.
 //
 // Multi-step UX for creating a risk profile + classifiers + (optionally) running
 // a scoring pass. Lives behind the "New Risk Profile" button on the Risk Scoring
@@ -316,10 +316,10 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
       {/* Step indicator */}
       <div className="flex items-center gap-2 px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 text-xs">
         {STEPS.map((s, i) => (
-          <div key={s.key} className={`flex items-center gap-2 ${i === stepIdx ? 'font-semibold text-indigo-700 dark:text-indigo-400' : i < stepIdx ? 'text-green-700 dark:text-green-400' : 'text-gray-400 dark:text-gray-500'}`}>
+          <div key={s.key} className={`flex items-center gap-2 ${i === stepIdx ? 'font-semibold text-indigo-700 dark:text-indigo-400' : i < stepIdx ? 'text-green-700 dark:text-green-400' : 'text-gray-600 dark:text-gray-500'}`}>
             <span className={`inline-flex w-5 h-5 rounded-full items-center justify-center text-[10px] ${i === stepIdx ? 'bg-indigo-600 text-white' : i < stepIdx ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-600'}`}>{i + 1}</span>
             <span>{s.label}</span>
-            {i < STEPS.length - 1 && <span className="text-gray-300 dark:text-gray-600 mx-1">›</span>}
+            {i < STEPS.length - 1 && <span className="text-gray-500 dark:text-gray-600 mx-1">›</span>}
           </div>
         ))}
       </div>

--- a/app/ui/src/components/RiskScoreSection.jsx
+++ b/app/ui/src/components/RiskScoreSection.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+﻿import { useState } from 'react';
 import { TIER_STYLES } from '../utils/tierStyles';
 
 function TierBadge({ tier }) {
@@ -124,7 +124,7 @@ export default function RiskScoreSection({ attributes, entityType, entityId, aut
       <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
         Risk Assessment
         {attributes.riskScoredAt && (
-          <span className="text-xs font-normal text-gray-400 dark:text-gray-500">
+          <span className="text-xs font-normal text-gray-600 dark:text-gray-500">
             scored {formatScoredAt(attributes.riskScoredAt)}
           </span>
         )}
@@ -149,9 +149,9 @@ export default function RiskScoreSection({ attributes, entityType, entityId, aut
       <div className="grid grid-cols-4 gap-3 mb-3">
         {layers.map(l => (
           <div key={l.key} className="text-center">
-            <div className="text-[10px] text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">{l.label}</div>
+            <div className="text-[10px] text-gray-600 dark:text-gray-500 uppercase tracking-wide mb-1">{l.label}</div>
             <div className="text-lg font-semibold text-gray-800 dark:text-gray-200">{l.score ?? 0}</div>
-            <div className="text-[10px] text-gray-400 dark:text-gray-500">{l.weight} weight</div>
+            <div className="text-[10px] text-gray-600 dark:text-gray-500">{l.weight} weight</div>
           </div>
         ))}
       </div>
@@ -205,7 +205,7 @@ export default function RiskScoreSection({ attributes, entityType, entityId, aut
                   if (!reasons || (Array.isArray(reasons) && reasons.length === 0)) return null;
                   return (
                     <div key={layerKey}>
-                      <div className="text-[10px] text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-0.5">
+                      <div className="text-[10px] text-gray-600 dark:text-gray-500 uppercase tracking-wide mb-0.5">
                         {layerKey.replace(/([A-Z])/g, ' $1').trim()}
                       </div>
                       {Array.isArray(reasons) ? (
@@ -238,7 +238,7 @@ export default function RiskScoreSection({ attributes, entityType, entityId, aut
           <div className="bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-lg p-3 space-y-3">
             <div className="flex items-center justify-between">
               <h5 className="text-xs font-semibold text-gray-700 dark:text-gray-300">Analyst Override</h5>
-              <button onClick={() => setOverrideOpen(false)} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-xs">Cancel</button>
+              <button onClick={() => setOverrideOpen(false)} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-xs">Cancel</button>
             </div>
 
             <div>
@@ -250,7 +250,7 @@ export default function RiskScoreSection({ attributes, entityType, entityId, aut
                 onChange={e => setAdjustment(parseInt(e.target.value))}
                 className="w-full h-2 bg-gray-200 dark:bg-gray-600 rounded-lg appearance-none cursor-pointer"
               />
-              <div className="flex justify-between text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">
+              <div className="flex justify-between text-[10px] text-gray-600 dark:text-gray-500 mt-0.5">
                 <span>-50 (lower risk)</span>
                 <span className={`font-mono font-bold ${adjustment > 0 ? 'text-red-600 dark:text-red-400' : adjustment < 0 ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}>
                   {adjustment > 0 ? '+' : ''}{adjustment}
@@ -286,7 +286,7 @@ export default function RiskScoreSection({ attributes, entityType, entityId, aut
                 </button>
               )}
               {adjustment !== 0 && (
-                <span className="text-xs text-gray-400 dark:text-gray-500">
+                <span className="text-xs text-gray-600 dark:text-gray-500">
                   Effective: {score} {adjustment > 0 ? '+' : ''}{adjustment} = {Math.max(0, Math.min(100, score + adjustment))}
                 </span>
               )}

--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+﻿import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { TIER_STYLES } from '../utils/tierStyles';
 
@@ -32,7 +32,7 @@ function DistributionChart({ label, byTier, total }) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
       <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">{label}</h3>
-      <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">{total} scored</p>
+      <p className="text-xs text-gray-600 dark:text-gray-500 mb-3">{total} scored</p>
       <div className="space-y-2">
         {tiers.map(tier => {
           const count = byTier[tier] || 0;
@@ -64,7 +64,7 @@ function DistributionChart({ label, byTier, total }) {
 
 function EntityTable({ entities, entityType, onOpenDetail }) {
   if (!entities || entities.length === 0) {
-    return <div className="py-8 text-center text-gray-400 dark:text-gray-500">No entities match the current filters</div>;
+    return <div className="py-8 text-center text-gray-600 dark:text-gray-500">No entities match the current filters</div>;
   }
 
   // Define extra columns per entity type
@@ -131,7 +131,7 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
                 <td className="py-2 px-3">
                   <span className="text-blue-600 dark:text-blue-400 hover:underline font-medium">{entity.displayName}</span>
                   {(entityType === 'group' || entityType === 'business-role') && entity.description && (
-                    <p className="text-xs text-gray-400 dark:text-gray-500 truncate max-w-xs">{entity.description}</p>
+                    <p className="text-xs text-gray-600 dark:text-gray-500 truncate max-w-xs">{entity.description}</p>
                   )}
                 </td>
                 {cols.map(c => (
@@ -154,13 +154,13 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
                         </span>
                       ))}
                       {matches.length > 3 && (
-                        <span className="text-[10px] text-gray-400 dark:text-gray-500">+{matches.length - 3}</span>
+                        <span className="text-[10px] text-gray-600 dark:text-gray-500">+{matches.length - 3}</span>
                       )}
                     </div>
                   ) : entity.riskMembershipScore > 0 ? (
-                    <span className="text-[10px] text-gray-400 dark:text-gray-500">small-group bonus</span>
+                    <span className="text-[10px] text-gray-600 dark:text-gray-500">small-group bonus</span>
                   ) : (
-                    <span className="text-[10px] text-gray-300">—</span>
+                    <span className="text-[10px] text-gray-500">—</span>
                   )}
                 </td>
                 <td className="py-2 px-3">
@@ -171,7 +171,7 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
                       {entity.riskOverride > 0 ? '+' : ''}{entity.riskOverride}
                     </span>
                   ) : (
-                    <span className="text-xs text-gray-300">&mdash;</span>
+                    <span className="text-xs text-gray-500">&mdash;</span>
                   )}
                 </td>
               </tr>
@@ -275,9 +275,9 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
                 c.clusterType === 'classifier' ? 'bg-blue-50 text-blue-700 dark:text-blue-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 dark:text-gray-500'
               }`}>{c.clusterType}</span>
               {c.sourceClassifierCategory && (
-                <span className="text-xs text-gray-400 dark:text-gray-500">{c.sourceClassifierCategory}</span>
+                <span className="text-xs text-gray-600 dark:text-gray-500">{c.sourceClassifierCategory}</span>
               )}
-              <span className="text-xs text-gray-400 dark:text-gray-500">{c.memberCount} member{c.memberCount !== 1 ? 's' : ''}</span>
+              <span className="text-xs text-gray-600 dark:text-gray-500">{c.memberCount} member{c.memberCount !== 1 ? 's' : ''}</span>
             </div>
           </div>
           <div className="flex items-center gap-3">
@@ -285,7 +285,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
               <div className="text-2xl font-bold text-gray-800 dark:text-gray-200">{c.aggregateRiskScore}</div>
               <TierBadge tier={c.riskTier} />
             </div>
-            <button onClick={onClose} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 p-1">
+            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 p-1">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
             </button>
           </div>
@@ -337,7 +337,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
                     {c.ownerDisplayName}
                   </button>
                   {c.ownerAssignedAt && (
-                    <span className="text-[10px] text-gray-400 dark:text-gray-500 ml-2">
+                    <span className="text-[10px] text-gray-600 dark:text-gray-500 ml-2">
                       assigned {new Date(c.ownerAssignedAt).toLocaleDateString()}
                     </span>
                   )}
@@ -379,7 +379,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
                             className="w-full text-left px-3 py-1.5 text-sm hover:bg-blue-50 border-b border-gray-100 dark:border-gray-700 last:border-0 disabled:opacity-40"
                           >
                             {u.displayName}
-                            {u.jobTitle && <span className="text-xs text-gray-400 dark:text-gray-500 ml-2">{u.jobTitle}</span>}
+                            {u.jobTitle && <span className="text-xs text-gray-600 dark:text-gray-500 ml-2">{u.jobTitle}</span>}
                           </button>
                         ))}
                       </div>
@@ -416,7 +416,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
               Members ({members.length})
             </h4>
             {loading ? (
-              <div className="text-xs text-gray-400 dark:text-gray-500 py-2">Loading members...</div>
+              <div className="text-xs text-gray-600 dark:text-gray-500 py-2">Loading members...</div>
             ) : (
               <div className="space-y-1 max-h-[300px] overflow-y-auto">
                 {members.map(m => (
@@ -444,7 +444,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
 
           {/* Scored timestamp */}
           {c.scoredAt && (
-            <div className="text-xs text-gray-400 dark:text-gray-500 pt-2 border-t border-gray-100 dark:border-gray-700">
+            <div className="text-xs text-gray-600 dark:text-gray-500 pt-2 border-t border-gray-100 dark:border-gray-700">
               Scored at: {new Date(c.scoredAt).toLocaleString()}
             </div>
           )}
@@ -640,7 +640,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
           </p>
         </div>
         {summary?.scoredAt && (
-          <span className="text-xs text-gray-400 dark:text-gray-500">
+          <span className="text-xs text-gray-600 dark:text-gray-500">
             Last scored: {new Date(summary.scoredAt).toLocaleString()}
           </span>
         )}
@@ -665,7 +665,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
             {hasCluster && (
               <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
                 <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">Resource Clusters</h3>
-                <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">{clusterSummary.total} clusters</p>
+                <p className="text-xs text-gray-600 dark:text-gray-500 mb-3">{clusterSummary.total} clusters</p>
                 <div className="space-y-2">
                   {['Critical', 'High', 'Medium', 'Low', 'Minimal'].map(tier => {
                     const count = clusterSummary.byTier?.[tier] || 0;
@@ -835,7 +835,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
         </div>
 
         {entityLoading ? (
-          <div className="py-8 text-center text-gray-400 dark:text-gray-500">Loading...</div>
+          <div className="py-8 text-center text-gray-600 dark:text-gray-500">Loading...</div>
         ) : (
           <EntityTable
             entities={entityData.data}

--- a/app/ui/src/components/RunDetailPage.jsx
+++ b/app/ui/src/components/RunDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+﻿import { useEffect, useState, useCallback, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 
 // ─── Plugin Run Detail Page ───────────────────────────────────────────────────
@@ -82,7 +82,7 @@ export default function RunDetailPage({ runId, onClose, onOpenDetail }) {
               {isDone && durationMs != null && <> · took {formatDuration(durationMs)}</>}
             </p>
           </div>
-          <button onClick={onClose} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500" aria-label="Close">
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500" aria-label="Close">
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/app/ui/src/components/SystemsPage.jsx
+++ b/app/ui/src/components/SystemsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+﻿import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../auth/AuthGate';
 
 function formatRelativeTime(dateStr) {
@@ -122,7 +122,7 @@ export default function SystemsPage() {
                     <span>
                       <span className="font-medium text-gray-900 dark:text-white">{(sys.assignmentCount || 0).toLocaleString()}</span> Assignments
                     </span>
-                    <span className="ml-auto text-gray-400 dark:text-gray-500">
+                    <span className="ml-auto text-gray-600 dark:text-gray-500">
                       Last sync: {formatRelativeTime(sys.lastSyncTime)}
                     </span>
                   </div>
@@ -193,7 +193,7 @@ export default function SystemsPage() {
                     )}
 
                     {sys.createdAt && (
-                      <div className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+                      <div className="mt-3 text-xs text-gray-600 dark:text-gray-500">
                         Created: {new Date(sys.createdAt).toLocaleString()}
                         {sys.updatedAt && ` | Updated: ${new Date(sys.updatedAt).toLocaleString()}`}
                       </div>

--- a/app/ui/src/components/TimeSeriesChart.jsx
+++ b/app/ui/src/components/TimeSeriesChart.jsx
@@ -59,7 +59,7 @@ export default function TimeSeriesChart({
   const isDark = useIsDark();
 
   const gridColor = isDark ? '#374151' : '#e5e7eb';
-  const axisColor = isDark ? '#9ca3af' : '#6b7280';
+  const axisColor = isDark ? '#9ca3af' : '#4b5563';
   const lineColor = color;
   const fillColor = color + '20';  // 12% opacity tint
 

--- a/app/ui/src/components/UserDetailPage.jsx
+++ b/app/ui/src/components/UserDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+﻿import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import RiskScoreSection, { RISK_FIELDS } from './RiskScoreSection';
 import { formatDate, computeHistoryDiffs, friendlyLabel } from '../utils/formatters';
@@ -158,19 +158,19 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
               </div>
               <p className="text-sm text-gray-500 dark:text-gray-400">{attributes.userPrincipalName || attributes.email}</p>
               {(attributes.systemDisplayName || attributes.systemId) && (
-                <p className="text-xs text-gray-400 dark:text-gray-500">System: {attributes.systemDisplayName || attributes.systemId}</p>
+                <p className="text-xs text-gray-600 dark:text-gray-500">System: {attributes.systemDisplayName || attributes.systemId}</p>
               )}
             </div>
           </div>
           <div className="flex items-center gap-4 mt-2 text-sm text-gray-600 dark:text-gray-400">
             {attributes.jobTitle && <span>{attributes.jobTitle}</span>}
-            {attributes.department && <span className="text-gray-400 dark:text-gray-500">|</span>}
+            {attributes.department && <span className="text-gray-600 dark:text-gray-500">|</span>}
             {attributes.department && <span>{attributes.department}</span>}
-            {attributes.companyName && <span className="text-gray-400 dark:text-gray-500">|</span>}
+            {attributes.companyName && <span className="text-gray-600 dark:text-gray-500">|</span>}
             {attributes.companyName && <span>{attributes.companyName}</span>}
           </div>
           {lastActivity?.lastActivityDateTime && (
-            <div className="flex items-center gap-1.5 mt-1 text-xs text-gray-400 dark:text-gray-500">
+            <div className="flex items-center gap-1.5 mt-1 text-xs text-gray-600 dark:text-gray-500">
               <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
@@ -189,7 +189,7 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
           )}
         </div>
         <button onClick={onClose}
-          className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
           title="Close tab">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -210,7 +210,7 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
                 onNodeClick={graph.handleNodeClick}
               />
               {graph.pathDepth > 0 && (
-                <div className="text-xs text-gray-400 dark:text-gray-500 text-center pb-2">
+                <div className="text-xs text-gray-600 dark:text-gray-500 text-center pb-2">
                   <span className="font-medium text-gray-600 dark:text-gray-300">{graph.activeListLabel}</span>
                   {' — '}
                   <button onClick={graph.reset} className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline">collapse</button>
@@ -227,7 +227,7 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
               />
             ) : (
               <div className="bg-white dark:bg-gray-800 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg p-6 text-center">
-                <p className="text-sm text-gray-400 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
+                <p className="text-sm text-gray-600 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
               </div>
             )}
           </div>
@@ -260,7 +260,7 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
           loading={historyLoading}
         >
           {historyDiffs.length === 0 ? (
-            <p className="text-sm text-gray-400 dark:text-gray-500 italic p-4">No changes recorded</p>
+            <p className="text-sm text-gray-600 dark:text-gray-500 italic p-4">No changes recorded</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
@@ -280,9 +280,9 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
                         {diff.changes.map((c, j) => (
                           <div key={j} className="text-xs">
                             <span className="font-medium text-gray-700 dark:text-gray-300">{friendlyLabel(c.field)}</span>
-                            <span className="text-gray-400 dark:text-gray-500 mx-1">:</span>
+                            <span className="text-gray-600 dark:text-gray-500 mx-1">:</span>
                             <span className="text-red-500 dark:text-red-400 line-through mr-1">{c.from}</span>
-                            <span className="text-gray-400 dark:text-gray-500 mr-1">&rarr;</span>
+                            <span className="text-gray-600 dark:text-gray-500 mr-1">&rarr;</span>
                             <span className="text-green-600 dark:text-green-400">{c.to}</span>
                           </div>
                         ))}
@@ -353,7 +353,7 @@ function IdentityMembershipSection({ identityInfo, onNavigateToIdentities }) {
             {identity.correlationConfidence != null && ` · ${identity.correlationConfidence}% confidence`}
           </div>
           {memberInfo.correlationSignals && (
-            <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+            <div className="text-xs text-gray-600 dark:text-gray-500 mt-0.5">
               Signals: {memberInfo.correlationSignals}
             </div>
           )}
@@ -376,8 +376,8 @@ function IdentityMembershipSection({ identityInfo, onNavigateToIdentities }) {
                     {m.isPrimary && <span className="text-blue-600 font-medium">Primary</span>}
                     {m.isHrAuthoritative && <span className="text-emerald-700 font-medium">HR</span>}
                     <span className="text-gray-700 dark:text-gray-300 font-medium truncate max-w-48">{m.displayName}</span>
-                    <span className="text-gray-400 dark:text-gray-500 truncate max-w-64">{m.userPrincipalName}</span>
-                    <span className={`ml-auto ${m.accountEnabled === 'True' || m.accountEnabled === true ? 'text-green-500' : 'text-gray-300'}`}>
+                    <span className="text-gray-600 dark:text-gray-500 truncate max-w-64">{m.userPrincipalName}</span>
+                    <span className={`ml-auto ${m.accountEnabled === 'True' || m.accountEnabled === true ? 'text-green-500' : 'text-gray-500'}`}>
                       {m.accountEnabled === 'True' || m.accountEnabled === true ? '●' : '○'}
                     </span>
                   </div>

--- a/app/ui/src/components/UsersPage.jsx
+++ b/app/ui/src/components/UsersPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+﻿import { useMemo, useState, useEffect } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import useEntityPage from '../hooks/useEntityPage';
 import FilterBar from './FilterBar';
@@ -318,7 +318,7 @@ export default function UsersPage({ onOpenDetail }) {
                       {ep.sortCol === col.key ? (
                         <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
                       ) : (
-                        <span className="text-gray-300 dark:text-gray-500 text-[10px]">{'▴'}</span>
+                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
                       )}
                     </span>
                   </th>

--- a/app/ui/src/components/contexts/ContextMemberPicker.jsx
+++ b/app/ui/src/components/contexts/ContextMemberPicker.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+﻿import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../../auth/AuthGate';
 
 // ─── Member typeahead for manual contexts ─────────────────────────────────────
@@ -119,7 +119,7 @@ export default function ContextMemberPicker({ contextId, targetType, onAdded, ex
                 className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 ${alreadyIn ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 <span className="truncate">{r.displayName || r.id}</span>
-                <span className="text-[11px] text-gray-400 dark:text-gray-500 ml-2">
+                <span className="text-[11px] text-gray-600 dark:text-gray-500 ml-2">
                   {alreadyIn ? 'already a member' : adding === r.id ? 'adding…' : 'add'}
                 </span>
               </button>

--- a/app/ui/src/components/contexts/ContextPicker.jsx
+++ b/app/ui/src/components/contexts/ContextPicker.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from 'react';
+﻿import { useEffect, useMemo, useState, useCallback } from 'react';
 import { useAuth } from '../../auth/AuthGate';
 import { Modal, SecondaryButton } from './ModalPrimitives';
 import { variantMeta, targetTypeMeta } from '../../utils/contextStyles';
@@ -269,7 +269,7 @@ function PickerNode({ node, depth, isLast, expanded, onToggleExpand, matchedSet,
           <button
             aria-expanded={isOpen}
             onClick={() => onToggleExpand(node.id)}
-            className="w-5 h-5 flex items-center justify-center text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded shrink-0"
+            className="w-5 h-5 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded shrink-0"
             title={isOpen ? 'Collapse' : 'Expand'}
           >
             {isOpen ? '▾' : '▸'}
@@ -293,7 +293,7 @@ function PickerNode({ node, depth, isLast, expanded, onToggleExpand, matchedSet,
           <span className="font-medium text-gray-900 dark:text-white truncate" title={node.displayName}>{node.displayName}</span>
           <span className={`text-[10px] px-1.5 py-0.5 rounded border ${t.badgeClass} whitespace-nowrap shrink-0`}>{t.label}</span>
           {node.contextType && (
-            <span className="text-[10px] text-gray-400 dark:text-gray-500 whitespace-nowrap shrink-0">{node.contextType}</span>
+            <span className="text-[10px] text-gray-600 dark:text-gray-500 whitespace-nowrap shrink-0">{node.contextType}</span>
           )}
           <MemberCount direct={node.directMemberCount} total={node.totalMemberCount} />
         </button>
@@ -338,7 +338,7 @@ function PickerListRow({ node, value, onPick }) {
         <span style={{ paddingLeft: `${node._depth * 16}px` }} className="inline-block" />
         <span className={`w-2 h-2 rounded-full ${v.dotClass} shrink-0`} aria-hidden="true" />
         <span className="font-medium text-gray-900 dark:text-white truncate flex-1 min-w-0" title={node.displayName}>{node.displayName}</span>
-        <span className="text-[10px] text-gray-400 dark:text-gray-500 whitespace-nowrap">{node.contextType}</span>
+        <span className="text-[10px] text-gray-600 dark:text-gray-500 whitespace-nowrap">{node.contextType}</span>
         <span className={`text-[10px] px-1.5 py-0.5 rounded border ${t.badgeClass} whitespace-nowrap`}>{t.label}</span>
         <MemberCount direct={node.directMemberCount} total={node.totalMemberCount} />
       </button>
@@ -352,12 +352,12 @@ function MemberCount({ direct, total }) {
   const t = total  || 0;
   if (t > d) {
     return (
-      <span className="text-[11px] text-gray-400 dark:text-gray-500 whitespace-nowrap shrink-0">
+      <span className="text-[11px] text-gray-600 dark:text-gray-500 whitespace-nowrap shrink-0">
         {d} · <span className="text-gray-600 dark:text-gray-400">{t}</span>
       </span>
     );
   }
-  return <span className="text-[11px] text-gray-400 dark:text-gray-500 whitespace-nowrap shrink-0">{d}</span>;
+  return <span className="text-[11px] text-gray-600 dark:text-gray-500 whitespace-nowrap shrink-0">{d}</span>;
 }
 
 // Counts visible nodes after filters / search.

--- a/app/ui/src/components/contexts/ContextTreeSelector.jsx
+++ b/app/ui/src/components/contexts/ContextTreeSelector.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+﻿import { useMemo, useState } from 'react';
 import { variantMeta, targetTypeMeta } from '../../utils/contextStyles';
 
 function renderMemberCounts(n) {
@@ -6,9 +6,9 @@ function renderMemberCounts(n) {
   const t = typeof n.totalMemberCount  === 'number' ? n.totalMemberCount  : null;
   if (d == null && t == null) return null;
   if (t != null && d != null && t > d) {
-    return <span className="text-[10px] text-gray-400 dark:text-gray-500">· {d}/{t}</span>;
+    return <span className="text-[10px] text-gray-600 dark:text-gray-500">· {d}/{t}</span>;
   }
-  return <span className="text-[10px] text-gray-400 dark:text-gray-500">· {d ?? t}</span>;
+  return <span className="text-[10px] text-gray-600 dark:text-gray-500">· {d ?? t}</span>;
 }
 
 // Left pane of the Contexts tab. Lists every root context. Grouped by
@@ -98,7 +98,7 @@ export default function ContextTreeSelector({ roots, selectedRootId, onSelectRoo
         {groups.map(([group, items]) => (
           <div key={group} className="mb-2">
             <div className="px-3 py-1 text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-700/50 border-y border-gray-100 dark:border-gray-700">
-              {group} <span className="text-gray-400 dark:text-gray-500">· {items.length}</span>
+              {group} <span className="text-gray-600 dark:text-gray-500">· {items.length}</span>
             </div>
             <ul>
               {items.map(n => {

--- a/app/ui/src/components/contexts/ContextTreeView.jsx
+++ b/app/ui/src/components/contexts/ContextTreeView.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+﻿import { useState } from 'react';
 import { variantMeta, targetTypeMeta } from '../../utils/contextStyles';
 
 // Recursive tree renderer. Each node is a rounded pill with a variant-colored
@@ -55,7 +55,7 @@ function TreeNode({ node, depth, isLast, onOpenDetail }) {
           <button
             aria-expanded={expanded}
             onClick={() => setExpanded(prev => !prev)}
-            className="w-5 h-5 flex items-center justify-center text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700 rounded shrink-0"
+            className="w-5 h-5 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700 rounded shrink-0"
             title={expanded ? 'Collapse' : 'Expand'}
           >
             {expanded ? '▾' : '▸'}
@@ -105,10 +105,10 @@ function MemberCount({ direct, total }) {
   const t = total  || 0;
   if (t > d) {
     return (
-      <span className="text-[11px] text-gray-400 dark:text-gray-500 whitespace-nowrap shrink-0">
+      <span className="text-[11px] text-gray-600 dark:text-gray-500 whitespace-nowrap shrink-0">
         {d} · <span className="text-gray-600 dark:text-gray-400 dark:text-gray-500">{t}</span>
       </span>
     );
   }
-  return <span className="text-[11px] text-gray-400 dark:text-gray-500 whitespace-nowrap shrink-0">{d}</span>;
+  return <span className="text-[11px] text-gray-600 dark:text-gray-500 whitespace-nowrap shrink-0">{d}</span>;
 }

--- a/app/ui/src/components/contexts/ManualContextEditor.jsx
+++ b/app/ui/src/components/contexts/ManualContextEditor.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+﻿import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../../auth/AuthGate';
 import ContextPicker from './ContextPicker';
 
@@ -153,7 +153,7 @@ export default function ManualContextEditor({ contextId, attrs, onUpdated, onDel
             >
               {parentId
                 ? <span className="text-gray-900 dark:text-white">{parentLabel || parentId.slice(0, 8)}</span>
-                : <span className="text-gray-400 dark:text-gray-500">(no parent — root)</span>}
+                : <span className="text-gray-600 dark:text-gray-500">(no parent — root)</span>}
             </button>
             {parentId && (
               <button

--- a/app/ui/src/components/contexts/ModalPrimitives.jsx
+++ b/app/ui/src/components/contexts/ModalPrimitives.jsx
@@ -1,4 +1,4 @@
-// Shared modal + form helpers used by every Contexts tab modal (create manual
+﻿// Shared modal + form helpers used by every Contexts tab modal (create manual
 // tree, run plugin, edit, etc.). Keeping them here so the visual language
 // stays consistent and we don't duplicate the overlay / close-on-backdrop-click
 // logic five times.
@@ -16,7 +16,7 @@ export function Modal({ title, subtitle, onClose, children, width = 480 }) {
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">{title}</h3>
             {subtitle && <p className="text-[11px] text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-0.5">{subtitle}</p>}
           </div>
-          <button onClick={onClose} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 ml-4" aria-label="Close">✕</button>
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 ml-4" aria-label="Close">✕</button>
         </div>
         {children}
       </div>

--- a/app/ui/src/components/contexts/RunPluginModal.jsx
+++ b/app/ui/src/components/contexts/RunPluginModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+﻿import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../auth/AuthGate';
 import { Modal, Field, ErrorBox, PrimaryButton, SecondaryButton } from './ModalPrimitives';
 import { targetTypeMeta } from '../../utils/contextStyles';
@@ -365,7 +365,7 @@ function DryRunSamples({ samples }) {
           <summary className="text-[11px] text-gray-700 dark:text-gray-300 cursor-pointer">Preview contexts ({ctxs.length})</summary>
           <ul className="text-[11px] text-gray-600 dark:text-gray-400 dark:text-gray-500 mt-1 pl-4 list-disc">
             {ctxs.map((c, i) => (
-              <li key={i}>{c.displayName} <span className="text-gray-400 dark:text-gray-500">({c.externalId})</span></li>
+              <li key={i}>{c.displayName} <span className="text-gray-600 dark:text-gray-500">({c.externalId})</span></li>
             ))}
           </ul>
         </details>

--- a/app/ui/src/components/matrix/MatrixFilterSummary.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterSummary.jsx
@@ -104,7 +104,7 @@ export default function MatrixFilterSummary({ filter, preview, onAdjust }) {
 function SavedBadge({ savedMatch, loading }) {
   if (loading) {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/30 text-gray-400 dark:text-gray-500 text-[11px]">
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 text-[11px]">
         …
       </span>
     );
@@ -141,7 +141,7 @@ function Section({ label, chips, preview }) {
     <span className="inline-flex items-center gap-1 flex-wrap max-w-[40%]">
       <span className="text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-semibold">{label}</span>
       {chips.length === 0
-        ? <span className="text-gray-400 dark:text-gray-500 italic">all</span>
+        ? <span className="text-gray-600 dark:text-gray-400 italic">all</span>
         : chips.map((c, i) => (
             <span
               key={i}

--- a/app/ui/src/components/matrix/MatrixFilterWizard.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.jsx
@@ -1,4 +1,4 @@
-// 3-step modal that builds a Matrix. The user must complete this before the
+﻿// 3-step modal that builds a Matrix. The user must complete this before the
 // matrix loads any data.
 //
 //   Step 1 — Setup              (subject type + orientation)
@@ -409,7 +409,7 @@ function StepIndicator({ step, onJump }) {
             }`}>{s.n}</span>
             {s.label}
           </button>
-          {idx < steps.length - 1 && <span className="text-gray-300 dark:text-gray-600">›</span>}
+          {idx < steps.length - 1 && <span className="text-gray-500 dark:text-gray-400">›</span>}
         </span>
       ))}
     </div>
@@ -452,7 +452,7 @@ function SavedFilterDropdown({ savedFilters, onLoad, onDelete }) {
                 </button>
                 <button
                   onClick={() => onDelete(f.id)}
-                  className="text-[10px] text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400"
+                  className="text-[10px] text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400"
                   title="Delete (org-wide)"
                 >
                   Delete
@@ -481,21 +481,21 @@ function LiveSummary({ preview, loading, rowType }) {
       <div>
         <span className="font-semibold text-gray-800 dark:text-gray-200">{preview.subjectCount.toLocaleString()}</span>
         {' '}of {preview.subjectTotal.toLocaleString()} {subjectLabel}
-        <span className="text-gray-400 dark:text-gray-500"> · {subjectPct}%</span>
+        <span className="text-gray-600 dark:text-gray-400"> · {subjectPct}%</span>
       </div>
-      <div className="text-gray-300 dark:text-gray-600">×</div>
+      <div className="text-gray-500 dark:text-gray-400">×</div>
       <div>
         <span className="font-semibold text-gray-800 dark:text-gray-200">{preview.resourceCount.toLocaleString()}</span>
         {' '}of {preview.resourceTotal.toLocaleString()} resources
-        <span className="text-gray-400 dark:text-gray-500"> · {resourcePct}%</span>
+        <span className="text-gray-600 dark:text-gray-400"> · {resourcePct}%</span>
       </div>
-      <div className="text-gray-300 dark:text-gray-600">·</div>
+      <div className="text-gray-500 dark:text-gray-400">·</div>
       <div>
         <span className="font-semibold text-gray-800 dark:text-gray-200">{preview.assignmentCount.toLocaleString()}</span>
         {' '}assignments
       </div>
       {loading && (
-        <div className="ml-auto text-[10px] text-gray-400 dark:text-gray-500">updating…</div>
+        <div className="ml-auto text-[10px] text-gray-600 dark:text-gray-400">updating…</div>
       )}
     </div>
   );
@@ -577,9 +577,9 @@ function OrientationVisual({ rowsLabel, colsLabel }) {
   // Tiny 2×3 grid that visually communicates which axis is rows / columns.
   return (
     <div className="flex flex-col items-end gap-0.5">
-      <div className="text-[8px] uppercase tracking-wider text-gray-400 dark:text-gray-500">{colsLabel}</div>
+      <div className="text-[8px] uppercase tracking-wider text-gray-600 dark:text-gray-400">{colsLabel}</div>
       <div className="flex items-center gap-1">
-        <div className="text-[8px] uppercase tracking-wider text-gray-400 dark:text-gray-500" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>{rowsLabel}</div>
+        <div className="text-[8px] uppercase tracking-wider text-gray-600 dark:text-gray-400" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>{rowsLabel}</div>
         <div className="grid grid-cols-3 gap-px bg-gray-300 dark:bg-gray-600 p-px rounded">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="w-2 h-2 bg-white dark:bg-gray-800" />
@@ -685,7 +685,7 @@ function ConditionList({ title, conditions, contextMeta, columns, onContextResol
       </div>
       <div className="p-2 space-y-1.5">
         {conditions.length === 0 ? (
-          <p className="text-[11px] text-gray-400 dark:text-gray-500 italic">{emptyHint}</p>
+          <p className="text-[11px] text-gray-600 dark:text-gray-400 italic">{emptyHint}</p>
         ) : (
           conditions.map((cond, idx) => (
             <ConditionRow
@@ -748,7 +748,7 @@ function ConditionRow({ cond, contextMeta, onRemove, onUpdate }) {
             <span>incl. descendants</span>
           </label>
         </span>
-        <button onClick={onRemove} className="text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400" aria-label="Remove">×</button>
+        <button onClick={onRemove} className="text-gray-600 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400" aria-label="Remove">×</button>
       </div>
     );
   }
@@ -757,12 +757,12 @@ function ConditionRow({ cond, contextMeta, onRemove, onUpdate }) {
       <div className="flex items-center gap-2 text-xs">
         <span className="inline-flex items-center gap-1 bg-slate-50 dark:bg-gray-700/50 border border-slate-200 dark:border-gray-600 rounded px-2 py-1 flex-1 min-w-0">
           <span className="text-gray-500 dark:text-gray-400 font-medium uppercase text-[10px]">{cond.field}</span>
-          <span className="text-gray-400 dark:text-gray-500">in</span>
+          <span className="text-gray-600 dark:text-gray-500">in</span>
           <span className="truncate text-gray-800 dark:text-gray-200 flex-1">
             {(cond.values || []).join(', ')}
           </span>
         </span>
-        <button onClick={onRemove} className="text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400" aria-label="Remove">×</button>
+        <button onClick={onRemove} className="text-gray-600 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400" aria-label="Remove">×</button>
       </div>
     );
   }
@@ -816,11 +816,11 @@ function AttributePicker({ columns, onPick, onClose }) {
         {field && (
           <>
             <label className="block text-[11px] font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Values <span className="text-gray-400 dark:text-gray-500">(any of these match — OR)</span>
+              Values <span className="text-gray-600 dark:text-gray-500">(any of these match — OR)</span>
             </label>
             <div className="border border-gray-200 dark:border-gray-700 rounded max-h-48 overflow-y-auto">
               {valueOptions.length === 0 ? (
-                <p className="text-[11px] text-gray-400 dark:text-gray-500 italic px-2 py-1">No values available</p>
+                <p className="text-[11px] text-gray-600 dark:text-gray-500 italic px-2 py-1">No values available</p>
               ) : (
                 valueOptions.map(v => (
                   <label key={v} className="flex items-center gap-1.5 px-2 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/30 text-xs cursor-pointer">
@@ -835,7 +835,7 @@ function AttributePicker({ columns, onPick, onClose }) {
                 ))
               )}
             </div>
-            <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">{selectedValues.length} selected</p>
+            <p className="text-[10px] text-gray-600 dark:text-gray-500 mt-1">{selectedValues.length} selected</p>
           </>
         )}
 

--- a/app/ui/src/components/matrix/MatrixGroupRow.jsx
+++ b/app/ui/src/components/matrix/MatrixGroupRow.jsx
@@ -1,4 +1,4 @@
-import MatrixCell from './MatrixCell';
+﻿import MatrixCell from './MatrixCell';
 import { getAccessPackageColor } from './MatrixColumnHeaders';
 import { useIsDark } from '../../contexts/ThemeContext';
 
@@ -60,7 +60,7 @@ export default function MatrixGroupRow({
         {...(group.isNestedRow ? {} : (sortableListeners || {}))}
       >
         {!group.isNestedRow && (
-          <span className="text-gray-300 dark:text-gray-600 text-xs select-none">&#x2630;</span>
+          <span className="text-gray-500 dark:text-gray-600 text-xs select-none">&#x2630;</span>
         )}
       </td>
 
@@ -74,7 +74,7 @@ export default function MatrixGroupRow({
           {canExpand && (
             <button
               onClick={(e) => { e.stopPropagation(); onToggleExpand?.(realGidForExpand); }}
-              className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600"
+              className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600"
               title={isExpanded ? 'Collapse nested groups' : 'Expand nested groups'}
             >
               {isLoadingNested ? (
@@ -88,7 +88,7 @@ export default function MatrixGroupRow({
             </button>
           )}
           {group.isNestedRow && (
-            <span className="text-gray-300 dark:text-gray-600 text-[10px] mr-0.5 flex-shrink-0">{'\u2514'}</span>
+            <span className="text-gray-500 dark:text-gray-600 text-[10px] mr-0.5 flex-shrink-0">{'\u2514'}</span>
           )}
           <div className="truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400"
             onClick={() => onOpenDetail?.('resource', group.realGroupId || group.id, group.displayName)}>
@@ -223,7 +223,7 @@ export default function MatrixGroupRow({
           style={{ minWidth: '40px' }}>
         {memberCount}
       </td>
-      <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-0.5 text-xs text-gray-400 dark:text-gray-500 max-w-[500px]"
+      <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-500 max-w-[500px]"
           title={group.description}>
         <div className="truncate">{group.description}</div>
       </td>

--- a/changes/wcag-contrast-fixes.md
+++ b/changes/wcag-contrast-fixes.md
@@ -3,3 +3,4 @@
 - Fixed SVG axis label color in TimeSeriesChart (gray-500 → gray-600, from ≈4.6:1 to ≈7.5:1 margin)
 - Fixed remaining pre-existing contrast violations across 44 UI components (gray-400/300 text on light backgrounds, blue-400 and red-400 status text)
 - Added ESLint rule `local/no-low-contrast-text` that blocks Tailwind `text-{color}-300` and `text-{color}-400` classes in JSX `className` attributes, enforcing WCAG 2.0 AA compliance at build time
+- Fixed MatrixView regression introduced by the CodeQL fix branch (PR #148 accidentally reverted MatrixView to the pre-wizard-refactor version, breaking the Matrix tab with "Cannot read properties of undefined" on first load)

--- a/changes/wcag-contrast-fixes.md
+++ b/changes/wcag-contrast-fixes.md
@@ -1,0 +1,5 @@
+- Fixed WCAG 2.0 AA contrast failures in MatrixFilterWizard: separator characters, percentage labels, orientation labels, hint text, and delete button labels were rendered in gray-300/400 (failing contrast) and upgraded to gray-500/600
+- Fixed low-contrast "all" placeholder and loading indicator in MatrixFilterSummary
+- Fixed SVG axis label color in TimeSeriesChart (gray-500 → gray-600, from ≈4.6:1 to ≈7.5:1 margin)
+- Fixed remaining pre-existing contrast violations across 44 UI components (gray-400/300 text on light backgrounds, blue-400 and red-400 status text)
+- Added ESLint rule `local/no-low-contrast-text` that blocks Tailwind `text-{color}-300` and `text-{color}-400` classes in JSX `className` attributes, enforcing WCAG 2.0 AA compliance at build time

--- a/changes/wcag-contrast-fixes.md
+++ b/changes/wcag-contrast-fixes.md
@@ -3,4 +3,3 @@
 - Fixed SVG axis label color in TimeSeriesChart (gray-500 → gray-600, from ≈4.6:1 to ≈7.5:1 margin)
 - Fixed remaining pre-existing contrast violations across 44 UI components (gray-400/300 text on light backgrounds, blue-400 and red-400 status text)
 - Added ESLint rule `local/no-low-contrast-text` that blocks Tailwind `text-{color}-300` and `text-{color}-400` classes in JSX `className` attributes, enforcing WCAG 2.0 AA compliance at build time
-- Fixed MatrixView regression introduced by the CodeQL fix branch (PR #148 accidentally reverted MatrixView to the pre-wizard-refactor version, breaking the Matrix tab with "Cannot read properties of undefined" on first load)


### PR DESCRIPTION
## Summary

- Fixed WCAG 2.0 AA contrast failures in `MatrixFilterWizard`: separator characters, percentage labels, orientation labels, hint text, and delete button labels were rendered in gray-300/400 (failing contrast) and upgraded to gray-500/600
- Fixed low-contrast "all" placeholder and loading indicator in `MatrixFilterSummary`
- Fixed SVG axis label color in `TimeSeriesChart` (gray-500 → gray-600, from ≈4.6:1 to ≈7.5:1 margin)
- Fixed remaining pre-existing contrast violations across 44 UI components (gray-400/300 text on light backgrounds, blue-400 and red-400 status text)
- Added ESLint rule `local/no-low-contrast-text` that blocks Tailwind `text-{color}-300` and `text-{color}-400` classes in JSX `className` attributes, enforcing WCAG 2.0 AA compliance at build time

## Test plan

- [ ] Run `npm run lint` in `app/ui` — should report zero errors
- [ ] Visually inspect MatrixFilterWizard (separator lines, percentage labels, hint text, delete buttons) on light background — all text should be clearly readable
- [ ] Visually inspect MatrixFilterSummary "all" placeholder and loading state on light background
- [ ] Check TimeSeriesChart axis labels (Trends tab) — should be darker than before
- [ ] Try adding a bare `text-gray-400` class to any JSX `className` and confirm ESLint blocks it with `local/no-low-contrast-text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)