### PR TITLE
fix: bump Azure worker CPU/memory across all size profiles

### DIFF
--- a/azure/main.bicep
+++ b/azure/main.bicep
@@ -53,46 +53,57 @@ param existingLogAnalyticsWorkspaceId string = ''
 
 // ─── Size profile → SKUs ─────────────────────────────────────────────────
 
+// Worker memory note: PowerShell crawlers use ForEach-Object -Parallel,
+// which spawns one runspace per parallel task. Each runspace duplicates the
+// session state, so memory pressure scales fast on real tenants. ACA's
+// Consumption profile pins the CPU:memory ratio at 0.25 CPU per 0.5 Gi —
+// 1 CPU = 2 Gi, 2 CPU = 4 Gi. We size the worker generously per tier; the
+// marginal cost is small compared with the cost of debugging an OOM crash
+// halfway through a customer's first sync.
+//
+// Real-world data points (Port of Rotterdam, May 2026):
+//   4,500 users + 9,900 groups + 3,600 SPs OOM'd at 0.5 CPU / 1 Gi.
+//   Same tenant ran clean at 2 CPU / 4 Gi.
 var sizeMap = {
   xs: {
     appServiceSku: 'B1'
     postgresSku: 'Standard_B1ms'
     postgresTier: 'Burstable'
     postgresStorageGb: 32
-    workerCpu: '0.25'
-    workerMemory: '0.5Gi'
+    workerCpu: '0.5'
+    workerMemory: '1Gi'
   }
   s: {
     appServiceSku: 'B2'
     postgresSku: 'Standard_B2s'
     postgresTier: 'Burstable'
     postgresStorageGb: 32
-    workerCpu: '0.25'
-    workerMemory: '0.5Gi'
+    workerCpu: '1'
+    workerMemory: '2Gi'
   }
   m: {
     appServiceSku: 'S1'
     postgresSku: 'Standard_B2s'
     postgresTier: 'Burstable'
     postgresStorageGb: 64
-    workerCpu: '0.25'
-    workerMemory: '0.5Gi'
+    workerCpu: '1'
+    workerMemory: '2Gi'
   }
   l: {
     appServiceSku: 'P1v3'
     postgresSku: 'Standard_D2ds_v5'
     postgresTier: 'GeneralPurpose'
     postgresStorageGb: 128
-    workerCpu: '0.5'
-    workerMemory: '1Gi'
+    workerCpu: '2'
+    workerMemory: '4Gi'
   }
   xl: {
     appServiceSku: 'P2v3'
     postgresSku: 'Standard_D4ds_v5'
     postgresTier: 'GeneralPurpose'
     postgresStorageGb: 256
-    workerCpu: '0.5'
-    workerMemory: '1Gi'
+    workerCpu: '2'
+    workerMemory: '4Gi'
   }
 }
 var profile = sizeMap[sizeProfile]

--- a/azure/main.json
+++ b/azure/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "7364131947686207352"
+      "templateHash": "12321276082931741227"
     }
   },
   "parameters": {
@@ -50,40 +50,40 @@
         "postgresSku": "Standard_B1ms",
         "postgresTier": "Burstable",
         "postgresStorageGb": 32,
-        "workerCpu": "0.25",
-        "workerMemory": "0.5Gi"
+        "workerCpu": "0.5",
+        "workerMemory": "1Gi"
       },
       "s": {
         "appServiceSku": "B2",
         "postgresSku": "Standard_B2s",
         "postgresTier": "Burstable",
         "postgresStorageGb": 32,
-        "workerCpu": "0.25",
-        "workerMemory": "0.5Gi"
+        "workerCpu": "1",
+        "workerMemory": "2Gi"
       },
       "m": {
         "appServiceSku": "S1",
         "postgresSku": "Standard_B2s",
         "postgresTier": "Burstable",
         "postgresStorageGb": 64,
-        "workerCpu": "0.25",
-        "workerMemory": "0.5Gi"
+        "workerCpu": "1",
+        "workerMemory": "2Gi"
       },
       "l": {
         "appServiceSku": "P1v3",
         "postgresSku": "Standard_D2ds_v5",
         "postgresTier": "GeneralPurpose",
         "postgresStorageGb": 128,
-        "workerCpu": "0.5",
-        "workerMemory": "1Gi"
+        "workerCpu": "2",
+        "workerMemory": "4Gi"
       },
       "xl": {
         "appServiceSku": "P2v3",
         "postgresSku": "Standard_D4ds_v5",
         "postgresTier": "GeneralPurpose",
         "postgresStorageGb": 256,
-        "workerCpu": "0.5",
-        "workerMemory": "1Gi"
+        "workerCpu": "2",
+        "workerMemory": "4Gi"
       }
     },
     "profile": "[variables('sizeMap')[parameters('sizeProfile')]]",

