### PR TITLE
feat(ui): shared Stepper + unify interactive colour to blue

### DIFF
--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -435,7 +435,7 @@ function ClassifiersSection() {
                 + Add Schedule
               </button>
               <button onClick={handleSaveSchedules} disabled={savingSchedules}
-                className="px-3 py-1.5 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50">
+                className="px-3 py-1.5 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
                 {savingSchedules ? 'Saving...' : 'Save Schedules'}
               </button>
               {scheduleError && <span className="text-xs text-red-600 dark:text-red-400">{scheduleError}</span>}
@@ -464,14 +464,14 @@ function NewCorrelationRulesetLauncher({ onRefresh }) {
   };
 
   return (
-    <div className="bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded-lg p-4 flex items-center justify-between mb-4">
+    <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4 flex items-center justify-between mb-4">
       <div>
-        <div className="text-sm font-medium text-indigo-900 dark:text-indigo-200">Create a new account correlation ruleset</div>
-        <div className="text-xs text-indigo-700 dark:text-indigo-300 mt-0.5">
+        <div className="text-sm font-medium text-blue-900 dark:text-blue-200">Create a new account correlation ruleset</div>
+        <div className="text-xs text-blue-700 dark:text-blue-300 mt-0.5">
           Generates correlation signals and account type rules to link accounts across systems.
         </div>
       </div>
-      <button onClick={() => setOpen(true)} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">
+      <button onClick={() => setOpen(true)} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
         New Ruleset
       </button>
       {open && (
@@ -1183,7 +1183,7 @@ function HistoryRetentionSection() {
         <button
           onClick={save}
           disabled={!dirty || !valid || saving || loading}
-          className="px-4 py-1.5 text-sm font-medium rounded bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:text-gray-500 dark:disabled:text-gray-400"
+          className="px-4 py-1.5 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:text-gray-500 dark:disabled:text-gray-400"
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
@@ -1555,7 +1555,7 @@ function LLMSettingsSection() {
                 type="button"
                 onClick={handleRefreshModels}
                 disabled={modelsLoading || (!config.apiKey && !apiKeySet)}
-                className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 disabled:text-gray-400 dark:disabled:text-gray-600"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200 disabled:text-gray-400 dark:disabled:text-gray-600"
                 title={(!config.apiKey && !apiKeySet) ? 'Enter an API key first' : 'Fetch available models from the provider'}
               >
                 {modelsLoading ? 'Loading…' : models ? 'Refresh' : 'Discover models'}
@@ -1645,7 +1645,7 @@ function LLMSettingsSection() {
           <button
             onClick={handleSave}
             disabled={saving}
-            className="px-4 py-1.5 text-sm font-medium rounded bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:text-gray-500"
+            className="px-4 py-1.5 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:text-gray-500"
           >
             {saving ? 'Saving…' : 'Save'}
           </button>
@@ -1697,14 +1697,14 @@ function NewRiskProfileLauncher({ onRiskScoresRefresh }) {
   const [open, setOpen] = useState(false);
   const [bumpKey, setBumpKey] = useState(0);
   return (
-    <div className="bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded-lg p-4 flex items-center justify-between">
+    <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4 flex items-center justify-between">
       <div>
-        <div className="text-sm font-medium text-indigo-900 dark:text-indigo-200">Create a new risk profile</div>
-        <div className="text-xs text-indigo-700 dark:text-indigo-300 mt-0.5">
+        <div className="text-sm font-medium text-blue-900 dark:text-blue-200">Create a new risk profile</div>
+        <div className="text-xs text-blue-700 dark:text-blue-300 mt-0.5">
           Walks you through generating an organisational profile and classifier set with the LLM, then optionally runs a scoring pass.
         </div>
       </div>
-      <button onClick={() => setOpen(true)} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">
+      <button onClick={() => setOpen(true)} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
         New profile
       </button>
       {open && (
@@ -1826,7 +1826,7 @@ function AdminSubTabs({ activeTab, onTabChange, tabs }) {
             onClick={() => onTabChange(tab.key)}
             className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
               activeTab === tab.key
-                ? 'border-indigo-600 text-indigo-700 dark:text-indigo-400'
+                ? 'border-blue-600 text-blue-700 dark:text-blue-400'
                 : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600'
             }`}
           >

--- a/app/ui/src/components/CorrelationWizard.jsx
+++ b/app/ui/src/components/CorrelationWizard.jsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '../auth/AuthGate';
+import Stepper from './Stepper';
 
 const STEPS = [
   { key: 'sources',   label: 'Sources' },
@@ -176,22 +177,8 @@ export default function CorrelationWizard({ onClose, onSaved }) {
     <Modal onClose={onClose} title="Account Correlation Wizard">
       <div className="flex flex-col h-[80vh]">
         {/* Progress bar */}
-        <div className="flex border-b border-gray-200 dark:border-gray-700 px-6 py-3 bg-gray-50 dark:bg-gray-700/50">
-          {STEPS.map((s, i) => {
-            const done = i < stepIdx;
-            const active = i === stepIdx;
-            return (
-              <div key={s.key} className="flex-1 flex items-center">
-                <div className={`flex items-center gap-2 ${active ? 'font-semibold text-indigo-700 dark:text-indigo-400' : done ? 'text-gray-700 dark:text-gray-300' : 'text-gray-600 dark:text-gray-500'}`}>
-                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs ${active ? 'bg-indigo-600 text-white' : done ? 'bg-green-500 text-white' : 'bg-gray-200 dark:bg-gray-600'}`}>
-                    {done ? '✓' : i + 1}
-                  </div>
-                  <span className="text-sm">{s.label}</span>
-                </div>
-                {i < STEPS.length - 1 && <div className={`flex-1 h-px ml-3 ${done ? 'bg-green-500' : 'bg-gray-200 dark:bg-gray-600'}`} />}
-              </div>
-            );
-          })}
+        <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-3 bg-gray-50 dark:bg-gray-700/50">
+          <Stepper steps={STEPS.map((s, i) => ({ n: i + 1, label: s.label }))} current={stepIdx + 1} />
         </div>
 
         {/* Step content */}
@@ -250,7 +237,7 @@ export default function CorrelationWizard({ onClose, onSaved }) {
               <button
                 onClick={handleGenerate}
                 disabled={!domain || generating}
-                className="px-4 py-2 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
               >
                 {generating ? `Generating… (${elapsedSec}s)` : 'Generate Ruleset'}
               </button>
@@ -259,7 +246,7 @@ export default function CorrelationWizard({ onClose, onSaved }) {
               <button
                 onClick={() => setStepIdx(2)}
                 disabled={!ruleset}
-                className="px-4 py-2 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
               >
                 Continue to Save
               </button>
@@ -421,7 +408,7 @@ function GenerateStep({ ruleset, transcript, chatInput, setChatInput, onRefine, 
           <button
             onClick={onRefine}
             disabled={!chatInput.trim() || refining}
-            className="px-4 py-2 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600"
           >
             {refining ? `${elapsedSec}s…` : 'Send'}
           </button>

--- a/app/ui/src/components/CrawlersPage.jsx
+++ b/app/ui/src/components/CrawlersPage.jsx
@@ -1,53 +1,10 @@
 ﻿import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import ScheduleEditor from './ScheduleEditor';
+import Stepper from './Stepper';
 import { formatDurationSeconds as formatDurationHMS } from '../utils/formatters';
 
 const SECRET_MASK = '••••••••';
-
-function StepIndicator({ steps, step, onStepClick, allowAll }) {
-  // onStepClick: (n) => void. allowAll=true lets the user jump to ANY step
-  // (used in edit mode because all config is already valid). Otherwise,
-  // only past and current steps are clickable — forward nav requires the
-  // wizard's Next button so step-level validation runs.
-  const isClickable = (n) => {
-    if (!onStepClick) return false;
-    if (allowAll) return true;
-    return n <= step;
-  };
-  return (
-    <div className="flex items-center gap-2 mb-5 text-xs">
-      {steps.filter(s => s.shown !== false).map((s, i, arr) => {
-        const clickable = isClickable(s.n);
-        const bubbleCls = s.n === step ? 'bg-indigo-600 text-white'
-          : s.n < step ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
-          : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400';
-        const labelCls = s.n === step ? 'font-medium text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400';
-        const content = (
-          <>
-            <div className={`w-6 h-6 rounded-full flex items-center justify-center font-semibold ${bubbleCls} ${clickable ? 'group-hover:ring-2 group-hover:ring-indigo-300 transition' : ''}`}>{i + 1}</div>
-            <span className={`${labelCls} ${clickable ? 'group-hover:text-indigo-700 dark:group-hover:text-indigo-300 group-hover:underline' : ''}`}>{s.label}</span>
-          </>
-        );
-        return (
-          <div key={s.n} className="flex items-center gap-2">
-            {clickable ? (
-              <button
-                type="button"
-                onClick={() => onStepClick(s.n)}
-                className="group flex items-center gap-2 cursor-pointer focus:outline-none"
-                aria-label={`Go to step ${i + 1}: ${s.label}`}
-              >{content}</button>
-            ) : (
-              <div className="flex items-center gap-2">{content}</div>
-            )}
-            {i < arr.length - 1 && <span className="text-gray-500 dark:text-gray-600">→</span>}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
 
 // ─── Crawler type catalog ─────────────────────────────────────────────────────
 const CRAWLER_TYPES = [
@@ -93,7 +50,7 @@ function SelectType({ onSelect, onCancel }) {
             disabled={!t.available}
             className={`flex flex-col items-start p-4 rounded-lg border-2 text-left transition-all ${
               t.available
-                ? 'border-gray-200 hover:border-indigo-400 hover:shadow-md cursor-pointer dark:border-gray-700 dark:hover:border-indigo-500'
+                ? 'border-gray-200 hover:border-blue-400 hover:shadow-md cursor-pointer dark:border-gray-700 dark:hover:border-blue-500'
                 : 'border-gray-100 opacity-50 cursor-not-allowed dark:border-gray-700'
             }`}
           >
@@ -148,7 +105,7 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
         <div className="flex items-center gap-2">
           <button
             onClick={selectAll}
-            className="px-2 py-1 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700"
+            className="px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
             type="button"
           >
             Select All
@@ -176,13 +133,13 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
               return (
                 <label key={attr}
                   className={`flex items-center gap-2 text-xs px-2 py-1 ${
-                    isCore ? 'cursor-default bg-indigo-50/40 dark:bg-indigo-900/20' : 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700'
+                    isCore ? 'cursor-default bg-blue-50/40 dark:bg-blue-900/20' : 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700'
                   }`}
                   title={isCore ? 'Core attribute (always synced)' : attr}>
                   <input type="checkbox" checked={isSelected} disabled={isCore}
                     onChange={() => toggle(attr)} className="rounded flex-shrink-0" />
                   <span className="truncate">{attr}</span>
-                  {isCore && <span className="text-indigo-700 text-[10px] flex-shrink-0">core</span>}
+                  {isCore && <span className="text-blue-700 text-[10px] flex-shrink-0">core</span>}
                 </label>
               );
             })}
@@ -190,7 +147,7 @@ function AttributePicker({ title, available, selected, onChange, coreAttrs = [] 
         )}
       </div>
       <p className="text-xs text-gray-600 mt-1 dark:text-gray-500">
-        <span className="text-indigo-500 dark:text-indigo-400">core</span> = always synced.
+        <span className="text-blue-500 dark:text-blue-400">core</span> = always synced.
         Extras go into the extendedAttributes JSON column.
       </p>
     </div>
@@ -488,7 +445,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
       </div>
 
-      <StepIndicator steps={entraSteps} step={step} onStepClick={setStep} allowAll={!!isEdit} />
+      <div className="mb-5"><Stepper steps={entraSteps} current={step} onStepClick={setStep} allowAll={!!isEdit} /></div>
 
       {/* ─── Step 1: Name + Credentials ─────────────────────────── */}
       {step === 1 && (
@@ -530,7 +487,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           <div className="flex justify-end">
             <button onClick={handleValidate}
               disabled={validating || !tenantId.trim() || !clientId.trim() || (!isEdit && !clientSecret.trim()) || !crawlerName.trim()}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
               {validating ? 'Validating...' : (isEdit && !clientSecret.trim() ? 'Next' : 'Validate & Next')}
             </button>
           </div>
@@ -581,7 +538,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
 
           <div className="flex justify-between">
             <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Back</button>
-            <button onClick={nextStep} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">Next</button>
+            <button onClick={nextStep} className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">Next</button>
           </div>
         </div>
       )}
@@ -672,7 +629,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
 
           <div className="flex justify-between">
             <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Back</button>
-            <button onClick={nextStep} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">Next</button>
+            <button onClick={nextStep} className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">Next</button>
           </div>
         </div>
       )}
@@ -711,7 +668,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
 
           <div className="flex justify-between">
             <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Back</button>
-            <button onClick={nextStep} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">Next</button>
+            <button onClick={nextStep} className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">Next</button>
           </div>
         </div>
       )}
@@ -791,7 +748,7 @@ function EntraIdWizard({ onComplete, onCancel, validateFn, discoverFn, initialCo
           <div className="flex justify-between border-t pt-4 dark:border-gray-700">
             <button onClick={prevStep} className="px-4 py-2 bg-gray-200 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Back</button>
             <button onClick={handleSave} disabled={saving}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
               {saving ? 'Saving...' : (isEdit ? 'Save Changes' : 'Deploy to Worker')}
             </button>
           </div>
@@ -856,7 +813,7 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onExport, onFor
               <button
                 onClick={() => onRunNow(config.id, 'delta')}
                 title="Queue a delta run — fetches only what changed since the last successful sync."
-                className="px-3 py-1 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700"
+                className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
               >
                 Run Delta
               </button>
@@ -893,7 +850,7 @@ function CrawlerConfigCard({ config, onRunNow, onEdit, onRemove, onExport, onFor
           <div>
             <span className="text-gray-500 dark:text-gray-400">Objects:</span>{' '}
             {objectLabels.length > 0
-              ? objectLabels.map(l => <span key={l} className="inline-block mr-1 px-1.5 py-0.5 bg-indigo-50 text-indigo-700 text-xs rounded dark:bg-indigo-900/30 dark:text-indigo-300">{l}</span>)
+              ? objectLabels.map(l => <span key={l} className="inline-block mr-1 px-1.5 py-0.5 bg-blue-50 text-blue-700 text-xs rounded dark:bg-blue-900/30 dark:text-blue-300">{l}</span>)
               : <span className="text-gray-600 text-xs dark:text-gray-500">none</span>
             }
           </div>
@@ -1170,7 +1127,7 @@ function JobPhasesModal({ job, onClose }) {
       onClick={() => setActiveTab(id)}
       className={`px-3 py-1.5 text-sm rounded-t border-b-2 -mb-px transition-colors ${
         activeTab === id
-          ? 'border-indigo-600 text-indigo-700 font-medium'
+          ? 'border-blue-600 text-blue-700 font-medium'
           : 'border-transparent text-gray-500 hover:text-gray-700'
       }`}
     >{label}</button>
@@ -1624,7 +1581,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
       </div>
 
-      <StepIndicator steps={csvSteps} step={step} onStepClick={setStep} allowAll={!!isEdit} />
+      <div className="mb-5"><Stepper steps={csvSteps} current={step} onStepClick={setStep} allowAll={!!isEdit} /></div>
 
       {error && (
         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700 dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">
@@ -1669,7 +1626,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
           </div>
           <div className="flex justify-end gap-2">
             <button onClick={() => setStep(2)} disabled={!canProceedFromInfo}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
               Next: Upload files
             </button>
           </div>
@@ -1682,7 +1639,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
           <div className="bg-blue-50 border border-blue-200 rounded p-3 text-sm text-blue-800 dark:bg-blue-900/20 dark:border-blue-700 dark:text-blue-300">
             <div>Upload CSV files in the <strong>Identity Atlas schema</strong>. Files are auto-mapped by name.</div>
             <div className="mt-1">
-              <a href="/api/admin/csv-schema" download className="text-indigo-700 underline hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">
+              <a href="/api/admin/csv-schema" download className="text-blue-700 underline hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-200">
                 Download schema templates
               </a>
               <span className="text-blue-600 ml-2 dark:text-blue-400">— empty CSVs with the expected column headers. Use a transform script to convert your source data to this format.</span>
@@ -1690,7 +1647,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
           </div>
 
           <div className="flex flex-wrap gap-2">
-            <label className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 cursor-pointer">
+            <label className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 cursor-pointer">
               Select folder
               <input type="file" multiple webkitdirectory="" directory="" onChange={handleFileSelect} className="hidden" />
             </label>
@@ -1775,7 +1732,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
           <div className="flex justify-between">
             <button onClick={() => setStep(1)} className="px-4 py-2 bg-gray-100 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Back</button>
             <button onClick={() => setStep(3)} disabled={missingRequired.length > 0 || allFiles.length === 0}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
               Next: Review
             </button>
           </div>
@@ -1794,7 +1751,7 @@ function CsvWizard({ onComplete, onCancel, initialConfig, isEdit, authFetch }) {
           <div className="flex justify-between">
             <button onClick={() => setStep(2)} className="px-4 py-2 bg-gray-100 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Back</button>
             <button onClick={handleSave} disabled={!canSave}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
               {uploading ? 'Uploading...' : saving ? 'Saving...' : (isEdit ? 'Save changes' : 'Create crawler')}
             </button>
           </div>
@@ -1933,7 +1890,7 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
         <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
       </div>
 
-      <StepIndicator steps={connectorSteps} step={step} />
+      <div className="mb-5"><Stepper steps={connectorSteps} current={step} /></div>
 
       {error && (
         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">{error}</div>
@@ -1961,7 +1918,7 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
           <div className="flex justify-end gap-2">
             <button onClick={onCancel} className="px-4 py-2 bg-gray-100 rounded text-sm dark:bg-gray-700 dark:text-gray-300">Cancel</button>
             <button onClick={handleRegister} disabled={!name.trim() || registering}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
               {registering ? 'Registering...' : 'Register Connector'}
             </button>
           </div>
@@ -1995,7 +1952,7 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
           </div>
           <div className="flex justify-end">
             <button onClick={() => setStep(3)}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">
               Next: Getting Started
             </button>
           </div>
@@ -2008,19 +1965,19 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
           {/* Quick links */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <a href={`${apiBaseUrl}/docs`} target="_blank" rel="noopener noreferrer"
-              className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-indigo-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-indigo-500">
+              className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-blue-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-blue-500">
               <span className="text-2xl mb-1">📖</span>
               <span className="font-medium text-sm dark:text-gray-200">Swagger UI</span>
               <span className="text-xs text-gray-500 dark:text-gray-400">Interactive API explorer</span>
             </a>
             <a href={`${apiBaseUrl}/openapi.json`} download="identity-atlas-openapi.json"
-              className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-indigo-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-indigo-500">
+              className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-blue-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-blue-500">
               <span className="text-2xl mb-1">📄</span>
               <span className="font-medium text-sm dark:text-gray-200">Download OpenAPI Spec</span>
               <span className="text-xs text-gray-500 dark:text-gray-400">JSON format</span>
             </a>
             <a href="https://fortigi.github.io/IdentityAtlas/datasources/csv-schema/" target="_blank" rel="noopener noreferrer"
-              className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-indigo-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-indigo-500">
+              className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-blue-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-blue-500">
               <span className="text-2xl mb-1">📋</span>
               <span className="font-medium text-sm dark:text-gray-200">CSV Schema Reference</span>
               <span className="text-xs text-gray-500 dark:text-gray-400">Field definitions for all entity types</span>
@@ -2056,7 +2013,7 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
 
           <div className="flex justify-end">
             <button onClick={onComplete}
-              className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">
+              className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">
               Done
             </button>
           </div>
@@ -2075,7 +2032,7 @@ function ExampleTabs({ examples, onCopy, copied }) {
         {examples.map((ex, i) => (
           <button key={ex.label} onClick={() => setActive(i)}
             className={`px-4 py-2 text-sm font-medium ${
-              i === active ? 'bg-white border-b-2 border-indigo-500 text-indigo-700 dark:bg-gray-800 dark:text-indigo-400' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+              i === active ? 'bg-white border-b-2 border-blue-500 text-blue-700 dark:bg-gray-800 dark:text-blue-400' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
             }`}>
             {ex.label}
           </button>
@@ -2476,7 +2433,7 @@ export default function CrawlersPage({ onNavigate }) {
               Import
             </button>
             <button onClick={() => setWizardStep('select')}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 text-sm font-medium">
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">
               Add Crawler
             </button>
           </div>

--- a/app/ui/src/components/RiskProfileWizard.jsx
+++ b/app/ui/src/components/RiskProfileWizard.jsx
@@ -19,6 +19,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import JsonViewer from './JsonViewer';
+import Stepper from './Stepper';
 
 const STEPS = [
   { key: 'sources',     label: 'Sources' },
@@ -314,14 +315,8 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
   return (
     <Modal onClose={onClose} title="Risk Profile Wizard" wide>
       {/* Step indicator */}
-      <div className="flex items-center gap-2 px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 text-xs">
-        {STEPS.map((s, i) => (
-          <div key={s.key} className={`flex items-center gap-2 ${i === stepIdx ? 'font-semibold text-indigo-700 dark:text-indigo-400' : i < stepIdx ? 'text-green-700 dark:text-green-400' : 'text-gray-600 dark:text-gray-500'}`}>
-            <span className={`inline-flex w-5 h-5 rounded-full items-center justify-center text-[10px] ${i === stepIdx ? 'bg-indigo-600 text-white' : i < stepIdx ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-600'}`}>{i + 1}</span>
-            <span>{s.label}</span>
-            {i < STEPS.length - 1 && <span className="text-gray-500 dark:text-gray-600 mx-1">›</span>}
-          </div>
-        ))}
+      <div className="px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
+        <Stepper steps={STEPS.map((s, i) => ({ n: i + 1, label: s.label }))} current={stepIdx + 1} />
       </div>
 
       <div className="p-6 max-h-[70vh] overflow-y-auto">
@@ -366,21 +361,21 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
 
             <div className="flex justify-end gap-2 pt-2">
               <button onClick={onClose} className="px-4 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:text-gray-300 dark:hover:bg-gray-700">Cancel</button>
-              <button onClick={handleGenerate} disabled={!domain || generating} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
+              <button onClick={handleGenerate} disabled={!domain || generating} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
                 {generating ? `Generating… (${elapsedSec}s)` : 'Generate profile →'}
               </button>
             </div>
             {generating && (
-              <div className="mt-3 p-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded text-sm">
-                <div className="flex items-center gap-2 text-indigo-900 dark:text-indigo-300">
+              <div className="mt-3 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded text-sm">
+                <div className="flex items-center gap-2 text-blue-900 dark:text-blue-300">
                   <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
                     <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
                     <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" className="opacity-75" />
                   </svg>
                   <span className="font-medium">The AI is researching the organisation…</span>
-                  <span className="text-xs text-indigo-700 dark:text-indigo-400 ml-auto">{elapsedSec}s elapsed</span>
+                  <span className="text-xs text-blue-700 dark:text-blue-400 ml-auto">{elapsedSec}s elapsed</span>
                 </div>
-                <div className="text-xs text-indigo-700 dark:text-indigo-400 mt-2 space-y-1">
+                <div className="text-xs text-blue-700 dark:text-blue-400 mt-2 space-y-1">
                   <div>1. {urls.filter(u => u.url).length > 0 ? `Scraping ${urls.filter(u => u.url).length} URL${urls.filter(u => u.url).length === 1 ? '' : 's'}` : 'Skipping URL scraping'}</div>
                   <div>2. Calling the LLM to generate the profile JSON</div>
                   <div className="opacity-70 mt-2">This typically takes 20–60 seconds depending on the model. Opus/GPT-4 are slower but produce better industry-specific profiles.</div>
@@ -423,12 +418,12 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                     <div className="text-xs text-gray-500 dark:text-gray-400">Ask the AI to adjust anything or ask a question: "drop NIS2 — we're US-only", "what software does this org use?", "add critical role for Customs Officer"…</div>
                   )}
                   {transcript.map((m, i) => (
-                    <div key={i} className={`text-xs ${m.role === 'user' ? 'text-gray-900 dark:text-gray-200' : 'text-indigo-700 dark:text-indigo-400'}`}>
+                    <div key={i} className={`text-xs ${m.role === 'user' ? 'text-gray-900 dark:text-gray-200' : 'text-blue-700 dark:text-blue-400'}`}>
                       <span className="font-semibold">{m.role === 'user' ? 'You' : 'AI'}:</span> {m.content}
                     </div>
                   ))}
                   {refining && (
-                    <div className="text-xs text-indigo-700 dark:text-indigo-400 flex items-center gap-2">
+                    <div className="text-xs text-blue-700 dark:text-blue-400 flex items-center gap-2">
                       <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
                         <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
                         <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" className="opacity-75" />
@@ -439,7 +434,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                 </div>
                 <div className="flex gap-2 mt-2">
                   <input value={chatInput} onChange={e => setChatInput(e.target.value)} onKeyDown={e => e.key === 'Enter' && handleRefine()} disabled={refining} placeholder="Ask for a change or a question…" className="flex-1 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500" />
-                  <button onClick={handleRefine} disabled={!chatInput.trim() || refining} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
+                  <button onClick={handleRefine} disabled={!chatInput.trim() || refining} className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
                     {refining ? `${elapsedSec}s` : 'Send'}
                   </button>
                 </div>
@@ -448,7 +443,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
 
             <div className="flex justify-between pt-2">
               <button onClick={() => setStepIdx(0)} className="px-4 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:text-gray-300 dark:hover:bg-gray-700">← Back</button>
-              <button onClick={() => setStepIdx(2)} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">Looks good — save →</button>
+              <button onClick={() => setStepIdx(2)} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">Looks good — save →</button>
             </div>
           </div>
         )}
@@ -467,7 +462,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             </label>
             <div className="flex justify-between pt-2">
               <button onClick={() => setStepIdx(1)} className="px-4 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:text-gray-300 dark:hover:bg-gray-700">← Back</button>
-              <button onClick={handleSaveProfile} disabled={!profileName || savingProfile} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
+              <button onClick={handleSaveProfile} disabled={!profileName || savingProfile} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
                 {savingProfile ? 'Saving…' : 'Save profile →'}
               </button>
             </div>
@@ -484,23 +479,23 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             </p>
             {!classifiers && (
               <div className="flex gap-2">
-                <button onClick={handleGenerateClassifiers} disabled={genClassifiers} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
+                <button onClick={handleGenerateClassifiers} disabled={genClassifiers} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
                   {genClassifiers ? `Generating… (${classifierElapsedSec}s)` : 'Generate classifiers'}
                 </button>
                 <button onClick={() => { onSaved?.(); onClose(); }} disabled={genClassifiers} className="px-4 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:text-gray-300 dark:hover:bg-gray-700 disabled:opacity-50">Skip — done for now</button>
               </div>
             )}
             {genClassifiers && (
-              <div className="mt-3 p-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded text-sm">
-                <div className="flex items-center gap-2 text-indigo-900 dark:text-indigo-300">
+              <div className="mt-3 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded text-sm">
+                <div className="flex items-center gap-2 text-blue-900 dark:text-blue-300">
                   <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
                     <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
                     <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="4" className="opacity-75" />
                   </svg>
                   <span className="font-medium">Generating regex classifiers from the profile…</span>
-                  <span className="text-xs text-indigo-700 dark:text-indigo-400 ml-auto">{classifierElapsedSec}s elapsed</span>
+                  <span className="text-xs text-blue-700 dark:text-blue-400 ml-auto">{classifierElapsedSec}s elapsed</span>
                 </div>
-                <div className="text-xs text-indigo-700 dark:text-indigo-400 mt-2 space-y-1">
+                <div className="text-xs text-blue-700 dark:text-blue-400 mt-2 space-y-1">
                   <div>The LLM is translating the profile's regulations, critical roles, and known systems into regex patterns that will match high-risk principals during scoring.</div>
                   <div className="opacity-70 mt-2">This typically takes 30–90 seconds with Opus — classifiers are larger than profiles. Switch to Sonnet or Haiku in Admin → LLM Settings for faster (but less nuanced) output.</div>
                 </div>
@@ -522,7 +517,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
                 </div>
                 <div className="flex justify-between pt-2">
                   <button onClick={handleGenerateClassifiers} disabled={genClassifiers} className="px-4 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:text-gray-300 dark:hover:bg-gray-700">Regenerate</button>
-                  <button onClick={handleSaveClassifiers} disabled={!classifierName || savingClassifiers} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
+                  <button onClick={handleSaveClassifiers} disabled={!classifierName || savingClassifiers} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600">
                     {savingClassifiers ? 'Saving…' : 'Save classifiers →'}
                   </button>
                 </div>
@@ -541,7 +536,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             </p>
             {!scoringRun && !scoring && (
               <div className="flex gap-2">
-                <button onClick={handleStartScoring} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">
+                <button onClick={handleStartScoring} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
                   Run scoring now
                 </button>
                 <button onClick={() => { onSaved?.(); onClose(); }} className="px-4 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded dark:text-gray-300 dark:hover:bg-gray-700">Done</button>
@@ -551,16 +546,16 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
             {scoringRun && (
               <div className="space-y-2">
                 <div className="text-sm dark:text-gray-300">
-                  Status: <span className={`font-semibold ${scoringRun.status === 'completed' ? 'text-green-700 dark:text-green-400' : scoringRun.status === 'failed' ? 'text-red-700 dark:text-red-400' : 'text-indigo-700 dark:text-indigo-400'}`}>{scoringRun.status}</span>
+                  Status: <span className={`font-semibold ${scoringRun.status === 'completed' ? 'text-green-700 dark:text-green-400' : scoringRun.status === 'failed' ? 'text-red-700 dark:text-red-400' : 'text-blue-700 dark:text-blue-400'}`}>{scoringRun.status}</span>
                   {scoringRun.step && <span className="text-gray-500 dark:text-gray-400"> · {scoringRun.step}</span>}
                 </div>
                 <div className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2">
-                  <div className="bg-indigo-600 h-2 rounded transition-all" style={{ width: `${scoringRun.pct || 0}%` }} />
+                  <div className="bg-blue-600 h-2 rounded transition-all" style={{ width: `${scoringRun.pct || 0}%` }} />
                 </div>
                 <div className="text-xs text-gray-500 dark:text-gray-400">{scoringRun.scoredEntities || 0} / {scoringRun.totalEntities || '?'} entities</div>
                 {scoringRun.errorMessage && <div className="text-sm text-red-700 dark:text-red-400">{scoringRun.errorMessage}</div>}
                 {(scoringRun.status === 'completed' || scoringRun.status === 'failed') && (
-                  <button onClick={() => { onSaved?.(); onClose(); }} className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">
+                  <button onClick={() => { onSaved?.(); onClose(); }} className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
                     Done
                   </button>
                 )}

--- a/app/ui/src/components/RolesPermissionsSection.jsx
+++ b/app/ui/src/components/RolesPermissionsSection.jsx
@@ -205,7 +205,7 @@ export default function RolesPermissionsSection() {
         </div>
         <div className="shrink-0 text-xs">
           {data.isCustom ? (
-            <span className="px-2 py-1 rounded bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">Custom mapping</span>
+            <span className="px-2 py-1 rounded bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">Custom mapping</span>
           ) : (
             <span className="px-2 py-1 rounded bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200">Default mapping</span>
           )}
@@ -305,7 +305,7 @@ export default function RolesPermissionsSection() {
           type="button"
           onClick={handleSave}
           disabled={!dirty || saving}
-          className="px-4 py-2 text-sm font-medium rounded bg-indigo-600 text-white hover:bg-indigo-700 dark:bg-indigo-700 dark:hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {saving ? 'Saving…' : 'Save changes'}
         </button>

--- a/app/ui/src/components/Stepper.jsx
+++ b/app/ui/src/components/Stepper.jsx
@@ -1,0 +1,60 @@
+// Shared multi-step wizard indicator — one component for every wizard so the
+// step UI is consistent everywhere. The active step is blue (the interactive
+// role in the UI Style Guide), completed steps show a ✓, and steps are joined
+// by chevron separators. Dark-mode aware.
+//
+// Props:
+//   steps        [{ n, label, shown? }] — n is the step number; shown:false hides it
+//   current      number                  — the active step's n
+//   onStepClick  (n) => void  (optional) — when provided, steps become clickable
+//   allowAll     boolean                  — also allow jumping to future steps (edit mode)
+export default function Stepper({ steps, current, onStepClick, allowAll = false }) {
+  const visible = steps.filter(s => s.shown !== false);
+  const isClickable = (n) => {
+    if (!onStepClick) return false;
+    if (allowAll) return true;
+    return n <= current;
+  };
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      {visible.map((s, i, arr) => {
+        const clickable = isClickable(s.n);
+        const active = s.n === current;
+        const done = s.n < current;
+        const bubbleCls = active
+          ? 'bg-blue-600 text-white'
+          : done
+            ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+            : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400';
+        const labelCls = active
+          ? 'font-medium text-gray-900 dark:text-white'
+          : done
+            ? 'text-gray-700 dark:text-gray-300'
+            : 'text-gray-500 dark:text-gray-400';
+        const content = (
+          <>
+            <span className={`w-6 h-6 rounded-full flex items-center justify-center font-semibold ${bubbleCls} ${clickable ? 'group-hover:ring-2 group-hover:ring-blue-300 transition' : ''}`}>
+              {done ? '✓' : i + 1}
+            </span>
+            <span className={`${labelCls} ${clickable ? 'group-hover:text-blue-700 dark:group-hover:text-blue-300 group-hover:underline' : ''}`}>{s.label}</span>
+          </>
+        );
+        return (
+          <div key={s.n} className="flex items-center gap-2">
+            {clickable ? (
+              <button
+                type="button"
+                onClick={() => onStepClick(s.n)}
+                className="group flex items-center gap-2 cursor-pointer focus:outline-none"
+                aria-label={`Go to step ${i + 1}: ${s.label}`}
+              >{content}</button>
+            ) : (
+              <div className="flex items-center gap-2">{content}</div>
+            )}
+            {i < arr.length - 1 && <span className="text-gray-500 dark:text-gray-600" aria-hidden="true">›</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/ui/src/components/Stepper.test.js
+++ b/app/ui/src/components/Stepper.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement as h } from 'react';
+import Stepper from './Stepper';
+
+const steps = [
+  { n: 1, label: 'One' },
+  { n: 2, label: 'Two' },
+  { n: 3, label: 'Three' },
+];
+
+describe('Stepper', () => {
+  it('uses blue for the active step and ✓ + chevrons (no legacy indigo)', () => {
+    const html = renderToStaticMarkup(h(Stepper, { steps, current: 2 }));
+    expect(html).toContain('bg-blue-600'); // active step — interactive role
+    expect(html).not.toContain('indigo'); // legacy colour removed
+    expect(html).toContain('✓'); // step 1 is completed
+    expect(html).toContain('›'); // chevron separators
+  });
+
+  it('hides steps marked shown:false', () => {
+    const html = renderToStaticMarkup(
+      h(Stepper, { steps: [{ n: 1, label: 'Alpha' }, { n: 2, label: 'Beta', shown: false }, { n: 3, label: 'Gamma' }], current: 1 }),
+    );
+    expect(html).toContain('Alpha');
+    expect(html).not.toContain('Beta');
+    expect(html).toContain('Gamma');
+  });
+
+  it('renders clickable step buttons only when onStepClick is provided', () => {
+    const plain = renderToStaticMarkup(h(Stepper, { steps, current: 1 }));
+    expect(plain).not.toContain('<button');
+    const clickable = renderToStaticMarkup(h(Stepper, { steps, current: 1, onStepClick: () => {} }));
+    expect(clickable).toContain('<button');
+    expect(clickable).toContain('Go to step');
+  });
+});

--- a/app/ui/src/components/matrix/MatrixFilterWizard.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.jsx
@@ -15,6 +15,7 @@
 
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { useAuth } from '../../auth/AuthGate';
+import Stepper from '../Stepper';
 import { Modal, PrimaryButton, SecondaryButton, ErrorBox } from '../contexts/ModalPrimitives';
 import ContextPicker from '../contexts/ContextPicker';
 import { variantMeta, targetTypeMeta } from '../../utils/contextStyles';
@@ -393,30 +394,7 @@ function StepIndicator({ step, onJump }) {
     { n: 2, label: 'Subjects' },
     { n: 3, label: 'Resources' },
   ];
-  return (
-    <div className="flex items-center gap-1 text-[11px]">
-      {steps.map((s, idx) => (
-        <span key={s.n} className="flex items-center gap-1">
-          <button
-            onClick={() => onJump(s.n)}
-            className={`flex items-center gap-1 px-2 py-0.5 rounded transition-colors ${
-              step === s.n
-                ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700'
-                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-            }`}
-          >
-            <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[10px] font-semibold ${
-              step === s.n
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
-            }`}>{s.n}</span>
-            {s.label}
-          </button>
-          {idx < steps.length - 1 && <span className="text-gray-500 dark:text-gray-400">›</span>}
-        </span>
-      ))}
-    </div>
-  );
+  return <Stepper steps={steps} current={step} onStepClick={onJump} allowAll />;
 }
 
 // ─── Saved-filter dropdown ─────────────────────────────────────────

--- a/changes/ds-interactive-consistency.md
+++ b/changes/ds-interactive-consistency.md
@@ -1,0 +1,2 @@
+- Unified the look of every step-by-step wizard (crawler setup, matrix filter, risk profile, account correlation) behind one shared stepper component — same blue active step, "✓" for completed steps, and chevron separators everywhere, instead of four slightly different hand-built versions.
+- Made interactive controls consistently **blue** across the app: the crawler wizard, Admin save/new buttons, and the risk-profile and correlation wizards previously used purple/indigo (and a few green) buttons, which now match the rest of the UI and the Style Guide.


### PR DESCRIPTION
First PR of the **visual-consistency sweep** (you asked why steppers/colours were inconsistent and to fix it systematically). Root cause: the app was built surface-by-surface and each wizard hand-rolled its own stepper and action colour — there were no shared primitives. This establishes them.

## Shared Stepper
New `components/Stepper.jsx` — one component, used by **all four** wizards:
- CrawlersPage (was indigo, `→` separators)
- MatrixFilterWizard (was blue, `›`)
- RiskProfileWizard (was indigo + green "done")
- CorrelationWizard (was indigo + green "done", full-width line)

Now every wizard shows the same **blue active step**, a **✓ for completed steps**, chevron separators, consistent bubble size, and dark mode.

## Interactive colour → blue
Recoloured every `indigo`/`emerald` **action button** to blue (the Style Guide's interactive role) across CrawlersPage, AdminPage, RiskProfileWizard, CorrelationWizard, RolesPermissionsSection. Status-semantic colours (success/failure dots, the on/off toggle) are deliberately left as-is.

## Tests / verification
- `Stepper.test.js` — renders the component (via `renderToStaticMarkup`) and asserts blue active step, ✓ on completed, chevrons, `shown:false` hiding, and clickable-only-with-handler. 3 tests pass.
- `eslint` clean on all touched files; full `vite build` succeeds.

Follow-ups in this sweep (separate PRs): soften saturated data-viz fills (ConfidenceBar, risk/score bars, EntityGraph nodes), docs theme to match the app, remove the matrix Tags column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)