### PR TITLE
fix(contexts): dark-mode variants for context badges/labels (UX audit H3)

### DIFF
--- a/app/ui/src/utils/contextStyles.js
+++ b/app/ui/src/utils/contextStyles.js
@@ -1,24 +1,29 @@
 // Visual language for the Contexts tab.
 // Two orthogonal dimensions — variant (who produced this context) and
 // targetType (what it contains) — each with a distinct visual treatment.
+//
+// Every text/badge class ships with a dark: variant: these metas are consumed
+// raw by every Contexts component, so a missing dark variant breaks the whole
+// tab in dark mode (contextStyles.test.js guards against regressions).
 
 export const VARIANT_META = {
-  synced:    { label: 'Synced',    borderClass: 'border-blue-500',   dotClass: 'bg-blue-500',   textClass: 'text-blue-700' },
-  generated: { label: 'Generated', borderClass: 'border-emerald-500', dotClass: 'bg-emerald-500', textClass: 'text-emerald-700' },
-  manual:    { label: 'Manual',    borderClass: 'border-amber-600',  dotClass: 'bg-amber-600',  textClass: 'text-amber-700' },
+  synced:    { label: 'Synced',    borderClass: 'border-blue-500',    dotClass: 'bg-blue-500',    textClass: 'text-blue-700 dark:text-blue-400' },
+  generated: { label: 'Generated', borderClass: 'border-emerald-500', dotClass: 'bg-emerald-500', textClass: 'text-emerald-700 dark:text-emerald-400' },
+  manual:    { label: 'Manual',    borderClass: 'border-amber-600',   dotClass: 'bg-amber-600',   textClass: 'text-amber-700 dark:text-amber-400' },
 };
 
 export const TARGET_TYPE_META = {
-  Identity:  { label: 'Identity',  badgeClass: 'bg-purple-100 text-purple-700 border-purple-200' },
-  Resource:  { label: 'Resource',  badgeClass: 'bg-orange-100 text-orange-700 border-orange-200' },
-  Principal: { label: 'Principal', badgeClass: 'bg-gray-100 text-gray-700 border-gray-200' },
-  System:    { label: 'System',    badgeClass: 'bg-yellow-100 text-yellow-800 border-yellow-200' },
+  Identity:  { label: 'Identity',  badgeClass: 'bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-700' },
+  Resource:  { label: 'Resource',  badgeClass: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-700' },
+  // Principal gets its own hue (sky) so it isn't visually identical to the Unknown fallback.
+  Principal: { label: 'Principal', badgeClass: 'bg-sky-100 text-sky-700 border-sky-200 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-700' },
+  System:    { label: 'System',    badgeClass: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700' },
 };
 
 export function variantMeta(variant) {
-  return VARIANT_META[variant] || { label: variant || 'Unknown', borderClass: 'border-gray-300', dotClass: 'bg-gray-300', textClass: 'text-gray-600' };
+  return VARIANT_META[variant] || { label: variant || 'Unknown', borderClass: 'border-gray-300', dotClass: 'bg-gray-300', textClass: 'text-gray-600 dark:text-gray-400' };
 }
 
 export function targetTypeMeta(t) {
-  return TARGET_TYPE_META[t] || { label: t || 'Unknown', badgeClass: 'bg-gray-100 text-gray-700 border-gray-200' };
+  return TARGET_TYPE_META[t] || { label: t || 'Unknown', badgeClass: 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600' };
 }

--- a/app/ui/src/utils/contextStyles.test.js
+++ b/app/ui/src/utils/contextStyles.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { VARIANT_META, TARGET_TYPE_META, variantMeta, targetTypeMeta } from './contextStyles';
+
+// These metas are applied raw (no per-call dark: overrides) by every Contexts
+// component, so a colour class without a dark: variant breaks the whole tab in
+// dark mode. Guard against that regressing.
+
+describe('contextStyles dark-mode coverage', () => {
+  it('every variant textClass has a dark: variant', () => {
+    for (const [key, meta] of Object.entries(VARIANT_META)) {
+      expect(meta.textClass, `VARIANT_META.${key}.textClass`).toMatch(/dark:/);
+    }
+  });
+
+  it('every target-type badgeClass has a dark: variant', () => {
+    for (const [key, meta] of Object.entries(TARGET_TYPE_META)) {
+      expect(meta.badgeClass, `TARGET_TYPE_META.${key}.badgeClass`).toMatch(/dark:/);
+    }
+  });
+
+  it('the unknown/fallback metas also carry dark: variants', () => {
+    expect(variantMeta('nope').textClass).toMatch(/dark:/);
+    expect(targetTypeMeta('nope').badgeClass).toMatch(/dark:/);
+  });
+
+  it('Principal is visually distinct from the Unknown fallback', () => {
+    expect(TARGET_TYPE_META.Principal.badgeClass).not.toEqual(targetTypeMeta('nope').badgeClass);
+  });
+});

--- a/changes/ux-contexts-darkmode.md
+++ b/changes/ux-contexts-darkmode.md
@@ -1,0 +1,1 @@
+- Fixed the Contexts tab in dark mode: the variant labels (Synced / Generated / Manual) and target-type badges (Identity / Resource / Principal / System) now render with proper dark-mode colours instead of washed-out pastel chips. "Principal" also gets its own colour so it's no longer visually identical to an unknown type.


### PR DESCRIPTION
## UX audit — High finding H3

`utils/contextStyles.js` shipped **zero `dark:` variants** and is consumed raw by every Contexts component (`ContextListView`, `ContextTreeView`, `ContextPicker`, `ContextsPage`, `RunPluginModal`, …), so the **entire Contexts tab was broken in dark mode** — washed-out pastel chips and low-contrast text. This violates the project's "every component must support dark mode" rule.

## Change
- Added `dark:` variants to every `textClass` (variants) and `badgeClass` (target types), plus the unknown/fallback metas.
- Gave **Principal** its own hue (sky) so it's no longer visually identical to the "Unknown" fallback.
- `contextStyles.test.js` guards dark-variant coverage so this can't regress.

## Scope
Centralized style fix — resolves the badge/label dark mode across the whole tab in one place. (Component-level bare `<input>`/table dark-mode in the context modals is a separate follow-up.)

## Validation
ESLint clean; `contextStyles.test.js` passes (4 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)