### PR TITLE
feat(ci): design-system lint gate (no native dialogs, no legacy jargon)

### DIFF
--- a/app/ui/eslint-rules/no-legacy-jargon.js
+++ b/app/ui/eslint-rules/no-legacy-jargon.js
@@ -1,0 +1,50 @@
+// ESLint rule: no-legacy-jargon
+//
+// Keeps internal/legacy jargon out of user-facing strings. Operates on string
+// literals and JSX text only (code comments are intentionally NOT checked).
+// See the UI Style Guide § Terminology.
+//
+//   SOLL / IST   -> Governed / Non-governed
+//   Org Unit(s)  -> Context
+//   Start-FGSync -> "Add a crawler in Admin → Crawlers"
+
+const PATTERNS = [
+  { re: /\bSOLL\b/, term: 'SOLL', use: 'Governed' },
+  { re: /\bIST\b/, term: 'IST', use: 'Non-governed' },
+  { re: /\bOrg Units?\b/i, term: 'Org Unit', use: 'Context' },
+  { re: /Start-FGSync/, term: 'Start-FGSync', use: 'an in-app crawler' },
+];
+
+function check(context, node, text) {
+  if (typeof text !== 'string') return;
+  for (const { re, term, use } of PATTERNS) {
+    if (re.test(text)) {
+      context.report({ node, messageId: 'legacyJargon', data: { term, use } });
+      break; // one report per node is enough
+    }
+  }
+}
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Disallow legacy/internal jargon in user-facing strings.' },
+    messages: {
+      legacyJargon: 'Avoid "{{term}}" in user-facing text — use "{{use}}" (see the UI Style Guide § Terminology).',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') check(context, node, node.value);
+      },
+      JSXText(node) {
+        check(context, node, node.value);
+      },
+      TemplateElement(node) {
+        check(context, node, node.value?.cooked ?? node.value?.raw);
+      },
+    };
+  },
+};

--- a/app/ui/eslint-rules/no-native-dialogs.js
+++ b/app/ui/eslint-rules/no-native-dialogs.js
@@ -1,0 +1,40 @@
+// ESLint rule: no-native-dialogs
+//
+// Flags native window.confirm() / alert() / prompt(). They're unstyled, not
+// dark-mode aware, block the thread, and aren't testable — use an in-app
+// confirm dialog / toast instead. See the UI Style Guide.
+//
+// Matches bare calls (confirm(...)) and member calls (window.confirm(...),
+// globalThis.alert(...)). Pre-existing offenders are downgraded to a warning
+// via a file allowlist in eslint.config.js; new code is an error.
+
+const BANNED = new Set(['confirm', 'alert', 'prompt']);
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Disallow native confirm/alert/prompt dialogs; use an in-app dialog or toast.' },
+    messages: {
+      nativeDialog: "Avoid native {{name}}() — use an in-app dialog/toast (see the UI Style Guide).",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const c = node.callee;
+        let name = null;
+        if (c.type === 'Identifier' && BANNED.has(c.name)) {
+          name = c.name;
+        } else if (
+          c.type === 'MemberExpression' && !c.computed &&
+          c.property.type === 'Identifier' && BANNED.has(c.property.name) &&
+          c.object.type === 'Identifier' && (c.object.name === 'window' || c.object.name === 'globalThis')
+        ) {
+          name = c.property.name;
+        }
+        if (name) context.report({ node, messageId: 'nativeDialog', data: { name } });
+      },
+    };
+  },
+};

