### PR TITLE
fix(systems): replace stale Start-FGSync onboarding with a crawler CTA (UX H12)

### DIFF
--- a/app/ui/src/components/EmptyState.jsx
+++ b/app/ui/src/components/EmptyState.jsx
@@ -1,0 +1,22 @@
+// Reusable empty / onboarding state. Standardises the "nothing here yet" panels
+// that were previously hand-rolled (and inconsistent) across list pages, and
+// lets each one offer a real next step instead of dead-ending the user.
+
+export default function EmptyState({ title, hint, actionLabel, onAction, icon }) {
+  return (
+    <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center bg-white dark:bg-gray-800">
+      {icon && <div className="mb-2 text-3xl" aria-hidden="true">{icon}</div>}
+      <h3 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">{title}</h3>
+      {hint && <p className="mx-auto mb-4 max-w-xl text-sm text-gray-600 dark:text-gray-400">{hint}</p>}
+      {actionLabel && onAction && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/ui/src/components/SystemsPage.jsx
+++ b/app/ui/src/components/SystemsPage.jsx
@@ -1,5 +1,6 @@
 ﻿import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../auth/AuthGate';
+import EmptyState from './EmptyState';
 
 function formatRelativeTime(dateStr) {
   if (!dateStr) return 'Never';
@@ -67,9 +68,12 @@ export default function SystemsPage() {
       </div>
 
       {systems.length === 0 ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          No systems configured. Run <code className="bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded text-sm dark:text-gray-200">Start-FGSync</code> to sync data and register systems.
-        </div>
+        <EmptyState
+          title="No systems yet"
+          hint="Systems are registered automatically when a crawler runs. Add a crawler to connect a source (Entra ID, CSV, …) and import data."
+          actionLabel="Add a crawler →"
+          onAction={() => { window.location.hash = 'admin?sub=crawlers'; }}
+        />
       ) : (
         <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2">
           {systems.map(sys => {

--- a/app/ui/src/components/SystemsPage.test.js
+++ b/app/ui/src/components/SystemsPage.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'SystemsPage.jsx'), 'utf8');
+
+describe('Systems page onboarding', () => {
+  it('no longer instructs users to run the stale Start-FGSync CLI command', () => {
+    expect(src).not.toContain('Start-FGSync');
+  });
+
+  it('points users to the supported "Add a crawler" path instead', () => {
+    expect(src).toContain('Add a crawler');
+    expect(src).toContain('EmptyState');
+  });
+});

--- a/changes/ux-systems-onboarding.md
+++ b/changes/ux-systems-onboarding.md
@@ -1,0 +1,1 @@
+- The Systems page no longer dead-ends new users with a stale `Start-FGSync` command. Its empty state now guides you to **Add a crawler** (the supported path), matching the Dashboard and Sync Log. Added a reusable empty-state panel for consistent onboarding across the app.


### PR DESCRIPTION
## UX audit — High finding H12 (onboarding dead-ends)

The Systems page's empty state instructed users to *"Run `Start-FGSync`…"* — a command a Dockerized-product user can't run — so it dead-ended new users, inconsistent with the Dashboard and Sync Log, which guide to **Admin → Crawlers**.

## Change
- New reusable `components/EmptyState.jsx` (title / hint / optional CTA) — standardises the hand-rolled empty panels.
- Systems empty state now uses it: *"No systems yet — systems are registered automatically when a crawler runs"* + an **"Add a crawler →"** button to Admin → Crawlers.

First slice of the onboarding-consistency work; the list pages (Users/Resources/…) can adopt `EmptyState` next.

## Validation
ESLint clean; `SystemsPage.test.js` guards that the stale CLI is gone and the CTA is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)