### PR TITLE
fix(auth): accept only api://<clientId> audience — reject id_tokens (H-01)

### DIFF
--- a/app/api/src/middleware/auth.js
+++ b/app/api/src/middleware/auth.js
@@ -85,7 +85,15 @@ export function authMiddleware(req, res, next) {
   const clientId = getClientId();
 
   jwt.verify(token, keyResolver, {
-    audience: [`api://${clientId}`, clientId],
+    // Accept ONLY access tokens issued for our exposed API scope
+    // (aud = api://<clientId>). The bare <clientId> audience is deliberately
+    // NOT accepted: an id_token's aud is the bare client ID, and id_tokens are
+    // minted on every interactive sign-in, cached in browsers/logs, and are not
+    // meant for API authorization (security finding H-01). The SPA already
+    // requests the `api://<clientId>/access` scope, so its access tokens carry
+    // aud = api://<clientId>. (Requires the Entra App ID URI to be the default
+    // `api://<clientId>` — see the setup walkthrough's "Expose an API" step.)
+    audience: `api://${clientId}`,
     issuer: [
       `https://login.microsoftonline.com/${tenantId}/v2.0`,
       `https://sts.windows.net/${tenantId}/`,

--- a/app/api/src/middleware/jwtValidation.test.js
+++ b/app/api/src/middleware/jwtValidation.test.js
@@ -69,9 +69,11 @@ describe('authMiddleware — real RS256 token validation', () => {
     expect(res.body.enabled).toBe(true);
   });
 
-  it('accepts the bare clientId audience too (documents current behaviour — finding H-01)', async () => {
+  it('rejects the bare clientId audience — id_tokens are not accepted (H-01 fixed)', async () => {
+    // An id_token carries aud = bare <clientId>. Only access tokens for the
+    // exposed API scope (aud = api://<clientId>) are accepted.
     const res = await callWith(mint({ aud: CLIENT }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
   });
 
   it('rejects a wrong audience (401)', async () => {

--- a/changes/auth-reject-idtoken.md
+++ b/changes/auth-reject-idtoken.md
@@ -1,0 +1,2 @@
+- Security: the API now accepts only Entra ID **access tokens** issued for its own API scope (audience `api://<client-id>`). ID tokens — and any token whose audience is the bare client ID — are rejected. This prevents an ID token (issued on every interactive sign-in and not intended for API authorization) from being used as an API credential.
+- This requires the Entra App Registration to expose its API with the default `api://<client-id>` Application ID URI, which the in-app setup walkthrough already configures.

--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -98,6 +98,7 @@ The SPA calls `GET /api/auth-me` after sign-in to learn its own permissions and 
 - **Open mode (`AUTH_ENABLED=false`)** — supported for local/evaluation use; all permission gates are bypassed.
 - **Azure App Service** — `AUTH_ENABLED=true` is set from first boot; the Authentication and Containers admin sub-tabs are hidden (managed platform).
 - Tenant/client IDs are configured via `AUTH_TENANT_ID` / `AUTH_CLIENT_ID`; the role→permission mapping is edited live in Admin → Authentication.
+- **Token audience** — the API accepts only access tokens whose audience is `api://<client-id>` (its exposed API scope). ID tokens are rejected. This is why the setup walkthrough has you "Expose an API" with the default `api://<client-id>` Application ID URI.
 
 ## Testing
 


### PR DESCRIPTION
## Security finding H-01 — id_token / bare-clientId audience acceptance

> **Stacked on #197 (C-01).** Base is `bugfixes/auth-fail-closed-no-role`; retarget to `main` once C-01 merges.

`authMiddleware` accepted `audience: ['api://<clientId>', '<clientId>']`. The bare `<clientId>` form is an **id_token's** audience — and id_tokens are minted on every interactive sign-in, cached in browsers/logs, and are not intended for API authorization. Accepting them let an id_token be replayed as an API bearer token. Together with C-01 this was the "roleless token → access" chain.

## The fix

Restrict the accepted audience to **`api://<clientId>`** only — the exposed API scope the SPA already requests (`api://<clientId>/access`). Access tokens are unaffected; id_tokens are rejected.

## Compatibility

- **Standard installs unaffected:** the in-app setup walkthrough's "Expose an API" step uses the default `api://<client-id>` Application ID URI, and the SPA requests that scope, so its access tokens carry `aud = api://<clientId>`.
- Requires that App ID URI to be the default `api://<client-id>` (documented in `permissions.md`). A non-standard install that set the App ID URI to the bare GUID would need to switch to `api://<client-id>`.

## Tests

The `jwtValidation` test that pinned bare-clientId acceptance is **flipped to assert rejection (401)**; the valid `api://<clientId>` access token still passes, and the existing wrong-aud/iss/expiry/tamper/HS256/tenant cases remain. Full suite: 363 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)