### PR TITLE
fix(ui): remove SOLL / Access-Package jargon from user-facing strings (UX H17)

### DIFF
--- a/app/ui/src/components/DashboardTrendsTab.jsx
+++ b/app/ui/src/components/DashboardTrendsTab.jsx
@@ -90,7 +90,7 @@ export default function DashboardTrendsTab() {
         <div className="flex items-start justify-between mb-2">
           <div>
             <div className="text-sm font-medium text-gray-800 dark:text-gray-200">Governed assignments — % of total</div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">How much of your access is wrapped by an Access Package or Business Role.</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">How much of your access is granted through a Business Role.</div>
           </div>
           {latest && (
             <div className="text-right">

--- a/app/ui/src/terminology.test.js
+++ b/app/ui/src/terminology.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Guards against internal/legacy jargon leaking back into user-facing strings.
+// Targeted at specific files + phrases so it won't false-positive on code
+// comments. Seed of the "terminology linter" proposed in the UX audit.
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel) => readFileSync(join(here, rel), 'utf8');
+
+describe('user-facing terminology', () => {
+  it('Excel export does not use the German "SOLL" jargon', () => {
+    expect(read('utils/exportToExcel.js')).not.toContain('SOLL');
+  });
+
+  it('Dashboard Trends presents Business Role as one concept (not "Access Package or Business Role")', () => {
+    expect(read('components/DashboardTrendsTab.jsx')).not.toContain('Access Package or Business Role');
+  });
+});

--- a/app/ui/src/utils/exportToExcel.js
+++ b/app/ui/src/utils/exportToExcel.js
@@ -93,7 +93,7 @@ export async function exportToExcel({ users, orderedGroups, memberships, managed
       ws.mergeCells(1, apColStart, 1, apColStart + apCount - 1);
     }
     const apBanner = ws.getCell(1, apColStart);
-    apBanner.value = 'Business Roles (SOLL)';
+    apBanner.value = 'Governed (via Business Roles)';
     apBanner.font = { size: 11, bold: true, color: { argb: 'FF3730A3' } };
     apBanner.alignment = { textRotation: 90, vertical: 'bottom', horizontal: 'center' };
     apBanner.fill = {

--- a/changes/ux-terminology.md
+++ b/changes/ux-terminology.md
@@ -1,0 +1,1 @@
+- Terminology consistency: the Excel export header no longer shows the internal German label "SOLL" (now "Governed (via Business Roles)"), and the Dashboard governance trend now describes access as granted through a **Business Role** rather than "an Access Package or Business Role" (they are the same thing).


### PR DESCRIPTION
## UX audit — High finding H17 (terminology)

- The Excel export header read **"Business Roles (SOLL)"** — leaking the internal German governance term to users. → **"Governed (via Business Roles)"**.
- The Dashboard governance trend read **"wrapped by an Access Package or Business Role"**, presenting one concept as two. → **"granted through a Business Role"**.

First slice of the terminology cleanup. Adds `terminology.test.js`, a targeted guard so these jargon strings can't return (seed of the "terminology linter" from the audit). Remaining items (OU/Org-Units, route vocabulary) will come with the app-shell PR.

## Validation
ESLint clean; `terminology.test.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)