--- a/changes/azure-worker-memory-sizing.md
+++ b/changes/azure-worker-memory-sizing.md
@@ -1,0 +1,11 @@
+- Increased the Azure worker container's CPU and memory allowance across all size profiles. PowerShell Graph crawlers spawn one runspace per parallel task via `ForEach-Object -Parallel`, and each runspace duplicates the session state — memory pressure scales fast on real tenants. The previous tiers maxed out at 0.5 CPU / 1 GB memory even on `xl`, which OOM-killed real customer syncs (4.5K users + 9.9K groups + 3.6K service principals — a mid-size tenant). New sizing keeps the same Postgres / App Service tiering but bumps the worker substantially:
+
+  | Profile | Web SKU | Worker (was → now) |
+  |---|---|---|
+  | xs | B1 | 0.25 CPU / 0.5Gi → **0.5 CPU / 1Gi** |
+  | s (default) | B2 | 0.25 CPU / 0.5Gi → **1 CPU / 2Gi** |
+  | m | S1 | 0.25 CPU / 0.5Gi → **1 CPU / 2Gi** |
+  | l | P1v3 | 0.5 CPU / 1Gi → **2 CPU / 4Gi** |
+  | xl | P2v3 | 0.5 CPU / 1Gi → **2 CPU / 4Gi** |
+
+  Marginal cost is small (~€5-15/month per tier) compared with the cost of debugging an OOM crash halfway through a customer's first sync. Existing deployments aren't affected automatically; redeploy or run `az containerapp update --name <worker> --resource-group <rg> --cpu 2.0 --memory 4.0Gi` to bump an existing worker.


### PR DESCRIPTION
## Summary

Real-world OOM at the Port of Rotterdam customer install. Worker on size profile `l` was at 0.5 CPU / 1 GB memory; the Entra crawler OOM-killed seven phases on a 4.5K-user / 9.9K-group / 3.6K-SP tenant — a mid-size customer, not unusual.

PowerShell's `ForEach-Object -Parallel` spawns one runspace per parallel task and each runspace duplicates the session state. A few dozen concurrent runspaces holding lookup tables easily push past 1 GB.

## Change

Bump worker CPU + memory across all five size profiles. ACA's Consumption profile pins CPU:memory at a fixed 1:2 ratio, so 1 CPU = 2 Gi and 2 CPU = 4 Gi.

| Profile | Web | Old worker | New worker |
|---|---|---|---|
| xs | B1 | 0.25 / 0.5 Gi | **0.5 / 1 Gi** |
| s (default) | B2 | 0.25 / 0.5 Gi | **1 / 2 Gi** |
| m | S1 | 0.25 / 0.5 Gi | **1 / 2 Gi** |
| l | P1v3 | 0.5 / 1 Gi | **2 / 4 Gi** |
| xl | P2v3 | 0.5 / 1 Gi | **2 / 4 Gi** |

Marginal cost: ~€5-15/month per tier. App Service SKU + Postgres SKU tiering unchanged.

## Validation

- [x] Live: `az containerapp update --cpu 2.0 --memory 4.0Gi` on the customer's worker. The crawler run that previously failed with 7 phase OOMs ran through cleanly.
- [x] `az bicep build` clean.
- [ ] CI: standard PR check suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)