### PR TITLE
fix(ui): dark-mode for compliance + account-type badges (UX audit H4)

### DIFF
--- a/app/ui/src/components/AccessPackagesPage.jsx
+++ b/app/ui/src/components/AccessPackagesPage.jsx
@@ -9,10 +9,10 @@ import { ASSIGNMENT_TYPE_STYLES } from '../utils/accessPackageStyles';
 const PAGE_SIZE = 100;
 
 const COMPLIANCE_STYLES = {
-  'Compliant': 'bg-green-100 text-green-800 border-green-200',
-  'In Progress': 'bg-blue-100 text-blue-800 border-blue-200',
-  'Missed': 'bg-red-100 text-red-800 border-red-200',
-  'Reviewed Late': 'bg-amber-100 text-amber-800 border-amber-200',
+  'Compliant': 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700',
+  'In Progress': 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700',
+  'Missed': 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700',
+  'Reviewed Late': 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700',
 };
 
 const ASSIGNMENT_TYPES = ['Auto-assigned', 'Request-based', 'Request-based with auto-removal', 'Both'];

--- a/app/ui/src/components/UserDetailPage.jsx
+++ b/app/ui/src/components/UserDetailPage.jsx
@@ -303,12 +303,12 @@ export default function UserDetailPage({ userId, cachedData, onCacheData, onClos
 // ─── Identity Membership banner — unchanged from v1 ────────────────────
 
 const ACCOUNT_TYPE_COLORS = {
-  Regular:  'bg-blue-100 text-blue-800 border-blue-200',
-  Admin:    'bg-red-100 text-red-800 border-red-200',
-  Test:     'bg-amber-100 text-amber-800 border-amber-200',
-  Service:  'bg-purple-100 text-purple-800 border-purple-200',
-  Shared:   'bg-teal-100 text-teal-800 border-teal-200',
-  External: 'bg-gray-100 text-gray-600 border-gray-200',
+  Regular:  'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700',
+  Admin:    'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700',
+  Test:     'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700',
+  Service:  'bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-700',
+  Shared:   'bg-teal-100 text-teal-800 border-teal-200 dark:bg-teal-900/30 dark:text-teal-300 dark:border-teal-700',
+  External: 'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600',
 };
 
 function IdentityMembershipSection({ identityInfo, onNavigateToIdentities }) {

--- a/app/ui/src/components/badgeDarkMode.test.js
+++ b/app/ui/src/components/badgeDarkMode.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// The compliance + account-type badge maps are applied raw (no per-call dark:
+// override), so each colour entry must carry a dark: variant or the badge is
+// a bright pastel block on a dark surface. Guard the dark coverage.
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (f) => readFileSync(join(here, f), 'utf8');
+
+describe('status/account badge dark-mode coverage', () => {
+  it('AccessPackages COMPLIANCE_STYLES all carry dark: variants', () => {
+    const src = read('AccessPackagesPage.jsx');
+    for (const tok of ['dark:bg-green-900/30', 'dark:bg-blue-900/30', 'dark:bg-red-900/30', 'dark:bg-amber-900/30']) {
+      expect(src, tok).toContain(tok);
+    }
+  });
+
+  it('UserDetail ACCOUNT_TYPE_COLORS all carry dark: variants', () => {
+    const src = read('UserDetailPage.jsx');
+    for (const tok of ['dark:bg-blue-900/30', 'dark:bg-red-900/30', 'dark:bg-amber-900/30', 'dark:bg-purple-900/30', 'dark:bg-teal-900/30', 'dark:bg-gray-800']) {
+      expect(src, tok).toContain(tok);
+    }
+  });
+});

--- a/changes/ux-badge-darkmode.md
+++ b/changes/ux-badge-darkmode.md
@@ -1,0 +1,1 @@
+- Fixed dark-mode rendering of status badges: the Business-Role review-compliance badges (Compliant / In Progress / Missed / Reviewed Late) and the account-type badges (Regular / Admin / Test / Service / Shared / External) now use proper dark colours instead of bright pastel blocks on a dark background.


### PR DESCRIPTION
## UX audit — High finding H4 (dark-mode gaps)

Two badge colour maps shipped **light-only** (no `dark:` variants), so they rendered as bright pastel blocks on dark surfaces:
- `COMPLIANCE_STYLES` (Business-Role review status: Compliant / In Progress / Missed / Reviewed Late) — `AccessPackagesPage.jsx`
- `ACCOUNT_TYPE_COLORS` (Regular / Admin / Test / Service / Shared / External) — `UserDetailPage.jsx`

## Change
Added `dark:` variants to every entry (e.g. `dark:bg-green-900/30 dark:text-green-300 dark:border-green-700`), and lifted External's borderline `text-gray-600` to a readable dark variant. `badgeDarkMode.test.js` guards the coverage.

## Validation
ESLint clean; `badgeDarkMode.test.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)