### PR TITLE
feat: add beta release channel for pre-release Docker images

### DIFF
--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -1,0 +1,85 @@
+# ─── Cut a Pre-Release (Beta / RC / Alpha) ────────────────────────────────────
+# Manually triggered. Tags the current main HEAD with vX.Y.Z-beta.N (or -rc.N /
+# -alpha.N) and lets docker-publish build and push :beta + :X.Y.Z-beta.N.
+#
+# :latest is never touched — users on docker-compose.prod.yml are unaffected.
+#
+# Usage:
+#   1. Go to Actions → Cut Beta → Run workflow
+#   2. Enter the version (e.g. "5.3.0-beta.1")
+#   3. The workflow creates tag v5.3.0-beta.1 on the current main HEAD
+#   4. docker-publish builds and pushes :beta + :5.3.0-beta.1
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Cut Beta
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Pre-release version (e.g. "5.3.0-beta.1", "5.3.0-rc.1", "5.3.0-alpha.1")'
+        required: true
+
+jobs:
+  cut-beta:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Validate version input
+        run: |
+          if ! echo "${{ github.event.inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-(beta|rc|alpha)\.[0-9]+$'; then
+            echo "::error::Version must be in Major.Minor.Patch-(beta|rc|alpha).N format (e.g. 5.3.0-beta.1)"
+            exit 1
+          fi
+
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Create and push pre-release tag
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          TAG="v${VERSION}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Pre-release $TAG"
+          git push origin "$TAG"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "✅ Tagged ${TAG} on $(git rev-parse --short HEAD)"
+
+      - name: Post run summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## ✅ Pre-release tagged
+
+          | | |
+          |---|---|
+          | **Tag** | \`${TAG}\` |
+          | **Version** | \`${VERSION}\` |
+          | **Commit** | \`$(git rev-parse --short HEAD)\` |
+
+          docker-publish is now building \`:beta\` + \`:${VERSION}\` — check the [Actions tab](../../actions) for progress.
+
+          > \`:latest\` is **not** affected. Users on \`docker-compose.prod.yml\` will not receive this build automatically.
+
+          ### To test this pre-release
+          \`\`\`yaml
+          # docker-compose.override.yml
+          services:
+            web:
+              image: ghcr.io/fortigi/identity-atlas:${VERSION}
+            worker:
+              image: ghcr.io/fortigi/identity-atlas-worker:${VERSION}
+          \`\`\`
+          EOF

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,8 @@
 #
 # Tags pushed depend on the trigger:
 #   main (via bump-version):  :edge  + Major.Minor.yyyyMMdd.HHmm
-#   v* tag push:              :latest + Major.Minor.Patch.0
+#   v5.2.0 tag push:          :latest + Major.Minor.Patch.0
+#   v5.2.0-beta.1 tag push:   :beta   + Major.Minor.Patch-beta.N  (never touches :latest)
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: Publish Docker Images
@@ -63,10 +64,16 @@ jobs:
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
-          if [[ "$REF" == v* ]]; then
-            # Release tag: v5.2.0 → version 5.2.0.0
+          if [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # Stable release tag: v5.2.0 → version 5.2.0.0
             VERSION="${REF#v}.0"
             echo "channel=release" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "use_tag_version=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc|alpha) ]]; then
+            # Pre-release tag: v5.2.0-beta.1 → version 5.2.0-beta.1 (no .0 suffix)
+            VERSION="${REF#v}"
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "use_tag_version=true" >> "$GITHUB_OUTPUT"
           else
@@ -205,6 +212,33 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:latest
+            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
+
+      - name: Push web image (pre-release tag → beta)
+        if: steps.config.outputs.channel == 'beta'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./app
+          file: ./app/api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/fortigi/identity-atlas:beta
+            ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
+          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
+      - name: Push worker image (pre-release tag → beta)
+        if: steps.config.outputs.channel == 'beta'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./setup/docker/Dockerfile.powershell
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:beta
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Identity Atlas is a Docker-deployed application that pulls authorization data fr
 | Context | Version format | Example | Docker tag pushed |
 |---------|---------------|---------|-------------------|
 | `main` dev builds | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` | `:edge` |
+| Pre-release tags (`v*-beta.*` etc.) | `Major.Minor.Patch-beta.N` | `5.3.0-beta.1` | `:beta` |
 | Release tags (`v*`) | `Major.Minor.Patch.0` | `5.2.1.0` | `:latest` |
 | `feature/*` / `bugfixes/*` | — | — | Nobody |
 
@@ -58,6 +59,7 @@ Identity Atlas is a Docker-deployed application that pulls authorization data fr
 | Context | Who updates it | When |
 |---------|---------------|------|
 | `main` dev builds | `bump-version.yml` (automated) | Every PR merge — increments `Minor`, updates timestamp |
