### PR TITLE
fix: remove unused variables flagged by CodeQL

### DIFF
--- a/app/api/src/ingest/engine.js
+++ b/app/api/src/ingest/engine.js
@@ -16,7 +16,6 @@
 //   - All identifiers are camelCase double-quoted to match the v4 column
 //     names exactly. This minimises the route changes needed for v5.
 
-import { from as copyFrom } from 'pg-copy-streams';
 import crypto from 'crypto';
 import * as db from '../db/connection.js';
 
@@ -80,21 +79,6 @@ function encodeCopyValue(val, dataType) {
 
 function escapeCopyText(s) {
   return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
-}
-
-function buildCopyRow(record, activeColumns) {
-  const fields = activeColumns.map(col => {
-    let val = record[col.name];
-    // Auto-generate a UUID for columns with gen_random_uuid() default when
-    // the caller doesn't supply one. Without this, the COPY writes NULL which
-    // overrides the column DEFAULT — postgres only applies defaults for
-    // missing columns, not for explicit NULLs.
-    if ((val === null || val === undefined) && col.hasUuidDefault) {
-      val = crypto.randomUUID();
-    }
-    return encodeCopyValue(val, col.sqlTypeName);
-  });
-  return fields.join('\t') + '\n';
 }
 
 /**

--- a/app/api/src/ingest/sessions.js
+++ b/app/api/src/ingest/sessions.js
@@ -12,7 +12,6 @@
 
 import crypto from 'crypto';
 import { discoverColumns, writeSyncLog, scopedDelete } from './engine.js';
-import { from as copyFrom } from 'pg-copy-streams';
 import * as db from '../db/connection.js';
 
 const sessions = new Map();
@@ -34,24 +33,6 @@ setInterval(async () => {
 
 function escapeCopyText(s) {
   return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
-}
-function buildCopyRow(record, activeColumns) {
-  const fields = activeColumns.map(col => {
-    const v = record[col.name];
-    if (v === null || v === undefined) return '\\N';
-    if (col.sqlTypeName === 'jsonb' || col.sqlTypeName === 'json') {
-      return escapeCopyText(typeof v === 'string' ? v : JSON.stringify(v));
-    }
-    if (col.sqlTypeName === 'boolean') {
-      return v === true || v === 1 || v === '1' || v === 'true' || v === 't' ? 't' : 'f';
-    }
-    if (col.sqlTypeName.startsWith('timestamp')) {
-      return v instanceof Date ? v.toISOString() : escapeCopyText(String(v));
-    }
-    if (typeof v === 'number') return String(v);
-    return escapeCopyText(String(v));
-  });
-  return fields.join('\t') + '\n';
 }
 
 async function copyRows(client, tempTable, activeColumns, records) {

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -592,13 +592,6 @@ router.post('/admin/features/toggle', async (req, res) => {
   }
 });
 
-// Helper: detect whether the request came from an interactive admin user.
-// In v5, the only mutation surface for admin endpoints is either an authenticated
-// UI session or a crawler with the 'admin' permission. We check both.
-function isAdminRequest(req) {
-  return !!req.user; // any signed-in UI user
-}
-
 // ─── Dashboard stats — one-shot overview of loaded data ────────────────────
 //
 // Used by the Dashboard / landing page to show a summary of what's in the

--- a/app/api/src/routes/contexts.js
+++ b/app/api/src/routes/contexts.js
@@ -26,7 +26,6 @@ const useSql = process.env.USE_SQL === 'true';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VARIANTS = new Set(['synced', 'generated', 'manual']);
 const TARGET_TYPES = new Set(['Identity', 'Resource', 'Principal', 'System']);
-const ADDED_BY = new Set(['sync', 'algorithm', 'analyst']);
 
 // Map targetType → the table name where memberIds live. Used to filter the
 // member list to live rows only (stale member rows are left to a background

--- a/app/api/src/routes/correlationRulesets.js
+++ b/app/api/src/routes/correlationRulesets.js
@@ -151,7 +151,7 @@ router.post('/correlation-rulesets/refine', async (req, res) => {
 router.post('/correlation-rulesets', async (req, res) => {
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
 
-  const { ruleset, version, makeActive } = req.body || {};
+  const { ruleset, version } = req.body || {};
   if (!ruleset) return res.status(400).json({ error: 'ruleset is required' });
 
   try {

--- a/app/api/src/routes/details.js
+++ b/app/api/src/routes/details.js
@@ -49,14 +49,6 @@ async function fetchHistory(tableName, rowId) {
   });
 }
 
-async function rowExistsInHistory(tableName, rowId) {
-  const r = await db.query(
-    `SELECT 1 FROM "_history" WHERE "tableName" = $1 AND "rowId" = $2 LIMIT 1`,
-    [tableName, rowId]
-  );
-  return r.rows.length > 0;
-}
-
 async function countHistory(tableName, rowId) {
   const r = await db.query(
     `SELECT COUNT(*)::int AS cnt FROM "_history" WHERE "tableName" = $1 AND "rowId" = $2`,

--- a/app/api/src/routes/governance.js
+++ b/app/api/src/routes/governance.js
@@ -108,7 +108,6 @@ router.get('/governance/summary', async (req, res) => {
 router.get('/governance/review-compliance', async (req, res) => {
   if (!useSql) return res.json([]);
   try {
-    const pool = await db.getPool();
     const filter = req.query.filter;
     const categoryId = req.query.category;
 

--- a/app/api/src/routes/permissions.js
+++ b/app/api/src/routes/permissions.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { permissionAssignments } from '../mock/data.js';
 import { ensureTagTables } from './tags.js';
 import { ensureCategoryTables } from './categories.js';
-import { getUserColumns, getGroupColumns, getResourceColumns, getPrincipalOrUserColumns, getUserColumnValues, getPrincipalOrUserColumnValues, FILTERABLE_TYPES } from '../db/columnCache.js';
+import { getGroupColumns, getResourceColumns, getPrincipalOrUserColumns, getPrincipalOrUserColumnValues } from '../db/columnCache.js';
 import { timedRequest } from '../perf/sqlTimer.js';
 import { buildContextFilterSql, parseAndResolveContextFilters } from '../contexts/contextFilters.js';
 
@@ -118,23 +118,9 @@ router.get('/permissions', async (req, res) => {
         return res.json({ data: [], totalUsers: 0, managedByPackages: [] });
       }
 
-      // v5: always use the unified view; no materialized tables exist.
-      const matCheck = await timedRequest(p, 'perm-mat-check', res).query(`
-        SELECT
-          to_regclass('"vw_ResourceUserPermissionAssignments"') AS "resourceViewExists",
-          to_regclass('"Principals"') AS "principalsExists",
-          to_regclass('"vw_UserPermissionAssignmentViaBusinessRole"') AS "matApExists"
-      `);
       // v5: always use the unified resource view + Principals table.
       // The legacy mat_/GraphUsers paths are gone.
       const permSource = '"vw_ResourceUserPermissionAssignments"';
-      const COL_RES = 'resourceId';
-      const COL_PRINC = 'principalId';
-      const COL_PTYPE = 'principalType';
-      const apSource = '"vw_UserPermissionAssignmentViaBusinessRole"';
-      const hasPrecomputedCounts = false;
-      const userTable = '"Principals"';
-      const upnCol = 'u."email"';
 
       // Discover user and group columns dynamically
       const allCols = await getPrincipalOrUserColumns(p);

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { timedRequest } from '../perf/sqlTimer.js';
-import { getResourceColumns, getResourceColumnValues, FILTERABLE_TYPES } from '../db/columnCache.js';
+import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
 import { ensureTagTables, buildFilterWhere } from './tags.js';
 
 const router = Router();

--- a/app/api/src/routes/tags.js
+++ b/app/api/src/routes/tags.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { randomUUID } from 'crypto';
-import { getUserColumns as getUserCols, getGroupColumns as getGroupCols, getResourceColumns as getResourceCols, getPrincipalOrUserColumns, getUserColumnValues, getPrincipalOrUserColumnValues, getGroupColumnValues, getResourceColumnValues, FILTERABLE_TYPES } from '../db/columnCache.js';
+import { getGroupColumns as getGroupCols, getResourceColumns as getResourceCols, getPrincipalOrUserColumns, getPrincipalOrUserColumnValues, getGroupColumnValues, getResourceColumnValues } from '../db/columnCache.js';
 import { getOrCreateTagRoot } from '../bootstrap.js';
 import { recalcMemberCountsForChain } from '../contexts/memberCounts.js';
 

--- a/app/api/src/secrets/vault.js
+++ b/app/api/src/secrets/vault.js
@@ -26,7 +26,6 @@ import * as db from '../db/connection.js';
 const ALGO = 'aes-256-gcm';
 const IV_LEN = 12;
 const KEY_LEN = 32;
-const TAG_LEN = 16;
 
 let cachedMasterKey = null;
 

--- a/app/ui/e2e/access-packages.spec.js
+++ b/app/ui/e2e/access-packages.spec.js
@@ -67,17 +67,11 @@ test.describe('Access Packages Page', () => {
 
   test('assignment type badges render', async ({ page }) => {
     // Mock data should have assignment types: Auto-assigned, Request-based, etc.
-    const badges = page.getByText(/Auto-assigned|Request-based/i);
-    // May or may not have these depending on mock data
-    // Just verify no crash
+    // May or may not have badge types depending on mock data — just verify no crash
     await expect(page.locator('table')).toBeVisible({ timeout: 5000 });
   });
 
   test('pagination controls exist', async ({ page }) => {
-    const pagination = page.getByRole('button', { name: /Next/i })
-      .or(page.getByRole('button', { name: /Previous/i }))
-      .or(page.getByText(/Page/i));
-
     // With mock data (probably < 100 APs), pagination may not show
     // Just check the page is stable
     await expect(page.locator('table')).toBeVisible({ timeout: 5000 });

--- a/app/ui/e2e/detail-pages.spec.js
+++ b/app/ui/e2e/detail-pages.spec.js
@@ -32,13 +32,9 @@ test.describe('Entity Detail Pages', () => {
     });
 
     if (await userLinks.count() > 0) {
-      const linkText = await userLinks.first().textContent();
       await userLinks.first().click();
       await page.waitForTimeout(500);
 
-      // A new tab should appear in the nav
-      // Detail tabs have a close button (×)
-      const closeButtons = page.locator('nav button svg, nav button:has-text("×")');
       // At least verify navigation didn't break
       const navButtons = page.locator('nav button');
       expect(await navButtons.count()).toBeGreaterThan(7); // 8 main tabs + at least 1 detail
@@ -88,15 +84,6 @@ test.describe('Entity Detail Pages', () => {
   });
 
   test.describe('Tab close navigation', () => {
-
-    // Helper: find and click the close span on a tab by its tabKey (e.g. "user:abc")
-    async function closeTab(page, tabKey) {
-      // The close button is a <span> inside the tab <button>; hover the tab first to reveal it
-      const tab = page.locator(`nav button`).filter({ hasText: new RegExp(tabKey.split(':')[0], 'i') }).last();
-      await tab.hover();
-      const closeSpan = tab.locator('span[title="Close"]');
-      await closeSpan.click();
-    }
 
     test('closing the active tab navigates to its originating page', async ({ page }) => {
       // Go to Users page first so openDetailTab records returnPage='users'

--- a/app/ui/e2e/identities.spec.js
+++ b/app/ui/e2e/identities.spec.js
@@ -123,8 +123,6 @@ test.describe('Identities Page', () => {
     if (!hasTable) { test.skip(); return; }
 
     // Confidence bar: a narrow horizontal bar element with inline width style
-    const bar = page.locator('[style*="width:"], [style*="width: "]').first();
-    const exists = await bar.count() > 0;
     // Accept either bar found or table has no rows with confidence
     expect(true).toBe(true);
   });
@@ -150,10 +148,6 @@ test.describe('Identities Page', () => {
     await page.waitForTimeout(1000);
     const notAvailable = await page.getByText(/not.*available|Invoke-FGAccountCorrelation/i).count();
     if (notAvailable > 0) { test.skip(); return; }
-
-    const searchInput = page.getByRole('textbox', { name: /search/i })
-      .or(page.locator('input[placeholder*="search" i]'))
-      .or(page.locator('input[placeholder*="identit" i]'));
 
     // Not all mock states will show a search bar — just verify no crash
     expect(true).toBe(true);
@@ -194,7 +188,6 @@ test.describe('Identities Page', () => {
   test('Verified badge is visible for verified identities', async ({ page }) => {
     await page.waitForTimeout(1000);
     // Just check the component doesn't crash — badge presence depends on data
-    const badge = page.getByText('Verified', { exact: true });
     // May or may not be present depending on mock data
     expect(true).toBe(true);
   });
@@ -212,9 +205,7 @@ test.describe('Identities Page', () => {
     await rows.first().click();
     await page.waitForTimeout(500);
 
-    // Look for a Verify button in the detail panel
-    const verifyBtn = page.getByRole('button', { name: /verify/i });
-    // Presence depends on whether a panel opened and data loaded
+    // Presence of a Verify button depends on whether a panel opened and data loaded
     expect(true).toBe(true);
   });
 

--- a/app/ui/e2e/matrix.spec.js
+++ b/app/ui/e2e/matrix.spec.js
@@ -92,8 +92,7 @@ test.describe('Matrix View', () => {
 
   test('owner rows are separated with (Owner) suffix', async ({ page }) => {
     // Mock data should have owner memberships that create separate rows
-    const ownerRows = page.getByText('(Owner)');
-    // May or may not be visible depending on mock data and user limit
+    // Owner rows may or may not be visible depending on mock data and user limit
     // Just verify the page doesn't crash
     expect(true).toBe(true);
   });

--- a/app/ui/e2e/multi-filter.spec.js
+++ b/app/ui/e2e/multi-filter.spec.js
@@ -2,7 +2,6 @@
 import { test, expect } from '@playwright/test';
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:3001';
-const API = `${BASE}/api`;
 
 test.describe('Multi-filter combinations', () => {
   test('resources page: search narrows results', async ({ page }) => {

--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -471,7 +471,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
   const [clusterData, setClusterData] = useState({ available: false, data: [], total: 0 });
   const [clusterSummary, setClusterSummary] = useState(null);
   const [selectedCluster, setSelectedCluster] = useState(null);
-  const [clusterSort, setClusterSort] = useState({ key: 'score', dir: 'desc' });
+  const [clusterSort] = useState({ key: 'score', dir: 'desc' });
   const PAGE_SIZE = 25;
 
   // Fetch summary

--- a/changes/bugfixes-codeql-unused-variables.md
+++ b/changes/bugfixes-codeql-unused-variables.md
@@ -1,0 +1,3 @@
+- Removed unused imports and variables flagged by CodeQL across API route files (admin, contexts, correlationRulesets, details, governance, permissions, resources, tags), ingest engine and sessions, and the secrets vault
+- Removed unused variable declarations in Playwright end-to-end test files (access-packages, detail-pages, identities, matrix, multi-filter)
+- Removed unused state setter in RiskScoringPage


### PR DESCRIPTION
## Summary
- Removed unused imports and variables across API route files (admin, contexts, correlationRulesets, details, governance, permissions, resources, tags), ingest engine and sessions, and the secrets vault
- Removed unused variable declarations in Playwright end-to-end test files (access-packages, detail-pages, identities, matrix, multi-filter)
- Removed unused state setter in RiskScoringPage

## Test plan
- [ ] API unit tests pass: `cd app/api && npm test`
- [ ] UI lints clean: `npm run lint --prefix app/ui` (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)