### PR TITLE
fix(dashboard): distinguish a load error from an empty database (UX H15)

### DIFF
--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -42,21 +42,31 @@ export default function DashboardPage({ onNavigate }) {
   const [stats, setStats] = useState(null);
   const [version, setVersion] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);   // dashboard-stats fetch failed (≠ empty DB)
+  const [reloadKey, setReloadKey] = useState(0);
   const [tab, setTab] = useState('overview');  // 'overview' | 'trends'
 
   useEffect(() => {
     let cancelled = false;
+    const STATS_ERR = Symbol('stats-error');
+    setLoading(true);
+    setError(false);
     Promise.all([
-      authFetch('/api/admin/dashboard-stats').then(r => r.ok ? r.json() : null).catch(() => null),
+      authFetch('/api/admin/dashboard-stats')
+        .then(r => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .catch(() => STATS_ERR),
       authFetch('/api/version').then(r => r.ok ? r.json() : null).catch(() => null),
     ]).then(([s, v]) => {
       if (cancelled) return;
-      setStats(s);
+      // Distinguish a failed stats fetch from a genuinely empty database — the
+      // former must NOT show the "configure a crawler" onboarding CTA.
+      if (s === STATS_ERR) { setError(true); setStats(null); }
+      else { setStats(s); }
       setVersion(v);
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [authFetch]);
+  }, [authFetch, reloadKey]);
 
   const hasData = stats?.hasData;
 
@@ -156,6 +166,20 @@ export default function DashboardPage({ onNavigate }) {
 
           {loading ? (
             <div className="text-sm text-gray-500 dark:text-gray-400">Loading…</div>
+          ) : error ? (
+            <div className="rounded-lg border border-red-200 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-6 text-center">
+              <h3 className="mb-1 text-base font-semibold text-red-800 dark:text-red-300">Couldn&apos;t load the dashboard</h3>
+              <p className="mx-auto mb-4 max-w-md text-sm text-red-700 dark:text-red-400">
+                There was a problem reaching the server. This is a load error — not an empty database, so your data is safe.
+              </p>
+              <button
+                type="button"
+                onClick={() => setReloadKey(k => k + 1)}
+                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
+              >
+                Retry
+              </button>
+            </div>
           ) : !hasData ? (
             <NoDataState onNavigate={onNavigate} />
           ) : (

--- a/app/ui/src/components/DashboardPage.test.js
+++ b/app/ui/src/components/DashboardPage.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'DashboardPage.jsx'), 'utf8');
+
+describe('Dashboard error vs empty', () => {
+  it('distinguishes a failed stats fetch from an empty database', () => {
+    expect(src).toContain('setError(true)');      // a real error path exists
+    expect(src).toContain('load the dashboard');  // distinct error UI, not the onboarding CTA
+  });
+  it('offers a retry that re-runs the fetch', () => {
+    expect(src).toContain('setReloadKey');
+  });
+});

--- a/changes/ux-dashboard-error.md
+++ b/changes/ux-dashboard-error.md
@@ -1,0 +1,1 @@
+- The Dashboard now tells the difference between "couldn't reach the server" and "no data yet". A load error shows a clear retry message instead of the "configure a crawler" onboarding panel, so a transient backend hiccup no longer looks like your data disappeared.


### PR DESCRIPTION
## UX audit — High finding H15

Both dashboard fetches did `.catch(() => null)`, so a **failed** `dashboard-stats` call left `stats=null` → `hasData` falsy → the **"No data — configure a crawler"** onboarding panel. A transient backend error therefore looked to an existing customer like their data had disappeared.

## Change
- Track a real `error` state (distinguished from empty via a sentinel on the stats fetch).
- Render a distinct **"Couldn't load the dashboard — Retry"** panel (with reassurance that it's a load error, not data loss) instead of the onboarding CTA.
- The Retry button re-runs the fetch (`reloadKey`).

## Validation
ESLint clean (0 errors; the set-state-in-effect note is the existing house pattern); `vite build` passes; `DashboardPage.test.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)