### PR TITLE
fix: matrix tab UX improvements (apply, size warnings, default filter, department contexts)

### DIFF
--- a/app/api/src/contexts/plugins/department-from-principal.js
+++ b/app/api/src/contexts/plugins/department-from-principal.js
@@ -1,0 +1,69 @@
+// department-from-principal plugin.
+//
+// Derives one Department context per unique Principals.department value and
+// assigns every matching principal as a member.  Run this after a CSV or
+// Entra sync to populate the Department contexts that the Matrix wizard can
+// then filter on.
+//
+// Optional parameter `scopeSystemId` restricts which principals are
+// considered.  Omit it to derive departments across all systems.
+
+import * as db from '../../db/connection.js';
+
+/** @type {import('./types.js').ContextPlugin} */
+export default {
+  name: 'department-from-principal',
+  displayName: 'Department from Principal',
+  description:
+    'Creates one Department context per unique department value on Principals and assigns each principal as a member. Run after a CSV or Entra sync.',
+  targetType: 'Principal',
+  parametersSchema: {
+    type: 'object',
+    properties: {
+      scopeSystemId: {
+        type: 'integer',
+        description: 'Restrict to principals in this system. Omit to include all systems.',
+      },
+    },
+  },
+  async run(params, ctx) {
+    const scopeSystemId = params.scopeSystemId ? parseInt(params.scopeSystemId, 10) : null;
+
+    const whereClause = scopeSystemId ? `WHERE "systemId" = $1 AND department IS NOT NULL AND department <> ''`
+                                      : `WHERE department IS NOT NULL AND department <> ''`;
+    const queryArgs   = scopeSystemId ? [scopeSystemId] : [];
+
+    const rows = (await db.query(
+      `SELECT id, department FROM "Principals" ${whereClause}`,
+      queryArgs,
+    )).rows;
+
+    if (rows.length === 0) {
+      ctx.log?.('No principals with a department value — nothing to do.');
+      return { contexts: [], members: [] };
+    }
+
+    // One context per unique department name.
+    const seen = new Map(); // department value → externalId
+    for (const r of rows) {
+      const dept = r.department.trim();
+      if (!seen.has(dept)) {
+        seen.set(dept, `dept:${dept}`);
+      }
+    }
+
+    const contexts = [...seen.entries()].map(([dept, extId]) => ({
+      externalId:  extId,
+      displayName: dept,
+      contextType: 'Department',
+    }));
+
+    const members = rows.map(r => ({
+      contextExternalId: seen.get(r.department.trim()),
+      memberId:          r.id,
+    }));
+
+    ctx.log?.(`Derived ${contexts.length} department(s), ${members.length} member links.`);
+    return { contexts, members };
+  },
+};

--- a/app/api/src/contexts/plugins/registry.js
+++ b/app/api/src/contexts/plugins/registry.js
@@ -6,15 +6,17 @@
 // ContextAlgorithms table at container startup so the UI picker is aware
 // of new plugins without manual DB writes.
 
-import managerHierarchy    from './manager-hierarchy.js';
-import adOuFromDn          from './ad-ou-from-dn.js';
+import managerHierarchy      from './manager-hierarchy.js';
+import adOuFromDn            from './ad-ou-from-dn.js';
 import { plugin as resourceCluster } from './resource-cluster/index.js';
+import departmentFromPrincipal from './department-from-principal.js';
 
 /** @type {import('./types.js').ContextPlugin[]} */
 export const REGISTERED_PLUGINS = [
   managerHierarchy,
   adOuFromDn,
   resourceCluster,
+  departmentFromPrincipal,
 ];
 
 export function getPlugin(name) {

--- a/app/api/src/db/migrations/028_default_matrix_filter.sql
+++ b/app/api/src/db/migrations/028_default_matrix_filter.sql
@@ -1,0 +1,11 @@
+-- Identity Atlas — Default matrix filter
+--
+-- Adds an isDefault flag to SavedMatrixFilters so that a single org-wide
+-- filter can be auto-applied when the Matrix tab is first visited (e.g. after
+-- loading the demo dataset). At most one row may have isDefault = true,
+-- enforced by a unique partial index.
+
+ALTER TABLE "SavedMatrixFilters" ADD COLUMN IF NOT EXISTS "isDefault" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ix_SavedMatrixFilters_isDefault"
+  ON "SavedMatrixFilters" ("isDefault") WHERE "isDefault" = true;

--- a/app/api/src/routes/ingest.js
+++ b/app/api/src/routes/ingest.js
@@ -401,6 +401,58 @@ async function refreshMatrixViews() {
   }
 }
 
