### PR TITLE
fix: docs build — convert broken relative links to absolute GitHub URLs

### DIFF
--- a/changes/fix-docs-broken-links.md
+++ b/changes/fix-docs-broken-links.md
@@ -1,0 +1,1 @@
+- Fixed broken links in architecture docs — source-code cross-references now point to GitHub URLs so the MkDocs strict build succeeds and docs deploy correctly to GitHub Pages.

--- a/docs/admin/excel-template-authoring.md
+++ b/docs/admin/excel-template-authoring.md
@@ -103,7 +103,7 @@ they ever change, tests catch it.
 ## M code per sheet
 
 Each block goes verbatim into the Advanced Editor. The names match the
-constants in [`app/api/src/export/queryTemplates.js`](../../app/api/src/export/queryTemplates.js)
+constants in [`app/api/src/export/queryTemplates.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/export/queryTemplates.js)
 — if the templates change there, regenerate the workbook by downloading
 the M-as-text MVP version (Admin → Data → Generate token & download
 workbook), open it, and copy the updated M from each sheet's cell A6.

--- a/docs/architecture/azure-deployment.md
+++ b/docs/architecture/azure-deployment.md
@@ -1,7 +1,7 @@
 # Azure deployment — Simple shape
 
-> Companion to the Bicep in [`/azure`](../../azure).
-> One-click install: see the [README's Deploy to Azure button](../../README.md#deploy-to-azure).
+> Companion to the Bicep in [`/azure`](https://github.com/Fortigi/IdentityAtlas/tree/main/azure).
+> One-click install: see the [README's Deploy to Azure button](https://github.com/Fortigi/IdentityAtlas/blob/main/README.md#deploy-to-azure).
 > **Target:** customers whose networking is owned by a central CCoE. No VNet, no private endpoints, no public IP that you provision.
 
 ## What you get
@@ -186,10 +186,10 @@ Key Vault has soft delete + purge protection (7-day retention). To redeploy with
 
 | File | Purpose |
 |---|---|
-| [`azure/main.bicep`](../../azure/main.bicep) | Top-level orchestrator |
-| [`azure/main.json`](../../azure/main.json) | Compiled ARM (used by the Deploy to Azure button) |
-| [`azure/main.parameters.example.json`](../../azure/main.parameters.example.json) | Example parameter file |
-| [`azure/deploy.ps1`](../../azure/deploy.ps1) | CLI deploy + post-deploy summary |
+| [`azure/main.bicep`](https://github.com/Fortigi/IdentityAtlas/blob/main/azure/main.bicep) | Top-level orchestrator |
+| [`azure/main.json`](https://github.com/Fortigi/IdentityAtlas/blob/main/azure/main.json) | Compiled ARM (used by the Deploy to Azure button) |
+| [`azure/main.parameters.example.json`](https://github.com/Fortigi/IdentityAtlas/blob/main/azure/main.parameters.example.json) | Example parameter file |
+| [`azure/deploy.ps1`](https://github.com/Fortigi/IdentityAtlas/blob/main/azure/deploy.ps1) | CLI deploy + post-deploy summary |
 | `azure/modules/log-analytics.bicep` | New workspace OR BYO lookup OR pass-through |
 | `azure/modules/storage.bicep` | Storage Account + Azure Files share |
 | `azure/modules/identities.bicep` | 2 user-assigned managed identities |

--- a/docs/architecture/dashboard-trends.md
+++ b/docs/architecture/dashboard-trends.md
@@ -1,6 +1,6 @@
 # Dashboard — Trends tab
 
-> Companion to [`027_dashboard_snapshots.sql`](../../app/api/src/db/migrations/027_dashboard_snapshots.sql), [`scheduler.js`](../../app/api/src/scheduler.js), [`DashboardTrendsTab.jsx`](../../app/ui/src/components/DashboardTrendsTab.jsx), [`TimeSeriesChart.jsx`](../../app/ui/src/components/TimeSeriesChart.jsx).
+> Companion to [`027_dashboard_snapshots.sql`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/db/migrations/027_dashboard_snapshots.sql), [`scheduler.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/scheduler.js), [`DashboardTrendsTab.jsx`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/DashboardTrendsTab.jsx), [`TimeSeriesChart.jsx`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/TimeSeriesChart.jsx).
 
 ## What it does
 
@@ -114,7 +114,7 @@ Response:
 
 ## Related references
 
