### PR TITLE
docs: add Portable Windows Launcher to nav

### DIFF
--- a/changes/docs-nav-desktop-portable.md
+++ b/changes/docs-nav-desktop-portable.md
@@ -1,0 +1,1 @@
+- Added **Portable Windows Launcher** page to the documentation navigation under Architecture.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Plugin Architecture: risk-scoring/plugin-architecture.md
   - Architecture:
       - Docker Setup: architecture/docker-setup.md
+      - Portable Windows Launcher: architecture/desktop-portable.md
       - Release & Branching Strategy: architecture/branching-strategy.md
       - Ingest API: architecture/ingest-api.md
       - Audit History: architecture/audit-history.md


### PR DESCRIPTION
- Added **Portable Windows Launcher** page to the documentation navigation under Architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)