+// ─── Seed default matrix filter ─────────────────────────────────────────────
+// Creates or replaces the org-wide default matrix filter (isDefault = true).
+// Called by Ingest-DemoDataset.ps1 to pre-configure the Matrix tab so new
+// installs with demo data don't require the wizard on first visit.
+
+router.post('/ingest/matrix-default-filter', async (req, res) => {
+  if (!crawlerHasPermission(req, 'admin') && !crawlerHasPermission(req, 'ingest')) {
+    return res.status(403).json({ error: 'Insufficient permissions' });
+  }
+  if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
+  const body = req.body || {};
+  const name = typeof body.name === 'string' ? body.name.trim().slice(0, 200) : 'Default';
+  const description = typeof body.description === 'string' ? body.description.slice(0, 1000) : null;
+  if (!body.filter || typeof body.filter !== 'object') {
+    return res.status(400).json({ error: 'filter is required' });
+  }
+  try {
+    const p = await db.getPool();
+    await p.query(`
+      CREATE TABLE IF NOT EXISTS "SavedMatrixFilters" (
+        "id"          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        "name"        TEXT NOT NULL,
+        "description" TEXT,
+        "filter"      JSONB NOT NULL,
+        "isDefault"   BOOLEAN NOT NULL DEFAULT false,
+        "createdBy"   TEXT,
+        "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT (now() AT TIME ZONE 'utc'),
+        "updatedBy"   TEXT,
+        "updatedAt"   TIMESTAMPTZ NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
+      )
+    `);
+    await p.query(`ALTER TABLE "SavedMatrixFilters" ADD COLUMN IF NOT EXISTS "isDefault" BOOLEAN NOT NULL DEFAULT false`);
+    await p.query(`UPDATE "SavedMatrixFilters" SET "isDefault" = false WHERE "isDefault" = true`);
+    await p.query(
+      `INSERT INTO "SavedMatrixFilters" (id, "name", "description", "filter", "isDefault", "createdBy", "updatedBy")
+       VALUES (gen_random_uuid(), $1, $2, $3, true, 'seed', 'seed')
+       ON CONFLICT (LOWER("name")) DO UPDATE
+         SET "filter"      = EXCLUDED."filter",
+             "description" = EXCLUDED."description",
+             "isDefault"   = true,
+             "updatedBy"   = 'seed',
+             "updatedAt"   = (now() AT TIME ZONE 'utc')`,
+      [name, description, body.filter],
+    );
+    const row = await db.queryOne(`SELECT * FROM "SavedMatrixFilters" WHERE "isDefault" = true LIMIT 1`);
+    res.status(201).json(row);
+  } catch (err) {
+    console.error('POST ingest/matrix-default-filter failed:', err.message);
+    res.status(500).json({ error: 'Failed to seed default filter' });
+  }
+});
+
 export { refreshMatrixViews };
 
 export default router;

--- a/app/api/src/routes/matrix.js
+++ b/app/api/src/routes/matrix.js
@@ -119,12 +119,6 @@ function normaliseBlock(b) {
   };
 }
 
