### PR TITLE
fix: boolean coercion and configurable app root for crawler jobs

### DIFF
--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -137,7 +137,7 @@ function coerceValue(value) {
   // timestamptz, integer, boolean). Treating them as null is always safe and
   // matches the intent of "this field was not supplied".
   if (value === '') return null;
-  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (typeof value === 'boolean') return value;
   if (typeof value === 'object' && !(value instanceof Date)) return JSON.stringify(value);
   return value;
 }

--- a/app/api/src/routes/jobs.js
+++ b/app/api/src/routes/jobs.js
@@ -9,11 +9,11 @@ import { readdirSync, promises as fs } from 'fs';
 import path from 'path';
 import { getCsvFolderPath, deleteConfigFolder } from './csvUploads.js';
 
-const TRACE_DIR = '/data/uploads/jobs';
+const TRACE_DIR = process.env.TRACE_DIR || '/data/uploads/jobs';
 // Pre-resolve once so path-containment checks can use a stable absolute base.
 const TRACE_DIR_RESOLVED = path.resolve(TRACE_DIR);
 // CSV uploads live under this base; configCsvFolder must stay within it.
-const CSV_BASE_DIR = path.resolve('/data/uploads');
+const CSV_BASE_DIR = path.resolve(process.env.UPLOAD_ROOT || '/data/uploads');
 // Tail endpoint returns at most this many bytes per request. If the file is
 // larger than offset + MAX, the client polls again with the new offset. Keeps
 // any single response small enough that a ~10 MB log on a long crawl streams

--- a/changes/prepare-portable-app.md
+++ b/changes/prepare-portable-app.md
@@ -1,0 +1,2 @@
+- Fixed boolean values being incorrectly coerced to integers (0/1) during data ingest, causing failures on strict boolean columns
+- Crawler job dispatcher now resolves script paths via `IA_APP_ROOT` environment variable, allowing the worker to run from any installation directory instead of requiring a fixed `/app` path

--- a/changes/prepare-portable-app.md
+++ b/changes/prepare-portable-app.md
@@ -1,2 +1,3 @@
 - Fixed boolean values being incorrectly coerced to integers (0/1) during data ingest, causing failures on strict boolean columns
 - Crawler job dispatcher now resolves script paths via `IA_APP_ROOT` environment variable, allowing the worker to run from any installation directory instead of requiring a fixed `/app` path
+- Crawler job trace logs and CSV upload paths now respect `TRACE_DIR` and `UPLOAD_ROOT` environment variables, removing the hardcoded Docker paths `/data/uploads/jobs` and `/data/uploads`

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -70,7 +70,7 @@ function Set-JobResult {
 # exactly what the crawler was doing at each step — without requiring
 # SSH into the worker container. The job_data volume is shared between
 # worker and web, so the web container can read the file back out.
-$traceDir  = '/data/uploads/jobs'
+$traceDir  = if ($env:TRACE_DIR) { $env:TRACE_DIR } else { '/data/uploads/jobs' }
 $traceFile = Join-Path $traceDir "$JobId.log"
 $transcriptStarted = $false
 try {

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -95,18 +95,20 @@ try {
     # Non-fatal: a failed retention sweep never blocks the job itself.
 }
 
+$appRoot = if ($env:IA_APP_ROOT) { $env:IA_APP_ROOT.TrimEnd('/\') } else { '/app' }
+
 try {
 switch ($JobType) {
 
     'demo' {
         Update-JobProgress -Step 'Loading demo dataset' -Pct 10
-        $datasetPath = '/app/test/demo-dataset/demo-company.json'
-        $ingestScript = '/app/test/demo-dataset/Ingest-DemoDataset.ps1'
+        $datasetPath = "$appRoot/test/demo-dataset/demo-company.json"
+        $ingestScript = "$appRoot/test/demo-dataset/Ingest-DemoDataset.ps1"
 
         if (-not (Test-Path $datasetPath)) {
             # Generate it first
             Update-JobProgress -Step 'Generating demo dataset' -Pct 5
-            $genScript = '/app/test/demo-dataset/Generate-DemoDataset.ps1'
+            $genScript = "$appRoot/test/demo-dataset/Generate-DemoDataset.ps1"
             if (Test-Path $genScript) {
                 & $genScript
             } else {
@@ -211,12 +213,12 @@ switch ($JobType) {
                 $crawlerParams['IdentityFilter'] = $Config['identityFilter']
             }
 
-            & /app/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1 @crawlerParams
+            & "$appRoot/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1" @crawlerParams
 
             # ── Post-sync: build contexts from principal data ────────────
             Update-JobProgress -Step 'Building contexts from principal data' -Pct 80
             try {
-                & /app/setup/docker/Build-FGContexts.ps1
+                & "$appRoot/setup/docker/Build-FGContexts.ps1"
             } catch {
                 Write-Host "  Context build failed (non-critical): $($_.Exception.Message)" -ForegroundColor Yellow
             }
@@ -275,7 +277,7 @@ switch ($JobType) {
 
         Update-JobProgress -Step 'Running CSV crawler' -Pct 10
 
-        & /app/tools/crawlers/csv/Start-CSVCrawler.ps1 `
+        & "$appRoot/tools/crawlers/csv/Start-CSVCrawler.ps1" `
             -ApiBaseUrl $apiBaseUrl `
             -ApiKey $ApiKey `
             -CsvFolder $csvFolder `
@@ -285,7 +287,7 @@ switch ($JobType) {
 
         # Post-sync: contexts + account correlation
         Update-JobProgress -Step 'Building contexts from principal data' -Pct 80
-        try { & /app/setup/docker/Build-FGContexts.ps1 } catch { Write-Host "  Context build failed: $($_.Exception.Message)" -ForegroundColor Yellow }
+        try { & "$appRoot/setup/docker/Build-FGContexts.ps1" } catch { Write-Host "  Context build failed: $($_.Exception.Message)" -ForegroundColor Yellow }
 
         Update-JobProgress -Step 'Linking accounts to identities' -Pct 90
         try {


### PR DESCRIPTION
- Fixed boolean values being incorrectly coerced to integers (0/1) during data ingest, causing failures on strict boolean columns
- Crawler job dispatcher now resolves script paths via `IA_APP_ROOT` environment variable, allowing the worker to run from any installation directory instead of requiring a fixed `/app` path
- Crawler job trace logs and CSV upload paths now respect `TRACE_DIR` and `UPLOAD_ROOT` environment variables, removing the hardcoded Docker paths `/data/uploads/jobs` and `/data/uploads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)