### PR TITLE
feat(docs): run mike deploy on every release and hotfix cut

### DIFF
--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -119,6 +119,11 @@ jobs:
             --notes-file release-notes.md \
             --latest
 
+      - name: Deploy versioned docs
+        run: |
+          pip install --quiet mike mkdocs-material
+          mike deploy --push --update-aliases "$VERSION" stable
+
       - name: Post run summary
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" << EOF

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -122,11 +122,7 @@ jobs:
       - name: Deploy versioned docs
         run: |
           pip install --quiet mike mkdocs-material
-          OLD=$(mike list --json 2>/dev/null \
-            | python3 -c "import json,sys; [print(v['version']) for v in json.load(sys.stdin) if 'stable' in v.get('aliases',[])]" \
-            || true)
-          [ -n "$OLD" ] && mike delete --push "$OLD" || true
-          mike deploy --push --update-aliases "$VERSION" stable
+          mike deploy --push --title "$VERSION" stable
 
       - name: Post run summary
         run: |

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -122,6 +122,10 @@ jobs:
       - name: Deploy versioned docs
         run: |
           pip install --quiet mike mkdocs-material
+          OLD=$(mike list --json 2>/dev/null \
+            | python3 -c "import json,sys; [print(v['version']) for v in json.load(sys.stdin) if 'stable' in v.get('aliases',[])]" \
+            || true)
+          [ -n "$OLD" ] && mike delete --push "$OLD" || true
           mike deploy --push --update-aliases "$VERSION" stable
 
       - name: Post run summary

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -132,11 +132,7 @@ jobs:
       - name: Deploy versioned docs
         run: |
           pip install --quiet mike mkdocs-material
-          OLD=$(mike list --json 2>/dev/null \
-            | python3 -c "import json,sys; [print(v['version']) for v in json.load(sys.stdin) if 'stable' in v.get('aliases',[])]" \
-            || true)
-          [ -n "$OLD" ] && mike delete --push "$OLD" || true
-          mike deploy --push --update-aliases "$VERSION" stable
+          mike deploy --push --title "$VERSION" stable
 
       - name: Post run summary
         run: |

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -129,6 +129,11 @@ jobs:
             --notes-file release-notes.md \
             --latest
 
+      - name: Deploy versioned docs
+        run: |
+          pip install --quiet mike mkdocs-material
+          mike deploy --push --update-aliases "$VERSION" stable
+
       - name: Post run summary
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" << EOF

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -132,6 +132,10 @@ jobs:
       - name: Deploy versioned docs
         run: |
           pip install --quiet mike mkdocs-material
+          OLD=$(mike list --json 2>/dev/null \
+            | python3 -c "import json,sys; [print(v['version']) for v in json.load(sys.stdin) if 'stable' in v.get('aliases',[])]" \
+            || true)
+          [ -n "$OLD" ] && mike delete --push "$OLD" || true
           mike deploy --push --update-aliases "$VERSION" stable
 
       - name: Post run summary

--- a/changes/docs-mike-versioning.md
+++ b/changes/docs-mike-versioning.md
@@ -1,0 +1,1 @@
+- Fixed: documentation site version dropdown now updates automatically when a release or hotfix is cut


### PR DESCRIPTION
- Fixed: documentation site version dropdown now updates automatically when a release or hotfix is cut

Adds a `mike deploy --push --update-aliases <version> stable` step to both `cut-release.yml` and `cut-hotfix.yml`, so the docs dropdown stays in sync without manual intervention.