### PR TITLE
test: add tests for department-from-principal plugin and filterSql

### DIFF
--- a/app/api/src/contexts/plugins/department-from-principal.js
+++ b/app/api/src/contexts/plugins/department-from-principal.js
@@ -46,8 +46,9 @@ export default {
     // One context per unique department name.
     const seen = new Map(); // department value → externalId
     for (const r of rows) {
+      if (!r.department) continue;
       const dept = r.department.trim();
-      if (!seen.has(dept)) {
+      if (dept && !seen.has(dept)) {
         seen.set(dept, `dept:${dept}`);
       }
     }
@@ -58,10 +59,12 @@ export default {
       contextType: 'Department',
     }));
 
-    const members = rows.map(r => ({
-      contextExternalId: seen.get(r.department.trim()),
-      memberId:          r.id,
-    }));
+    const members = rows
+      .filter(r => r.department?.trim())
+      .map(r => ({
+        contextExternalId: seen.get(r.department.trim()),
+        memberId:          r.id,
+      }));
 
     ctx.log?.(`Derived ${contexts.length} department(s), ${members.length} member links.`);
     return { contexts, members };

--- a/app/api/src/contexts/plugins/department-from-principal.test.js
+++ b/app/api/src/contexts/plugins/department-from-principal.test.js
@@ -1,0 +1,93 @@
+// Unit tests for the department-from-principal context plugin.
+// Uses vi.doMock to inject a stub db so no real database is needed.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const PRINCIPALS = [
+  { id: 'p1', department: 'Finance' },
+  { id: 'p2', department: 'Finance' },
+  { id: 'p3', department: 'IT' },
+  { id: 'p4', department: '  IT  ' },   // whitespace — should normalise to 'IT'
+  { id: 'p5', department: null },        // null — must be excluded
+  { id: 'p6', department: '' },          // empty string — must be excluded
+];
+
+async function loadPlugin(rows) {
+  vi.resetModules();
+  vi.doMock('../../db/connection.js', () => ({
+    query: vi.fn(async () => ({ rows })),
+  }));
+  const mod = await import('./department-from-principal.js');
+  return mod.default;
+}
+
+describe('department-from-principal plugin', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('returns empty when no principals have a department', async () => {
+    const plugin = await loadPlugin([]);
+    const out = await plugin.run({}, {});
+    expect(out.contexts).toHaveLength(0);
+    expect(out.members).toHaveLength(0);
+  });
+
+  it('creates one context per unique department value', async () => {
+    const plugin = await loadPlugin(PRINCIPALS);
+    const out = await plugin.run({}, {});
+    const depts = out.contexts.map(c => c.displayName).sort();
+    expect(depts).toEqual(['Finance', 'IT']);
+  });
+
+  it('sets contextType to Department on every context', async () => {
+    const plugin = await loadPlugin(PRINCIPALS);
+    const out = await plugin.run({}, {});
+    expect(out.contexts.every(c => c.contextType === 'Department')).toBe(true);
+  });
+
+  it('uses a stable externalId derived from the department name', async () => {
+    const plugin = await loadPlugin(PRINCIPALS);
+    const out = await plugin.run({}, {});
+    const finance = out.contexts.find(c => c.displayName === 'Finance');
+    expect(finance.externalId).toBe('dept:Finance');
+  });
+
+  it('assigns each principal to their department context', async () => {
+    const plugin = await loadPlugin(PRINCIPALS);
+    const out = await plugin.run({}, {});
+    const financeMembers = out.members
+      .filter(m => m.contextExternalId === 'dept:Finance')
+      .map(m => m.memberId)
+      .sort();
+    expect(financeMembers).toEqual(['p1', 'p2']);
+  });
+
+  it('trims whitespace from department values', async () => {
+    const plugin = await loadPlugin(PRINCIPALS);
+    const out = await plugin.run({}, {});
+    // p3 and p4 both have department 'IT' (p4 after trim) — one context, two members.
+    const itMembers = out.members
+      .filter(m => m.contextExternalId === 'dept:IT')
+      .map(m => m.memberId)
+      .sort();
+    expect(itMembers).toEqual(['p3', 'p4']);
+  });
+
+  it('excludes principals with null or empty department', async () => {
+    const plugin = await loadPlugin(PRINCIPALS);
+    const out = await plugin.run({}, {});
+    const memberIds = out.members.map(m => m.memberId);
+    expect(memberIds).not.toContain('p5');
+    expect(memberIds).not.toContain('p6');
+  });
+
+  it('passes scopeSystemId to the db query when provided', async () => {
+    vi.resetModules();
+    const mockQuery = vi.fn(async () => ({ rows: [] }));
+    vi.doMock('../../db/connection.js', () => ({ query: mockQuery }));
+    const mod = await import('./department-from-principal.js');
+    await mod.default.run({ scopeSystemId: 42 }, {});
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/systemId/);
+    expect(args).toContain(42);
+  });
+});

