### PR TITLE
fix: documentation standardise docker compose up to always use --pull always

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,6 @@ Then: **Actions → Cut Hotfix** with branch name and new version (e.g. `5.2.1`)
 
 ```bash
 curl -O https://raw.githubusercontent.com/Fortigi/IdentityAtlas/main/docker-compose.prod.yml
-docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml up -d --pull always
 # Open http://localhost:3001 → Admin → Crawlers → Add Crawler
 ```

--- a/changes/quickstart-docker-pull-always.md
+++ b/changes/quickstart-docker-pull-always.md
@@ -1,0 +1,1 @@
+- Fixed inconsistent docker startup commands: all documented `docker compose up` invocations now consistently use `--pull always` to ensure the latest image is pulled on every start.

--- a/docs/reference/sbom.md
+++ b/docs/reference/sbom.md
@@ -218,11 +218,7 @@ Identity Atlas follows semantic versioning with automated version bumping on eve
 To check for updates:
 
 ```bash
-# Pull latest images
-docker compose -f docker-compose.prod.yml pull
-
-# Restart with new images
-docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml up -d --pull always
 ```
 
 For security advisories and CVE notifications, monitor the [GitHub Security Advisories](https://github.com/Fortigi/IdentityAtlas/security/advisories) page.


### PR DESCRIPTION
Fixes #83.

- Fixed inconsistent docker startup commands: all documented `docker compose up` invocations now consistently use `--pull always` to ensure the latest image is pulled on every start.

Two locations were missing the flag:
- `CLAUDE.md` — User Workflow (Getting Started) snippet
- `docs/reference/sbom.md` — "To check for updates" section (also simplified from a two-step pull+up to the single recommended command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)