### PR TITLE
fix: resolve remaining 7 CodeQL alerts

### DIFF
--- a/app/api/src/ingest/engine.js
+++ b/app/api/src/ingest/engine.js
@@ -51,35 +51,6 @@ export async function discoverColumns(_pool, tableName) {
   return cols;
 }
 
-// Encode a JS value into a postgres TEXT-format COPY field.
-// Special chars per the COPY spec: \\ → \\\\, \n → \\n, \r → \\r, \t → \\t,
-// NULL → \N. JSON columns get JSON.stringify-ed and then escaped.
-function encodeCopyValue(val, dataType) {
-  if (val === null || val === undefined) return '\\N';
-  if (dataType === 'jsonb' || dataType === 'json') {
-    if (typeof val === 'string') return escapeCopyText(val);
-    return escapeCopyText(JSON.stringify(val));
-  }
-  if (dataType === 'boolean') {
-    if (val === true || val === 1 || val === '1' || val === 'true' || val === 't') return 't';
-    if (val === false || val === 0 || val === '0' || val === 'false' || val === 'f') return 'f';
-    return '\\N';
-  }
-  if (typeof dataType === 'string' && dataType.startsWith('timestamp')) {
-    if (val instanceof Date) return val.toISOString();
-    return escapeCopyText(String(val));
-  }
-  if (dataType === 'integer' || dataType === 'bigint' || dataType === 'numeric' || dataType === 'real' || dataType === 'double precision') {
-    if (typeof val === 'number') return String(val);
-    if (typeof val === 'boolean') return val ? '1' : '0';
-    return escapeCopyText(String(val));
-  }
-  return escapeCopyText(String(val));
-}
-
-function escapeCopyText(s) {
-  return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
-}
 
 /**
  * Core ingest operation. Bulk-COPY records into a temp table, then upsert

--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -47,7 +47,7 @@ export function normalizeRecords(records, coreColumns, options = {}) {
 
   return records.map(rec => {
     const normalized = {};
-    const extended = {};
+    const extended = Object.create(null);
 
     // Write only property names sourced from the trusted coreSet, not from
     // the user-provided record keys, to avoid remote-property-injection.

--- a/app/api/src/ingest/sessions.js
+++ b/app/api/src/ingest/sessions.js
@@ -31,9 +31,6 @@ setInterval(async () => {
   }
 }, 5 * 60 * 1000);
 
-function escapeCopyText(s) {
-  return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
-}
 
 async function copyRows(client, tempTable, activeColumns, records) {
   // Batched INSERT instead of COPY FROM STDIN. The COPY approach had a crash

--- a/app/api/src/llm/providers.js
+++ b/app/api/src/llm/providers.js
@@ -39,12 +39,6 @@ function validateAzureEndpoint(endpoint) {
   return parsed;
 }
 
-// Trim trailing slashes without a backtracking-vulnerable regex.
-function trimTrailingSlashes(s) {
-  let i = s.length;
-  while (i > 0 && s[i - 1] === '/') i--;
-  return s.slice(0, i);
-}
 
 const DEFAULT_MODELS = {
   anthropic: 'claude-sonnet-4-20250514',

--- a/app/api/src/routes/identities.js
+++ b/app/api/src/routes/identities.js
@@ -54,7 +54,7 @@ router.get('/identities', async (req, res) => {
       return res.json({ available: false, data: [], total: 0, summary: null });
     }
 
-    const { search, minAccounts, accountType, confidence, verified, hrAnchored, orphanStatus, sort, limit, offset } = req.query;
+    const { search, minAccounts, confidence, verified, hrAnchored, orphanStatus, sort, limit, offset } = req.query;
     const pageLimit = Math.min(parseInt(limit) || 50, 500);
     const pageOffset = parseInt(offset) || 0;
 

--- a/app/api/src/routes/jobs.js
+++ b/app/api/src/routes/jobs.js
@@ -856,14 +856,14 @@ router.get('/admin/crawler-jobs/:id/log', async (req, res) => {
     return res.status(400).json({ error: 'Invalid job ID' });
   }
   try {
-    const stat = await fs.stat(logPath);
-    const totalLength = stat.size;
-    if (offset >= totalLength) {
-      return res.json({ text: '', offset, totalLength, truncated: false, exists: true });
-    }
-    const length = Math.min(MAX_TRACE_CHUNK, totalLength - offset);
     const fh = await fs.open(logPath, 'r');
     try {
+      const stat = await fh.stat();
+      const totalLength = stat.size;
+      if (offset >= totalLength) {
+        return res.json({ text: '', offset, totalLength, truncated: false, exists: true });
+      }
+      const length = Math.min(MAX_TRACE_CHUNK, totalLength - offset);
       const buf = Buffer.alloc(length);
       await fh.read(buf, 0, length, offset);
       const text = buf.toString('utf8');

--- a/app/ui/e2e/export-validation.spec.js
+++ b/app/ui/e2e/export-validation.spec.js
@@ -18,11 +18,9 @@ test.describe('Export validation', () => {
       ]);
       const path = await download.path();
       expect(path).toBeTruthy();
-      // Verify the file has content (not empty)
-      const stats = fs.statSync(path);
-      expect(stats.size).toBeGreaterThan(0);
-      // XLSX files start with PK (ZIP magic bytes)
+      // Verify the file has content and starts with PK (ZIP/XLSX magic bytes)
       const buf = fs.readFileSync(path);
+      expect(buf.length).toBeGreaterThan(0);
       expect(buf[0]).toBe(0x50); // P
       expect(buf[1]).toBe(0x4B); // K
     } else {

--- a/changes/codeql-warnings-round2.md
+++ b/changes/codeql-warnings-round2.md
@@ -1,0 +1,1 @@
+- Fixed remaining CodeQL warnings: removed unused internal helper functions, eliminated a TOCTOU file-system race in the job-log endpoint, and hardened ingest normalization against prototype-injection via user-supplied property names.


### PR DESCRIPTION
- Fixed remaining CodeQL warnings: removed unused internal helper functions, eliminated a TOCTOU file-system race in the job-log endpoint, and hardened ingest normalization against prototype-injection via user-supplied property names.

## Detail

| Alert | File | Fix |
|-------|------|-----|
| `trimTrailingSlashes` unused | `app/api/src/llm/providers.js` | Removed dead function |
| `escapeCopyText` unused | `app/api/src/ingest/sessions.js` | Removed dead function |
| `encodeCopyValue` + `escapeCopyText` unused | `app/api/src/ingest/engine.js` | Removed both (leftover from abandoned COPY approach) |
| `accountType` unused | `app/api/src/routes/identities.js` | Removed from destructuring |
| TOCTOU race (stat → open) | `app/api/src/routes/jobs.js` | Open file handle first, then `fh.stat()` |
| TOCTOU race (statSync → readFileSync) | `app/ui/e2e/export-validation.spec.js` | Single `readFileSync`, check `buf.length` |
| Remote property injection | `app/api/src/ingest/normalization.js` | `Object.create(null)` for the `extended` accumulator |

## Test plan

- [ ] CodeQL scan passes with 0 open alerts
- [ ] Job log polling endpoint still returns correct `text`/`totalLength`/`truncated` fields
- [ ] Ingest normalization still stores extended attributes correctly in `extendedAttributes` JSON column

🤖 Generated with [Claude Code](https://claude.com/claude-code)