### PR TITLE
fix: resolve medium-severity CodeQL alerts

### DIFF
--- a/app/api/src/index.js
+++ b/app/api/src/index.js
@@ -120,12 +120,19 @@ app.use(helmet({
 }));
 
 // ─── CORS ────────────────────────────────────────────────────────
+// ALLOWED_ORIGINS must not contain '*' — filter it out to prevent accidental
+// broad access. In development, restrict to known localhost origins instead
+// of `true` (which would allow any origin including cross-site attackers).
+const DEV_ORIGINS = [
+  'http://localhost:5173', 'http://localhost:3000', 'http://localhost:3001',
+  'http://127.0.0.1:5173', 'http://127.0.0.1:3000', 'http://127.0.0.1:3001',
+];
 const corsOptions = {
   origin: process.env.ALLOWED_ORIGINS
-    ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
+    ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim()).filter(o => o && o !== '*')
     : isProduction
       ? false  // Disallow cross-origin in production if not explicitly configured
-      : true,  // Allow all origins in development
+      : DEV_ORIGINS,
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
   allowedHeaders: ['Content-Type', 'Authorization'],
@@ -300,7 +307,7 @@ app.use('/api', crawlerAuthMiddleware, ingestRouter);
 // In production, serve the frontend build output
 const frontendDist = join(__dirname, '../../frontend/dist');
 app.use(express.static(frontendDist));
-app.get('*', (req, res, next) => {
+app.get('*', publicLimiter, (req, res, next) => {
   // Only serve index.html for non-API routes (SPA fallback)
   if (req.path.startsWith('/api')) return next();
   res.sendFile(join(frontendDist, 'index.html'));

--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -49,11 +49,16 @@ export function normalizeRecords(records, coreColumns, options = {}) {
     const normalized = {};
     const extended = {};
 
+    // Write only property names sourced from the trusted coreSet, not from
+    // the user-provided record keys, to avoid remote-property-injection.
+    for (const key of coreSet) {
+      if (Object.prototype.hasOwnProperty.call(rec, key)) {
+        normalized[key] = coerceValue(rec[key]);
+      }
+    }
+    // Collect non-core, non-reserved fields for extendedAttributes JSON.
     for (const [key, value] of Object.entries(rec)) {
-      if (coreSet.has(key)) {
-        normalized[key] = coerceValue(value);
-      } else if (key !== 'externalId') {
-        // Non-core fields go into extendedAttributes
+      if (!coreSet.has(key) && key !== 'externalId') {
         extended[key] = value;
       }
     }

--- a/app/api/src/routes/contextPlugins.js
+++ b/app/api/src/routes/contextPlugins.js
@@ -52,11 +52,14 @@ router.post('/context-plugins/:name/dry-run', async (req, res) => {
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const plugin = getPlugin(req.params.name);
   if (!plugin) return res.status(404).json({ error: 'Plugin not found' });
+  // Use the validated name from the registry, not the raw URL param, to avoid
+  // log injection / tainted-format-string issues.
+  const pluginName = plugin.name;
   try {
-    const out = await dryRun(plugin.name, req.body || {});
+    const out = await dryRun(pluginName, req.body || {});
     res.json(out);
   } catch (err) {
-    console.error(`POST /context-plugins/${req.params.name}/dry-run failed:`, err.message);
+    console.error(`POST /context-plugins/${pluginName}/dry-run failed:`, err.message);
     res.status(400).json({ error: err.message });
   }
 });
@@ -66,12 +69,13 @@ router.post('/context-plugins/:name/run', async (req, res) => {
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const plugin = getPlugin(req.params.name);
   if (!plugin) return res.status(404).json({ error: 'Plugin not found' });
+  const pluginName = plugin.name;
   const triggeredBy = (req.user && (req.user.email || req.user.upn || req.user.name)) || 'unknown';
   try {
-    const runId = await enqueueRun(plugin.name, req.body || {}, triggeredBy);
+    const runId = await enqueueRun(pluginName, req.body || {}, triggeredBy);
     res.status(202).json({ runId, status: 'queued' });
   } catch (err) {
-    console.error(`POST /context-plugins/${req.params.name}/run failed:`, err.message);
+    console.error(`POST /context-plugins/${pluginName}/run failed:`, err.message);
     res.status(400).json({ error: err.message });
   }
 });

--- a/app/api/src/routes/ingest.js
+++ b/app/api/src/routes/ingest.js
@@ -46,8 +46,10 @@ function createIngestHandler(entityType) {
     const recResult = validateRecords(body.records, entityType, body.idGeneration, body.syncMode);
     if (!recResult.valid) {
       const preview = recResult.errors.slice(0, 5).join(' | ');
+      // Sanitize syncMode before logging to prevent log-injection via newline chars.
+      const safeSyncMode = body.syncMode === 'full' || body.syncMode === 'delta' ? body.syncMode : 'full';
       console.warn(
-        `Ingest validation failed [${entityType}] (${body.syncMode || 'full'} mode): ` +
+        `Ingest validation failed [${entityType}] (${safeSyncMode} mode): ` +
         `${recResult.errors.length} record error(s) — first ${Math.min(5, recResult.errors.length)}: ${preview}`
       );
       return res.status(400).json({ error: 'Record validation failed', details: recResult.errors });

--- a/app/ui/src/auth/AuthGate.jsx
+++ b/app/ui/src/auth/AuthGate.jsx
@@ -31,6 +31,13 @@ export default function AuthGate({ children }) {
           return;
         }
 
+        // Validate tenant ID before embedding in the authority URL — prevents
+        // open-redirect/SSRF if the server were to return an unexpected value.
+        const TENANT_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$|^[a-z0-9][a-z0-9-]*\.[a-z]{2,}$/i;
+        if (!config.tenantId || !TENANT_RE.test(config.tenantId)) {
+          throw new Error('Invalid tenant configuration received from server');
+        }
+
         const pca = new PublicClientApplication({
           auth: {
             clientId: config.clientId,

--- a/changes/bugfixes-codeql-medium-severity.md
+++ b/changes/bugfixes-codeql-medium-severity.md
@@ -1,0 +1,5 @@
+- Fixed log injection in context plugin dry-run and ingest routes by sanitising user-controlled values before logging
+- Fixed remote property injection in ingest normalisation by iterating the trusted column set instead of request-supplied keys
+- Hardened CORS configuration: replaced permissive wildcard origin with an explicit localhost allowlist for development; production defaults to same-origin only
+- Added rate limiting to the SPA HTML fallback route
+- Added tenant ID format validation in MSAL AuthGate to prevent client-side request forgery via a crafted server config response


### PR DESCRIPTION
## Summary
- Fixed log injection in context plugin dry-run and ingest routes by sanitising user-controlled values before logging
- Fixed remote property injection in ingest normalisation by iterating the trusted column set instead of request-supplied keys
- Hardened CORS configuration: explicit localhost allowlist in development, same-origin only in production
- Added rate limiting to the SPA HTML fallback route
- Added tenant ID format validation in MSAL AuthGate to prevent client-side request forgery

## Test plan
- [ ] `docker compose build web && docker compose up -d web` — container starts cleanly
- [ ] `curl http://localhost:3001/api/health` returns `{"status":"ok"}`
- [ ] API unit tests pass: `cd app/api && npm test`
- [ ] Verify UI loads correctly in development (CORS allowlist covers localhost:5173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)