### PR TITLE
feat: create GitHub release automatically on cut-release and cut-beta

### DIFF
--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -58,6 +58,15 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "✅ Tagged ${TAG} on $(git rev-parse --short HEAD)"
 
+      - name: Create GitHub pre-release
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --prerelease
+
       - name: Post run summary
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" << EOF

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -61,6 +61,15 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "✅ Tagged ${TAG} on $(git rev-parse --short HEAD)"
 
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --latest
+
       - name: Post run summary
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" << EOF

--- a/changes/github-releases.md
+++ b/changes/github-releases.md
@@ -1,0 +1,1 @@
+- Cut Release and Cut Beta workflows now automatically create a GitHub Release (with auto-generated notes from merged PRs) in addition to pushing the git tag and Docker image.

--- a/changes/github-releases.md
+++ b/changes/github-releases.md
@@ -1,1 +1,0 @@
-- Cut Release and Cut Beta workflows now automatically create a GitHub Release (with auto-generated notes from merged PRs) in addition to pushing the git tag and Docker image.


### PR DESCRIPTION
## Summary

- Cut Release and Cut Beta workflows now automatically create a GitHub Release after pushing the git tag
- Uses `--generate-notes` to populate release notes from merged PRs since the previous tag
- Cut Release marks the release as latest; Cut Beta marks it as pre-release
- No new secrets needed — uses the existing bot token

## Test plan

- [ ] Run Actions → Cut Beta with a test version and verify a pre-release appears on the Releases page with auto-generated notes
- [ ] Run Actions → Cut Release and verify a release appears marked as latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)