### PR TITLE
fix(sync-log): guard null RecordCount so one bad row can't crash the page (UX)

### DIFF
--- a/app/ui/src/components/SyncLogPage.jsx
+++ b/app/ui/src/components/SyncLogPage.jsx
@@ -85,7 +85,7 @@ export default function SyncLogPage() {
                   <td className="px-3 py-2 text-gray-600 dark:text-gray-400 tabular-nums">{formatDateTime(log.StartTime)}</td>
                   <td className="px-3 py-2 text-gray-500 dark:text-gray-400">{formatTimeAgo(log.StartTime)}</td>
                   <td className="px-3 py-2 text-right text-gray-600 dark:text-gray-400 tabular-nums">{formatDuration(log.DurationSeconds)}</td>
-                  <td className="px-3 py-2 text-right text-gray-900 dark:text-white tabular-nums">{log.RecordCount.toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right text-gray-900 dark:text-white tabular-nums">{(log.RecordCount ?? 0).toLocaleString()}</td>
                   <td className="px-3 py-2">
                     <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${statusColors[log.Status] || 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}`}>
                       {log.Status}

--- a/app/ui/src/components/SyncLogPage.test.js
+++ b/app/ui/src/components/SyncLogPage.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'SyncLogPage.jsx'), 'utf8');
+
+describe('Sync Log record count', () => {
+  it('guards a null/undefined RecordCount so a single bad row cannot crash the page', () => {
+    // Must not call .toLocaleString() directly on the possibly-null field.
+    expect(src).not.toMatch(/log\.RecordCount\.toLocaleString\(\)/);
+    expect(src).toContain('(log.RecordCount ?? 0).toLocaleString()');
+  });
+});

--- a/changes/ux-synclog-guard.md
+++ b/changes/ux-synclog-guard.md
@@ -1,0 +1,1 @@
+- Hardened the Sync Log: a row with a missing record count no longer crashes the page (it now shows 0).


### PR DESCRIPTION
## UX audit — finding (Sync Log robustness)

`SyncLogPage` rendered `{log.RecordCount.toLocaleString()}` directly. A failed run with no record count is `null`, so `.toLocaleString()` throws — and since it's inside the table render, one bad row blanks the **entire Sync Log** via the error boundary (on the very page used to diagnose failures).

## Change
`(log.RecordCount ?? 0).toLocaleString()`. Guard test added.

## Validation
ESLint clean (the one warning is pre-existing, unrelated); `SyncLogPage.test.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)