+| Pre-release tags | `cut-beta.yml` (automated) | When you run Actions → Cut Beta |
 | Release tags | `cut-release.yml` / `cut-hotfix.yml` (automated) | When you run Actions → Cut Release or Cut Hotfix |
 | `feature/*` / `bugfixes/*` | **Nobody** | Never touch `setup/IdentityAtlas.psd1` on a branch |
 

--- a/changes/feature-beta-release-channel.md
+++ b/changes/feature-beta-release-channel.md
@@ -1,0 +1,1 @@
+- Added a **Cut Beta** GitHub Actions workflow (`Actions → Cut Beta`) to publish pre-release Docker images tagged `:beta` and the exact version (e.g. `5.3.0-beta.1`) without touching `:latest`. Users on `docker-compose.prod.yml` are unaffected.

--- a/docs/architecture/branching-strategy.md
+++ b/docs/architecture/branching-strategy.md
@@ -40,11 +40,10 @@ git checkout -b bugfixes/<name> v5.2.0
 
 ## Version Number Format
 
-Two formats, both 4-part (PowerShell-compatible):
-
 | Context | Format | Example |
 |---------|--------|---------|
 | `main` dev builds (`:edge`) | `Major.Minor.yyyyMMdd.HHmm` | `5.3.20260419.1430` |
+| Pre-release tags (`:beta`) | `Major.Minor.Patch-beta.N` | `5.3.0-beta.1` |
 | Release tags (`:latest`) | `Major.Minor.Patch.0` | `5.2.1.0` |
 
 **Who updates what:**
@@ -52,6 +51,7 @@ Two formats, both 4-part (PowerShell-compatible):
 | Action | Who | When |
 |--------|-----|------|
 | `Minor` bump + timestamp | `bump-version.yml` GitHub Action | Automatically on every PR merge to `main` |
+| Pre-release version | `cut-beta.yml` GitHub Action | When you run Actions → Cut Beta |
 | Release version | `cut-release.yml` GitHub Action | When you run Actions → Cut Release |
 | Hotfix version | `cut-hotfix.yml` GitHub Action | When you run Actions → Cut Hotfix |
 | `Major` bump | Developer, via PR to `main` | Only for breaking changes |
@@ -84,6 +84,17 @@ Write in user-facing language. One bullet per functional change. Add the file al
 4. After merge, `bump-version.yml` automatically increments `Minor`, updates the timestamp, and merges all `changes/*.md` fragments into `CHANGES.md`. The `docker-publish.yml` action then builds and pushes Docker images tagged `:edge`.
 
 ---
+
+## Cutting a Pre-Release (Beta / RC)
+
+To publish a build for testers without touching `:latest`:
+
+1. Go to **Actions → Cut Beta → Run workflow**
+2. Enter the version: `Major.Minor.Patch-beta.N` (e.g. `5.3.0-beta.1`, `5.3.0-rc.1`, `5.3.0-alpha.1`)
+3. The workflow creates the tag on the current `main` HEAD
+4. `docker-publish.yml` builds `:beta` + `:5.3.0-beta.1`
+
+Users on `docker-compose.prod.yml` tracking `:latest` are **not** affected.
 
 ## Cutting a Release
 
@@ -148,7 +159,9 @@ When a bottom PR merges, retarget the next one: `gh pr edit <number> --base main
 | Tag | Published when | Who uses it |
 |-----|---------------|-------------|
 | `:latest` | A release tag (`v5.2.0`) is created via Actions → Cut Release or Cut Hotfix | Customers (default) |
+| `:beta` | A pre-release tag is created via Actions → Cut Beta | Beta testers |
 | `:edge` | Every PR merges to `main` | Developers and testers |
 | `:5.2.0.0` | Same time as `:latest` — exact pinned version | Production deployments needing controlled upgrades |
+| `:5.3.0-beta.1` | Same time as `:beta` — exact pre-release version | Testers who want a reproducible pre-release build |
 
 See [Docker Setup](docker-setup.md) for how to select a channel via `IMAGE_TAG`.

--- a/docs/architecture/docker-setup.md
+++ b/docs/architecture/docker-setup.md
@@ -68,14 +68,19 @@ The compose file uses the `IMAGE_TAG` variable to select which build to pull:
 | `IMAGE_TAG` | What you get | Who should use it |
 |---|---|---|
 | *(unset or blank)* | `:latest` — last stable release, published when a release tag is cut | Customers and production deployments |
+| `beta` | `:beta` — latest pre-release build, published via Actions → Cut Beta | Beta testers |
 | `edge` | `:edge` — latest commit on `main`, updated on every PR merge, may include unreleased features | Developers and testers |
-| `5.2.1.0` | Exact pinned version, never auto-updates | Production deployments needing controlled upgrade timing |
+| `5.2.1.0` | Exact pinned stable version, never auto-updates | Production deployments needing controlled upgrade timing |
+| `5.3.0-beta.1` | Exact pinned pre-release version | Testers who want a reproducible pre-release build |
 
 The running version is always visible in the footer of the UI. Edge builds show an amber **edge** badge so it is immediately obvious which channel is running.
 
 ```bash
 # Run the stable release (default)
 docker compose -f docker-compose.prod.yml up -d --pull always
