### PR TITLE
docs: distribute reuse-before-creating rule into subdirectory CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## Coding Principles
 
-> **Reuse before creating.** Before writing any function, constant, helper, hook, or component — search the codebase first. If equivalent logic already exists, use or extend it. Only create something new when nothing suitable exists. This applies across all languages in this repo (PowerShell, JavaScript, SQL).
+> **Reuse before creating.** Search before writing any function, constant, helper, hook, or component. Only create something new when nothing suitable exists. Applies across all languages (PowerShell, JavaScript, SQL). See each subdirectory CLAUDE.md for known utilities specific to that layer.
 
 ## Project Overview
 

--- a/Functions/CLAUDE.md
+++ b/Functions/CLAUDE.md
@@ -83,6 +83,18 @@ function Get-FGSQLResource {
 }
 ```
 
+## Reuse Before Creating
+
+Before writing any function — search `Functions/` first. If equivalent logic exists, use or extend it.
+
+**Known function categories to search:**
+- HTTP / auth → `Functions/Base/` (`Invoke-FGGetRequest`, `Invoke-FGPostRequest`, `Get-FGAccessToken`, etc.)
+- Graph API entities → `Functions/Generic/` (users, groups, service principals, access packages, etc.)
+- Data sync → `Functions/Sync/` (`Sync-FGPrincipal`, `Sync-FGResource`, `Sync-FGResourceAssignment`, etc.)
+- SQL operations → `Functions/SQL/` (`Invoke-FGSQLCommand` and table/view helpers)
+- Business logic → `Functions/Specific/`
+- LLM / risk / clustering → `Functions/RiskScoring/`
+
 ## Rules
 
 **DO:**

--- a/app/api/CLAUDE.md
+++ b/app/api/CLAUDE.md
@@ -1,5 +1,17 @@
 # Node.js API — Coding Guide
 
+## Reuse Before Creating
+
+Before writing any helper, utility, middleware, or route logic — search first. If equivalent logic already exists, use or extend it.
+
+**Known shared utilities in `src/`:**
+- `db/connection.js` — connection pool; never create one-off connections
+- `db/columnCache.js` — column discovery with 5-minute TTL; never query `information_schema` per-request
+- `db/migrate.js` — migration runner; add files to `src/db/migrations/`, never edit existing ones
+- `middleware/auth.js` — Entra ID JWT validation (v1 + v2 tokens)
+- `middleware/perfMetrics.js` — request timing + Server-Timing headers
+- `secrets/vault.js` — encrypted secret storage/retrieval for crawler credentials
+
 ## Always Test Locally Before Committing
 
 After any change to the API, rebuild the container and verify the fix before touching git:


### PR DESCRIPTION
## Summary

- Root `CLAUDE.md` slimmed to a one-line cross-cutting principle pointing to subdirectory guides for specifics
- `app/api/CLAUDE.md` — new **Reuse Before Creating** section listing known shared utilities (connection pool, column cache, migration runner, auth/perf middleware, secrets vault)
- `Functions/CLAUDE.md` — new **Reuse Before Creating** section listing all 6 function categories with examples, placed before the DO/DON'T rules
- `app/ui/CLAUDE.md` already had this from the previous refactor PR — no changes needed

## Test plan

- [ ] Verify each CLAUDE.md loads correctly in Claude Code context

🤖 Generated with [Claude Code](https://claude.com/claude-code)