### PR TITLE
fix(auth): read-token admin-path guard must use originalUrl (H-08)

### DIFF
--- a/app/api/src/middleware/auth.js
+++ b/app/api/src/middleware/auth.js
@@ -67,7 +67,12 @@ export function authMiddleware(req, res, next) {
     if (req.method !== 'GET') {
       return res.status(403).json({ error: 'Read API keys may only be used for GET requests' });
     }
-    if (req.path.startsWith('/api/admin/')) {
+    // Use originalUrl, not req.path: under app.use('/api', ...) the mount prefix
+    // is stripped from req.path, so a `/api/admin/` check on req.path would never
+    // match — leaving admin GET endpoints reachable with a leaked read token
+    // (security finding H-08). originalUrl preserves the full path (same fix the
+    // fgc_ block above uses).
+    if (req.originalUrl.split('?')[0].startsWith('/api/admin/')) {
       return res.status(403).json({ error: 'Read API keys cannot access admin endpoints' });
     }
     findActiveByPlaintext(token).then(row => {

--- a/app/api/src/middleware/auth.test.js
+++ b/app/api/src/middleware/auth.test.js
@@ -118,6 +118,25 @@ describe('authMiddleware — fgr_ token scoping', () => {
     }
   });
 
+  it('rejects admin paths even when req.path is mount-stripped — uses originalUrl (H-08)', async () => {
+    // Under app.use('/api', ...) Express strips the mount prefix, so the
+    // middleware sees req.path = '/admin/read-tokens' while originalUrl keeps
+    // '/api/admin/read-tokens'. A req.path-based check would miss it and let a
+    // leaked read token reach admin GET endpoints. The guard must use originalUrl.
+    findActive.mockResolvedValue({ id: 7, name: 'x', expiresAt: null, revoked: false });
+    const req = {
+      path: '/admin/read-tokens',             // mount-stripped (what the middleware actually sees)
+      originalUrl: '/api/admin/read-tokens',  // full request path
+      method: 'GET',
+      headers: { authorization: `Bearer ${GOOD_TOKEN}` },
+    };
+    const { res, nextCalled } = await run(req);
+    expect(nextCalled).toBe(false);
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toMatch(/admin/i);
+    expect(findActive).not.toHaveBeenCalled(); // short-circuits before the DB
+  });
+
   it('short-circuits: admin-path check happens before the DB lookup', async () => {
     // Defence in depth: even with a valid token, never touch the DB on a
     // path we're going to reject anyway. Keeps a leaked token that's

--- a/changes/read-token-admin-path.md
+++ b/changes/read-token-admin-path.md
@@ -1,0 +1,1 @@
+- Security: fixed a guard that was meant to keep read-only API keys (`fgr_…`) out of admin endpoints but never actually triggered — it checked the mount-stripped request path instead of the full URL, so a leaked read-only key could reach admin GET endpoints (information disclosure). The check now uses the full request URL and correctly rejects read-only keys on `/api/admin/*`.


### PR DESCRIPTION
## Security finding H-08 — read-token admin-path bypass

The `fgr_` read-only API-key path in `authMiddleware` blocks admin endpoints with:

```js
if (req.path.startsWith('/api/admin/')) return res.status(403)...
```

But the middleware is mounted via `app.use('/api', authMiddleware, ...)`, and Express **strips the mount prefix** from `req.path` — so the middleware sees `req.path = '/admin/read-tokens'`, which never starts with `/api/admin/`. The guard never fires. Combined with the GET-only rule, a **leaked read-only key could reach ungated admin GET endpoints** (dashboard/container stats, risk-profile, classifiers, …) — information disclosure.

## Fix

Use `req.originalUrl` (the full path) — exactly the fix the `fgc_` block immediately above already uses for the same reason. One line:

```js
if (req.originalUrl.split('?')[0].startsWith('/api/admin/')) return res.status(403)...
```

## Tests

Adds a regression test that reproduces the **production** condition (`req.path = '/admin/read-tokens'`, `originalUrl = '/api/admin/read-tokens'`) and asserts a 403 + that the DB lookup is short-circuited. The pre-existing test set `req.path === originalUrl`, so it passed despite the bug — this one fails on the old code and passes on the fix. Full API suite: 364 tests pass.

Independent of the in-flight #201/#202 (different file); branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)