### PR TITLE
feat(matrix): remove the Tags column

### DIFF
--- a/app/ui/src/components/matrix/MatrixColumnHeaders.jsx
+++ b/app/ui/src/components/matrix/MatrixColumnHeaders.jsx
@@ -103,10 +103,9 @@ export default function MatrixColumnHeaders({
           );
         })}
 
-        {/* Right metadata column headers row 1 - empty placeholders (#, Description, Tags) */}
+        {/* Right metadata column headers row 1 - empty placeholders (#, Description) */}
         <th className="border-b border-l-2 border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800" style={{ minWidth: '40px' }} />
         <th className="border-b border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800" style={{ minWidth: '500px' }} />
-        <th className="border-b border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800" style={{ minWidth: '120px' }} />
       </tr>
 
       {/* Row 2: User names */}
@@ -154,7 +153,7 @@ export default function MatrixColumnHeaders({
           </th>
         ))}
 
-        {/* Right metadata column headers row 2 — # | Description | Tags */}
+        {/* Right metadata column headers row 2 — # | Description */}
         <th className="border-b border-l-2 border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 px-1 py-1 text-[10px] text-gray-500 dark:text-gray-400 font-medium cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 select-none"
             onClick={onSortByCount}
             title="Sort by member count (descending)">
@@ -163,10 +162,6 @@ export default function MatrixColumnHeaders({
         <th className="border-b border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 px-2 py-1 text-xs text-gray-500 dark:text-gray-400 font-medium text-left"
             style={{ minWidth: '500px' }}>
           Description
-        </th>
-        <th className="border-b border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 px-2 py-1 text-xs font-medium text-left text-gray-500 dark:text-gray-400"
-            style={{ minWidth: '120px' }}>
-          Tags
         </th>
       </tr>
     </thead>

--- a/app/ui/src/components/matrix/MatrixGroupRow.jsx
+++ b/app/ui/src/components/matrix/MatrixGroupRow.jsx
@@ -218,7 +218,7 @@ export default function MatrixGroupRow({
         );
       })}
 
-      {/* Right-side metadata: # | Description | Tags */}
+      {/* Right-side metadata: # | Description */}
       <td className="border-l-2 border-b border-gray-200 dark:border-gray-700 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-400 text-center"
           style={{ minWidth: '40px' }}>
         {memberCount}
@@ -226,21 +226,6 @@ export default function MatrixGroupRow({
       <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-500 max-w-[500px]"
           title={group.description}>
         <div className="truncate">{group.description}</div>
-      </td>
-      <td className="border-b border-gray-200 dark:border-gray-700 px-1 py-0.5"
-          style={{ minWidth: '120px', maxWidth: '180px' }}>
-        <div className="flex flex-wrap gap-0.5">
-          {(group.tags || []).map(t => (
-            <span
-              key={t.id}
-              className="inline-block px-1 py-0 rounded-full text-[9px] font-medium border leading-tight"
-              style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-              title={t.name}
-            >
-              {t.name}
-            </span>
-          ))}
-        </div>
       </td>
     </tr>
   );

--- a/app/ui/src/components/matrix/matrixTagsRemoved.test.js
+++ b/app/ui/src/components/matrix/matrixTagsRemoved.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// The matrix Tags column was removed (tags are no longer a meaningful axis
+// here). Guard against it creeping back into the header or the group rows.
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (f) => readFileSync(join(here, f), 'utf8');
+
+describe('matrix Tags column removed', () => {
+  it('column header no longer renders a Tags header cell', () => {
+    expect(read('MatrixColumnHeaders.jsx')).not.toMatch(/>\s*Tags\s*</);
+  });
+  it('group rows no longer render a tags cell', () => {
+    expect(read('MatrixGroupRow.jsx')).not.toContain('group.tags');
+  });
+});

--- a/changes/matrix-remove-tags.md
+++ b/changes/matrix-remove-tags.md
@@ -1,0 +1,1 @@
+- Removed the **Tags** column from the matrix — it no longer carried meaningful information now that tags are modelled as contexts. The matrix right-side metadata is now just member count and description.


### PR DESCRIPTION
You asked to drop the matrix **Tags** column — it no longer makes sense now that tags are modelled as contexts.

Removes the Tags header (both the placeholder row and the labelled row in `MatrixColumnHeaders`) and the per-row tags cell in `MatrixGroupRow`. The right-side metadata is now **# (member count) · Description**. The rotated matrix view never had a Tags column, so it's unaffected; `infoColumnCount`/colspans cover the left sticky columns only, so alignment is unchanged.

Tags are still fetched into the row data (harmless, unused) — left in place to keep this PR a focused UI removal.

`matrixTagsRemoved.test.js` guards against the column creeping back. eslint clean; `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)