--- a/app/api/src/matrix/filterSql.test.js
+++ b/app/api/src/matrix/filterSql.test.js
@@ -4,7 +4,6 @@ import { describe, it, expect } from 'vitest';
 import { buildEntitySubquery, collectContextIds } from './filterSql.js';
 
 const PRINCIPAL_COLS = new Set(['displayName', 'department', 'jobTitle', 'email']);
-const RESOURCE_COLS  = new Set(['displayName', 'resourceType', 'systemId']);
 const CTX_PRINCIPAL  = 'a0000001-0000-0000-0000-000000000001';
 const CTX_RESOURCE   = 'a0000002-0000-0000-0000-000000000002';
 const CONTEXT_TYPES  = new Map([

--- a/app/api/src/matrix/filterSql.test.js
+++ b/app/api/src/matrix/filterSql.test.js
@@ -1,0 +1,132 @@
+// Unit tests for matrix/filterSql.js — pure logic, no DB needed.
+
+import { describe, it, expect } from 'vitest';
+import { buildEntitySubquery, collectContextIds } from './filterSql.js';
+
+const PRINCIPAL_COLS = new Set(['displayName', 'department', 'jobTitle', 'email']);
+const RESOURCE_COLS  = new Set(['displayName', 'resourceType', 'systemId']);
+const CTX_PRINCIPAL  = 'a0000001-0000-0000-0000-000000000001';
+const CTX_RESOURCE   = 'a0000002-0000-0000-0000-000000000002';
+const CONTEXT_TYPES  = new Map([
+  [CTX_PRINCIPAL, 'Principal'],
+  [CTX_RESOURCE,  'Resource'],
+]);
+
+// Convenience: run buildEntitySubquery for Principals with given conditions.
+function buildPrincipal(include = [], exclude = []) {
+  return buildEntitySubquery({
+    entity: 'Principal',
+    include,
+    exclude,
+    validColumns: PRINCIPAL_COLS,
+    contextTypes: CONTEXT_TYPES,
+    bindingPrefix: 'sf',
+  });
+}
+
+describe('buildEntitySubquery', () => {
+  it('returns sql=null when no conditions are given', () => {
+    const out = buildPrincipal();
+    expect(out.sql).toBeNull();
+    expect(out.warnings).toHaveLength(0);
+  });
+
+  it('returns sql=null for empty include and exclude arrays', () => {
+    const out = buildPrincipal([], []);
+    expect(out.sql).toBeNull();
+  });
+
+  it('generates an IN clause for a single attribute include', () => {
+    const out = buildPrincipal([{ kind: 'attribute', field: 'department', values: ['Finance'] }]);
+    expect(out.sql).toMatch(/SELECT id FROM "Principals"/);
+    expect(out.sql).toMatch(/"department"::text IN/);
+    expect(Object.values(out.bindings)).toContain('Finance');
+  });
+
+  it('generates a NOT IN clause for an attribute exclude', () => {
+    const out = buildPrincipal([], [{ kind: 'attribute', field: 'department', values: ['Finance'] }]);
+    expect(out.sql).toMatch(/IS NOT TRUE/);
+  });
+
+  it('ORs multiple values in a single attribute condition', () => {
+    const out = buildPrincipal([{ kind: 'attribute', field: 'department', values: ['Finance', 'IT', 'HR'] }]);
+    const bindingCount = Object.keys(out.bindings).length;
+    expect(bindingCount).toBe(3);
+    expect(out.sql).toMatch(/"department"::text IN/);
+  });
+
+  it('warns and drops an attribute condition for an unknown column', () => {
+    const out = buildPrincipal([{ kind: 'attribute', field: 'nonexistent', values: ['x'] }]);
+    expect(out.sql).toBeNull();
+    expect(out.warnings).toHaveLength(1);
+    expect(out.warnings[0]).toMatch(/nonexistent/);
+  });
+
+  it('generates a context membership subquery for a valid context', () => {
+    const out = buildPrincipal([{
+      kind: 'context',
+      contextId: CTX_PRINCIPAL,
+      includeChildren: false,
+    }]);
+    expect(out.sql).toMatch(/ContextMembers/);
+    expect(out.sql).toMatch(/memberType/);
+  });
+
+  it('uses recursive CTE when includeChildren is true', () => {
+    const out = buildPrincipal([{
+      kind: 'context',
+      contextId: CTX_PRINCIPAL,
+      includeChildren: true,
+    }]);
+    expect(out.sql).toMatch(/WITH RECURSIVE/);
+  });
+
+  it('warns and drops a context with an unknown id', () => {
+    const out = buildPrincipal([{ kind: 'context', contextId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', includeChildren: false }]);
+    expect(out.sql).toBeNull();
+    expect(out.warnings).toHaveLength(1);
+  });
+
+  it('warns and drops a context whose targetType is incompatible with the entity', () => {
+    // Resource context used on a Principal entity with no IdentityMembers bridge.
+    const out = buildPrincipal([{
+      kind: 'context',
+      contextId: CTX_RESOURCE,
+      includeChildren: false,
+    }]);
+    expect(out.sql).toBeNull();
+    expect(out.warnings).toHaveLength(1);
+  });
+});
+
+describe('collectContextIds', () => {
+  it('returns empty array when no context conditions exist', () => {
+    const ids = collectContextIds({
+      subject:  { include: [{ kind: 'attribute', field: 'department', values: ['x'] }], exclude: [] },
+      resource: { include: [], exclude: [] },
+    });
+    expect(ids).toHaveLength(0);
+  });
+
+  it('collects context ids from both subject and resource sides', () => {
+    const ids = collectContextIds({
+      subject:  { include: [{ kind: 'context', contextId: CTX_PRINCIPAL, includeChildren: false }], exclude: [] },
+      resource: { include: [{ kind: 'context', contextId: CTX_RESOURCE, includeChildren: false }], exclude: [] },
+    });
+    expect(ids.sort()).toEqual([
+      CTX_PRINCIPAL,
+      CTX_RESOURCE,
+    ]);
+  });
+
+  it('deduplicates repeated context ids', () => {
+    const ids = collectContextIds({
+      subject: {
+        include: [{ kind: 'context', contextId: CTX_PRINCIPAL, includeChildren: false }],
+        exclude: [{ kind: 'context', contextId: CTX_PRINCIPAL, includeChildren: false }],
+      },
+      resource: { include: [], exclude: [] },
+    });
+    expect(ids).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Tests missed from #169 — the commit landed on the branch after the PR was already merged.

- `department-from-principal.test.js` — 8 tests covering the new context-algorithm plugin (empty input, one context per unique department, whitespace trimming, null exclusion, scopeSystemId passthrough). Also fixes a null-guard bug in the plugin itself: `department` values that are `null` would crash `.trim()` if the SQL filter were bypassed (e.g. in tests or edge cases).
- `filterSql.test.js` — 13 tests covering `buildEntitySubquery` and `collectContextIds` (no conditions → sql null, attribute clauses, context membership subqueries, recursive CTE, warnings for unknown columns/contexts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)