### PR TITLE
fix: resolve 3 warning-severity CodeQL alerts

### DIFF
--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -57,8 +57,10 @@ export function normalizeRecords(records, coreColumns, options = {}) {
       }
     }
     // Collect non-core, non-reserved fields for extendedAttributes JSON.
+    // Skip prototype-poisoning keys to prevent remote-property-injection.
     for (const [key, value] of Object.entries(rec)) {
-      if (!coreSet.has(key) && key !== 'externalId') {
+      if (!coreSet.has(key) && key !== 'externalId' &&
+          key !== '__proto__' && key !== 'constructor' && key !== 'prototype') {
         extended[key] = value;
       }
     }

--- a/app/api/src/routes/jobs.js
+++ b/app/api/src/routes/jobs.js
@@ -856,14 +856,16 @@ router.get('/admin/crawler-jobs/:id/log', async (req, res) => {
     return res.status(400).json({ error: 'Invalid job ID' });
   }
   try {
-    const stat = await fs.stat(logPath);
-    const totalLength = stat.size;
-    if (offset >= totalLength) {
-      return res.json({ text: '', offset, totalLength, truncated: false, exists: true });
-    }
-    const length = Math.min(MAX_TRACE_CHUNK, totalLength - offset);
+    // Open first, then stat via the handle — avoids a TOCTOU race between
+    // checking the file size and reading it (file-system-race mitigation).
     const fh = await fs.open(logPath, 'r');
     try {
+      const stat = await fh.stat();
+      const totalLength = stat.size;
+      if (offset >= totalLength) {
+        return res.json({ text: '', offset, totalLength, truncated: false, exists: true });
+      }
+      const length = Math.min(MAX_TRACE_CHUNK, totalLength - offset);
       const buf = Buffer.alloc(length);
       await fh.read(buf, 0, length, offset);
       const text = buf.toString('utf8');

--- a/app/ui/e2e/export-validation.spec.js
+++ b/app/ui/e2e/export-validation.spec.js
@@ -18,11 +18,10 @@ test.describe('Export validation', () => {
       ]);
       const path = await download.path();
       expect(path).toBeTruthy();
-      // Verify the file has content (not empty)
-      const stats = fs.statSync(path);
-      expect(stats.size).toBeGreaterThan(0);
-      // XLSX files start with PK (ZIP magic bytes)
+      // Read once — avoids a TOCTOU race between statSync and readFileSync.
       const buf = fs.readFileSync(path);
+      expect(buf.length).toBeGreaterThan(0);
+      // XLSX files start with PK (ZIP magic bytes)
       expect(buf[0]).toBe(0x50); // P
       expect(buf[1]).toBe(0x4B); // K
     } else {

--- a/changes/codeql-warnings.md
+++ b/changes/codeql-warnings.md
@@ -1,0 +1,3 @@
+- Fixed file-system race in trace-log reader: open the file handle first, then stat via the handle, eliminating the TOCTOU window between size-check and read
+- Fixed file-system race in export E2E test: read file once and derive size from the buffer instead of calling statSync then readFileSync separately
+- Fixed remote-property-injection in record normalizer: skip prototype-poisoning keys (__proto__, constructor, prototype) when collecting extended attributes


### PR DESCRIPTION
Stacked on top of #156 (`bugfixes/codeql-critical`).

## Summary

Resolves the following CodeQL `warning`-severity alerts:

| # | Rule | File |
|---|------|------|
| #50 | `js/remote-property-injection` | `app/api/src/ingest/normalization.js:62` |
| #53 | `js/file-system-race` | `app/api/src/routes/jobs.js:865` |
| #54 | `js/file-system-race` | `app/ui/e2e/export-validation.spec.js:25` |

### Fixes

- **file-system-race (#53):** The trace-log reader previously called `fs.stat()` to get the file size, then separately opened the file handle — leaving a TOCTOU window where the file could change between the two calls. Fixed by opening the handle first and calling `fh.stat()` on it, so stat and read operate on the same file descriptor.
- **file-system-race (#54):** The E2E export test called `fs.statSync` to check the file size and then `fs.readFileSync` to read it. Fixed by reading the file once and checking `buf.length`, eliminating the TOCTOU window.
- **remote-property-injection (#50):** When collecting non-core record fields into `extendedAttributes`, user-supplied keys like `__proto__`, `constructor`, and `prototype` were not filtered. Added an explicit guard to skip these prototype-poisoning keys before assignment.

## Test plan

- [x] `npm test` in `app/api` — 216 tests pass
- [ ] Verify CodeQL alerts #50, #53, #54 are dismissed after CI scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)