### PR TITLE
fix: reject fgc_ tokens in authMiddleware to prevent admin route bypass

### DIFF
--- a/app/api/src/middleware/auth.js
+++ b/app/api/src/middleware/auth.js
@@ -40,10 +40,12 @@ export function authMiddleware(req, res, next) {
 
   const token = authHeader.split(' ')[1];
 
-  // Crawler API keys start with 'fgc_'. Skip JWT validation and let the
-  // request fall through to the crawler auth middleware which handles these.
+  // Crawler API keys (fgc_) are only valid on routes protected by
+  // crawlerAuthMiddleware, which has its own middleware stack and never also
+  // uses authMiddleware. Passing them through here would allow any fgc_-prefixed
+  // string to reach admin routes without any credential check.
   if (token.startsWith('fgc_')) {
-    return next();
+    return res.status(401).json({ error: 'Crawler API keys are not valid for this endpoint' });
   }
 
   // Read-only API keys (`fgr_…`) are accepted on GET requests to non-admin

--- a/changes/broken-access-control-fgc-token-bypass.md
+++ b/changes/broken-access-control-fgc-token-bypass.md
@@ -1,0 +1,1 @@
+- Fixed security vulnerability: crawler API keys (`fgc_`) were incorrectly passed through JWT auth middleware, allowing any string with the `fgc_` prefix to reach admin endpoints without valid credentials.


### PR DESCRIPTION
- Fixed security vulnerability: crawler API keys (`fgc_`) were incorrectly passed through JWT auth middleware, allowing any string with the `fgc_` prefix to reach admin endpoints without valid credentials.

## Details

`authMiddleware` had a branch that called `next()` unconditionally for any Bearer token starting with `fgc_`, with a comment saying "let the request fall through to the crawler auth middleware". However, crawler routes (`/api/ingest`, `/api/crawlers/self-service`) use `crawlerAuthMiddleware` exclusively and are never also wrapped in `authMiddleware`. All admin/user routes use `authMiddleware` only, with `crawlerAuthMiddleware` never in their chain.

This meant any request with `Authorization: Bearer fgc_<anything>` would pass `authMiddleware` and reach admin handlers (including `POST /api/admin/clean-database`) with no credential check whatsoever.

## Fix

The `fgc_` branch now returns `401` instead of `next()`. Legitimate crawler requests go through `crawlerAuthMiddleware` directly and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)