--- a/app/ui/eslint.config.js
+++ b/app/ui/eslint.config.js
@@ -2,6 +2,22 @@ import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import noLowContrastText from './eslint-rules/no-low-contrast-text.js';
+import noNativeDialogs from './eslint-rules/no-native-dialogs.js';
+import noLegacyJargon from './eslint-rules/no-legacy-jargon.js';
+
+// Files that still use native confirm()/alert()/prompt() (the pre-existing
+// backlog). They're downgraded to a warning so CI stays green while new code
+// is gated as an error. Remove a file from this list once it's migrated to an
+// in-app dialog/toast. See the UI Style Guide § Enforcement.
+const NATIVE_DIALOG_ALLOWLIST = [
+  '**/components/AccessPackagesPage.jsx',
+  '**/components/AdminPage.jsx',
+  '**/components/CrawlersPage.jsx',
+  '**/components/RiskProfileWizard.jsx',
+  '**/components/RolesPermissionsSection.jsx',
+  '**/components/matrix/MatrixFilterWizard.jsx',
+  '**/hooks/useEntityPage.js',
+];
 
 export default [
   { ignores: ['dist', 'playwright-report', 'test-results'] },
@@ -19,11 +35,19 @@ export default [
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
-      'local': { rules: { 'no-low-contrast-text': noLowContrastText } },
+      'local': {
+        rules: {
+          'no-low-contrast-text': noLowContrastText,
+          'no-native-dialogs': noNativeDialogs,
+          'no-legacy-jargon': noLegacyJargon,
+        },
+      },
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       'local/no-low-contrast-text': 'error',
+      'local/no-native-dialogs': 'error',
+      'local/no-legacy-jargon': 'error',
       // React Compiler strict rules — downgrade to warnings until data-fetching
       // patterns are refactored to avoid setState-in-effect (requires Suspense or
       // useTransition migration across all detail pages).
@@ -34,6 +58,17 @@ export default [
         { allowConstantExport: true },
       ],
     },
+  },
+  {
+    // Pre-existing native-dialog offenders: warn (don't fail CI) until migrated.
+    files: NATIVE_DIALOG_ALLOWLIST,
+    rules: { 'local/no-native-dialogs': 'warn' },
+  },
+  {
+    // The jargon rule definition, tests, and e2e specs legitimately contain the
+    // banned terms (as patterns / assertions / test names) — don't flag them.
+    files: ['eslint-rules/**', '**/*.test.{js,jsx}', 'e2e/**'],
+    rules: { 'local/no-legacy-jargon': 'off' },
   },
   {
     // Playwright E2E tests run in Node.js, not the browser

--- a/app/ui/src/__tests__/design-system-eslint-rules.test.js
+++ b/app/ui/src/__tests__/design-system-eslint-rules.test.js
@@ -1,0 +1,38 @@
+// Unit tests for the design-system ESLint rules (the "CI test" half of the
+// UI Style Guide). Uses ESLint's Linter API so they run under vitest without
+// the RuleTester test-framework coupling.
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import noNativeDialogs from '../../eslint-rules/no-native-dialogs.js';
+import noLegacyJargon from '../../eslint-rules/no-legacy-jargon.js';
+
+const linter = new Linter();
+function lint(code, name, rule) {
+  return linter.verify(code, {
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module', parserOptions: { ecmaFeatures: { jsx: true } } },
+    plugins: { local: { rules: { [name]: rule } } },
+    rules: { [`local/${name}`]: 'error' },
+  });
+}
+
+describe('no-native-dialogs', () => {
+  it('flags confirm/alert/prompt (bare and window.*/globalThis.*)', () => {
+    expect(lint("confirm('x')", 'no-native-dialogs', noNativeDialogs)).toHaveLength(1);
+    expect(lint("window.alert('x')", 'no-native-dialogs', noNativeDialogs)).toHaveLength(1);
+    expect(lint("globalThis.prompt('x')", 'no-native-dialogs', noNativeDialogs)).toHaveLength(1);
+  });
+  it('allows unrelated calls', () => {
+    expect(lint("toast('x'); doConfirmThing();", 'no-native-dialogs', noNativeDialogs)).toHaveLength(0);
+  });
+});
+
+describe('no-legacy-jargon', () => {
+  it('flags banned terms in user-facing strings', () => {
+    expect(lint("const s = 'Business Roles (SOLL)';", 'no-legacy-jargon', noLegacyJargon)).toHaveLength(1);
+    expect(lint("const s = 'Run Start-FGSync now';", 'no-legacy-jargon', noLegacyJargon)).toHaveLength(1);
+    expect(lint("const s = 'Contexts (Org Units)';", 'no-legacy-jargon', noLegacyJargon)).toHaveLength(1);
+  });
+  it('ignores clean strings', () => {
+    expect(lint("const s = 'Governed via Business Roles';", 'no-legacy-jargon', noLegacyJargon)).toHaveLength(0);
+  });
+});

--- a/app/ui/src/components/CrawlersPage.jsx
+++ b/app/ui/src/components/CrawlersPage.jsx
@@ -1444,7 +1444,7 @@ function GettingStarted({ onAddCrawler }) {
 // csvUploads.js and the schema templates in tools/csv-templates/schema/.
 const CSV_SLOTS = [
   { key: 'systems',              file: 'Systems.csv',              label: 'Systems',                required: false, hint: 'Optional. Columns: ExternalId, DisplayName, SystemType, Description' },
-  { key: 'contexts',             file: 'Contexts.csv',             label: 'Contexts (Org Units)',   required: false, hint: 'Optional. Columns: ExternalId, DisplayName, ContextType, TargetType, Description, ParentExternalId, SystemName, OwnerUserId' },
+  { key: 'contexts',             file: 'Contexts.csv',             label: 'Contexts',               required: false, hint: 'Optional. Columns: ExternalId, DisplayName, ContextType, TargetType, Description, ParentExternalId, SystemName, OwnerUserId' },
   { key: 'context-members',      file: 'ContextMembers.csv',       label: 'Context Members',        required: false, hint: 'Optional. Columns: ContextExternalId, MemberExternalId, MemberType (Identity / Resource / Principal / System).' },
   { key: 'resources',            file: 'Resources.csv',            label: 'Resources',              required: true,  hint: 'Required. Columns: ExternalId, DisplayName, ResourceType, Description, SystemName, Enabled' },
   { key: 'resourceRelationships',file: 'ResourceRelationships.csv',label: 'Resource Relationships', required: false, hint: 'Optional. Columns: ParentExternalId, ChildExternalId, RelationshipType, SystemName' },

--- a/changes/ci-design-system-lint.md
+++ b/changes/ci-design-system-lint.md
@@ -1,0 +1,3 @@
+- Added a CI lint gate that blocks native browser dialogs (`confirm`/`alert`/`prompt`) in new UI code — these aren't styled, dark-mode aware, or testable; use an in-app dialog or toast instead.
+- Added a CI lint gate that keeps legacy/internal jargon (SOLL, IST, "Org Unit", Start-FGSync) out of user-facing UI text, steering contributors to the current terminology (Governed/Non-governed, Context, in-app crawlers).
+- Renamed the stale "Contexts (Org Units)" crawler label to "Contexts".


### PR DESCRIPTION
The **CI test** half of the UI Style Guide (the doc half is #237). Two local ESLint rules turn the style guide's hard rules into a gate that runs on every PR.

## What's enforced
- **`local/no-native-dialogs`** — errors on `confirm()` / `alert()` / `prompt()` (bare, `window.*`, `globalThis.*`). They're unstyled, not dark-mode aware, block the thread, and aren't testable. Use an in-app dialog/toast instead. The pre-existing offenders (7 files) are downgraded to **warn** via a file allowlist so CI stays green — remove a file from the list once it's migrated.
- **`local/no-legacy-jargon`** — errors on `SOLL`, `IST`, `Org Unit(s)`, `Start-FGSync` in user-facing strings (string literals, JSX text, template literals). Rule definitions, tests, and e2e specs are exempt (they legitimately contain the terms). Steers contributors to the current terminology: Governed / Non-governed, Context, in-app crawlers.

## Also
- Renamed the stale **"Contexts (Org Units)"** crawler label → **"Contexts"** (the one genuine offender the new rule surfaced).

## Tests
- `src/__tests__/design-system-eslint-rules.test.js` — unit-tests both rules via ESLint's `Linter` API (4 tests, valid + invalid cases). Verified locally: `eslint .` → 0 errors / 48 warnings (the allowlisted native dialogs), vitest → 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)