### PR TITLE
fix(ci): repair cut-release, cut-beta and cut-hotfix workflows

### DIFF
--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -43,7 +43,7 @@ jobs:
         id: bot-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Generate release notes
         run: |
           # Find the previous stable release tag (excludes beta/rc/alpha)
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vE '-(beta|rc|alpha)' | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | head -1)
 
           # Slice the CHANGES.md entries that are new since PREV_TAG
           if [ -n "$PREV_TAG" ]; then

--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           token: ${{ steps.bot-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Create and push pre-release tag
         run: |
@@ -82,9 +83,7 @@ jobs:
       - name: Generate release notes
         run: |
           # Find the previous stable release tag (excludes beta/rc/alpha)
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
-            | grep -vE '-(beta|rc|alpha)' \
-            | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vE '-(beta|rc|alpha)' | head -1)
 
           # Slice the CHANGES.md entries that are new since PREV_TAG
           if [ -n "$PREV_TAG" ]; then

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
           token: ${{ steps.bot-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Create and push hotfix tag
         run: |
@@ -80,10 +81,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
-            | grep -vE '-(beta|rc|alpha)' \
-            | grep -v "^${TAG}$" \
-            | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vE '-(beta|rc|alpha)' | grep -v "^${TAG}$" | head -1)
 
           if [ -n "$PREV_TAG" ]; then
             FIRST_OLD=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | head -1)

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vE '-(beta|rc|alpha)' | grep -v "^${TAG}$" | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | grep -v "^${TAG}$" | head -1)
 
           if [ -n "$PREV_TAG" ]; then
             FIRST_OLD=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | head -1)

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -40,7 +40,7 @@ jobs:
         id: bot-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -47,7 +47,7 @@ jobs:
         id: bot-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Generate release notes
         run: |
           # Find the previous stable release tag (excludes beta/rc/alpha)
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vE '-(beta|rc|alpha)' | grep -v "^${TAG}$" | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | grep -v "^${TAG}$" | head -1)
 
           # Slice the CHANGES.md entries that are new since PREV_TAG
           if [ -n "$PREV_TAG" ]; then

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           token: ${{ steps.bot-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Create and push release tag
         run: |
@@ -86,10 +87,7 @@ jobs:
       - name: Generate release notes
         run: |
           # Find the previous stable release tag (excludes beta/rc/alpha)
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
-            | grep -vE '-(beta|rc|alpha)' \
-            | grep -v "^${TAG}$" \
-            | head -1)
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -vE '-(beta|rc|alpha)' | grep -v "^${TAG}$" | head -1)
 
           # Slice the CHANGES.md entries that are new since PREV_TAG
           if [ -n "$PREV_TAG" ]; then

--- a/changes/fix-release-workflows.md
+++ b/changes/fix-release-workflows.md
@@ -1,0 +1,2 @@
+- Fixed: Cut Release, Cut Beta and Cut Hotfix workflows now correctly generate release notes (missing fetch-depth caused grep to fail on the tag list)
+- Fixed: deprecated `app-id` input replaced with `client-id` for the GitHub App token action


### PR DESCRIPTION
## Summary

- Fixed: Cut Release, Cut Beta and Cut Hotfix workflows now correctly generate release notes (missing `fetch-depth: 0` caused the tag list to be empty, making the grep pipeline fail)
- Fixed: deprecated `app-id` input replaced with `client-id` for the GitHub App token action

🤖 Generated with [Claude Code](https://claude.com/claude-code)