+
+# Run the latest pre-release beta
+IMAGE_TAG=beta docker compose -f docker-compose.prod.yml up -d --pull always
 
 # Run the edge build (latest merged to main, may be unstable)
 IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d --pull always
@@ -368,7 +373,7 @@ Both compose files (`docker-compose.yml` and `docker-compose.prod.yml`) read fro
 
 | Variable | Default | Description |
 |---|---|---|
-| `IMAGE_TAG` | *(blank → `latest`)* | Docker image tag to pull. Leave blank for the stable release, set `edge` for the latest dev build, or pin to a specific version like `5.2.1.0`. |
+| `IMAGE_TAG` | *(blank → `latest`)* | Docker image tag to pull. Leave blank for the stable release, `beta` for the latest pre-release build, `edge` for the latest dev build, or pin to a specific version like `5.2.1.0`. |
 
 #### Database
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,20 +76,24 @@ Open the UI at [http://localhost:3001](http://localhost:3001) and the Admin → 
 
 ## Image channels
 
-Identity Atlas publishes two channels:
+Identity Atlas publishes three channels:
 
 | Channel | Tag | Updated when | Use it for |
 |---------|-----|-------------|-----------|
 | **Stable** | `:latest` | A new release is cut (e.g. `v5.2.0`) | Customers and production — default |
+| **Beta** | `:beta` | A pre-release is cut via Actions → Cut Beta | Beta testers |
 | **Edge** | `:edge` | Every PR merges to `main` | Developers and testers who want unreleased features |
 
-Both channels also publish an exact version tag (`:5.2.0.0`, `:5.2.1.0`) at the same time as `:latest`, so you can pin to a specific build.
+Stable and beta channels also publish an exact version tag (`:5.2.0.0`, `:5.3.0-beta.1`) at the same time, so you can pin to a specific build.
 
 === "Linux / macOS"
 
     ```bash
     # Default: pull the latest stable release
     docker compose -f docker-compose.prod.yml up -d --pull always
+
+    # Beta: latest pre-release build
+    IMAGE_TAG=beta docker compose -f docker-compose.prod.yml up -d --pull always
 
     # Edge: latest commit on main (may include unreleased features)
     IMAGE_TAG=edge docker compose -f docker-compose.prod.yml up -d --pull always
@@ -99,6 +103,10 @@ Both channels also publish an exact version tag (`:5.2.0.0`, `:5.2.1.0`) at the 
 
     ```powershell
     # Default: pull the latest stable release
+    docker compose -f docker-compose.prod.yml up -d --pull always
+
+    # Beta: latest pre-release build
+    $env:IMAGE_TAG = "beta"
     docker compose -f docker-compose.prod.yml up -d --pull always
 
     # Edge: latest commit on main (may include unreleased features)


### PR DESCRIPTION
- Added a **Cut Beta** GitHub Actions workflow (`Actions → Cut Beta`) to publish pre-release Docker images tagged `:beta` and the exact version (e.g. `5.3.0-beta.1`) without touching `:latest`. Users on `docker-compose.prod.yml` are unaffected.

## How it works

| Tag pushed | Docker tags published | `:latest` touched? |
|---|---|---|
| `v5.2.0` | `:latest`, `:5.2.0.0` | Yes |
| `v5.3.0-beta.1` | `:beta`, `:5.3.0-beta.1` | **No** |
| `main` merge | `:edge`, `Major.Minor.yyyyMMdd.HHmm` | No |

## Changes

- **`docker-publish.yml`** — channel detection now splits `v*` tags into `release` (exact `vX.Y.Z`) and `beta` (pre-release suffix); added push steps for `:beta` channel
- **`cut-beta.yml`** — new workflow; accepts `5.3.0-beta.1` / `-rc.1` / `-alpha.1`, validates format, tags `main` HEAD, triggers docker-publish; run summary includes a ready-to-paste `docker-compose.override.yml` for testers
- **Docs** — updated `CLAUDE.md`, `branching-strategy.md`, `docker-setup.md`, `quickstart.md` to document the new channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)