### PR TITLE
fix: matrix loads cleanly after demo import without error flash

### DIFF
--- a/app/ui/e2e/matrix.spec.js
+++ b/app/ui/e2e/matrix.spec.js
@@ -12,7 +12,22 @@ const API = 'http://localhost:3001/api';
 //
 // Requires the full Docker stack (USE_SQL=true + worker). Skipped in mock mode.
 test.describe('Matrix loads after demo import', () => {
-  test.setTimeout(180000); // demo import can take up to 2 min in CI
+  // Reload demo data after this describe block so the rest of the suite
+  // still sees a populated DB (this block wipes the DB as part of the test).
+  test.afterAll(async ({ request }) => {
+    const cleanRes = await request.post(`${API}/admin/clean-database`);
+    if (!cleanRes.ok()) return; // mock mode — nothing to restore
+    const jobRes = await request.post(`${API}/admin/crawler-jobs`, { data: { jobType: 'demo' } });
+    if (!jobRes.ok()) return;
+    const { id } = await jobRes.json();
+    const deadline = Date.now() + 120000;
+    while (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 3000));
+      const poll = await request.get(`${API}/admin/crawler-jobs/${id}`);
+      const { status } = await poll.json();
+      if (status === 'completed' || status === 'failed') break;
+    }
+  });
 
   test('matrix renders without error after importing demo data from empty DB', async ({ page, request }) => {
     test.setTimeout(180000); // demo import + polling can take up to 2 min

--- a/app/ui/e2e/matrix.spec.js
+++ b/app/ui/e2e/matrix.spec.js
@@ -3,6 +3,77 @@ import { test, expect } from '@playwright/test';
 
 const API = 'http://localhost:3001/api';
 
+// ─── Regression: matrix loads after demo import without error flash ────────────
+//
+// Covers the bug where useMatrix cached hasData=false on mount and never
+// re-checked, causing the Matrix tab to stay blank after a demo import until
+// the user forced a page refresh. Also covers the "Backend not responding"
+// flash caused by a spurious POST with a null filter during the debounce window.
+//
+// Requires the full Docker stack (USE_SQL=true + worker). Skipped in mock mode.
+test.describe('Matrix loads after demo import', () => {
+  test.setTimeout(180000); // demo import can take up to 2 min in CI
+
+  test('matrix renders without error after importing demo data from empty DB', async ({ page, request }) => {
+    test.setTimeout(180000); // demo import + polling can take up to 2 min
+    // Only runs against the Docker stack — clean-database requires USE_SQL=true.
+    const cleanRes = await request.post(`${API}/admin/clean-database`);
+    if (cleanRes.status() === 503) {
+      test.skip(true, 'clean-database not available in mock mode — skipping Docker-only test');
+      return;
+    }
+    expect(cleanRes.ok()).toBe(true);
+
+    // Step 1: visit Matrix tab while DB is empty — hook caches hasData=false.
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const matrixTab = page.getByRole('button', { name: /^matrix$/i })
+      .or(page.getByRole('link', { name: /^matrix$/i }))
+      .or(page.getByRole('tab', { name: /^matrix$/i }))
+      .first();
+    await matrixTab.click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('body')).not.toContainText('Backend not responding');
+
+    // Step 2: navigate away so a return trip counts as fresh navigation.
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Step 3: submit demo import job and wait for completion.
+    const workerKey = await request.get(`${API.replace('/api', '')}/api/admin/worker-key`)
+      .then(r => r.ok() ? r.text() : null)
+      .catch(() => null);
+    const jobRes = await request.post(`${API}/admin/crawler-jobs`, {
+      data: { jobType: 'demo' },
+      headers: workerKey ? { Authorization: `Bearer ${workerKey}` } : {},
+    });
+    expect(jobRes.ok()).toBe(true);
+    const job = await jobRes.json();
+
+    // Poll until completed (or 2 min).
+    const deadline = Date.now() + 120000;
+    let status = job.status;
+    while (['queued', 'running'].includes(status) && Date.now() < deadline) {
+      await page.waitForTimeout(3000);
+      const poll = await request.get(`${API}/admin/crawler-jobs/${job.id}`);
+      status = (await poll.json()).status;
+    }
+    expect(status).toBe('completed');
+
+    // Step 4: navigate to Matrix — refetchPreChecks fires, default filter auto-applies.
+    const matrixTab2 = page.getByRole('button', { name: /^matrix$/i })
+      .or(page.getByRole('link', { name: /^matrix$/i }))
+      .or(page.getByRole('tab', { name: /^matrix$/i }))
+      .first();
+    await matrixTab2.click();
+    await page.waitForTimeout(4000); // allow refetch + debounce + data fetch
+
+    // Assert: no error screen, matrix rendered.
+    await expect(page.locator('body')).not.toContainText('Backend not responding');
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 10000 });
+  });
+});
+
 test.describe('Matrix View', () => {
   // The permissions API cold start in CI can take 20-30s (complex SQL join + query planning).
   // Increase test timeout for the matrix spec to accommodate this.

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -115,7 +115,7 @@ export default function App() {
   const [managedFilter, setManagedFilter] = useState(initial.managed);
   const [wizardOpen, setWizardOpen] = useState(false);
 
-  const { data, counts, accessPackageGroups, managedByPackages, groupTagMap, loading, refreshing, error, forceRefresh, hasData, defaultFilter } = useMatrix(matrixFilter);
+  const { data, counts, accessPackageGroups, managedByPackages, groupTagMap, loading, refreshing, error, forceRefresh, hasData, defaultFilter, refetchPreChecks } = useMatrix(matrixFilter);
   const { account, logout, authFetch } = useAuth();
   const [page, navigate] = useHashRoute();
   const [moduleVersion, setModuleVersion] = useState(null);
@@ -270,19 +270,27 @@ export default function App() {
   const autoOpenFiredRef = useRef(false);
   useEffect(() => {
     const freshNav = page === 'matrix' && prevPageRef.current !== 'matrix';
-    if (freshNav) autoOpenFiredRef.current = false;
     prevPageRef.current = page;
+    if (freshNav) {
+      autoOpenFiredRef.current = false;
+      // Re-check DB state on every fresh nav — picks up data loaded since mount
+      // (e.g. demo import or crawler run completed while on another tab).
+      // Return immediately so the auto-open logic only runs once the fresh
+      // values land; the version bump resets hasData/defaultFilter to their
+      // loading states, which holds the gate until the fetch resolves.
+      if (!matrixFilter) { refetchPreChecks(); return; }
+    }
     if (page !== 'matrix' || autoOpenFiredRef.current || matrixFilter || wizardOpen) return;
     // Still waiting for hasData or defaultFilter to resolve
     if (hasData === null || defaultFilter === undefined) return;
+    if (hasData === false) return; // don't lock out — DB may get data after import
     autoOpenFiredRef.current = true;
-    if (hasData === false) return; // empty DB — EmptyFilterState handles the message
     if (defaultFilter !== null) {
       setMatrixFilter(defaultFilter.filter); // skip wizard, apply saved default
     } else {
       setWizardOpen(true); // no default — let user configure
     }
-  }, [page, matrixFilter, wizardOpen, hasData, defaultFilter]);
+  }, [page, matrixFilter, wizardOpen, hasData, defaultFilter, refetchPreChecks]);
 
   // Sync URL when on matrix page (debounced replaceState — no history entry)
   useEffect(() => {

--- a/app/ui/src/hooks/useMatrix.js
+++ b/app/ui/src/hooks/useMatrix.js
@@ -51,6 +51,9 @@ export function useMatrix(filter) {
   const [hasData, setHasData] = useState(null);
   // undefined = still loading, null = no default, object = default filter row
   const [defaultFilter, setDefaultFilter] = useState(undefined);
+  // Incrementing this triggers a re-fetch of hasData + defaultFilter.
+  const [preCheckVersion, setPreCheckVersion] = useState(0);
+  const refetchPreChecks = useCallback(() => setPreCheckVersion(v => v + 1), []);
 
   // Load access-package groups + tags + Principal column metadata once.
   useEffect(() => {
@@ -78,23 +81,26 @@ export function useMatrix(filter) {
       .then(r => r.ok ? r.json() : [])
       .then(cols => { if (!cancelled) setUserColumns(cols); })
       .catch(() => {});
-    // Lightweight check: does the DB have any users or resources at all?
-    // Falls back to true (optimistic) on error or non-SQL mode so the wizard
-    // still opens on deployments where this endpoint isn't available.
+    return () => { cancelled = true; };
+  }, [authFetch]);
+
+  // hasData + defaultFilter are re-fetched on every fresh navigation to the
+  // matrix tab (via refetchPreChecks) so that data loaded after mount — e.g.
+  // a demo import or crawler run — is picked up without a page refresh.
+  useEffect(() => {
+    let cancelled = false;
+    setHasData(null);
+    setDefaultFilter(undefined);
     authFetch('/api/admin/dashboard-stats')
       .then(r => r.ok ? r.json() : null)
       .then(d => { if (!cancelled) setHasData(d ? (d.hasData !== false) : true); })
       .catch(() => { if (!cancelled) setHasData(true); });
-
-    // Default filter — auto-applied on first Matrix visit to skip the wizard.
-    // Falls back to null (no default) on any error.
     authFetch('/api/matrix/default-filter')
       .then(r => r.ok ? r.json() : null)
       .then(d => { if (!cancelled) setDefaultFilter(d || null); })
       .catch(() => { if (!cancelled) setDefaultFilter(null); });
-
     return () => { cancelled = true; };
-  }, [authFetch]);
+  }, [authFetch, preCheckVersion]);
 
   // Stable cache key for the filter — only re-fetch when conditions change.
   const filterKey = useMemo(() => filter ? JSON.stringify(filter) : null, [filter]);
@@ -120,6 +126,8 @@ export function useMatrix(filter) {
       setError(null);
       return;
     }
+    // hasConditions is true but the debounce hasn't fired yet — wait for debouncedKey.
+    if (!debouncedKey) return;
     const controller = new AbortController();
     let cancelled = false;
     (async () => {
@@ -190,6 +198,7 @@ export function useMatrix(filter) {
     forceRefresh,
     hasData,
     defaultFilter,
+    refetchPreChecks,
   };
 }
 

--- a/changes/matrix-stale-after-demo-import.md
+++ b/changes/matrix-stale-after-demo-import.md
@@ -1,0 +1,1 @@
+- Fixed: the matrix no longer stays blank after importing the demo dataset in Docker — navigating to the Matrix tab now picks up the newly loaded data and auto-applies the default filter without requiring a page refresh.


### PR DESCRIPTION
- Fixed: the matrix no longer stays blank after importing the demo dataset in Docker — navigating to the Matrix tab now picks up the newly loaded data and auto-applies the default filter without requiring a page refresh.
- Fixed: brief "Backend not responding" error that flashed before the matrix rendered after a fresh navigation.

## Root causes fixed

**Stale hasData cache:** `useMatrix` fetched `hasData` and `defaultFilter` once on mount and never again. After a demo import on another tab, navigating back to Matrix used the cached `hasData=false`, so auto-open never fired.

**autoOpenFiredRef premature lock:** The ref was set to `true` before the `hasData === false` guard, so a single render with stale data permanently blocked the auto-open even after the refetch resolved.

**Spurious null-filter POST:** When the auto-open set `matrixFilter`, `hasConditions` flipped to `true` immediately but `debouncedKey` was still `null` for 400ms. The data-fetch effect fired with `{"filter":null}`, the backend returned an error, causing the "Backend not responding" flash before the real fetch succeeded 400ms later.

## Test plan

- [ ] Fresh Docker container, empty DB
- [ ] Navigate to Matrix tab (sees "No data yet")
- [ ] Navigate to Crawlers, run demo import, wait for completion
- [ ] Click "Open Matrix" (or switch to Matrix tab)
- [ ] Matrix renders with demo data — no "Backend not responding" flash, no page refresh needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)