### PR TITLE
style(docs): match the app shell — white header instead of green band

### DIFF
--- a/changes/docs-theme-app-match.md
+++ b/changes/docs-theme-app-match.md
@@ -1,0 +1,1 @@
+- Reworked the documentation site to look like the app: the bright solid-green header and tab bar are now a clean white shell with a dark title and the green logo as the accent (dark slate header in dark mode), with the active tab marked by a green underline and a soft grey search field — so the docs and the product feel like one product.

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -39,12 +39,15 @@
 /* mkdocs-material emits `data-md-color-primary=custom` when
    `primary: custom` is set in mkdocs.yml. */
 [data-md-color-primary=custom] {
-  /* Brand chrome stays lime; links (interactive) go blue. */
-  --md-primary-fg-color:               var(--ia-lime-700);
-  --md-primary-fg-color--light:        var(--ia-lime-600);
-  --md-primary-fg-color--dark:         var(--ia-lime-800);
-  --md-primary-bg-color:               #ffffff;
-  --md-primary-bg-color--light:        #ffffffcc;
+  /* The app shell has a WHITE top bar (logo + dark title), not a solid
+     colour band — mirror that: primary (header/tabs bg) = white, header
+     foreground (title/icons) = dark. Green is a brand ACCENT, not the
+     whole header. Links (interactive) stay blue. */
+  --md-primary-fg-color:               #ffffff;
+  --md-primary-fg-color--light:        var(--ia-gray-100);
+  --md-primary-fg-color--dark:         var(--ia-gray-200);
+  --md-primary-bg-color:               var(--ia-gray-900);
+  --md-primary-bg-color--light:        var(--ia-gray-700);
   --md-typeset-a-color:                var(--ia-blue-600);
 }
 
@@ -56,11 +59,14 @@
   --md-accent-bg-color--light:         #ffffffcc;
 }
 
-/* Dark (slate) scheme — lighter brand lime + lighter blue links for contrast */
+/* Dark (slate) scheme — dark header (matches the app's dark shell), light
+   header text, lighter blue links for contrast. */
 [data-md-color-scheme=slate][data-md-color-primary=custom] {
-  --md-primary-fg-color:               var(--ia-lime-600);
-  --md-primary-fg-color--light:        var(--ia-lime-500);
-  --md-primary-fg-color--dark:         var(--ia-lime-700);
+  --md-primary-fg-color:               #1e293b;
+  --md-primary-fg-color--light:        #334155;
+  --md-primary-fg-color--dark:         #0f172a;
+  --md-primary-bg-color:               #f1f5f9;
+  --md-primary-bg-color--light:        #cbd5e1;
   --md-typeset-a-color:                var(--ia-blue-400);
 }
 [data-md-color-scheme=slate][data-md-color-accent=custom] {
@@ -114,30 +120,47 @@ body,
   margin-bottom: 0.5rem;
 }
 
-/* ── Header bar ────────────────────────────────────────────────── */
+/* ── Header bar — white app-shell look (bg comes from --md-primary-* above) */
 .md-header {
-  background-color: var(--ia-lime-700);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid var(--ia-gray-200);
 }
 .md-header__title {
   font-weight: 600;
   letter-spacing: -0.01em;
 }
+[data-md-color-scheme=slate] .md-header {
+  border-bottom-color: #334155;
+}
 
-/* Tabs row — same lime so it reads as one unit */
+/* Tabs row — white bar with a green (brand) underline on the active tab,
+   matching the app's tab strip. */
 .md-tabs {
-  background-color: var(--ia-lime-700);
+  border-bottom: 1px solid var(--ia-gray-200);
 }
 .md-tabs__link {
-  opacity: 0.8;
+  opacity: 1;
+  color: var(--ia-gray-600);
   font-weight: 500;
 }
 .md-tabs__link:hover,
 .md-tabs__link--active {
-  opacity: 1;
+  color: var(--ia-lime-700);
 }
 .md-tabs__link--active {
-  border-bottom: 2px solid #ffffff;
+  font-weight: 600;
+  border-bottom: 2px solid var(--ia-lime-700);
+}
+[data-md-color-scheme=slate] .md-tabs {
+  border-bottom-color: #334155;
+}
+[data-md-color-scheme=slate] .md-tabs__link {
+  color: #cbd5e1;
+}
+[data-md-color-scheme=slate] .md-tabs__link:hover,
+[data-md-color-scheme=slate] .md-tabs__link--active {
+  color: var(--ia-lime-300);
+  border-bottom-color: var(--ia-lime-300);
 }
 
 /* ── Logo: don't let mkdocs squish it too much ─────────────────── */
@@ -308,12 +331,20 @@ body,
   color: var(--ia-blue-400);
 }
 
-/* ── Search bar ────────────────────────────────────────────────── */
+/* ── Search bar — soft grey field on the white header (like the app) ── */
 .md-search__input {
-  background-color: rgba(255, 255, 255, 0.15);
+  background-color: var(--ia-gray-100);
+  color: var(--ia-gray-900);
 }
 .md-search__input::placeholder {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--ia-gray-500);
+}
+[data-md-color-scheme=slate] .md-search__input {
+  background-color: #334155;
+  color: #f1f5f9;
+}
+[data-md-color-scheme=slate] .md-search__input::placeholder {
+  color: #94a3b8;
 }
 
 /* ── Footer — softer on light background ───────────────────────── */


### PR DESCRIPTION
You flagged that the docs look nothing like the app. The biggest mismatch was the **solid bright-green header + tab band** — the app shell is a **white top bar** with a dark "Identity Atlas" title and the green logo as the accent.

## What changed (`docs/assets/extra.css`)
- **Header + tabs → white** (the mkdocs-native way: `--md-primary-fg-color` = white, `--md-primary-bg-color` = dark text), with a subtle bottom border + shadow like the app shell.
- **Active tab** → green underline + green text; inactive tabs grey (matches the app's tab strip).
- **Search field** → soft grey box (was translucent-white, which is invisible on a white header).
- **Dark mode** → dark slate header/tabs with light text and lime-300 active tab, matching the app's dark shell.

Green is now a **brand accent** (logo, active tab, section labels), not the whole header — consistent with the Style Guide. Builds clean under `mkdocs build --strict`.

Note: complements @TaekeK's #240 (nav consolidation) — that touches `mkdocs.yml` nav, this touches `extra.css`, so they don't conflict.

> Earlier #239 moved doc links to blue; this is the structural shell change on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)