### PR TITLE
fix: add missing app/desktop/package.json for cut-beta CI

### DIFF
--- a/app/desktop/package.json
+++ b/app/desktop/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "identityatlas-desktop",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Desktop dependencies for the Identity Atlas portable launcher (PGlite)",
+  "dependencies": {
+    "@electric-sql/pglite": "0.2.17"
+  }
+}

--- a/changes/desktop-package-json.md
+++ b/changes/desktop-package-json.md
@@ -1,0 +1,1 @@
+- Fixed cut-beta and cut-release workflows failing because `app/desktop/package.json` was missing


### PR DESCRIPTION
- Fixed cut-beta and cut-release workflows failing because `app/desktop/package.json` was missing

## Root cause

The `feature/node-launcher` branch added a CI step that runs `npm install` in `app/desktop/` to fetch `@electric-sql/pglite` before the build script copies it into the portable ZIP. The `package.json` was never committed alongside it, causing the step to fail with `ENOENT: no such file or directory`.

## Test plan

- [x] `npm install --prefer-offline` in `app/desktop/` succeeds locally
- [ ] cut-beta workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)