-- Live dashboard cards endpoint: [`/admin/dashboard-stats`](../../app/api/src/routes/admin.js) — used by the Overview tab. Same fast-path technique (reltuples + targeted COUNTs).
-- Migration: [`027_dashboard_snapshots.sql`](../../app/api/src/db/migrations/027_dashboard_snapshots.sql).
-- Scheduler: [`scheduler.js`](../../app/api/src/scheduler.js) — `captureDashboardSnapshotIfMissing` is the first call in each tick.
-- Frontend entry: [`DashboardPage.jsx`](../../app/ui/src/components/DashboardPage.jsx) — tab strip between Overview and Trends.
+- Live dashboard cards endpoint: [`/admin/dashboard-stats`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/routes/admin.js) — used by the Overview tab. Same fast-path technique (reltuples + targeted COUNTs).
+- Migration: [`027_dashboard_snapshots.sql`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/db/migrations/027_dashboard_snapshots.sql).
+- Scheduler: [`scheduler.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/scheduler.js) — `captureDashboardSnapshotIfMissing` is the first call in each tick.
+- Frontend entry: [`DashboardPage.jsx`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/DashboardPage.jsx) — tab strip between Overview and Trends.

--- a/docs/architecture/entity-detail-pages.md
+++ b/docs/architecture/entity-detail-pages.md
@@ -10,7 +10,7 @@ kinds consistent.
 
 ## Layout
 
-All four detail pages use the same three-region layout ([EntityDetailLayout.jsx](../../app/ui/src/components/EntityDetailLayout.jsx)):
+All four detail pages use the same three-region layout ([EntityDetailLayout.jsx](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/EntityDetailLayout.jsx)):
 
 ```
 ┌───────────────────────────────────────────────┐
@@ -31,7 +31,7 @@ All four detail pages use the same three-region layout ([EntityDetailLayout.jsx]
 └───────────────────────────────────────────────┘
 ```
 
-The left column's [AttributesTable](../../app/ui/src/components/EntityDetailLayout.jsx) merges the entity's real columns and its `extendedAttributes` JSONB into one `label | value` table. JSON-derived rows carry a faded `ext` tag so readers can still tell them apart.
+The left column's [AttributesTable](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/EntityDetailLayout.jsx) merges the entity's real columns and its `extendedAttributes` JSONB into one `label | value` table. JSON-derived rows carry a faded `ext` tag so readers can still tell them apart.
 
 ---
 
@@ -75,9 +75,9 @@ Large fanouts cap at 10 satellites; overflow becomes a `+N more` bubble.
 
 Three files own the model:
 
-- [entityGraphShape.js](../../app/ui/src/components/entityGraphShape.js) — the single source of truth. Exports `getRootNodes(kind, core, extras)` and `fetchCategoryItems(kind, id, categoryKey, authFetch, extras)`. Adding a new entity kind is a single switch-case addition plus its fetch helpers.
-- [useExpandableGraph.js](../../app/ui/src/hooks/useExpandableGraph.js) — React hook. Owns the expansion path (a stack of alternating category/item steps), fetches on click, handles collapse/replace.
-- [EntityGraph.jsx](../../app/ui/src/components/EntityGraph.jsx) — dumb SVG renderer. Takes a node tree and the expansion path, recursively lays out each fanout on an arc pointing outward from its parent. The viewBox grows with drill depth to stop deep chains running off canvas.
+- [entityGraphShape.js](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/entityGraphShape.js) — the single source of truth. Exports `getRootNodes(kind, core, extras)` and `fetchCategoryItems(kind, id, categoryKey, authFetch, extras)`. Adding a new entity kind is a single switch-case addition plus its fetch helpers.
+- [useExpandableGraph.js](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/hooks/useExpandableGraph.js) — React hook. Owns the expansion path (a stack of alternating category/item steps), fetches on click, handles collapse/replace.
+- [EntityGraph.jsx](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/EntityGraph.jsx) — dumb SVG renderer. Takes a node tree and the expansion path, recursively lays out each fanout on an arc pointing outward from its parent. The viewBox grows with drill depth to stop deep chains running off canvas.
 
 ### Styling signals
 
@@ -152,18 +152,18 @@ To give a new entity kind its own detail page with the graph + recent-changes tr
 1. **Backend**
    - Expose a core detail endpoint that returns attributes, tags, and the counts you want shown as graph nodes.
    - Expose a list endpoint for each relationship category (or extend an existing one).
-   - Add a `/:id/recent-changes` handler — follow the pattern in [recentChanges.js](../../app/api/src/routes/recentChanges.js). Decide which `_history` tables are relevant and how to summarise each operation type into human-readable text.
+   - Add a `/:id/recent-changes` handler — follow the pattern in [recentChanges.js](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/routes/recentChanges.js). Decide which `_history` tables are relevant and how to summarise each operation type into human-readable text.
 
 2. **Frontend**
-   - In [entityGraphShape.js](../../app/ui/src/components/entityGraphShape.js):
+   - In [entityGraphShape.js](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/entityGraphShape.js):
      - Add `<kind>RootNodes(core)` returning the first-ring node spec.
      - Add `fetch<Kind>Items(id, categoryKey, authFetch, extras)` returning item arrays for each category.
      - Wire both into the top-level `getRootNodes` / `fetchCategoryItems` switch statements.
      - Add an entry to `fetchEntityCore` so drill-in from another page can pick up the kind.
-   - In [useRecentChanges.js](../../app/ui/src/hooks/useRecentChanges.js): add the endpoint URL for the new kind.
+   - In [useRecentChanges.js](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/hooks/useRecentChanges.js): add the endpoint URL for the new kind.
    - Create a `<Kind>DetailPage.jsx` following the pattern of the existing four. It mostly just fetches the core payload, calls `useExpandableGraph` + `useRecentChanges`, and renders `EntityDetailLayout`.
 
-3. **Routing** — add the hash-route handler in [App.jsx](../../app/ui/src/App.jsx) so `onOpenDetail('<kind>', id, label)` opens your new page.
+3. **Routing** — add the hash-route handler in [App.jsx](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/App.jsx) so `onOpenDetail('<kind>', id, label)` opens your new page.
 
 The shared `EntityGraph`, `ExpandedItemsList`, `RecentChangesSection`, `EntityDetailLayout`, and `AttributesTable` components require no changes.
 
@@ -172,4 +172,4 @@ The shared `EntityGraph`, `ExpandedItemsList`, `RecentChangesSection`, `EntityDe
 ## Related docs
 
 - [audit-history.md](audit-history.md) — how `_history` is populated and queried.
-- [postgres-migration.md](postgres-migration.md) — context on the v4→v5 switch that replaced temporal tables with `_history`.
+- [audit-history.md](audit-history.md) — how `_history` is populated and queried (includes context on the v4→v5 switch that replaced temporal tables).

--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -1,7 +1,7 @@
 # Matrix view — architecture
 
 > **Status:** current as of May 2026.
-> Companion to [`013_matrix_matviews_and_indexes.sql`](../../app/api/src/db/migrations/013_matrix_matviews_and_indexes.sql), [`024_matrix_view_all_assignment_types.sql`](../../app/api/src/db/migrations/024_matrix_view_all_assignment_types.sql), [`025_matrix_view_governed_renders_as_direct.sql`](../../app/api/src/db/migrations/025_matrix_view_governed_renders_as_direct.sql).
+> Companion to [`013_matrix_matviews_and_indexes.sql`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/db/migrations/013_matrix_matviews_and_indexes.sql), [`024_matrix_view_all_assignment_types.sql`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/db/migrations/024_matrix_view_all_assignment_types.sql), [`025_matrix_view_governed_renders_as_direct.sql`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/db/migrations/025_matrix_view_governed_renders_as_direct.sql).
 
 ## The grid
 
@@ -89,7 +89,7 @@ A user who is both a member and an owner of a group gets two rows in the data �
 
 ## Related references
 
-- Crawler emits — [`tools/crawlers/entra-id/Start-EntraIDCrawler.ps1`](../../tools/crawlers/entra-id/Start-EntraIDCrawler.ps1) (phases `Assignments`, `PIM`, `Governance`, `OAuth2Grants`, `AppRoles`)
-- Frontend renderer — [`app/ui/src/components/MatrixView.jsx`](../../app/ui/src/components/MatrixView.jsx) and `app/ui/src/components/matrix/*`
-- Badge color map — [`app/ui/src/utils/colors.js`](../../app/ui/src/utils/colors.js) (`TYPE_COLORS`)
-- Permissions endpoint — [`app/api/src/routes/permissions.js`](../../app/api/src/routes/permissions.js) (`GET /api/permissions`, `GET /api/groups-with-nested`, `GET /api/group/:id/nested-groups`)
+- Crawler emits — [`tools/crawlers/entra-id/Start-EntraIDCrawler.ps1`](https://github.com/Fortigi/IdentityAtlas/blob/main/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1) (phases `Assignments`, `PIM`, `Governance`, `OAuth2Grants`, `AppRoles`)
+- Frontend renderer — [`app/ui/src/components/MatrixView.jsx`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/components/MatrixView.jsx) and `app/ui/src/components/matrix/*`
+- Badge color map — [`app/ui/src/utils/colors.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/src/utils/colors.js) (`TYPE_COLORS`)
+- Permissions endpoint — [`app/api/src/routes/permissions.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/routes/permissions.js) (`GET /api/permissions`, `GET /api/groups-with-nested`, `GET /api/group/:id/nested-groups`)

--- a/docs/architecture/resource-cluster-algorithm.md
+++ b/docs/architecture/resource-cluster-algorithm.md
@@ -92,7 +92,7 @@ Four built-in categories, combined into a single `Set`:
 | **NL connectives** | Clutter from descriptive Dutch display names. | `van`, `voor`, `naar`, `bij`, `aan`, `uit`, `over`, `met`, `als`, `door`, … (short ones like `de`, `en`, `op`, `te` fall out via `minTokenLength`) |
 
 The full set lives in
-[`tokenize.js`](../../app/api/src/contexts/plugins/resource-cluster/tokenize.js)
+[`tokenize.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/contexts/plugins/resource-cluster/tokenize.js)
 as `DEFAULT_STOPWORDS`. Tenant-specific additions go through the
 `additionalStopwords` parameter.
 
@@ -221,8 +221,8 @@ resources that don't share a token.
 
 | File | Purpose |
 |---|---|
-| [`app/api/src/contexts/plugins/resource-cluster/index.js`](../../app/api/src/contexts/plugins/resource-cluster/index.js) | Plugin entry (`parametersSchema`, `run`) |
-| [`app/api/src/contexts/plugins/resource-cluster/tokenize.js`](../../app/api/src/contexts/plugins/resource-cluster/tokenize.js) | Tokenizer + stopword set + `prettifyToken` |
-| [`app/api/src/contexts/plugins/resource-cluster/tokenize.test.js`](../../app/api/src/contexts/plugins/resource-cluster/tokenize.test.js) | Unit tests for the tokenizer |
-| [`app/api/src/contexts/plugins/resource-cluster/index.test.js`](../../app/api/src/contexts/plugins/resource-cluster/index.test.js) | Integration test for `run()` with a mocked db |
-| [`app/api/src/contexts/plugins/runner.js`](../../app/api/src/contexts/plugins/runner.js) | Generic plugin runner (reconciler, member-count rollup) — not specific to this plugin |
+| [`app/api/src/contexts/plugins/resource-cluster/index.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/contexts/plugins/resource-cluster/index.js) | Plugin entry (`parametersSchema`, `run`) |
+| [`app/api/src/contexts/plugins/resource-cluster/tokenize.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/contexts/plugins/resource-cluster/tokenize.js) | Tokenizer + stopword set + `prettifyToken` |
+| [`app/api/src/contexts/plugins/resource-cluster/tokenize.test.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/contexts/plugins/resource-cluster/tokenize.test.js) | Unit tests for the tokenizer |
+| [`app/api/src/contexts/plugins/resource-cluster/index.test.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/contexts/plugins/resource-cluster/index.test.js) | Integration test for `run()` with a mocked db |
+| [`app/api/src/contexts/plugins/runner.js`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/src/contexts/plugins/runner.js) | Generic plugin runner (reconciler, member-count rollup) — not specific to this plugin |


### PR DESCRIPTION
- Fixed broken links in architecture docs — source-code cross-references now point to GitHub URLs so the MkDocs strict build succeeds and docs deploy correctly to GitHub Pages.

## Details

The `Deploy documentation` workflow has been failing on every run since the docs were added. Root cause: `mkdocs build --strict` treats unresolvable relative links as errors, and many doc files linked to source files outside the `docs/` tree using `../../app/...` style paths that MkDocs cannot resolve.

Fixed 6 files, 33 links total:
- `admin/excel-template-authoring.md`
- `architecture/azure-deployment.md`
- `architecture/dashboard-trends.md`
- `architecture/entity-detail-pages.md` (also replaced dead `postgres-migration.md` ref with `audit-history.md`)
- `architecture/matrix.md`
- `architecture/resource-cluster-algorithm.md`

All relative `../../<source-file>` paths converted to `https://github.com/Fortigi/IdentityAtlas/blob/main/<path>` absolute URLs.

## Test plan

- [ ] Merge and verify `Deploy documentation` workflow passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)