-function hasAnyCondition(filter) {
-  for (const b of [filter.subject, filter.resource]) {
-    if (b.include.length > 0 || b.exclude.length > 0) return true;
-  }
-  return false;
-}
 
 async function resolveContextTypes(filter) {
   const ids = collectContextIds(filter);
@@ -274,9 +268,6 @@ router.post('/matrix/data', async (req, res) => {
   }
   const filter = parseFilter(req.body);
   if (!filter) return res.status(400).json({ error: 'Invalid filter body' });
-  if (!hasAnyCondition(filter)) {
-    return res.status(400).json({ error: 'At least one subject or resource condition is required' });
-  }
 
   try {
     const built = await buildSubqueries(filter);
@@ -474,6 +465,7 @@ async function ensureSavedFiltersTable() {
       "name"        TEXT NOT NULL,
       "description" TEXT,
       "filter"      JSONB NOT NULL,
+      "isDefault"   BOOLEAN NOT NULL DEFAULT false,
       "createdBy"   TEXT,
       "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT (now() AT TIME ZONE 'utc'),
       "updatedBy"   TEXT,
@@ -483,6 +475,11 @@ async function ensureSavedFiltersTable() {
   await db.query(`
     CREATE UNIQUE INDEX IF NOT EXISTS "ix_SavedMatrixFilters_name"
       ON "SavedMatrixFilters" (LOWER("name"))
+  `);
+  await db.query(`ALTER TABLE "SavedMatrixFilters" ADD COLUMN IF NOT EXISTS "isDefault" BOOLEAN NOT NULL DEFAULT false`);
+  await db.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS "ix_SavedMatrixFilters_isDefault"
+      ON "SavedMatrixFilters" ("isDefault") WHERE "isDefault" = true
   `);
 }
 
@@ -495,7 +492,7 @@ router.get('/matrix/saved-filters', async (req, res) => {
   try {
     await ensureSavedFiltersTable();
     const r = await db.query(`
-      SELECT id, "name", "description", "filter", "createdBy", "createdAt", "updatedBy", "updatedAt"
+      SELECT id, "name", "description", "filter", "isDefault", "createdBy", "createdAt", "updatedBy", "updatedAt"
         FROM "SavedMatrixFilters"
        ORDER BY LOWER("name")
     `);
@@ -547,6 +544,7 @@ router.put('/matrix/saved-filters/:id', async (req, res) => {
     push('description', body.description ? body.description.slice(0, 1000) : null);
   }
   if (body.filter && typeof body.filter === 'object') push('filter', body.filter);
+  if (typeof body.isDefault === 'boolean') push('isDefault', body.isDefault);
   if (sets.length === 0) return res.status(400).json({ error: 'No updatable fields' });
 
   push('updatedBy', getActor(req));
@@ -580,6 +578,23 @@ router.delete('/matrix/saved-filters/:id', async (req, res) => {
   } catch (err) {
     console.error('DELETE matrix/saved-filters/:id failed:', err.message);
     res.status(500).json({ error: 'Failed to delete filter' });
+  }
+});
+
+// ─── Default filter (auto-apply on first Matrix visit) ──────────────
+
+router.get('/matrix/default-filter', async (req, res) => {
+  if (!useSql) return res.json(null);
+  try {
+    await ensureSavedFiltersTable();
+    const row = await db.queryOne(
+      `SELECT id, "name", "description", "filter", "isDefault", "createdBy", "createdAt", "updatedBy", "updatedAt"
+         FROM "SavedMatrixFilters" WHERE "isDefault" = true LIMIT 1`
+    );
+    res.json(row || null);
+  } catch (err) {
+    console.error('GET matrix/default-filter failed:', err.message);
+    res.status(500).json({ error: 'Failed to fetch default filter' });
   }
 });
 

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -115,7 +115,7 @@ export default function App() {
   const [managedFilter, setManagedFilter] = useState(initial.managed);
   const [wizardOpen, setWizardOpen] = useState(false);
 
-  const { data, counts, accessPackageGroups, managedByPackages, groupTagMap, loading, refreshing, error, forceRefresh } = useMatrix(matrixFilter);
+  const { data, counts, accessPackageGroups, managedByPackages, groupTagMap, loading, refreshing, error, forceRefresh, hasData, defaultFilter } = useMatrix(matrixFilter);
   const { account, logout, authFetch } = useAuth();
   const [page, navigate] = useHashRoute();
   const [moduleVersion, setModuleVersion] = useState(null);
@@ -259,16 +259,30 @@ export default function App() {
     }
   }, [page]);
 
-  // When the user lands on the matrix tab without an applied filter, open the
-  // wizard automatically so they can build one. We only do this on a fresh
-  // visit — if they close the wizard intentionally, we leave them alone.
+  // When the user lands on the matrix tab without an applied filter:
+  //  - If a default filter is seeded (e.g. demo data): auto-apply it, no wizard.
+  //  - If there IS data but no default filter: open the wizard.
+  //  - If the DB is empty: do nothing (EmptyFilterState shows "no data" message).
+  // We wait until both hasData and defaultFilter have resolved (neither null/undefined
+  // as "still loading") before acting. autoOpenFiredRef prevents re-firing after the
+  // user closes the wizard or navigates away and back.
   const prevPageRef = useRef(null);
+  const autoOpenFiredRef = useRef(false);
   useEffect(() => {
-    if (page === 'matrix' && prevPageRef.current !== 'matrix' && !matrixFilter && !wizardOpen) {
-      setWizardOpen(true);
-    }
+    const freshNav = page === 'matrix' && prevPageRef.current !== 'matrix';
+    if (freshNav) autoOpenFiredRef.current = false;
     prevPageRef.current = page;
-  }, [page, matrixFilter, wizardOpen]);
+    if (page !== 'matrix' || autoOpenFiredRef.current || matrixFilter || wizardOpen) return;
+    // Still waiting for hasData or defaultFilter to resolve
+    if (hasData === null || defaultFilter === undefined) return;
+    autoOpenFiredRef.current = true;
+    if (hasData === false) return; // empty DB — EmptyFilterState handles the message
+    if (defaultFilter !== null) {
+      setMatrixFilter(defaultFilter.filter); // skip wizard, apply saved default
+    } else {
+      setWizardOpen(true); // no default — let user configure
+    }
+  }, [page, matrixFilter, wizardOpen, hasData, defaultFilter]);
 
   // Sync URL when on matrix page (debounced replaceState — no history entry)
   useEffect(() => {
@@ -572,6 +586,7 @@ export default function App() {
                   shareUrl={shareUrl}
                   onOpenDetail={openDetailTab}
                   onAdjustFilter={() => setWizardOpen(true)}
+                  hasData={hasData}
                 />
               ) : (
                 <MatrixView
@@ -587,6 +602,7 @@ export default function App() {
                   shareUrl={shareUrl}
                   onOpenDetail={openDetailTab}
                   onAdjustFilter={() => setWizardOpen(true)}
+                  hasData={hasData}
                 />
               )}
               <MatrixFilterWizard

--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -5,7 +5,6 @@ import MatrixToolbar from './matrix/MatrixToolbar';
 import MatrixFilterSummary from './matrix/MatrixFilterSummary';
 import MatrixColumnHeaders from './matrix/MatrixColumnHeaders';
 import MatrixGroupRow from './matrix/MatrixGroupRow';
-import { filterHasAnyCondition } from './matrix/MatrixFilterWizard';
 
 // Inline arrayMove so MatrixView doesn't depend on @dnd-kit
 function arrayMove(arr, from, to) {
@@ -16,11 +15,22 @@ function arrayMove(arr, from, to) {
 }
 
 // Empty state shown when the user hasn't created a matrix yet.
-function EmptyFilterState({ onAdjustFilter }) {
+function EmptyFilterState({ onAdjustFilter, hasData }) {
+  if (hasData === false) {
+    return (
+      <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
+        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">No data available yet</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
+          Run a crawler first to import users and resources. Once data is loaded you can build a matrix here.
+        </p>
+      </div>
+    );
+  }
+  if (hasData === null) return null;
   return (
     <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
       <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">Pick a slice to inspect</h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xl mx-auto mb-4">
+      <p className="text-sm text-gray-600 dark:text-gray-400 max-w-xl mx-auto mb-4">
         The Matrix tab always operates on a defined sub-selection of subjects (users or
         identities) and resources. Open the wizard to set up which slice to compare.
       </p>
@@ -44,6 +54,7 @@ export default function MatrixView({
   shareUrl,
   onOpenDetail,
   onAdjustFilter,
+  hasData,
 }) {
   // ─── Nested group expansion ─────────────────────────────────────
   const { authFetch } = useAuth();
@@ -582,7 +593,7 @@ export default function MatrixView({
   // Ref for the scroll container (needed by virtualizer)
   const scrollRef = useRef(null);
 
-  const filterIsApplied = filterHasAnyCondition(filter);
+  const filterIsApplied = filter !== null && filter !== undefined;
 
   return (
     <div className="flex flex-col gap-3">
@@ -608,7 +619,7 @@ export default function MatrixView({
       />
 
       {!filterIsApplied ? (
-        <EmptyFilterState onAdjustFilter={onAdjustFilter} />
+        <EmptyFilterState onAdjustFilter={onAdjustFilter} hasData={hasData} />
       ) : users.length === 0 || orderedGroups.length === 0 ? (
         <div className="text-center text-gray-500 dark:text-gray-400 py-12">
           No assignments match the current filter. Adjust the subjects or resources to widen the view.

--- a/app/ui/src/components/RotatedMatrixView.jsx
+++ b/app/ui/src/components/RotatedMatrixView.jsx
@@ -17,13 +17,23 @@ import { useMemo, useCallback, useState } from 'react';
 import MatrixToolbar from './matrix/MatrixToolbar';
 import MatrixFilterSummary from './matrix/MatrixFilterSummary';
 import MatrixCell from './matrix/MatrixCell';
-import { filterHasAnyCondition } from './matrix/MatrixFilterWizard';
 
-function EmptyState({ onAdjustFilter }) {
+function EmptyState({ onAdjustFilter, hasData }) {
+  if (hasData === false) {
+    return (
+      <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
+        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">No data available yet</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
+          Run a crawler first to import users and resources. Once data is loaded you can build a matrix here.
+        </p>
+      </div>
+    );
+  }
+  if (hasData === null) return null;
   return (
     <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
       <h2 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">Pick a slice to inspect</h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xl mx-auto mb-4">
+      <p className="text-sm text-gray-600 dark:text-gray-400 max-w-xl mx-auto mb-4">
         The Matrix tab always operates on a defined sub-selection of subjects (users or
         identities) and resources. Open the wizard to set up which slice to compare.
       </p>
@@ -46,8 +56,9 @@ export default function RotatedMatrixView({
   shareUrl,
   onOpenDetail,
   onAdjustFilter,
+  hasData,
 }) {
-  const filterIsApplied = filterHasAnyCondition(filter);
+  const filterIsApplied = filter !== null && filter !== undefined;
 
   // Same client-side managed-state toggle as MatrixView.
   const filteredData = useMemo(() => {
@@ -159,7 +170,7 @@ export default function RotatedMatrixView({
       )}
 
       {!filterIsApplied ? (
-        <EmptyState onAdjustFilter={onAdjustFilter} />
+        <EmptyState onAdjustFilter={onAdjustFilter} hasData={hasData} />
       ) : users.length === 0 || resources.length === 0 ? (
         <div className="text-center text-gray-500 dark:text-gray-400 py-12">
           No assignments match the current matrix. Adjust the subjects or resources to widen the view.

--- a/app/ui/src/components/matrix/MatrixFilterWizard.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.jsx
@@ -21,6 +21,9 @@ import { variantMeta, targetTypeMeta } from '../../utils/contextStyles';
 
 // ─── Constants ──────────────────────────────────────────────────────
 
+export const WARN_ASSIGNMENTS  =  5_000;
+export const BLOCK_ASSIGNMENTS = 25_000;
+
 export const EMPTY_FILTER = {
   rowType: 'principal',
   // 'rows-as-resources' — resources on the row axis, subjects on the column
@@ -230,8 +233,8 @@ export default function MatrixFilterWizard({
   // ─── Apply / Cancel ────────────────────────────────────────────
 
   const handleApply = () => {
-    if (!filterHasAnyCondition(filter)) {
-      setError('Add at least one Subject or Resource condition before applying.');
+    if (preview.assignmentCount > BLOCK_ASSIGNMENTS) {
+      setError(`Matrix too large (${preview.assignmentCount.toLocaleString()} assignments). Add filters to reduce below ${BLOCK_ASSIGNMENTS.toLocaleString()}.`);
       return;
     }
     onApply(filter);
@@ -360,7 +363,7 @@ export default function MatrixFilterWizard({
           {step > 1 && <SecondaryButton onClick={() => setStep(s => s - 1)}>Back</SecondaryButton>}
           {step < 3 && <PrimaryButton onClick={() => setStep(s => s + 1)}>Next</PrimaryButton>}
           {step === 3 && (
-            <PrimaryButton onClick={handleApply} disabled={!filterHasAnyCondition(filter)}>
+            <PrimaryButton onClick={handleApply} disabled={preview.assignmentCount > BLOCK_ASSIGNMENTS}>
               Apply
             </PrimaryButton>
           )}
@@ -476,8 +479,20 @@ function LiveSummary({ preview, loading, rowType }) {
   const resourcePct = preview.resourceTotal > 0
     ? Math.round((preview.resourceCount / preview.resourceTotal) * 100)
     : 0;
+
+  const tooLarge = preview.assignmentCount > BLOCK_ASSIGNMENTS;
+  const large    = !tooLarge && preview.assignmentCount > WARN_ASSIGNMENTS;
+
+  const countClass = tooLarge
+    ? 'font-semibold text-red-700 dark:text-red-400'
+    : large
+      ? 'font-semibold text-amber-700 dark:text-amber-400'
+      : 'font-semibold text-gray-800 dark:text-gray-200';
+
   return (
-    <div className="mt-3 text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/30 border border-gray-100 dark:border-gray-700 rounded px-3 py-2 flex flex-wrap items-center gap-x-4 gap-y-1">
+    <div className={`mt-3 text-xs bg-gray-50 dark:bg-gray-700/30 border rounded px-3 py-2 flex flex-wrap items-center gap-x-4 gap-y-1 ${
+      tooLarge ? 'border-red-300 dark:border-red-700' : large ? 'border-amber-300 dark:border-amber-700' : 'border-gray-100 dark:border-gray-700'
+    } text-gray-600 dark:text-gray-400`}>
       <div>
         <span className="font-semibold text-gray-800 dark:text-gray-200">{preview.subjectCount.toLocaleString()}</span>
         {' '}of {preview.subjectTotal.toLocaleString()} {subjectLabel}
@@ -491,8 +506,10 @@ function LiveSummary({ preview, loading, rowType }) {
       </div>
       <div className="text-gray-500 dark:text-gray-400">·</div>
       <div>
-        <span className="font-semibold text-gray-800 dark:text-gray-200">{preview.assignmentCount.toLocaleString()}</span>
+        <span className={countClass}>{preview.assignmentCount.toLocaleString()}</span>
         {' '}assignments
+        {tooLarge && <span className="ml-1 text-red-700 dark:text-red-400">— too large to load, add filters to reduce below {BLOCK_ASSIGNMENTS.toLocaleString()}</span>}
+        {large    && <span className="ml-1 text-amber-700 dark:text-amber-400">— large, consider narrowing</span>}
       </div>
       {loading && (
         <div className="ml-auto text-[10px] text-gray-600 dark:text-gray-400">updating…</div>

--- a/app/ui/src/hooks/useMatrix.js
+++ b/app/ui/src/hooks/useMatrix.js
@@ -47,6 +47,11 @@ export function useMatrix(filter) {
   const [refreshCounter, setRefreshCounter] = useState(0);
   const forceRefresh = useCallback(() => setRefreshCounter(c => c + 1), []);
 
+  // null = still checking, true = DB has data, false = DB is empty
+  const [hasData, setHasData] = useState(null);
+  // undefined = still loading, null = no default, object = default filter row
+  const [defaultFilter, setDefaultFilter] = useState(undefined);
+
   // Load access-package groups + tags + Principal column metadata once.
   useEffect(() => {
     let cancelled = false;
@@ -73,12 +78,27 @@ export function useMatrix(filter) {
       .then(r => r.ok ? r.json() : [])
       .then(cols => { if (!cancelled) setUserColumns(cols); })
       .catch(() => {});
+    // Lightweight check: does the DB have any users or resources at all?
+    // Falls back to true (optimistic) on error or non-SQL mode so the wizard
+    // still opens on deployments where this endpoint isn't available.
+    authFetch('/api/admin/dashboard-stats')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (!cancelled) setHasData(d ? (d.hasData !== false) : true); })
+      .catch(() => { if (!cancelled) setHasData(true); });
+
+    // Default filter — auto-applied on first Matrix visit to skip the wizard.
+    // Falls back to null (no default) on any error.
+    authFetch('/api/matrix/default-filter')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (!cancelled) setDefaultFilter(d || null); })
+      .catch(() => { if (!cancelled) setDefaultFilter(null); });
+
     return () => { cancelled = true; };
   }, [authFetch]);
 
   // Stable cache key for the filter — only re-fetch when conditions change.
   const filterKey = useMemo(() => filter ? JSON.stringify(filter) : null, [filter]);
-  const hasConditions = useMemo(() => filterHasConditions(filter), [filter]);
+  const hasConditions = filter !== null && filter !== undefined;
 
   // Debounce filter changes.
   const [debouncedKey, setDebouncedKey] = useState(filterKey);
@@ -168,13 +188,8 @@ export function useMatrix(filter) {
     refreshing,
     error,
     forceRefresh,
+    hasData,
+    defaultFilter,
   };
 }
 
-function filterHasConditions(filter) {
-  if (!filter) return false;
-  for (const block of [filter.subject, filter.resource]) {
-    if (block && ((block.include?.length || 0) > 0 || (block.exclude?.length || 0) > 0)) return true;
-  }
-  return false;
-}

--- a/changes/bugfixes-matview-concurrently-first-boot.md
+++ b/changes/bugfixes-matview-concurrently-first-boot.md
@@ -1,0 +1,4 @@
+- Fixed: Matrix "Apply" button was disabled when no conditions were added to the wizard, making it impossible to create a matrix without first setting filters. The matrix now loads all subjects and resources when applied with no conditions.
+- Fixed: Matrix tab showed a "Create matrix" call-to-action even when the database contained no data. It now shows a "No data available yet — run a crawler" message instead, and the wizard no longer auto-opens when there is nothing to display.
+- Improved: Demo dataset (`Ingest-DemoDataset.ps1`) now seeds a default matrix filter so the Matrix tab opens straight to data on first visit, without requiring the wizard.
+- Improved: Matrix wizard now warns when the selected slice exceeds 5,000 assignments and blocks Apply above 25,000, preventing accidentally loading very large datasets.

--- a/test/demo-dataset/Ingest-DemoDataset.ps1
+++ b/test/demo-dataset/Ingest-DemoDataset.ps1
@@ -133,4 +133,24 @@ catch {
     Write-Host "  View refresh skipped (non-critical)" -ForegroundColor Yellow
 }
 
+# Seed default matrix filter so the Matrix tab shows data immediately on first visit
+Write-Host "`nSeeding default matrix filter..." -ForegroundColor Cyan
+$defaultFilter = @{
+    name        = 'Fortigi Demo Corp — All'
+    description = 'Demo default: all users and resources'
+    filter      = @{
+        rowType     = 'principal'
+        orientation = 'rows-as-resources'
+        subject     = @{ include = @(); exclude = @() }
+        resource    = @{ include = @(); exclude = @() }
+    }
+} | ConvertTo-Json -Depth 10 -Compress
+try {
+    $result = Invoke-RestMethod -Uri "$ApiBaseUrl/ingest/matrix-default-filter" -Method Post -Headers $headers -Body $defaultFilter -ContentType 'application/json' -TimeoutSec 30
+    Write-Host "  Default matrix filter set: '$($result.name)'" -ForegroundColor Green
+}
+catch {
+    Write-Host "  Default matrix filter skipped (non-critical): $($_.Exception.Message)" -ForegroundColor Yellow
+}
+
 Write-Host "`n=== Ingest Complete ===" -ForegroundColor Green


### PR DESCRIPTION
- Fixed: Matrix "Apply" button was disabled when no conditions were added to the wizard, making it impossible to create a matrix without first setting filters. The matrix now loads all subjects and resources when applied with no conditions.
- Fixed: Matrix tab showed a "Create matrix" call-to-action even when the database contained no data. It now shows a "No data available yet — run a crawler" message instead, and the wizard no longer auto-opens when there is nothing to display.
- Improved: Demo dataset (`Ingest-DemoDataset.ps1`) now seeds a default matrix filter so the Matrix tab opens straight to data on first visit, without requiring the wizard.
- Improved: Matrix wizard now warns when the selected slice exceeds 5,000 assignments and blocks Apply above 25,000, preventing accidentally loading very large datasets.
- Fixed: Department context filters in the matrix wizard showed "0 of N users" because `ContextMembers` was never populated from the `department` column. New `department-from-principal` context-algorithm plugin derives Department contexts and their members from `Principals.department`. Run it from the Contexts tab after any sync that populates the department column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)