### PR TITLE
chore: disable Issue Triage & Auto-fix workflow

### DIFF
--- a/.github/workflows/issue-autofix.yml
+++ b/.github/workflows/issue-autofix.yml
@@ -32,14 +32,7 @@
 name: Issue Triage & Auto-fix
 
 on:
-  issues:
-    types: [opened]
-
-  schedule:
-    # 21:00 UTC = 23:00 CEST (summer) / 22:00 CET (winter)
-    - cron: '0 21 * * *'
-
-  workflow_dispatch:
+  workflow_dispatch:  # disabled: issues/schedule triggers removed
 
 jobs:
   # ── Job 1: Ensure all required labels exist ────────────────────────────────

--- a/changes/disable-issue-autofix.md
+++ b/changes/disable-issue-autofix.md
@@ -1,0 +1,1 @@
+- Disabled the Issue Triage & Auto-fix GitHub Actions workflow (no longer triggers on new issues or nightly schedule).


### PR DESCRIPTION
## Summary

- Disabled the Issue Triage & Auto-fix GitHub Actions workflow (no longer triggers on new issues or nightly schedule).

## Test plan

- [ ] Confirm workflow no longer appears as a trigger on new issues
- [ ] Confirm workflow can still be triggered manually via workflow_dispatch if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)