### PR TITLE
docs(style-guide): add saturation rule (soft fills vs saturated marks)

### DIFF
--- a/changes/style-guide-saturation.md
+++ b/changes/style-guide-saturation.md
@@ -1,0 +1,1 @@
+- Documented the colour-saturation rule in the UI Style Guide: solid fills (bars, chips, graph nodes) use soft pastel tiers while thin marks (chart lines, borders, icons, text) keep stronger colour — so future contributions stay consistent with the app's soft look.

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -29,6 +29,13 @@ Rationale: green is who we *are* (it echoes the logo); blue is what you *click*.
 - `utils/accessPackageStyles.js` — assignment-policy badges.
 - `utils/contextStyles.js` — context variant/target badges.
 
+### Saturation: match the fill to the shape
+The app reads as *soft* — badges are `bg-{color}-50/100`, the data-viz pastels in `AP_COLORS` sit around the 200 tier. Pick saturation by **how much area the colour covers**, not by hue:
+- **Solid fills** — progress/ratio bars, chips, swatches, graph nodes, large blocks → **soft pastel tier (200–300)**. A saturated 500/600-tier block reads as "hard" next to everything else.
+- **Thin marks** — chart lines, 1–2px borders, small icons, coloured **text** → keep the **saturated tier (500+ / 700 for text)**; they're too small to register otherwise.
+
+The same hue therefore often needs *two* tokens — don't reuse a chart-line colour as a bar fill. (This was the "hard governed/non-governed bar" and "bright entity-graph nodes" bug: `MatrixScopePanel` now splits `GOV_LINE` from `GOV_BAR`, and the `EntityGraph` node gradients end soft.)
+
 ---
 
 ## 2. Dark mode (hard rule)


### PR DESCRIPTION
Documents the rule behind the visual-consistency sweep so it's enforced going forward, not just fixed once. Adds a **"Saturation: match the fill to the shape"** subsection to the Colour System:

- **Solid fills** (bars, chips, swatches, graph nodes) → soft pastel **200–300**.
- **Thin marks** (chart lines, borders, icons, text) → keep **500+/700**.

Calls out that the same hue often needs two tokens (the governed-bar and entity-graph-node bugs that started this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)