### PR TITLE
fix(run-detail): "Go there now" navigates to Contexts, not context:null (UX F2)

### DIFF
--- a/app/ui/src/components/RunDetailPage.jsx
+++ b/app/ui/src/components/RunDetailPage.jsx
@@ -9,7 +9,7 @@ import { formatDurationMs } from '../utils/formatters';
 
 const TERMINAL = new Set(['succeeded', 'failed']);
 
-export default function RunDetailPage({ runId, onClose, onOpenDetail }) {
+export default function RunDetailPage({ runId, onClose }) {
   const { authFetch } = useAuth();
   const [run, setRun] = useState(null);
   const [error, setError] = useState(null);
@@ -142,19 +142,14 @@ export default function RunDetailPage({ runId, onClose, onOpenDetail }) {
       </div>
 
       {run.status === 'succeeded' && (
-        <p className="text-center text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
-          Generated contexts are visible in the Contexts tab.
-          {onOpenDetail && (
-            <>
-              {' '}
-              <button
-                onClick={() => onOpenDetail?.('context', null)}
-                className="text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                Go there now →
-              </button>
-            </>
-          )}
+        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+          Generated contexts are visible in the Contexts tab.{' '}
+          <button
+            onClick={() => { window.location.hash = 'contexts'; }}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Go there now →
+          </button>
         </p>
       )}
     </div>

--- a/app/ui/src/components/RunDetailPage.test.js
+++ b/app/ui/src/components/RunDetailPage.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'RunDetailPage.jsx'), 'utf8');
+
+describe('Run detail — "Go there now" navigation', () => {
+  it('no longer opens a context detail tab with a null id', () => {
+    expect(src).not.toMatch(/onOpenDetail\?\.\('context',\s*null\)/);
+  });
+  it('navigates to the Contexts page instead', () => {
+    expect(src).toContain("window.location.hash = 'contexts'");
+  });
+});

--- a/changes/ux-rundetail-nav.md
+++ b/changes/ux-rundetail-nav.md
@@ -1,0 +1,1 @@
+- Fixed the run-detail "Go there now →" link, which opened a broken/empty detail tab; it now correctly navigates to the Contexts page. Also cleaned up a dark-mode style glitch on that screen.


### PR DESCRIPTION
## UX audit — finding F2

On a successful run, the **"Go there now →"** link called `onOpenDetail('context', null)`, which opens a detail tab with a **null id** → fetches `/api/contexts/null` → error card. The intent was to go to the **Contexts page**, not a context detail.

## Change
- Navigate via `window.location.hash = 'contexts'` (the pattern used elsewhere), and drop the now-unused `onOpenDetail` prop.
- Bonus: removed a doubled/contradictory `dark:` class on the same line (one of the botched-dark-pass glitches the audit flagged).

## Validation
ESLint clean (no unused-prop warning); `RunDetailPage.test.js` guards the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)