### PR TITLE
feat(omada): native Omada IGA PowerShell crawler

### DIFF
--- a/Functions/CLAUDE.md
+++ b/Functions/CLAUDE.md
@@ -1,5 +1,40 @@
 # PowerShell Functions — Coding Guide
 
+### Style preset: Stroustrup
+- Opening brace on the same line as the statement
+- Closing brace on its own line
+- Blank line after every closing brace
+
+### Formatting rules
+- Whitespace around all operators (`=`, `-eq`, `+`, etc.)
+- Align property/value pairs in hashtables and `[PSCustomObject]`
+- No aliases — always use full cmdlet names (`ForEach-Object`, not `%`; `Where-Object`, not `?`)
+- Correct Pascal/camelCasing for cmdlets, parameters, and types as defined by PowerShell standards
+- Trim whitespace around pipe characters
+- No semicolons as line terminators — use newlines
+
+### Regions
+Structure scripts using `#region` / `#endregion` blocks with descriptive headings. Required regions for any non-trivial script:
+
+```powershell
+#region Parameters
+#endregion Parameters
+
+#region Configuration
+#endregion Configuration
+
+#region Functions
+#endregion Functions
+
+#region Main
+#endregion Main
+```
+
+Add additional regions as needed (e.g. `#region Authentication`, `#region Output`). Region names should be PascalCase nouns or noun phrases. Never nest regions more than one level deep.
+
+### PSScriptAnalyzer
+Scripts must pass PSScriptAnalyzer with no warnings or errors under default rules.
+
 ## File Organization
 
 All function files live under `Functions/`:
@@ -72,13 +107,13 @@ function Get-FGSQLResource {
     )
 
     Invoke-FGSQLCommand -ScriptBlock {
-        param($connection)
-        $cmd = $connection.CreateCommand()
-        $cmd.CommandText = "SELECT * FROM dbo.Resources WHERE Name = @Name"
-        $cmd.Parameters.AddWithValue("@Name", $Name)
-        $reader = $cmd.ExecuteReader()
+        param($Connection)
+        $Cmd = $Connection.CreateCommand()
+        $Cmd.CommandText = "SELECT * FROM dbo.Resources WHERE Name = @Name"
+        $Cmd.Parameters.AddWithValue("@Name", $Name)
+        $Reader = $Cmd.ExecuteReader()
         # Process results...
-        return $results
+        return $Results
     }
 }
 ```

--- a/changes/omada-crawler-core.md
+++ b/changes/omada-crawler-core.md
@@ -13,3 +13,5 @@
 - Added 42 Pester unit tests for the Omada SDK (auth methods, helper functions, URL normalisation, config forwarding)
 - Added data model reference documentation for the Omada crawler (`docs/architecture/omada-crawler-datamodel.md`)
 - Added PowerShell formatting style guide to `Functions/CLAUDE.md` (Stroustrup preset, region blocks, operator spacing)
+- Fixed: Omada crawler script path in job dispatcher now respects the `IA_APP_ROOT` environment variable instead of hardcoding `/app`
+- Fixed: CRA summary log line reported wrong record count (referenced a removed variable from before the streaming refactor)

--- a/changes/omada-crawler-core.md
+++ b/changes/omada-crawler-core.md
@@ -1,0 +1,15 @@
+- Added native Omada IGA crawler that syncs directly from the Omada OData 4.0 REST API — no manual CSV export or transform step required
+- Supports six authentication methods: Form/Cookie (on-premise), HTTP Basic Auth, OAuth2 Client Credentials (cloud), OAuth2 ROPC, API Token, and Cookie String (session cookie from browser DevTools)
+- Syncs systems, contexts (OrgUnits + configured types), identities, accounts/principals, resources (business roles and permissions), entitlements (CHILDROLES nesting), role assignments (Resourceassignment), and effective account assignments (CalculatedAssignments/CRA)
+- Each of Omada's connected target systems (SAP, AD, Salesforce, etc.) is registered as a separate Identity Atlas System; resources and assignments are linked to their correct system
+- Fetches OData `$metadata` at startup to discover available entity sets — phases that require missing sets are skipped with a warning
+- Context types are configurable (`contextObjectTypes`): each entry specifies entity set, contextType label, and an optional identity reference field for direct context membership
+- Resource category mapping is configurable (`resourceCategoryMapping`): maps Omada ROLECATEGORY to Identity Atlas resourceType
+- CRA (CalculatedAssignments) pages are streamed one-at-a-time to prevent OOM on large cloud datasets
+- Added step-by-step logging throughout the crawler — each fetch, build and ingest operation prints a `→` indicator in the job transcript
+- Base URL is normalised using `System.Uri` — both root URLs and explicit OData paths are accepted; the Builtin service URL is derived automatically
+- Fixed: `oisauthtoken=` prefix is auto-prepended to bare CookieString tokens for Omada Cloud
+- Fixed: `$metadata` fetch no longer sends JSON Accept headers (caused HTTP 500 on cloud); XML is accepted as returned
+- Added 42 Pester unit tests for the Omada SDK (auth methods, helper functions, URL normalisation, config forwarding)
+- Added data model reference documentation for the Omada crawler (`docs/architecture/omada-crawler-datamodel.md`)
+- Added PowerShell formatting style guide to `Functions/CLAUDE.md` (Stroustrup preset, region blocks, operator spacing)

--- a/changes/omada-crawler-core.md
+++ b/changes/omada-crawler-core.md
@@ -15,3 +15,4 @@
 - Added PowerShell formatting style guide to `Functions/CLAUDE.md` (Stroustrup preset, region blocks, operator spacing)
 - Fixed: Omada crawler script path in job dispatcher now respects the `IA_APP_ROOT` environment variable instead of hardcoding `/app`
 - Fixed: CRA summary log line reported wrong record count (referenced a removed variable from before the streaming refactor)
+- Omada post-sync now calls account correlation (cross-system identity linking with Entra and other crawlers)

--- a/docs/architecture/omada-crawler-datamodel.md
+++ b/docs/architecture/omada-crawler-datamodel.md
@@ -1,0 +1,504 @@
+# Omada IGA Crawler — Data Model Reference
+
+> **Last updated:** 2026-06-04  
+> **Tested against:** Omada Identity v15.0 on-premise (OData 4.0) and Omada Cloud (rdw-stg.omada.cloud)
+
+---
+
+## Overview
+
+The Omada IGA crawler pulls data directly from Omada's OData 4.0 REST API (`/odata/dataobjects` and `/odata/builtin`) and pushes it into Identity Atlas via the Ingest API.
+
+**Key characteristics:**
+- Always performs a **full sync** (Omada has no delta API; `SyncMode` is accepted for dispatcher compatibility but ignored)
+- Registers every Omada connected system as a separate Identity Atlas **System**
+- Uses configurable type mappings, context object types, and resource category mapping
+- Supports on-premise and Omada Cloud deployments
+
+---
+
+## Authentication Methods
+
+Configure `authMethod` in the crawler config. All methods work for both on-premise and cloud.
+
+| Method | Required fields | Description |
+|--------|----------------|-------------|
+| `BasicAuth` | `username`, `password` | HTTP Basic Auth — most common for on-premise |
+| `FormCookie` | `username`, `password` | POST to `/api/authenticate`, capture session cookie |
+| `OAuth2CC` | `clientId`, `clientSecret`, `tokenEndpoint` | OAuth2 client credentials (app registration) |
+| `OAuth2ROPC` | `username`, `password`, `clientId`, `clientSecret`, `tokenEndpoint` | OAuth2 resource owner password credentials |
+| `ApiToken` | `apiToken` | Static Bearer token (no refresh) |
+| `CookieString` | `cookieString` | Pre-built cookie string — use for Omada Cloud when only browser/PS session cookies are available |
+
+**CookieString (cloud):** Paste the `oisauthtoken` value from your browser DevTools or from OmadaWeb.PS. A bare token value is automatically prefixed with `oisauthtoken=`. A valid `name=value` cookie string is sent as-is. Multi-cookie strings (`ASP.NET_SessionId=x; Auth=y`) are also supported unchanged.
+
+---
+
+## URL and Service Root
+
+Configure `baseUrl` as either:
+- The OData service root: `https://tenant.omada.cloud/odata/dataobjects` (explicit)
+- The server root: `https://tenant.omada.cloud/` (auto-appended with `/odata/dataobjects`)
+
+The crawler uses `System.Uri` to normalise the URL and derives the Builtin service URL automatically:
+
+```
+DataObjects: https://tenant.omada.cloud/odata/dataobjects
+Builtin:     https://tenant.omada.cloud/odata/builtin
+```
+
+The `$metadata` endpoint (used for entity-set discovery) is fetched at startup as a non-blocking diagnostic. If it fails (e.g. HTTP 500 on some cloud instances), all phases still attempt to run.
+
+---
+
+## OData Endpoints Used
+
+| Service | Base URL | Entity sets used |
+|---------|----------|-----------------|
+| DataObjects | `{baseUrl}` | System, Orgunit, Identity, User, Resource, Resourceassignment, Contextassignment, Employment, Usergroup, Country, Job_titles, + configured context types |
+| Builtin | `{builtinBaseUrl}` (derived from DataObjects URL) | CalculatedAssignments |
+
+**Pagination:** `$top=N&$skip=M` offset paging. Stops on **empty page** (not short page — Builtin returns variable-size pages). Default page size: 100 (Builtin CRA: 1000). CRA pages are streamed one-at-a-time to avoid OOM on large datasets.
+
+---
+
+## Configurable Settings
+
+### `contextObjectTypes` (array)
+
+Which Omada entity sets to sync as Identity Atlas Contexts. Each entry:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `entitySet` | Yes | Omada entity set name (case-sensitive, from `$metadata`) |
+| `contextType` | No | Identity Atlas contextType label (defaults to entitySet) |
+| `identityField` | No | Field on Identity entity that references this context type, used to create ContextMembers automatically |
+
+**Default:**
+```json
+[{ "entitySet": "Orgunit", "contextType": "OrgUnit", "identityField": "OUREF" }]
+```
+
+**Well-known identity→context field mappings** (implicit fallback):
+
+| Identity field | Context entity set |
+|----------------|--------------------|
+| OUREF | Orgunit |
+| COUNTRY | Country |
+| BUILDING | Building |
+| BUSINESSUNIT | Businessunit |
+| COSTCENTER | Costcenter |
+| DIVISION | Division |
+| JOBTITLE_REF | Job_titles |
+| LOCATION | Location |
+| SUBAREA | Subarea |
+
+### `resourceCategoryMapping` (array)
+
+Maps Omada `ROLECATEGORY` to Identity Atlas `resourceType`. First matching entry wins; leave `category` blank for the default/catch-all (must be last).
+
+**Default:**
+
+| ROLECATEGORY | Identity Atlas resourceType |
+|---|---|
+| Role | BusinessRole |
+| Permission | Resource |
+| *(blank = default)* | Resource |
+
+### `typeMappings` (object, overrides defaults)
+
+| Key | Maps | Default examples |
+|-----|------|-----------------|
+| `identityTypeToIdentityAtlas` | IDENTITYTYPE.Value → principalType | Employee→User, Contractor→ExternalUser, Machine→ServicePrincipal |
+| `contextTypeToIdentityAtlas` | OUTYPE.Value → contextType | OrgUnit→OrgUnit, Department→Department |
+| `identityTypesForIdentityTable` | Which IDENTITYTYPE values go into Identities table | [Employee, Primary, Person] |
+
+---
+
+## Sync Phases
+
+### Phase 0: Systems
+
+Every `System` entity in Omada is registered as a separate Identity Atlas System. This drives per-system scoping of resources and assignments.
+
+| | |
+|--|--|
+| **OData source** | `/System?$filter=Deleted eq false` |
+| **IA destination** | `ingest/systems` (full sync) |
+
+**Mapping:**
+
+| Omada field | Identity Atlas field |
+|-------------|---------------------|
+| UId | tenantId |
+| DisplayName | displayName |
+| *(constant)* | systemType = `'Omada'` |
+
+`Omada Identity` system (main IGA platform) → used as `systemId` for Contexts, Identities, Principals.
+
+---
+
+### Phase 1: Contexts
+
+Syncs every configured `contextObjectType`. Orgunit uses topological sort (parents before children via `PARENTOU`); all other types are flat.
+
+| | |
+|--|--|
+| **OData source** | `/{entitySet}?$filter=Deleted eq false` (per configured type) |
+| **IA destination** | `ingest/contexts` (full sync, scoped by `{ variant:'synced', contextType }`) |
+
+**Mapping:**
+
+| Omada field | Identity Atlas field |
+|-------------|---------------------|
+| UId | id, externalId |
+| NAME or DisplayName | displayName |
+| OUTYPE.Value (mapped) | contextType (Orgunit only; others use config value) |
+| PARENTOU.UId | parentContextId (Orgunit only) |
+| *(constant)* | variant = `'synced'`, targetType = `'Identity'` |
+
+---
+
+### Phase 2: Identities
+
+Only **person-type** identities (IDENTITYTYPE in `identityTypesForIdentityTable`) are stored in the Identities table.
+
+| | |
+|--|--|
+| **OData source** | `/Identity?$filter=Deleted eq false` |
+| **IA destination** | `ingest/identities` (full sync) |
+
+**Column mapping:**
+
+| Omada field | Identities column |
+|-------------|-------------------|
+| UId | id, externalId |
+| FIRSTNAME + LASTNAME | displayName, givenName, surname |
+| EMAIL | email |
+| EMPLOYEEID | employeeId |
+| JOBTITLE | jobTitle |
+| COMPANY.DisplayName | companyName |
+| CITY | city |
+| COUNTRY.DisplayName | country |
+
+**`extendedAttributes` JSON:**
+
+| Key | Source |
+|-----|--------|
+| identityType | IDENTITYTYPE.Value |
+| identityCategory | IDENTITYCATEGORY.Value |
+| identityStatus | IDENTITYSTATUS.Value |
+| identityId | IDENTITYID |
+| oisId | OISID |
+| email2 | EMAIL2 |
+| zipCode | ZIPCODE |
+| validFrom / validTo | VALIDFROM / VALIDTO |
+| riskScore | RISKSCORE |
+| riskLevel | RISKLEVEL.DisplayName |
+| manager | MANAGER[].DisplayName (joined `'; '`) |
+| identityOwner | IDENTITYOWNER.DisplayName |
+| explicitOwners | EXPLICITOWNER[].DisplayName (joined `'; '`) |
+| ouRefId / ouRefName | OUREF.UId / .DisplayName |
+| countryId / countryName | COUNTRY.UId / .DisplayName |
+| locationId | LOCATION.UId |
+| buildingId | BUILDING.UId |
+| businessUnitId | BUSINESSUNIT.UId |
+| costCenterId | COSTCENTER.UId |
+| divisionId | DIVISION.UId |
+| subAreaId | SUBAREA.UId |
+| jobTitleRefId / jobTitleRef | JOBTITLE_REF.UId / .DisplayName |
+| company | COMPANY.DisplayName |
+
+---
+
+### Phase 3: Accounts (Principals)
+
+Omada `User` entities (accounts) become Identity Atlas Principals. `principalType` is resolved from the linked Identity's IDENTITYTYPE.
+
+| | |
+|--|--|
+| **OData source** | `/User?$filter=Deleted eq false` |
+| **Join key** | User.IDENTITYREF.IDENTITYID = Identity.IDENTITYID |
+| **IA destination** | `ingest/principals` (full sync, batched per principalType) |
+
+**Mapping:**
+
+| Omada field | Principals column / extendedAttributes |
+|-------------|----------------------------------------|
+| UId | id, externalId |
+| FIRSTNAME + LASTNAME | displayName |
+| EMAIL | email |
+| JOBTITLE | jobTitle |
+| *(from linked Identity)* | principalType (mapped via typeMappings) |
+| *(constant)* | accountEnabled = true |
+| UserName | extendedAttributes.userName |
+
+---
+
+### Phase 4: IdentityMembers
+
+Links each Omada User account to its Identity. Only person-type identities (FK guard).
+
+| | |
+|--|--|
+| **IA destination** | `ingest/identity-members` (full sync) |
+
+| Source | Target field |
+|--------|-------------|
+| Identity.UId | identityId |
+| User.UId | principalId |
+| *(constant)* | accountType = `'Primary'` |
+
+---
+
+### Phase 5: Context Members
+
+Three sources combined, deduplicated on `(contextId, memberId)`. Stored with `memberType='Identity'` and `memberId=Identity.UId` so the context detail page query (`WHERE memberType = context.targetType`) finds members correctly.
+
+| | |
+|--|--|
+| **IA destination** | `ingest/context-members` (full sync, deduped) |
+
+**Source 1 — Contextassignment entity:**
+```
+CA_IDENTITY.UId → memberId
+CA_CONTEXT.UId  → contextId
+```
+
+**Source 2 — Direct Identity reference fields** (OUREF, COUNTRY, JOBTITLE_REF, …):
+```
+Identity.UId                  → memberId
+identity.{identityField}.UId  → contextId  (only if UId in $SyncedContextIds)
+```
+
+**Source 3 — Employment entity** (IDENTITYREF → OUREF, if entity set available):
+```
+IDENTITYREF.UId → memberId
+OUREF.UId       → contextId
+```
+
+All records: `memberType='Identity'`, `addedBy='sync'`. FK guard: memberId must be in Identities table.
+
+---
+
+### Phase 6: Resources
+
+Resources grouped by their connected system (`SYSTEMREF`) for correct per-system scoped-delete.
+
+| | |
+|--|--|
+| **OData source** | `/Resource?$filter=Deleted eq false` |
+| **Pre-fetch** | `/Usergroup` (for USERGROUPREF name lookup) |
+| **IA destination** | `ingest/resources` (full sync, per-system batches) |
+| **Type mapping** | ROLECATEGORY.Value → resourceType via `resourceCategoryMapping` |
+
+**Column mapping:**
+
+| Omada field | Resources column |
+|-------------|-----------------|
+| UId | id, externalId |
+| NAME or DisplayName | displayName |
+| DESCRIPTION | description |
+| ROLECATEGORY (mapped) | resourceType |
+| RESOURCESTATUS | enabled (false if Inactive/Disabled/Deleted) |
+
+**`extendedAttributes` JSON:**
+
+| Key | Source |
+|-----|--------|
+| resourceCategory | ROLECATEGORY.Value |
+| resourceType | ROLETYPEREF.DisplayName |
+| roleFolder | ROLEFOLDER.DisplayName |
+| skipProvisioning | SKIPPROVISIONING (bool) |
+| userGroupName | USERGROUPREF → Usergroup.DisplayName lookup |
+| explicitOwner | EXPLICITOWNER[].DisplayName (joined `'; '`) |
+| manualOwner | MANUALOWNER[].DisplayName (joined `'; '`) |
+| omadaSystem | SYSTEMREF.DisplayName |
+
+---
+
+### Phase 7: Entitlements
+
+Role nesting extracted from `Resource.CHILDROLES` — no separate endpoint exists.
+
+| | |
+|--|--|
+| **Source** | `$AllResources` (pre-fetched in Phase 6), `Resource.CHILDROLES` collection |
+| **IA destination** | `ingest/resource-relationships` (full sync, scope `{relationshipType:'Contains'}`) |
+
+| Field | Value |
+|-------|-------|
+| parentResourceId | Resource.UId |
+| childResourceId | CHILDROLES[n].UId |
+| relationshipType | `'Contains'` |
+
+---
+
+### Phase 8: Assignments
+
+Two sources combined for comprehensive coverage:
+
+#### Source A — Resourceassignment (role/permission assignments, IGA-governed)
+
+| | |
+|--|--|
+| **OData source** | `/Resourceassignment?$filter=Deleted eq false` |
+| **Filter** | ROLEASSNSTATUS.Value in `['Active', 'Pending']` |
+| **Fan-out** | Each identity assignment → one record per linked User account (via `$IdentityUidToUserUids`) |
+| **IA destination** | `ingest/resource-assignments` (full sync, per-system, `assignmentType='Governed'`) |
+| **Deduplication** | YES — on `principalId|resourceId` per system |
+
+| Omada field | ResourceAssignments column / extendedAttributes |
+|-------------|------------------------------------------------|
+| ROLEREF.UId | resourceId |
+| *(fanned via Identity.UId)* | principalId (User.UId) |
+| *(constant)* | assignmentType = `'Governed'` |
+| VALIDFROM / VALIDTO | extendedAttributes.validFrom / validTo |
+
+#### Source B — CalculatedAssignments (account provisioning, all systems)
+
+| | |
+|--|--|
+| **OData source** | `/odata/builtin/CalculatedAssignments?$filter=Status eq true&$expand=Identity,Resource,System,ResourceType` |
+| **Page size** | 1000 (server default; stops on empty page) |
+| **IA destination** | `ingest/principals` (delta) + `ingest/identity-members` (delta) + `ingest/resource-assignments` (full sync, per-system) |
+
+Two sub-tracks based on which Omada system the account belongs to:
+
+**Omada Identity accounts** (AccountName → `$UserNameToUid` lookup):
+```
+principalId  = existing User.UId
+assignmentType = Governed (IsManaged=true) or Direct (IsManaged=false)
+```
+
+**Connected-system accounts** (Salesforce, AD, etc. — AccountKey as new Principal id):
+```
+New Principal:
+  AccountKey       → id
+  AccountName      → externalId
+  FIRSTNAME/LASTNAME → displayName
+  EMAIL            → email
+  (constant)       → principalType = 'User'
+  Status           → accountEnabled
+
+New IdentityMember:
+  Identity.UId     → identityId  (FK guard: person types only)
+  AccountKey       → principalId
+  ResourceType.DisplayName → accountType
+
+ResourceAssignment:
+  Resource.UId     → resourceId
+  AccountKey       → principalId
+  IsManaged=true   → assignmentType = 'Governed'
+  IsManaged=false  → assignmentType = 'Direct'
+```
+
+**`extendedAttributes` on CRA assignments:**
+
+| Key | Source |
+|-----|--------|
+| validFrom / validTo | ValidFrom / ValidTo |
+| status | `'Enabled'` (Status=true) or `'Disabled'` |
+| reasons | Reasons[].Description (joined `'; '`) |
+| accountType | ResourceType.DisplayName |
+| accountName | AccountName |
+
+---
+
+## Entity Relationship Summary
+
+```
+Systems (58 connected systems, 1 per Omada System entity)
+  └─ Resources       (grouped by systemId)
+  └─ Principals      (grouped by systemId — Omada accounts + CRA-derived accounts)
+  └─ ResourceAssignments (grouped by systemId)
+
+Identities (person-type identities only: Employee, Primary, Person)
+  └─ IdentityMembers → Principals (Omada User accounts)
+  └─ IdentityMembers → Principals (connected-system accounts, from CRA)
+  └─ ContextMembers  → Contexts (memberType='Identity')
+
+Contexts (OrgUnit hierarchy + configured flat types e.g. JOB_TITLES)
+  └─ ContextMembers  (from Contextassignment + direct refs + Employment)
+
+Resources → ResourceRelationships (Contains, from CHILDROLES)
+Principals → ResourceAssignments → Resources
+```
+
+---
+
+## Shared State Variables (inter-phase dependencies)
+
+| Variable | Built in phase | Used in phases |
+|----------|---------------|----------------|
+| `$AllOmadaSystems` | Systems | Contexts, Resources, Assignments (label lookups) |
+| `$OmadaSystemMap` (UId→systemId) | Systems | Resources, Assignments |
+| `$OmadaIdentitySystemUId` | Systems | Assignments (distinguishes Omada vs connected-system accounts) |
+| `$SyncedContextIds` | Contexts | ContextMembers (filter out unknown CA_CONTEXT refs) |
+| `$AllIdentities` | Identities | Accounts (principalType lookup), ContextMembers (direct refs) |
+| `$IdentityLookup` (IDENTITYID→{uid,type}) | Identities | Accounts |
+| `$IdentityUidInIdentitiesTable` | Identities | ContextMembers, Assignments (FK guard) |
+| `$AllAccounts` | Accounts | IdentityMembers, ContextMembers, Assignments |
+| `$UserNameToUid` (UserName→UId) | Accounts | Assignments (CRA Omada-account lookup) |
+| `$IdentityUidToUserUids` (IdentityUId→[UserUIds]) | Accounts | ContextMembers, Assignments (fan-out) |
+| `$UserGroupMap` (UId→DisplayName) | Resources (pre-fetch) | Resources |
+| `$AllResources` | Resources | Entitlements |
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Ingest HTTP 429 / 5xx | Retry with exponential backoff: 2s, 4s, 8s, 16s, 32s (max 5 retries) |
+| Ingest HTTP 409 (job cancelled) | Throw immediately — aborts crawl |
+| Ingest HTTP 4xx (non-429) | Throw immediately |
+| OData entity set not in `$metadata` | Skip with yellow warning; continue |
+| CRA endpoint HTTP 404/400/501 | Skip gracefully (module not installed) |
+| Build-FGContexts 404 | Not called for Omada (Omada syncs its own contexts directly) |
+| `JOBTITLE_REF` contextId not in `$SyncedContextIds` | Skip ContextMember silently |
+| Identity not in `$IdentityUidInIdentitiesTable` | Skip IdentityMember / ContextMember (FK guard) |
+
+---
+
+## Post-Sync Hooks
+
+After all phases complete:
+
+1. **Phase results** → `POST /api/crawlers/jobs/:id/phases` (per-phase timing + status)
+2. **View refresh** → `POST /api/ingest/refresh-views` — refreshes `vw_ResourceUserPermissionAssignments` materialized view, recalculates `directMemberCount`/`totalMemberCount` on all Contexts, updates `lastSyncDateTime` on all Systems that have synced data
+
+---
+
+## Test Environments
+
+### On-Premise (masterdemo)
+
+| Property | Value |
+|----------|-------|
+| Hostname | `omada-server.example.com` (→ `masterdemo.example.com` → `192.0.2.28`) |
+| Auth method | BasicAuth (`DOMAIN\demouser`) |
+| API version | v15.0 |
+| Entity sets | 25 (DataObjects) + CalculatedAssignments (Builtin) |
+| Systems | 58 connected systems |
+| Identities | 332 (321 person-type) |
+| Contexts | 322 OrgUnits + 28 Job Titles |
+| Resources | 13,220 across all systems |
+| CRA records | ~37,961 active (Status=true) |
+
+DNS: AD DNS at `192.0.2.25`/`192.0.2.28` resolves `example.com` zone. Persisted via `extra_hosts` in `docker-compose.yml`.
+
+### Cloud (yourtenant.omada.cloud)
+
+| Property | Value |
+|----------|-------|
+| Base URL | `https://yourtenant.omada.cloud/` (auto-normalised to `/odata/dataobjects`) |
+| Auth method | CookieString (`oisauthtoken=<token>`) |
+| Entity sets | 18 available (subset of on-premise; `$metadata` may return 500 — gracefully skipped) |
+| Systems | 41 connected systems |
+| Identities | 4,279 |
+| Contexts | 403 OrgUnits + 277 Job Titles |
+| Resources | 30,355+ across all systems |
+| CRA records | 12,421+ active |
+
+**Cloud notes:** The `$metadata` endpoint on cloud may return HTTP 500 — this is handled gracefully (all phases still run). CookieString auth sends the cookie in a `Cookie` request header (not via WebSession), which is required for cloud HTTPS URLs where WebSession cookie-domain matching is unreliable.

--- a/setup/IdentityAtlas.psm1
+++ b/setup/IdentityAtlas.psm1
@@ -6,16 +6,17 @@
 
 $repoRoot = Split-Path $PSScriptRoot -Parent
 
-# Tools — PowerShell SDK (Graph API wrappers, idempotent helpers)
+# Tools — PowerShell SDK (Graph API wrappers, idempotent helpers, Omada client)
 $graph   = @( Get-ChildItem -Path (Join-Path $repoRoot 'tools\powershell-sdk\graph')   -Include *.ps1 -Recurse -ErrorAction SilentlyContinue )
 $helpers = @( Get-ChildItem -Path (Join-Path $repoRoot 'tools\powershell-sdk\helpers') -Include *.ps1 -Recurse -ErrorAction SilentlyContinue )
+$omada   = @( Get-ChildItem -Path (Join-Path $repoRoot 'tools\powershell-sdk\omada')   -Include *.ps1 -Recurse -ErrorAction SilentlyContinue )
 
 # Tools — Risk scoring and account correlation
 $riskScoring = @( Get-ChildItem -Path (Join-Path $repoRoot 'tools\riskscoring') -Include *.ps1 -Recurse -ErrorAction SilentlyContinue )
 $correlation = @( Get-ChildItem -Path (Join-Path $repoRoot 'tools\correlation') -Include *.ps1 -Recurse -ErrorAction SilentlyContinue )
 
 # Dot source all function files
-foreach ($import in @($graph + $helpers + $riskScoring + $correlation)) {
+foreach ($import in @($graph + $helpers + $omada + $riskScoring + $correlation)) {
     try {
         . $import.fullname
     }

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -366,7 +366,7 @@ switch ($JobType) {
                 if ($objects.ContainsKey('cras'))            { $crawlerParams['SyncCRAs']            = [bool]$objects['cras'] }
             }
 
-            & /app/tools/crawlers/omada/Start-OmadaCrawler.ps1 @crawlerParams
+            & "$appRoot/tools/crawlers/omada/Start-OmadaCrawler.ps1" @crawlerParams
 
             Update-JobProgress -Step 'Complete' -Pct 100
             Set-JobResult @{ status = 'Omada sync completed successfully' }

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -307,6 +307,75 @@ switch ($JobType) {
         Set-JobResult @{ status = 'CSV import completed successfully' }
     }
 
+    'omada' {
+        Update-JobProgress -Step 'Preparing Omada sync' -Pct 5
+
+        # Fail fast if required connection fields are absent — prevents a
+        # misleading "null authMethod" validation error deep in the crawler.
+        if (-not $Config['baseUrl']) {
+            throw "Omada config is missing 'baseUrl' — check the crawler configuration."
+        }
+        if (-not $Config['authMethod']) {
+            throw "Omada config is missing 'authMethod' — check the crawler configuration."
+        }
+
+        $tempConfig = "/tmp/omada-config-$JobId.json"
+        $omadaConfig = @{
+            baseUrl               = $Config['baseUrl']
+            apiVersion            = if ($Config['apiVersion']) { $Config['apiVersion'] } else { 'v14' }
+            authMethod            = $Config['authMethod']
+            username              = $Config['username']
+            password              = $Config['password']
+            clientId              = $Config['clientId']
+            clientSecret          = $Config['clientSecret']
+            tokenEndpoint         = $Config['tokenEndpoint']
+            apiToken              = $Config['apiToken']
+            cookieString          = $Config['cookieString']
+            sessionTimeoutMinutes = if ($Config['sessionTimeoutMinutes']) { $Config['sessionTimeoutMinutes'] } else { 30 }
+            pageSize              = if ($Config['pageSize']) { $Config['pageSize'] } else { 100 }
+            typeMappings              = $Config['typeMappings']
+            selectedObjects           = $Config['selectedObjects']
+            contextObjectTypes        = $Config['contextObjectTypes']
+            resourceCategoryMapping   = $Config['resourceCategoryMapping']
+        }
+        $omadaConfig | ConvertTo-Json -Depth 10 | Set-Content $tempConfig -Encoding UTF8
+
+        try {
+            Update-JobProgress -Step 'Running Omada crawler' -Pct 10
+
+            $syncMode = if ($Config['_syncMode'] -in @('full','delta')) { $Config['_syncMode'] } else { 'full' }
+
+            $crawlerParams = @{
+                ApiBaseUrl = $apiBaseUrl
+                ApiKey     = $ApiKey
+                ConfigFile = $tempConfig
+                JobId      = $JobId
+                SyncMode   = $syncMode
+            }
+
+            # Apply selectedObjects toggles
+            $objects = $Config['selectedObjects']
+            if ($objects) {
+                if ($objects.ContainsKey('contexts'))        { $crawlerParams['SyncContexts']       = [bool]$objects['contexts'] }
+                if ($objects.ContainsKey('identities'))      { $crawlerParams['SyncIdentities']     = [bool]$objects['identities'] }
+                if ($objects.ContainsKey('accounts'))        { $crawlerParams['SyncAccounts']        = [bool]$objects['accounts'] }
+                if ($objects.ContainsKey('contextMembers'))  { $crawlerParams['SyncContextMembers']  = [bool]$objects['contextMembers'] }
+                if ($objects.ContainsKey('resources'))       { $crawlerParams['SyncResources']       = [bool]$objects['resources'] }
+                if ($objects.ContainsKey('entitlements'))    { $crawlerParams['SyncEntitlements']    = [bool]$objects['entitlements'] }
+                if ($objects.ContainsKey('assignments'))     { $crawlerParams['SyncAssignments']     = [bool]$objects['assignments'] }
+                if ($objects.ContainsKey('cras'))            { $crawlerParams['SyncCRAs']            = [bool]$objects['cras'] }
+            }
+
+            & /app/tools/crawlers/omada/Start-OmadaCrawler.ps1 @crawlerParams
+
+            Update-JobProgress -Step 'Complete' -Pct 100
+            Set-JobResult @{ status = 'Omada sync completed successfully' }
+        }
+        finally {
+            if (Test-Path $tempConfig) { Remove-Item $tempConfig -Force }
+        }
+    }
+
     default {
         throw "Unknown job type: $JobType"
     }

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -368,6 +368,13 @@ switch ($JobType) {
 
             & "$appRoot/tools/crawlers/omada/Start-OmadaCrawler.ps1" @crawlerParams
 
+            # Post-sync: account-to-identity correlation (cross-system — links Omada identities
+            # to the same Identity records as Entra/other crawler accounts for the same person)
+            Update-JobProgress -Step 'Linking accounts to identities' -Pct 90
+            try {
+                if (Get-Command Invoke-FGAccountCorrelation -ErrorAction SilentlyContinue) { Invoke-FGAccountCorrelation }
+            } catch { Write-Host "  Account correlation failed: $($_.Exception.Message)" -ForegroundColor Yellow }
+
             Update-JobProgress -Step 'Complete' -Pct 100
             Set-JobResult @{ status = 'Omada sync completed successfully' }
         }

--- a/test/unit/IdentityAtlas.Tests.ps1
+++ b/test/unit/IdentityAtlas.Tests.ps1
@@ -27,12 +27,14 @@ BeforeAll {
     $script:graphRoot   = Join-Path $script:repoRoot 'tools\powershell-sdk\graph'
     $script:helpersRoot = Join-Path $script:repoRoot 'tools\powershell-sdk\helpers'
     $script:riskRoot    = Join-Path $script:repoRoot 'tools\riskscoring'
+    $script:omadaRoot   = Join-Path $script:repoRoot 'tools\powershell-sdk\omada'
 
     Import-Module $script:modulePath -Force -ErrorAction Stop
 
     $script:allPs1Files = @(
         Get-ChildItem -Path $script:graphRoot   -Include '*.ps1' -Recurse -ErrorAction SilentlyContinue
         Get-ChildItem -Path $script:helpersRoot -Include '*.ps1' -Recurse -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $script:omadaRoot   -Include '*.ps1' -Recurse -ErrorAction SilentlyContinue
         Get-ChildItem -Path $script:riskRoot    -Include '*.ps1' -Recurse -ErrorAction SilentlyContinue
     )
 }
@@ -92,6 +94,19 @@ Describe 'Function Availability — Helpers (idempotent)' {
         'Get-FGServicePrincipalType',
         'Add-FGEntraCalculatedAttributes', 'Get-FGEntraPortalLink',
         'Test-FGDistinguishedName', 'Convert-FGDistinguishedNameToOUPath'
+    ) {
+        Get-Command $_ -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+}
+
+Describe 'Function Availability — Omada SDK' {
+    It 'exports <_>' -ForEach @(
+        'Connect-OmadaAPI',
+        'Get-OmadaEntitySets',
+        'Invoke-OmadaPagedRequest',
+        'Invoke-OmadaGetRequest',
+        'Get-OmadaRefValue',
+        'Get-OmadaRefUid'
     ) {
         Get-Command $_ -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
     }
@@ -413,14 +428,16 @@ Describe 'File Structure' {
         $script:riskRoot | Should -Exist
     }
 
-    It 'all .ps1 files follow Verb-FGNoun naming' {
-        $bad = $script:allPs1Files | Where-Object { $_.BaseName -notmatch '^[A-Z][a-z]+-FG[A-Z]' }
+    It 'all .ps1 files follow Verb-FGNoun or Verb-OmadaNoun naming' {
+        $bad = $script:allPs1Files | Where-Object { $_.BaseName -notmatch '^[A-Z][a-z]+-(FG|Omada)[A-Z]' }
+        $bad = $bad | Where-Object { $_.FullName -notmatch 'riskscoring' }
         $bad | Should -BeNullOrEmpty -Because "bad names: $($bad.BaseName -join ', ')"
     }
 
     It 'IdentityAtlas.psm1 dot-sources <_>' -ForEach @(
         "tools\powershell-sdk\graph",
         "tools\powershell-sdk\helpers",
+        "tools\powershell-sdk\omada",
         "tools\riskscoring"
     ) {
         $psm1 = Get-Content (Join-Path $script:repoRoot 'setup\IdentityAtlas.psm1') -Raw
@@ -437,6 +454,12 @@ Describe 'File Structure' {
 
     It 'setup/azure folder is gone (Docker-only)' {
         Join-Path $script:repoRoot 'setup\azure' | Should -Not -Exist
+    }
+    It 'tools/powershell-sdk/omada folder exists' {
+        $script:omadaRoot | Should -Exist
+    }
+    It 'tools/crawlers/omada/Start-OmadaCrawler.ps1 exists' {
+        Join-Path $script:repoRoot 'tools\crawlers\omada\Start-OmadaCrawler.ps1' | Should -Exist
     }
 }
 

--- a/test/unit/Omada.Tests.ps1
+++ b/test/unit/Omada.Tests.ps1
@@ -1,0 +1,222 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Pester unit tests for the Omada SDK (tools/powershell-sdk/omada).
+
+.DESCRIPTION
+    Tests the pure helper functions exported by the Omada SDK.
+    No network calls are made — Omada API connectivity is out of scope.
+
+.USAGE
+    Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser
+    Invoke-Pester -Path test/unit/Omada.Tests.ps1 -Output Detailed
+#>
+
+BeforeAll {
+    $script:repoRoot   = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:modulePath = Join-Path $script:repoRoot 'setup\IdentityAtlas.psd1'
+    Import-Module $script:modulePath -Force -ErrorAction Stop
+}
+
+# ─── Get-OmadaRefValue ────────────────────────────────────────────────────────
+Describe 'Get-OmadaRefValue' {
+    It 'returns Fallback for null input' {
+        Get-OmadaRefValue -Ref $null -Fallback 'default' | Should -Be 'default'
+    }
+    It 'returns empty string Fallback when Fallback not specified' {
+        Get-OmadaRefValue -Ref $null | Should -Be ''
+    }
+    It 'returns the string as-is when Ref is a string' {
+        Get-OmadaRefValue -Ref 'Employee' | Should -Be 'Employee'
+    }
+    It 'extracts .Value from an OIS.SetValue-shaped object' {
+        $ref = [PSCustomObject]@{ Value = 'Business Role' }
+        Get-OmadaRefValue -Ref $ref | Should -Be 'Business Role'
+    }
+    It 'extracts .DisplayName from an OIS.ReferenceValue-shaped object' {
+        $ref = [PSCustomObject]@{ DisplayName = 'OrgUnit' }
+        Get-OmadaRefValue -Ref $ref | Should -Be 'OrgUnit'
+    }
+    It '.Value takes precedence over .DisplayName' {
+        $ref = [PSCustomObject]@{ Value = 'Employee'; DisplayName = 'ignored' }
+        Get-OmadaRefValue -Ref $ref | Should -Be 'Employee'
+    }
+    It 'falls back to .english when neither .Value nor .DisplayName exists' {
+        $ref = [PSCustomObject]@{ english = 'EnglishLabel' }
+        Get-OmadaRefValue -Ref $ref | Should -Be 'EnglishLabel'
+    }
+    It 'returns Fallback when no known property exists' {
+        $ref = [PSCustomObject]@{ SomethingElse = 'irrelevant' }
+        Get-OmadaRefValue -Ref $ref -Fallback 'unknown' | Should -Be 'unknown'
+    }
+}
+
+# ─── Get-OmadaRefUid ─────────────────────────────────────────────────────────
+Describe 'Get-OmadaRefUid' {
+    It 'returns Fallback for null input' {
+        Get-OmadaRefUid -Ref $null -Fallback 'fb' | Should -Be 'fb'
+    }
+    It 'returns empty string Fallback when Fallback not specified' {
+        Get-OmadaRefUid -Ref $null | Should -Be ''
+    }
+    It 'returns the string as-is when Ref is a string' {
+        Get-OmadaRefUid -Ref 'uid-abc-123' | Should -Be 'uid-abc-123'
+    }
+    It 'extracts .UId from an OData ReferenceValue-shaped object' {
+        $uid = '11111111-1111-1111-1111-111111111111'
+        $ref = [PSCustomObject]@{ UId = $uid }
+        Get-OmadaRefUid -Ref $ref | Should -Be $uid
+    }
+    It 'falls back to ._UID when .UId is absent' {
+        $ref = [PSCustomObject]@{ _UID = 'legacy-uid' }
+        Get-OmadaRefUid -Ref $ref | Should -Be 'legacy-uid'
+    }
+    It 'falls back to .id when no .UId or ._UID exists' {
+        $ref = [PSCustomObject]@{ id = 'id-42' }
+        Get-OmadaRefUid -Ref $ref | Should -Be 'id-42'
+    }
+    It 'returns Fallback when no known property exists' {
+        $ref = [PSCustomObject]@{ Something = 'x' }
+        Get-OmadaRefUid -Ref $ref -Fallback 'none' | Should -Be 'none'
+    }
+}
+
+# ─── Omada SDK function availability ─────────────────────────────────────────
+Describe 'Omada SDK — function availability' {
+    It 'exports <_>' -ForEach @(
+        'Connect-OmadaAPI',
+        'Get-OmadaEntitySets',
+        'Invoke-OmadaPagedRequest',
+        'Invoke-OmadaGetRequest',
+        'Get-OmadaRefValue',
+        'Get-OmadaRefUid'
+    ) {
+        Get-Command $_ -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+}
+
+# ─── Connect-OmadaAPI — ApiToken (no HTTP) ────────────────────────────────────
+Describe 'Connect-OmadaAPI — ApiToken auth' {
+    It 'succeeds without making any HTTP call' {
+        { Connect-OmadaAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'ApiToken' -ApiToken 'test-static-token' } |
+            Should -Not -Throw
+    }
+}
+
+# ─── Connect-OmadaAPI — BasicAuth (no HTTP) ───────────────────────────────────
+Describe 'Connect-OmadaAPI — BasicAuth auth' {
+    It 'succeeds without making any HTTP call' {
+        { Connect-OmadaAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'BasicAuth' -Username 'admin' -Password 'pass' } |
+            Should -Not -Throw
+    }
+    It 'throws when username is missing' {
+        { Connect-OmadaAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'BasicAuth' -Password 'pass' } |
+            Should -Throw
+    }
+}
+
+# ─── Connect-OmadaAPI — CookieString (no HTTP) ────────────────────────────────
+Describe 'Connect-OmadaAPI — CookieString auth' {
+    It 'succeeds with an explicit name=value cookie string' {
+        { Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+            -AuthMethod 'CookieString' -CookieString 'oisauthtoken=MHXp1OG0seFfKwNYzQkZwA==' } |
+            Should -Not -Throw
+    }
+    It 'succeeds with a bare token — auto-prefix oisauthtoken= is applied' {
+        { Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+            -AuthMethod 'CookieString' -CookieString 'MHXp1OG0seFfKwNYzQkZwA==' } |
+            Should -Not -Throw
+    }
+    It 'throws when CookieString is empty' {
+        { Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+            -AuthMethod 'CookieString' -CookieString '' } |
+            Should -Throw
+    }
+    It 'passes an ASP.NET multi-cookie string as-is (already name=value)' {
+        { Connect-OmadaAPI -BaseUrl 'https://server/odata/dataobjects' `
+            -AuthMethod 'CookieString' -CookieString 'ASP.NET_SessionId=abc123; Auth=xyz' } |
+            Should -Not -Throw
+    }
+}
+
+# ─── Get-OmadaAuthRoot ─────────────────────────────────────────────────────────
+Describe 'Get-OmadaAuthRoot' {
+    BeforeEach {
+        # Seed the session so Get-OmadaAuthRoot can read BaseUrl
+        Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+            -AuthMethod 'ApiToken' -ApiToken 'tok'
+    }
+
+    It 'strips /odata/dataobjects from a cloud URL' {
+        Get-OmadaAuthRoot | Should -Be 'https://tenant.omada.cloud'
+    }
+
+    It 'strips /odata/dataobjects from an on-prem URL' {
+        Connect-OmadaAPI -BaseUrl 'http://server/odata/dataobjects' `
+            -AuthMethod 'ApiToken' -ApiToken 'tok'
+        Get-OmadaAuthRoot | Should -Be 'http://server'
+    }
+
+    It 'returns the base URL unchanged when no /odata/ segment is present' {
+        Connect-OmadaAPI -BaseUrl 'http://server/api' `
+            -AuthMethod 'ApiToken' -ApiToken 'tok'
+        Get-OmadaAuthRoot | Should -Be 'http://server/api'
+    }
+}
+
+# ─── URL normalisation — System.Uri logic (in Start-OmadaCrawler) ─────────────
+Describe 'Omada URL normalisation' {
+    BeforeAll {
+        $script:crawlerContent = Get-Content (Join-Path $script:repoRoot 'tools\crawlers\omada\Start-OmadaCrawler.ps1') -Raw
+    }
+
+    It 'crawler normalises base URL using System.Uri' {
+        $script:crawlerContent | Should -Match 'System\.Uri'
+    }
+    It 'crawler auto-appends /odata/dataobjects to root URLs' {
+        $script:crawlerContent | Should -Match '/odata/dataobjects'
+    }
+    It 'crawler derives Builtin URL from DataObjects path' {
+        $script:crawlerContent | Should -Match 'BuiltinBaseUrl'
+    }
+}
+
+# ─── File structure ────────────────────────────────────────────────────────────
+Describe 'Omada file structure' {
+    BeforeAll {
+        $script:omadaRoot    = Join-Path $script:repoRoot 'tools\powershell-sdk\omada'
+        $script:crawlerPath  = Join-Path $script:repoRoot 'tools\crawlers\omada\Start-OmadaCrawler.ps1'
+        $script:dispatchPath = Join-Path $script:repoRoot 'setup\docker\Invoke-CrawlerJob.ps1'
+    }
+
+    It 'tools/powershell-sdk/omada folder exists' {
+        $script:omadaRoot | Should -Exist
+    }
+    It 'Start-OmadaCrawler.ps1 exists' {
+        $script:crawlerPath | Should -Exist
+    }
+    It 'Invoke-CrawlerJob.ps1 handles omada jobType' {
+        $content = Get-Content $script:dispatchPath -Raw
+        $content | Should -Match "'omada'"
+    }
+    It 'Invoke-CrawlerJob.ps1 validates baseUrl before writing temp config' {
+        $content = Get-Content $script:dispatchPath -Raw
+        $content | Should -Match "Config\['baseUrl'\]"
+    }
+    It 'Invoke-CrawlerJob.ps1 validates authMethod before writing temp config' {
+        $content = Get-Content $script:dispatchPath -Raw
+        $content | Should -Match "Config\['authMethod'\]"
+    }
+    It 'Invoke-CrawlerJob.ps1 forwards contextObjectTypes to the crawler' {
+        $content = Get-Content $script:dispatchPath -Raw
+        $content | Should -Match 'contextObjectTypes'
+    }
+    It 'Invoke-CrawlerJob.ps1 forwards resourceCategoryMapping to the crawler' {
+        $content = Get-Content $script:dispatchPath -Raw
+        $content | Should -Match 'resourceCategoryMapping'
+    }
+    It 'SDK files export expected functions' {
+        $sdkFiles = Get-ChildItem (Join-Path $script:repoRoot 'tools\powershell-sdk\omada') -Filter '*.ps1'
+        $sdkFiles.Count | Should -BeGreaterOrEqual 3
+    }
+}

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -1229,7 +1229,6 @@ if ($SyncAssignments) {
             $SysId = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
             $Seen  = [System.Collections.Generic.HashSet[string]]::new()
             $Dedup = @($CaPrincipalsBySys[$Key] | Where-Object { $Seen.Add($_.id) })
-        Write-Host "  CRA: $CaTotalCount records → $TotalCaPrincipals connected-system accounts, $($CaIdentityMembers.Count) identity-member links" -ForegroundColor Green
                 Send-IngestBatch -Endpoint 'ingest/principals' -SystemId $SysId `
                     -SyncMode 'delta' -Records $Dedup | Out-Null
                 $TotalCaPrincipals += $Dedup.Count

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -1,0 +1,1343 @@
+<#
+.SYNOPSIS
+    Synchronise Omada IGA data to Identity Atlas via the Ingest API.
+
+.DESCRIPTION
+    Pulls data directly from the Omada REST API (no manual CSV export required)
+    and pushes it to the Identity Atlas Ingest API in structured batches.
+
+    Omada uses a generic data model: a single endpoint returns all variants of
+    an entity, differentiated by reference-typed fields (IdentityType,
+    ResourceType, ContextType, etc.). The typeMappings config section controls
+    how these Omada-specific values map to Identity Atlas schema values.
+
+    Omada exposes an OData 4.0 REST API at /odata/dataobjects (on-premise) or the
+    equivalent Cloud endpoint. Configure baseUrl as the OData service root; entity
+    sets (Identities, OrgUnits, etc.) are addressed directly under it.
+    Check /odata/dataobjects/$metadata on your server to confirm entity set names.
+
+    Supported auth methods: FormCookie, BasicAuth, OAuth2CC, OAuth2ROPC, ApiToken, CookieString.
+    WindowsAuth is not supported — use FormCookie, BasicAuth, or OAuth2ROPC for on-premise.
+
+    NOTE: Omada has no native delta/change-feed API. SyncMode is accepted for
+    dispatcher compatibility but the crawler always performs a full sync.
+
+.PARAMETER ApiBaseUrl
+    Identity Atlas API base URL (e.g. http://localhost:3001/api)
+
+.PARAMETER ApiKey
+    Identity Atlas crawler API key (fgc_...)
+
+.PARAMETER ConfigFile
+    Path to JSON config file written by Invoke-CrawlerJob.ps1.
+
+.PARAMETER SyncContexts
+    Sync Omada contexts (OrgUnits, Departments, etc.) → Contexts table.
+
+.PARAMETER SyncIdentities
+    Sync Omada identities → Identities + IdentityMembers tables.
+
+.PARAMETER SyncAccounts
+    Sync Omada user accounts → Principals table.
+
+.PARAMETER SyncResources
+    Sync Omada resources/permissions → Resources table.
+
+.PARAMETER SyncEntitlements
+    Sync Omada permission nesting → ResourceRelationships (Contains).
+
+.PARAMETER SyncAssignments
+    Sync Omada role assignments → ResourceAssignments (Governed).
+
+.PARAMETER SyncContextMembers
+    Sync Omada context assignments (Contextassignment) → ContextMembers table.
+    Requires SyncContexts and SyncAccounts to have run in the same job.
+
+.PARAMETER SyncCRAs
+    Sync Omada certification review activities → CertificationDecisions.
+
+.PARAMETER RefreshViews
+    Refresh SQL views after sync (default: true).
+
+.PARAMETER SyncMode
+    'full' or 'delta' — accepted for dispatcher compatibility.
+    Omada has no native delta API; this parameter is ignored and a full sync
+    is always performed.
+
+.PARAMETER JobId
+    Job ID for live progress reporting to the UI. 0 = standalone (no reporting).
+
+.EXAMPLE
+    .\Start-OmadaCrawler.ps1 -ApiBaseUrl http://localhost:3001/api -ApiKey fgc_... -ConfigFile .\omada.json
+#>
+
+#region Parameters
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory)] [string]$ApiBaseUrl,
+    [Parameter(Mandatory)] [string]$ApiKey,
+    [Parameter(Mandatory)] [string]$ConfigFile,
+
+    [switch]$SyncContexts        = $True,
+    [switch]$SyncIdentities      = $True,
+    [switch]$SyncAccounts        = $True,
+    [switch]$SyncContextMembers  = $True,
+    [switch]$SyncResources       = $True,
+    [switch]$SyncEntitlements    = $True,
+    [switch]$SyncAssignments     = $True,
+    [switch]$SyncCRAs            = $True,
+    [switch]$RefreshViews        = $True,
+
+    [ValidateSet('full','delta')]
+    [string]$SyncMode = 'full',
+
+    [int]$JobId = 0
+)
+
+#endregion Parameters
+
+#region Configuration
+
+$ErrorActionPreference = 'Stop'
+$ApiBaseUrl = $ApiBaseUrl.TrimEnd('/')
+
+# ─── Load config ─────────────────────────────────────────────────
+if (-not (Test-Path $ConfigFile)) { throw "Config file not found: $ConfigFile" }
+$Cfg = Get-Content $ConfigFile -Raw | ConvertFrom-Json
+
+# ── Normalise base URL via System.Uri ─────────────────────────────
+# Accepts both:
+#   https://tenant.omada.cloud/               (root — auto-appends /odata/dataobjects)
+#   https://tenant.omada.cloud/odata/dataobjects   (explicit — used as-is)
+#   http://server/odata/dataobjects               (on-prem)
+$_rawUri  = [System.Uri]::new(($Cfg.baseUrl.Trim().TrimEnd('/')))
+$_host    = $_rawUri.Scheme + '://' + $_rawUri.Authority   # scheme + host + non-default port
+$_path    = $_rawUri.AbsolutePath.TrimEnd('/')
+if ($_path -notmatch '(?i)/odata/dataobjects$') { $_path = '/odata/dataobjects' }
+$BaseUrl        = $_host + $_path
+$BuiltinBaseUrl = $_host + ($_path -replace '(?i)/dataobjects$', '/builtin')
+# ──────────────────────────────────────────────────────────────────
+
+$ApiVersion            = if ($Cfg.apiVersion) { $Cfg.apiVersion } else { 'v14' }
+$PageSize              = if ($Cfg.pageSize)   { [int]$Cfg.pageSize } else { 100 }
+$SessionTimeoutMinutes = if ($Cfg.sessionTimeoutMinutes) { [int]$Cfg.sessionTimeoutMinutes } else { 30 }
+
+# contextObjectTypes: list of Omada entity sets to sync as Identity Atlas Contexts.
+# Each entry: { entitySet: "Orgunit", contextType: "OrgUnit", identityField: "OUREF" }
+# identityField: the field on the Identity entity that references this context type (for direct ContextMember creation).
+# Default: Orgunit only (backward-compatible). Operators add Country, Building, etc. as needed.
+$DefaultContextObjectTypes = @(
+    @{ entitySet = 'Orgunit'; contextType = 'OrgUnit'; identityField = 'OUREF' }
+)
+$ContextObjectTypes = if ($Cfg.contextObjectTypes) {
+    @($Cfg.contextObjectTypes | ForEach-Object {
+        @{ entitySet    = [string]$_.entitySet
+           contextType  = if ($_.contextType)  { [string]$_.contextType  } else { [string]$_.entitySet }
+           identityField = if ($_.identityField) { [string]$_.identityField } else { $Null } }
+    })
+} else {
+    $DefaultContextObjectTypes
+}
+# Map: entitySet → identityField (for ContextMember creation from Identity references)
+$ContextEntitySetToIdentityField = @{}
+foreach ($Cot in $ContextObjectTypes) {
+    if ($Cot.identityField) { $ContextEntitySetToIdentityField[$Cot.entitySet] = $Cot.identityField }
+}
+
+# Built-in field→entitySet map for well-known Omada context reference fields on Identity.
+# Used as a fallback when identityField is not explicitly configured.
+$WellKnownIdentityContextFields = @{
+    OUREF        = 'Orgunit'
+    COUNTRY      = 'Country'
+    BUILDING     = 'Building'
+    BUSINESSUNIT = 'Businessunit'
+    COSTCENTER   = 'Costcenter'
+    DIVISION     = 'Division'
+    JOBTITLE_REF = 'Jobtitle'
+    LOCATION     = 'Location'
+    SUBAREA      = 'Subarea'
+}
+
+# resourceCategoryMapping — maps Omada ROLECATEGORY to Identity Atlas resourceType + optional tags.
+# Entry with empty category = default/catch-all (must be last).
+# Tags land in extendedAttributes.tags and can be used for filtering in the UI.
+$DefaultResourceCategoryMapping = @(
+    @{ category = 'Role';       resourceType = 'BusinessRole' }
+    @{ category = 'Permission'; resourceType = 'Resource' }
+    @{ category = '';           resourceType = 'Resource' }  # default/catch-all
+)
+$ResourceCategoryMapping = if ($Cfg.resourceCategoryMapping) {
+    @($Cfg.resourceCategoryMapping | ForEach-Object {
+        @{ category    = if ($_.category)    { [string]$_.category    } else { '' }
+           resourceType = if ($_.resourceType){ [string]$_.resourceType } else { 'Resource' } }
+    })
+} else {
+    $DefaultResourceCategoryMapping
+}
+
+#endregion Configuration
+
+#region Functions
+
+function Map-ResourceCategory {
+    param([string]$Category)
+    foreach ($M in $ResourceCategoryMapping) {
+        if ($M.category -eq $Category -or $M.category -eq '') {
+            return $M.resourceType
+        }
+    }
+    return 'Resource'
+}
+
+# Default type mappings (operator can override in config)
+$DefaultTypeMappings = @{
+    identityTypeToIdentityAtlas    = @{ Employee = 'User'; Primary = 'User'; Person = 'User'; Contractor = 'ExternalUser'; 'External Worker' = 'ExternalUser'; 'Service Account' = 'ServicePrincipal'; 'Non-Person' = 'ServicePrincipal'; Machine = 'ServicePrincipal' }
+    resourceTypeToIdentityAtlas    = @{ 'Business Role' = 'BusinessRole' }
+    contextTypeToIdentityAtlas     = @{ 'OrgUnit' = 'OrgUnit'; 'Organisational Unit' = 'OrgUnit'; Department = 'Department'; Location = 'Location'; 'Cost Center' = 'CostCenter'; CostCenter = 'CostCenter' }
+    identityTypesForIdentityTable  = @('Employee', 'Primary', 'Person')
+    resourceTypesAsBusinessRoles   = @('Business Role')
+}
+
+function Merge-TypeMappings {
+    param($Defaults, $Overrides)
+    if (-not $Overrides) { return $Defaults }
+    $Result = @{}
+    foreach ($K in $Defaults.Keys) {
+        if ($Overrides.PSObject.Properties.Name -contains $K) {
+            $Ov = $Overrides.$K
+            if ($Ov -is [System.Management.Automation.PSCustomObject]) {
+                # Convert PSCustomObject to hashtable and merge
+                $Merged = @{}
+                foreach ($Dk in $Defaults[$K].Keys) { $Merged[$Dk] = $Defaults[$K][$Dk] }
+                foreach ($Ok in $Ov.PSObject.Properties) { $Merged[$Ok.Name] = $Ok.Value }
+                $Result[$K] = $Merged
+            } elseif ($Ov -is [array]) {
+                $Result[$K] = @($Ov)
+            } else {
+                $Result[$K] = $Ov
+            }
+        } else {
+            $Result[$K] = $Defaults[$K]
+        }
+    }
+    return $Result
+}
+
+$TypeMappings = Merge-TypeMappings -Defaults $DefaultTypeMappings -Overrides $Cfg.typeMappings
+$IdentityTypesForIdentityTable = @($TypeMappings['identityTypesForIdentityTable'])
+
+function Map-IdentityTypeToAtlas {
+    param([string]$OmadaType)
+    $Map = $TypeMappings['identityTypeToIdentityAtlas']
+    if ($Map.ContainsKey($OmadaType)) { return $Map[$OmadaType] }
+    Write-Host "    Warning: unknown IdentityType '$OmadaType' — defaulting to 'User'" -ForegroundColor Yellow
+    return 'User'
+}
+
+function Map-ResourceTypeToAtlas {
+    param([string]$OmadaType)
+    $Map = $TypeMappings['resourceTypeToIdentityAtlas']
+    if ($Map.ContainsKey($OmadaType)) { return $Map[$OmadaType] }
+    # Normalise: remove spaces, keep as-is
+    return $OmadaType -replace '\s+', ''
+}
+
+function Map-ContextTypeToAtlas {
+    param([string]$OmadaType)
+    $Map = $TypeMappings['contextTypeToIdentityAtlas']
+    if ($Map.ContainsKey($OmadaType)) { return $Map[$OmadaType] }
+    return $OmadaType -replace '\s+', ''
+}
+
+# ─── Step logging ─────────────────────────────────────────────────
+function Write-Step {
+    param([string]$Msg)
+    Write-Host "  → $Msg" -ForegroundColor DarkGray
+}
+
+# ─── Phase tracking ───────────────────────────────────────────────
+$Script:phases      = [System.Collections.Generic.List[object]]::new()
+$Script:phaseErrors = [System.Collections.Generic.List[string]]::new()
+$Script:startTime   = [datetime]::UtcNow
+
+function Write-Phase {
+    param([string]$Name, [TimeSpan]$Duration, [string]$ErrorMsg = $Null, [hashtable]$Records = $Null)
+    $Phase = @{ name = $Name; durationMs = [int]$Duration.TotalMilliseconds; status = if ($ErrorMsg) { 'failed' } else { 'ok' } }
+    if ($ErrorMsg)  { $Phase.error   = $ErrorMsg }
+    if ($Records)   { $Phase.records = $Records }
+    $Script:phases.Add($Phase)
+}
+
+# ─── Progress reporting ───────────────────────────────────────────
+function Update-CrawlerProgress {
+    param([string]$Step, [int]$Pct = -1, [string]$Detail = '')
+    if (-not $JobId -or $JobId -le 0) { return }
+    $Body = @{ jobId = $JobId }
+    if ($PSBoundParameters.ContainsKey('Step'))   { $Body['step']   = $Step }
+    if ($Pct -ge 0)                                { $Body['pct']    = $Pct }
+    if ($PSBoundParameters.ContainsKey('Detail')) { $Body['detail'] = $Detail }
+    try {
+        Invoke-RestMethod -Uri "$ApiBaseUrl/crawlers/job-progress" -Method Post -TimeoutSec 10 `
+            -Headers @{ 'Authorization' = "Bearer $ApiKey"; 'Content-Type' = 'application/json' } `
+            -Body ($Body | ConvertTo-Json -Compress) | Out-Null
+    } catch {
+        $Sc = $Null; try { $Sc = $_.Exception.Response.StatusCode.value__ } catch {}
+        if ($Sc -eq 409) { throw "Job $JobId terminated server-side (HTTP 409) — aborting crawl" }
+        # Transient errors are non-fatal for progress reporting
+    }
+}
+
+# ─── Ingest API helpers ───────────────────────────────────────────
+function Invoke-IngestAPI {
+    param([string]$Endpoint, [hashtable]$Body)
+    $Delays = @(2, 4, 8, 16, 32)
+    $Uri    = "$ApiBaseUrl/$Endpoint"
+    $Headers = @{ 'Authorization' = "Bearer $ApiKey"; 'Content-Type' = 'application/json' }
+    for ($I = 0; $I -le $Delays.Count; $I++) {
+        try {
+            return Invoke-RestMethod -Uri $Uri -Method Post -Headers $Headers `
+                -Body ($Body | ConvertTo-Json -Depth 20 -Compress) -TimeoutSec 300
+        } catch {
+            $Sc = $Null; try { $Sc = $_.Exception.Response.StatusCode.value__ } catch {}
+            if ($Sc -eq 409) { throw "Job $JobId terminated server-side (HTTP 409)" }
+            $IsTransient = ($Null -eq $Sc) -or ($Sc -eq 429) -or ($Sc -ge 500 -and $Sc -le 504)
+            if (-not $IsTransient -or $I -ge $Delays.Count) { throw }
+            Write-Host "    Ingest retry in $($Delays[$I])s (HTTP $Sc)..." -ForegroundColor Yellow
+            Start-Sleep -Seconds $Delays[$I]
+        }
+    }
+}
+
+function ConvertTo-JsonArray {
+    param([array]$Items)
+    if (-not $Items -or $Items.Count -eq 0) { return @() }
+    return ,$Items
+}
+
+function Send-IngestBatch {
+    param(
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [Parameter(Mandatory)] [int]$SystemId,
+        [string]$SyncMode   = 'full',
+        [hashtable]$Scope   = @{},
+        [array]$Records     = @(),
+        [string[]]$DeletedIds = @(),
+        [int]$BatchSize     = 5000
+    )
+    if (-not $Records -or $Records.Count -eq 0) {
+        # Still send an empty full-sync batch so the server can scoped-delete stale data
+        $Body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = @() }
+        return Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
+    }
+
+    if ($DeletedIds.Count -gt 0) {
+        $DelBody = @{ systemId = $SystemId; syncMode = 'delta'; scope = $Scope; records = @(); deletedIds = ConvertTo-JsonArray $DeletedIds }
+        Invoke-IngestAPI -Endpoint $Endpoint -Body $DelBody | Out-Null
+    }
+
+    if ($Records.Count -le $BatchSize) {
+        $Body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Records }
+        return Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
+    }
+
+    # Chunked session for large batches
+    $SyncId = $Null; $TotalInserted = 0; $TotalUpdated = 0; $TotalDeleted = 0
+    for ($I = 0; $I -lt $Records.Count; $I += $BatchSize) {
+        $Chunk   = $Records[$I..([Math]::Min($I + $BatchSize - 1, $Records.Count - 1))]
+        $IsFirst = ($I -eq 0)
+        $IsLast  = ($I + $BatchSize -ge $Records.Count)
+        $Body    = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Chunk
+                      syncSession = if ($IsFirst) { 'start' } elseif ($IsLast) { 'end' } else { 'continue' } }
+        if ($SyncId) { $Body.syncId = $SyncId }
+        $Result = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
+        if ($IsFirst -and $Result.syncId) { $SyncId = $Result.syncId }
+        $TotalInserted += ($Result.inserted ?? 0); $TotalUpdated += ($Result.updated ?? 0); $TotalDeleted += ($Result.deleted ?? 0)
+    }
+    return @{ inserted = $TotalInserted; updated = $TotalUpdated; deleted = $TotalDeleted }
+}
+
+#endregion Functions
+
+#region Main
+
+Write-Host "`n=== Omada Crawler ===" -ForegroundColor Cyan
+Write-Host "Base URL:    $BaseUrl" -ForegroundColor Gray
+Write-Host "API version: $ApiVersion" -ForegroundColor Gray
+Write-Host "Auth method: $($Cfg.authMethod)" -ForegroundColor Gray
+Write-Host "Sync mode:   full (Omada has no delta API)" -ForegroundColor Gray
+
+Update-CrawlerProgress -Step 'Authenticating to Omada' -Pct 2
+
+# Authenticate
+$AuthParams = @{
+    BaseUrl               = $BaseUrl
+    AuthMethod            = $Cfg.authMethod
+    ApiVersion            = $ApiVersion
+    SessionTimeoutMinutes = $SessionTimeoutMinutes
+}
+if ($Cfg.username)      { $AuthParams['Username']      = $Cfg.username }
+if ($Cfg.password)      { $AuthParams['Password']      = $Cfg.password }
+if ($Cfg.clientId)      { $AuthParams['ClientId']      = $Cfg.clientId }
+if ($Cfg.clientSecret)  { $AuthParams['ClientSecret']  = $Cfg.clientSecret }
+if ($Cfg.tokenEndpoint) { $AuthParams['TokenEndpoint'] = $Cfg.tokenEndpoint }
+if ($Cfg.apiToken)      { $AuthParams['ApiToken']      = $Cfg.apiToken }
+if ($Cfg.cookieString)  { $AuthParams['CookieString']  = $Cfg.cookieString }
+Connect-OmadaAPI @authParams
+
+# Derive the Builtin OData service URL from the DataObjects base URL
+Write-Host "Builtin URL: $BuiltinBaseUrl" -ForegroundColor Gray
+
+# Discover available entity sets from OData $metadata (diagnostic — non-blocking)
+Update-CrawlerProgress -Step 'Checking Omada API' -Pct 3
+$AvailableEntitySets = @(Get-OmadaEntitySets)
+if ($AvailableEntitySets.Count -gt 0) {
+    Write-Host "  Entity sets: $($AvailableEntitySets -join ', ')" -ForegroundColor Gray
+} else {
+    Write-Host "  Entity set check skipped (metadata unavailable — all phases will attempt to run)" -ForegroundColor Yellow
+}
+
+function Test-EntitySetAvailable {
+    param([string]$Name)
+    if ($AvailableEntitySets.Count -eq 0) { return $True }
+    return $AvailableEntitySets -contains $Name
+}
+
+# Register all Omada connected systems as separate Identity Atlas Systems
+Update-CrawlerProgress -Step 'Registering Omada connected systems' -Pct 5
+$AllOmadaSystems = $Null
+$OmadaSystemMap  = @{}  # Omada System.UId → Identity Atlas system.id
+$SystemId        = 0    # ID for the main Omada IGA system (used for Contexts/Identities)
+try {
+    Write-Step 'Fetching connected systems from Omada...'
+    $AllOmadaSystems = Invoke-OmadaPagedRequest -Path '/System' `
+        -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize 100
+    Write-Host "  $($AllOmadaSystems.Count) connected systems in Omada" -ForegroundColor Gray
+
+    $SysRecords = @($AllOmadaSystems | ForEach-Object {
+        [PSCustomObject]@{
+            systemType  = 'Omada'
+            displayName = $_.DisplayName
+            tenantId    = [string]$_.UId
+            enabled     = $True
+            syncEnabled = $True
+        }
+    })
+
+    Write-Step "Registering $($SysRecords.Count) systems in Identity Atlas..."
+    Invoke-IngestAPI -Endpoint 'ingest/systems' -Body @{
+        syncMode = 'full'
+        records  = ConvertTo-JsonArray $SysRecords
+    } | Out-Null
+
+    # Build UId → system.id map by querying Identity Atlas
+    $AtlasSystems = Invoke-RestMethod -Uri "$ApiBaseUrl/systems" `
+        -Headers @{ Authorization = "Bearer $ApiKey" } -TimeoutSec 30
+    foreach ($S in $AtlasSystems) {
+        if ($S.systemType -eq 'Omada' -and $S.tenantId) {
+            $OmadaSystemMap[$S.tenantId] = [int]$S.id
+        }
+    }
+    Write-Host "  System map: $($OmadaSystemMap.Count) entries" -ForegroundColor Gray
+
+    # Omada Identity is the main IGA system — use it for Contexts/Identities
+    $MainSysEntry = $AllOmadaSystems | Where-Object { $_.DisplayName -eq 'Omada Identity' } | Select-Object -First 1
+    $MainSysUId   = if ($MainSysEntry) { [string]$MainSysEntry.UId } else { $null }
+    # $OmadaIdentitySystemUId is used in the Assignments phase to distinguish Omada-internal
+    # accounts (already synced via User entity) from connected-system accounts (derived from CA).
+    $OmadaIdentitySystemUId = $MainSysUId
+    if ($MainSysUId -and $OmadaSystemMap.ContainsKey($MainSysUId)) {
+        $SystemId = $OmadaSystemMap[$MainSysUId]
+    } elseif ($OmadaSystemMap.Count -gt 0) {
+        $SystemId = ($OmadaSystemMap.Values | Select-Object -First 1)
+    }
+    Write-Host "  Main Omada IGA system ID: $SystemId (UId: $MainSysUId)" -ForegroundColor Gray
+} catch {
+    Write-Host "  Warning: could not register Omada systems — $($_.Exception.Message)" -ForegroundColor Yellow
+    # Fall back to single system registration
+    $FbResult = Invoke-IngestAPI -Endpoint 'ingest/systems' -Body @{
+        syncMode = 'full'
+        records  = @(@{ systemType = 'Omada'; displayName = "Omada ($BaseUrl)"; tenantId = $BaseUrl; enabled = $True; syncEnabled = $True })
+    }
+    $SystemId = [int]($FbResult.systemIds[0])
+    Write-Host "  Fallback system ID: $SystemId" -ForegroundColor Gray
+}
+
+# Shared state across phases
+$AllIdentities                = $Null  # Identity records — retained for Accounts principalType lookup and IdentityMembers join
+$AllAccounts                  = $Null  # User records — retained for IdentityMembers, ContextMembers, Assignments joins
+$IdentityLookup               = @{}    # IDENTITYID (string) → @{ uid = UId; identityType = string }
+$UserNameToUid                = @{}    # UserName (string) → User.UId — for resolving Assignments AccountName to Principal FK
+$IdentityUidToUserUids        = @{}    # Identity.UId → List[User.UId] — for fanning out Contextassignment to all accounts
+$IdentityUidInIdentitiesTable = [System.Collections.Generic.HashSet[string]]::new()  # set of Identity.UId values stored in Identities table
+$SyncedContextIds             = [System.Collections.Generic.HashSet[string]]::new()  # UIds of synced Contexts (OrgUnits) — filters CA_CONTEXT refs
+$AllResources                 = $Null  # Resource records — retained for Entitlements (CHILDROLES extraction)
+$UserGroupMap                 = @{}    # Usergroup.UId → DisplayName — for USERGROUPREF lookups on Resources
+
+# ─── Phase: Contexts ─────────────────────────────────────────────
+# Syncs all context object types configured in contextObjectTypes (default: Orgunit only).
+# Each type is fetched from its own entity set and registered as Identity Atlas Contexts.
+# Orgunit uses topological sort (PARENTOU hierarchy); other types are flat.
+if ($SyncContexts) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nContexts:" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing contexts' -Pct 10
+    $TotalContextsInserted = 0; $TotalContextsUpdated = 0
+    $ContextPhaseErrors    = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($Cot in $ContextObjectTypes) {
+        $EntitySet   = $Cot.entitySet
+        $ContextType = $Cot.contextType
+        try {
+            if (-not (Test-EntitySetAvailable $EntitySet)) {
+                Write-Host "  Skipping $EntitySet — entity set not in OData metadata" -ForegroundColor Yellow
+                continue
+            }
+            Write-Step "Fetching $EntitySet entities from Omada..."
+            $Items = Invoke-OmadaPagedRequest -Path "/$EntitySet" `
+                -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
+            Write-Host "  $($Items.Count) $EntitySet records from Omada" -ForegroundColor Gray
+
+            if ($EntitySet -eq 'Orgunit') {
+                # Orgunit has a parent hierarchy — topological sort required
+                $RawRecords = @($Items | ForEach-Object {
+                    $CtxType   = Map-ContextTypeToAtlas -OmadaType (Get-OmadaRefValue -Ref $_.OUTYPE -Fallback $ContextType)
+                    $ParentUid = Get-OmadaRefUid -Ref $_.PARENTOU
+                    [PSCustomObject]@{
+                        id              = [string]$_.UId
+                        externalId      = [string]$_.UId
+                        displayName     = if ($_.NAME) { $_.NAME } else { $_.DisplayName }
+                        contextType     = $CtxType
+                        variant         = 'synced'
+                        targetType      = 'Identity'
+                        parentContextId = if ($ParentUid) { $ParentUid } else { $Null }
+                    }
+                } | Where-Object { $_.externalId -and $_.displayName })
+
+                # Topological sort — parents before children
+                $Records   = [System.Collections.Generic.List[object]]::new()
+                $Remaining = [System.Collections.Generic.List[object]]::new($RawRecords)
+                $Inserted  = [System.Collections.Generic.HashSet[string]]::new()
+                $Pass = 0; $MaxPasses = $RawRecords.Count + 1
+                while ($Remaining.Count -gt 0 -and $Pass -lt $MaxPasses) {
+                    $Pass++
+                    $NextRem = [System.Collections.Generic.List[object]]::new()
+                    foreach ($Rec in $Remaining) {
+                        $ParentId = $Rec.parentContextId
+                        if (-not $ParentId -or $Inserted.Contains($ParentId)) {
+                            $Records.Add($Rec); $Inserted.Add($Rec.id) | Out-Null
+                        } else { $NextRem.Add($Rec) }
+                    }
+                    $Remaining = $NextRem
+                }
+                foreach ($Rec in $Remaining) { $Records.Add($Rec) }
+            } else {
+                # Flat context type — no hierarchy
+                $Records = @($Items | ForEach-Object {
+                    [PSCustomObject]@{
+                        id          = [string]$_.UId
+                        externalId  = [string]$_.UId
+                        displayName = if ($_.NAME) { $_.NAME } else { $_.DisplayName }
+                        contextType = $ContextType
+                        variant     = 'synced'
+                        targetType  = 'Identity'
+                    }
+                } | Where-Object { $_.externalId -and $_.displayName })
+            }
+
+            Write-Step "Ingesting $($Records.Count) $ContextType contexts..."
+            $R = Send-IngestBatch -Endpoint 'ingest/contexts' -SystemId $SystemId -SyncMode 'full' `
+                -Scope @{ variant = 'synced'; contextType = $ContextType } -Records @($Records)
+            Write-Host "  Contexts ($EntitySet): +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+            foreach ($Rec in $Records) { $SyncedContextIds.Add($Rec.id) | Out-Null }
+            $TotalContextsInserted += ($R.inserted ?? 0); $TotalContextsUpdated += ($R.updated ?? 0)
+        } catch {
+            $EMsg = $_.Exception.Message
+            Write-Host "  Contexts ($EntitySet) failed: $EMsg" -ForegroundColor Yellow
+            $ContextPhaseErrors.Add($EntitySet + ': ' + $EMsg)
+        }
+    }
+
+    if ($ContextPhaseErrors.Count -eq $ContextObjectTypes.Count) {
+        $Script:phaseErrors.Add("Contexts: all context types failed")
+        Write-Phase -Name 'Contexts' -Duration ([datetime]::UtcNow - $T) -ErrorMsg "All context types failed"
+    } else {
+        Write-Phase -Name 'Contexts' -Duration ([datetime]::UtcNow - $T) -Records @{ contexts = $SyncedContextIds.Count }
+    }
+}
+
+# ─── Phase: Identities ───────────────────────────────────────────
+# OData entity: Identity
+# Type discriminator: IDENTITYTYPE (OIS.SetValue) — .Value gives the type label
+# Builds $IdentityLookup (IDENTITYID→uid+identityType) used by Accounts and IdentityMembers phases
+if ($SyncIdentities) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nIdentities:" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing identities' -Pct 20
+    try {
+        if (-not (Test-EntitySetAvailable 'Identity')) {
+            throw "Identity entity set not found in OData metadata"
+        }
+        Write-Step 'Fetching identities from Omada...'
+        $AllIdentities = Invoke-OmadaPagedRequest -Path '/Identity' `
+            -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
+        Write-Host "  $($AllIdentities.Count) identity records from Omada" -ForegroundColor Gray
+
+        # Build lookup: Identity.IDENTITYID (string) → { uid, identityType }
+        # IDENTITYID is Omada's internal string key (not EMPLOYEEID which is the HR number)
+        $IdentityLookup = @{}
+        foreach ($Id in $AllIdentities) {
+            $Key = [string]$Id.IDENTITYID
+            if ($Key) {
+                $IdType = if ($Id.IDENTITYTYPE) { [string]$Id.IDENTITYTYPE.Value } else { 'Employee' }
+                $IdentityLookup[$Key] = @{ uid = [string]$Id.UId; identityType = $IdType }
+            }
+        }
+
+        # Person-type identities go to the Identities table
+        $PersonIdentities = @($AllIdentities | Where-Object {
+            $IdType = if ($_.IDENTITYTYPE) { [string]$_.IDENTITYTYPE.Value } else { 'Employee' }
+            $IdentityTypesForIdentityTable -contains $IdType
+        })
+
+        $IdentRecords = @($PersonIdentities | ForEach-Object {
+            $IdType = if ($_.IDENTITYTYPE)     { [string]$_.IDENTITYTYPE.Value }     else { 'Employee' }
+            $IdCat  = if ($_.IDENTITYCATEGORY) { [string]$_.IDENTITYCATEGORY.Value } else { '' }
+            $FName  = if ($_.FIRSTNAME)        { [string]$_.FIRSTNAME } else { '' }
+            $LName  = if ($_.LASTNAME)         { [string]$_.LASTNAME  } else { '' }
+            $Name   = "$FName $LName".Trim()
+            if (-not $Name) { $Name = $_.DisplayName }
+            [PSCustomObject]@{
+                id                 = [string]$_.UId  # Omada UId is a valid UUID
+                externalId         = [string]$_.UId
+                displayName        = $Name
+                givenName          = $FName
+                surname            = $LName
+                email              = $_.EMAIL
+                employeeId         = $_.EMPLOYEEID
+                jobTitle           = $_.JOBTITLE
+                companyName        = Get-OmadaRefValue -Ref $_.COMPANY -Fallback ''
+                city               = if ($_.CITY)    { [string]$_.CITY    } else { '' }
+                country            = Get-OmadaRefValue -Ref $_.COUNTRY -Fallback ''
+                extendedAttributes = @{
+                    # Identity type/category/status
+                    identityType     = $IdType
+                    identityCategory = $IdCat
+                    identityStatus   = if ($_.IDENTITYSTATUS)   { [string]$_.IDENTITYSTATUS.Value }   else { '' }
+                    identityId       = if ($_.IDENTITYID)        { [string]$_.IDENTITYID }             else { '' }
+                    oisId            = if ($_.OISID)             { [string]$_.OISID }                  else { '' }
+                    # Contact / location
+                    email2           = if ($_.EMAIL2)            { [string]$_.EMAIL2 }                 else { '' }
+                    city             = if ($_.CITY)              { [string]$_.CITY }                   else { '' }
+                    zipCode          = if ($_.ZIPCODE)           { [string]$_.ZIPCODE }                else { '' }
+                    # Validity
+                    validFrom        = $_.VALIDFROM
+                    validTo          = $_.VALIDTO
+                    # Org references (UIds for use as context IDs)
+                    ouRefId          = Get-OmadaRefUid -Ref $_.OUREF
+                    countryId        = Get-OmadaRefUid -Ref $_.COUNTRY
+                    locationId       = Get-OmadaRefUid -Ref $_.LOCATION
+                    buildingId       = Get-OmadaRefUid -Ref $_.BUILDING
+                    businessUnitId   = Get-OmadaRefUid -Ref $_.BUSINESSUNIT
+                    costCenterId     = Get-OmadaRefUid -Ref $_.COSTCENTER
+                    divisionId       = Get-OmadaRefUid -Ref $_.DIVISION
+                    subAreaId        = Get-OmadaRefUid -Ref $_.SUBAREA
+                    jobTitleRefId    = Get-OmadaRefUid -Ref $_.JOBTITLE_REF
+                    # Org display names (human-readable counterparts)
+                    company          = Get-OmadaRefValue -Ref $_.COMPANY       -Fallback ''
+                    ouRefName        = Get-OmadaRefValue -Ref $_.OUREF         -Fallback ''
+                    countryName      = Get-OmadaRefValue -Ref $_.COUNTRY       -Fallback ''
+                    jobTitleRef      = Get-OmadaRefValue -Ref $_.JOBTITLE_REF  -Fallback ''
+                    # Risk
+                    riskScore        = if ($_.RISKSCORE)         { [string]$_.RISKSCORE }              else { '' }
+                    riskLevel        = Get-OmadaRefValue -Ref $_.RISKLEVEL     -Fallback ''
+                    # People references
+                    manager          = ($_.MANAGER        | ForEach-Object { $_.DisplayName }) -join '; '
+                    identityOwner    = Get-OmadaRefValue -Ref $_.IDENTITYOWNER  -Fallback ''
+                    explicitOwners   = ($_.EXPLICITOWNER   | ForEach-Object { $_.DisplayName }) -join '; '
+                }
+            }
+        } | Where-Object { $_.externalId -and $_.displayName })
+
+        Write-Step "Ingesting $($IdentRecords.Count) identity records..."
+        $R = Send-IngestBatch -Endpoint 'ingest/identities' -SystemId $SystemId -SyncMode 'full' -Records $IdentRecords
+        Write-Host "  Identities: +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+
+        # Build set of Identity UIds stored in Identities table so CA processing can
+        # guard IdentityMembers against FK violations on non-person identity types.
+        foreach ($Rec in $IdentRecords) { $IdentityUidInIdentitiesTable.Add($Rec.id) | Out-Null }
+
+        Write-Phase -Name 'Identities' -Duration ([datetime]::UtcNow - $T) -Records @{ identities = $IdentRecords.Count }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  Identities phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("Identities: $Msg")
+        Write-Phase -Name 'Identities' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# ─── Phase: Accounts / Principals ────────────────────────────────
+# OData entity: User
+# principalType resolved from linked Identity's IDENTITYTYPE via $IdentityLookup
+# Join key: User.IDENTITYREF.IDENTITYID (string) = Identity.IDENTITYID (string)
+if ($SyncAccounts) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nAccounts (Principals):" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing accounts' -Pct 30
+    try {
+        if (-not (Test-EntitySetAvailable 'User')) {
+            throw "User entity set not found in OData metadata"
+        }
+        Write-Step 'Fetching user accounts from Omada...'
+        $AllAccounts = Invoke-OmadaPagedRequest -Path '/User' `
+            -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
+        Write-Host "  $($AllAccounts.Count) account records from Omada" -ForegroundColor Gray
+
+        Write-Step "Building $($AllAccounts.Count) account records..."
+        $AccountRecords = @($AllAccounts | Where-Object { -not $_.Inactive } | ForEach-Object {
+            $ExtId = [string]$_.UId
+            $Name  = "$($_.FIRSTNAME) $($_.LASTNAME)".Trim()
+            if (-not $Name) { $Name = $_.DisplayName }
+
+            # Resolve principalType from the linked Identity's IDENTITYTYPE
+            $PrincipalType = 'User'
+            $IdentId = if ($_.IDENTITYREF) { [string]$_.IDENTITYREF.IDENTITYID } else { $Null }
+            if ($IdentId -and $IdentityLookup.ContainsKey($IdentId)) {
+                $PrincipalType = Map-IdentityTypeToAtlas -OmadaType $IdentityLookup[$IdentId].identityType
+            }
+
+            [PSCustomObject]@{
+                id                 = $ExtId  # Omada UId is a valid UUID
+                externalId         = $ExtId
+                displayName        = $Name
+                email              = $_.EMAIL
+                principalType      = $PrincipalType
+                accountEnabled     = $True
+                jobTitle           = $_.JOBTITLE
+                extendedAttributes = @{ userName = $_.UserName }
+            }
+        } | Where-Object { $_.externalId -and $_.displayName })
+
+        foreach ($PType in @('User', 'ExternalUser', 'ServicePrincipal')) {
+            $Subset = @($AccountRecords | Where-Object { $_.principalType -eq $PType })
+            if ($Subset.Count -eq 0) { continue }
+            $R = Send-IngestBatch -Endpoint 'ingest/principals' -SystemId $SystemId -SyncMode 'full' `
+                -Scope @{ principalType = $PType } -Records $Subset
+            Write-Host "  Principals ($PType): +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+        }
+        $OtherTypes = @($AccountRecords | Where-Object { $_.principalType -notin @('User','ExternalUser','ServicePrincipal') })
+        if ($OtherTypes.Count -gt 0) {
+            $Grouped = $OtherTypes | Group-Object principalType
+            foreach ($G in $Grouped) {
+                $R = Send-IngestBatch -Endpoint 'ingest/principals' -SystemId $SystemId -SyncMode 'full' `
+                    -Scope @{ principalType = $G.Name } -Records @($G.Group)
+                Write-Host "  Principals ($($G.Name)): +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+            }
+        }
+
+        # Build shared lookups used by ContextMembers and Assignments phases:
+        #   $UserNameToUid:         UserName → User.UId (CalculatedAssignment.AccountName lookup)
+        #   $IdentityUidToUserUids: Identity.UId → [User.UIds] (Contextassignment fan-out to all accounts)
+        foreach ($Acc in $AllAccounts) {
+            if ($Acc.Inactive) { continue }
+            if ($Acc.UserName) { $UserNameToUid[[string]$Acc.UserName] = [string]$Acc.UId }
+            $IdentIdStr = if ($Acc.IDENTITYREF) { [string]$Acc.IDENTITYREF.IDENTITYID } else { $Null }
+            if ($IdentIdStr -and $IdentityLookup.ContainsKey($IdentIdStr)) {
+                $IdentUid = $IdentityLookup[$IdentIdStr].uid
+                if (-not $IdentityUidToUserUids.ContainsKey($IdentUid)) {
+                    $IdentityUidToUserUids[$IdentUid] = [System.Collections.Generic.List[string]]::new()
+                }
+                $IdentityUidToUserUids[$IdentUid].Add([string]$Acc.UId)
+            }
+        }
+
+        Write-Phase -Name 'Accounts' -Duration ([datetime]::UtcNow - $T) -Records @{ accounts = $AccountRecords.Count }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  Accounts phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("Accounts: $Msg")
+        Write-Phase -Name 'Accounts' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# ─── Phase: IdentityMembers ───────────────────────────────────────
+# Join: User.IDENTITYREF.IDENTITYID (string) = Identity.IDENTITYID (string)
+# identityExternalId = Identity.UId, principalExternalId = User.UId
+if ($SyncIdentities -and $AllIdentities -and $SyncAccounts -and $AllAccounts) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nIdentity Members:" -ForegroundColor Cyan
+    try {
+        $MemberRecords = [System.Collections.Generic.List[object]]::new()
+        foreach ($Acc in $AllAccounts) {
+            if ($Acc.Inactive) { continue }
+            $IdentId = if ($Acc.IDENTITYREF) { [string]$Acc.IDENTITYREF.IDENTITYID } else { $Null }
+            if (-not $IdentId -or -not $IdentityLookup.ContainsKey($IdentId)) { continue }
+            # Only link accounts whose identity type is stored in the Identities table.
+            # Non-person identities (Machine, etc.) are not in Identities → skip to avoid FK errors.
+            $IdentEntry = $IdentityLookup[$IdentId]
+            if ($IdentityTypesForIdentityTable -notcontains $IdentEntry.identityType) { continue }
+            $MemberRecords.Add([PSCustomObject]@{
+                identityId  = $IdentEntry.uid                 # direct UUID FK to Identities.id
+                principalId = [string]$Acc.UId                # direct UUID FK to Principals.id
+                accountType = 'Primary'
+            })
+        }
+
+        Write-Step "Ingesting $($MemberRecords.Count) identity-member links..."
+        $R = Send-IngestBatch -Endpoint 'ingest/identity-members' -SystemId $SystemId -SyncMode 'full' -Records @($MemberRecords)
+        Write-Host "  IdentityMembers: +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+        Write-Phase -Name 'IdentityMembers' -Duration ([datetime]::UtcNow - $T) -Records @{ members = $MemberRecords.Count }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  IdentityMembers phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("IdentityMembers: $Msg")
+        Write-Phase -Name 'IdentityMembers' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# ─── Phase: Context Members ──────────────────────────────────────
+# OData entity: Contextassignment
+# Maps Identity → OrgUnit/Context. Stored as ContextMembers (memberType='Principal')
+# so the UI query (IdentityMembers → ContextMembers via principalId) resolves correctly.
+# Each identity assignment is fanned out to all the identity's active User accounts.
+if ($SyncContextMembers) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nContext Members:" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing context members' -Pct 45
+    try {
+        if (-not (Test-EntitySetAvailable 'Contextassignment')) {
+            throw "Contextassignment entity set not found in OData metadata"
+        }
+        Write-Step 'Fetching context assignments from Omada...'
+        $Items = Invoke-OmadaPagedRequest -Path '/Contextassignment' `
+            -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
+        Write-Host "  $($Items.Count) context assignment records from Omada" -ForegroundColor Gray
+
+        # ContextMembers use memberType='Identity' and memberId=Identity.UId so the
+        # context detail page (which queries WHERE memberType = context.targetType
+        # and joins to the Identities table) can find members correctly.
+        # One record per (contextId, identityId) pair — no per-account fanout needed.
+        $CtxMemberRecords = [System.Collections.Generic.List[object]]::new()
+
+        # ── Source 1: Contextassignment (Omada's explicit context assignment entity) ──
+        foreach ($Item in $Items) {
+            $IdentUid   = if ($Item.CA_IDENTITY) { [string]$Item.CA_IDENTITY.UId } else { $Null }
+            $ContextUid = if ($Item.CA_CONTEXT)  { [string]$Item.CA_CONTEXT.UId  } else { $Null }
+            if (-not $IdentUid -or -not $ContextUid) { continue }
+            # Skip when no contexts were synced (empty set = all IDs unknown) OR this specific ID wasn't synced.
+            # The previous check ($Count -gt 0 -and -not Contains) allowed ALL IDs through when the set was
+            # empty, causing FK violations if the Contexts table is empty (e.g. cloud with no Orgunit entity set).
+            if ($SyncedContextIds.Count -eq 0 -or -not $SyncedContextIds.Contains($ContextUid)) { continue }
+            if (-not $IdentityUidInIdentitiesTable.Contains($IdentUid)) { continue }
+            $CtxMemberRecords.Add([PSCustomObject]@{
+                contextId  = $ContextUid
+                memberId   = $IdentUid   # Identity.UId → matches Identities table
+                memberType = 'Identity'
+                addedBy    = 'sync'
+            })
+        }
+
+        # ── Source 2: Direct context reference fields on Identity (OUREF, COUNTRY, etc.) ──
+        if ($AllIdentities) {
+            $FieldsToCheck = @{}
+            foreach ($Cot in $ContextObjectTypes) {
+                if ($Cot.identityField) { $FieldsToCheck[$Cot.identityField] = $True }
+            }
+            foreach ($Field in $WellKnownIdentityContextFields.Keys) { $FieldsToCheck[$Field] = $True }
+
+            foreach ($Ident in $AllIdentities) {
+                $IdentUid = [string]$Ident.UId
+                if (-not $IdentityUidInIdentitiesTable.Contains($IdentUid)) { continue }
+                foreach ($Field in $FieldsToCheck.Keys) {
+                    $ContextUid = Get-OmadaRefUid -Ref $Ident.$Field
+                    if (-not $ContextUid -or -not $SyncedContextIds.Contains($ContextUid)) { continue }
+                    $CtxMemberRecords.Add([PSCustomObject]@{
+                        contextId  = $ContextUid
+                        memberId   = $IdentUid
+                        memberType = 'Identity'
+                        addedBy    = 'sync'
+                    })
+                }
+            }
+        }
+
+        # ── Source 3: Employment entity (IDENTITYREF → OUREF) ──
+        if (Test-EntitySetAvailable 'Employment') {
+            try {
+                Write-Step 'Fetching employment records from Omada...'
+                $EmpItems = Invoke-OmadaPagedRequest -Path '/Employment' `
+                    -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
+                foreach ($Emp in $EmpItems) {
+                    $IdentUid   = Get-OmadaRefUid -Ref $Emp.IDENTITYREF
+                    $ContextUid = Get-OmadaRefUid -Ref $Emp.OUREF
+                    if (-not $IdentUid -or -not $ContextUid) { continue }
+                    if (-not $SyncedContextIds.Contains($ContextUid)) { continue }
+                    if (-not $IdentityUidInIdentitiesTable.Contains($IdentUid)) { continue }
+                    $CtxMemberRecords.Add([PSCustomObject]@{
+                        contextId  = $ContextUid
+                        memberId   = $IdentUid
+                        memberType = 'Identity'
+                        addedBy    = 'sync'
+                    })
+                }
+                Write-Host "  Employment-based context links added from $($EmpItems.Count) employment records" -ForegroundColor Gray
+            } catch {
+                Write-Host "  Warning: Employment-based context members skipped — $($_.Exception.Message)" -ForegroundColor Yellow
+            }
+        }
+
+        # Deduplicate before ingest (multiple sources can produce the same contextId+memberId pair)
+        $Seen     = [System.Collections.Generic.HashSet[string]]::new()
+        $Deduped  = @($CtxMemberRecords | Where-Object { $Seen.Add("$($_.contextId)|$($_.memberId)") })
+
+        Write-Step "Ingesting $($Deduped.Count) context-member links..."
+        $R = Send-IngestBatch -Endpoint 'ingest/context-members' -SystemId $SystemId -SyncMode 'full' -Records $Deduped
+        Write-Host "  ContextMembers: +$($R.inserted) ~$($R.updated) -$($R.deleted) (from $($Deduped.Count) deduped records)" -ForegroundColor Green
+        Write-Phase -Name 'ContextMembers' -Duration ([datetime]::UtcNow - $T) -Records @{ members = $Deduped.Count }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  ContextMembers phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("ContextMembers: $Msg")
+        Write-Phase -Name 'ContextMembers' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# ─── Phase: Resources ────────────────────────────────────────────
+# OData entity: Resource
+# Primary type discriminator: ROLECATEGORY → resourceCategoryMapping (configurable)
+# Additional properties: ROLEFOLDER, EXPLICITOWNER, MANUALOWNER, SKIPPROVISIONING,
+#   ROLETYPEREF, USERGROUPREF (looked up from Usergroup entity set)
+# $AllResources retained for Entitlements phase (CHILDROLES extraction)
+if ($SyncResources) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nResources:" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing resources' -Pct 50
+    try {
+        if (-not (Test-EntitySetAvailable 'Resource')) {
+            throw "Resource entity set not found in OData metadata"
+        }
+
+        # Pre-fetch Usergroups for USERGROUPREF name lookup
+        if ($UserGroupMap.Count -eq 0 -and (Test-EntitySetAvailable 'Usergroup')) {
+            try {
+                $Ugs = Invoke-OmadaPagedRequest -Path '/Usergroup' `
+                    -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
+                foreach ($Ug in $Ugs) { $UserGroupMap[[string]$Ug.UId] = $Ug.DisplayName }
+                Write-Host "  Loaded $($UserGroupMap.Count) usergroups for USERGROUPREF lookup" -ForegroundColor Gray
+            } catch {
+                Write-Host "  Warning: Usergroup fetch failed — USERGROUPREF names unavailable" -ForegroundColor Yellow
+            }
+        }
+
+        Write-Step 'Fetching resources from Omada (this may take a few minutes)...'
+        $AllResources = Invoke-OmadaPagedRequest -Path '/Resource' `
+            -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
+        Write-Host "  $($AllResources.Count) resource records from Omada" -ForegroundColor Gray
+
+        Write-Step "Building resource records from $($AllResources.Count) Omada resources..."
+        # Group resources by connected system (SYSTEMREF) for correct scoped-delete
+        $BySysUId = @{}
+        foreach ($Item in $AllResources) {
+            $OmadaCat    = if ($Item.ROLECATEGORY)    { [string]$Item.ROLECATEGORY.Value }   else { '' }
+            $AtlasType   = Map-ResourceCategory -Category $OmadaCat
+
+            $SysUId      = Get-OmadaRefUid  -Ref $Item.SYSTEMREF
+            $SysName     = Get-OmadaRefValue -Ref $Item.SYSTEMREF   -Fallback ''
+            $RoleType    = Get-OmadaRefValue -Ref $Item.ROLETYPEREF  -Fallback ''
+            $FolderName  = Get-OmadaRefValue -Ref $Item.ROLEFOLDER   -Fallback ''
+            $Status      = if ($Item.RESOURCESTATUS) { [string]$Item.RESOURCESTATUS.Value } else { 'Active' }
+            $Enabled     = $Status -notin @('Inactive', 'Disabled', 'Deleted')
+            $ExtId       = [string]$Item.UId
+            $DispName    = if ($Item.NAME) { $Item.NAME } else { $Item.DisplayName }
+            if (-not $ExtId -or -not $DispName) { continue }
+
+            # USERGROUPREF — look up name from pre-fetched map
+            $UgUId   = Get-OmadaRefUid -Ref $Item.USERGROUPREF
+            $UgName  = if ($UgUId -and $UserGroupMap.ContainsKey($UgUId)) { $UserGroupMap[$UgUId] } else { '' }
+
+            # Owner references (EXPLICITOWNER, MANUALOWNER) — take first if collection
+            $ExplicitOwner = ''
+            if ($Item.EXPLICITOWNER -and $Item.EXPLICITOWNER.Count -gt 0) {
+                $ExplicitOwner = ($Item.EXPLICITOWNER | ForEach-Object { $_.DisplayName }) -join '; '
+            }
+            $ManualOwner = ''
+            if ($Item.MANUALOWNER -and $Item.MANUALOWNER.Count -gt 0) {
+                $ManualOwner = ($Item.MANUALOWNER | ForEach-Object { $_.DisplayName }) -join '; '
+            }
+
+            $Rec = [PSCustomObject]@{
+                id                 = $ExtId
+                externalId         = $ExtId
+                displayName        = $DispName
+                resourceType       = $AtlasType
+                description        = $Item.DESCRIPTION
+                enabled            = $Enabled
+                extendedAttributes = @{
+                    resourceCategory  = $OmadaCat
+                    resourceType      = $RoleType          # ROLETYPEREF.DisplayName
+                    roleFolder        = $FolderName        # ROLEFOLDER.DisplayName
+                    skipProvisioning  = if ($Null -ne $Item.SKIPPROVISIONING) { [bool]$Item.SKIPPROVISIONING } else { $False }
+                    userGroupName     = $UgName            # USERGROUPREF → Usergroup.DisplayName
+                    explicitOwner     = $ExplicitOwner     # EXPLICITOWNER collection
+                    manualOwner       = $ManualOwner        # MANUALOWNER collection
+                    omadaSystem       = $SysName
+                }
+            }
+            $Key = if ($SysUId -and $OmadaSystemMap.ContainsKey($SysUId)) { $SysUId } else { '__main__' }
+            if (-not $BySysUId.ContainsKey($Key)) { $BySysUId[$Key] = [System.Collections.Generic.List[object]]::new() }
+            $BySysUId[$Key].Add($Rec)
+        }
+
+        Write-Step "Ingesting resources across $($BySysUId.Keys.Count) system(s)..."
+        $TotalInserted = 0; $TotalUpdated = 0; $TotalDeleted = 0
+        foreach ($Key in $BySysUId.Keys) {
+            $SysId    = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
+            $SysLabel = if ($Key -eq '__main__') { 'Omada' } else {
+                ($AllOmadaSystems | Where-Object { $_.UId -eq $Key } | Select-Object -First 1).DisplayName
+            }
+            $Recs = @($BySysUId[$Key])
+            $R = Send-IngestBatch -Endpoint 'ingest/resources' -SystemId $SysId -SyncMode 'full' `
+                -Scope @{} -Records $Recs
+            Write-Host "  Resources ($SysLabel, $($Recs.Count) records): +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+            $TotalInserted += ($R.inserted ?? 0); $TotalUpdated += ($R.updated ?? 0); $TotalDeleted += ($R.deleted ?? 0)
+        }
+        Write-Host "  Resources total: +$TotalInserted ~$TotalUpdated -$TotalDeleted" -ForegroundColor Green
+        Write-Phase -Name 'Resources' -Duration ([datetime]::UtcNow - $T) -Records @{ resources = $AllResources.Count }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  Resources phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("Resources: $Msg")
+        Write-Phase -Name 'Resources' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# ─── Phase: Entitlements (Resource Relationships) ─────────────────
+# Omada stores child role nesting in Resource.CHILDROLES (Collection(OIS.ReferenceValue)).
+# No separate PermissionNesting endpoint — relationships are extracted from $AllResources.
+if ($SyncEntitlements) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nEntitlements (Resource Relationships):" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing entitlements' -Pct 65
+    try {
+        if (-not $AllResources) {
+            Write-Host "  Skipping entitlements — resources were not synced" -ForegroundColor Yellow
+            Write-Phase -Name 'Entitlements' -Duration ([datetime]::UtcNow - $T) -Records @{ relationships = 0 }
+        } else {
+            Write-Step "Extracting entitlements (CHILDROLES) from $($AllResources.Count) resources..."
+            $RelRecords = [System.Collections.Generic.List[object]]::new()
+            foreach ($Item in $AllResources) {
+                if (-not $Item.CHILDROLES) { continue }
+                $ParentUid = [string]$Item.UId
+                foreach ($Child in $Item.CHILDROLES) {
+                    $ChildUid = Get-OmadaRefUid -Ref $Child
+                    if ($ChildUid) {
+                        $RelRecords.Add([PSCustomObject]@{
+                            parentResourceId = $ParentUid   # direct UUID FK to Resources.id
+                            childResourceId  = $ChildUid    # direct UUID FK to Resources.id
+                            relationshipType = 'Contains'
+                        })
+                    }
+                }
+            }
+
+            Write-Step "Ingesting $($RelRecords.Count) resource relationships (Contains)..."
+            $R = Send-IngestBatch -Endpoint 'ingest/resource-relationships' -SystemId $SystemId -SyncMode 'full' `
+                -Scope @{ relationshipType = 'Contains' } -Records @($RelRecords)
+            Write-Host "  Entitlements: +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
+            Write-Phase -Name 'Entitlements' -Duration ([datetime]::UtcNow - $T) -Records @{ relationships = $RelRecords.Count }
+        }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  Entitlements phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("Entitlements: $Msg")
+        Write-Phase -Name 'Entitlements' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# ─── Phase: Assignments ───────────────────────────────────────────
+# Uses /OData/Builtin/CalculatedAssignments — authoritative source for all effective access.
+# Two sources of assignments are combined:
+#   1. Resourceassignment (DataObjects) — IGA-governed role assignments (Identity → Role/Resource).
+#      All records are Governed. Grouped per connected system for correct scoped-delete.
+#   2. CalculatedAssignments (Builtin) — effective account provisioning (Identity → Account resource).
+#      IsManaged=true → Governed, IsManaged=false → Direct. Also grouped per system.
+if ($SyncAssignments) {
+    $T = [datetime]::UtcNow
+    Write-Host "`nAssignments:" -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing assignments' -Pct 75
+    try {
+        # ── Source 1: Resourceassignment (role/permission assignments) ─────────
+        Write-Step 'Fetching role assignments from Omada...'
+        $RaItems = Invoke-OmadaPagedRequest -Path '/Resourceassignment' `
+            -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
+        Write-Host "  $($RaItems.Count) Resourceassignment records from Omada" -ForegroundColor Gray
+
+        # Group by system for per-system full-sync batches
+        $RaBySys = @{}
+        foreach ($Item in $RaItems) {
+            $Status = if ($Item.ROLEASSNSTATUS) { [string]$Item.ROLEASSNSTATUS.Value } else { 'Active' }
+            if ($Status -notin @('Active', 'Pending')) { continue }
+
+            $IdentUid    = if ($Item.IDENTITYREF) { [string]$Item.IDENTITYREF.UId } else { $Null }
+            $ResourceUid = Get-OmadaRefUid -Ref $Item.ROLEREF
+            $SysUId      = Get-OmadaRefUid -Ref $Item.SYSTEMREF
+            if (-not $IdentUid -or -not $ResourceUid) { continue }
+
+            # Fan out to all User accounts for this identity
+            $UserUids = if ($IdentityUidToUserUids.ContainsKey($IdentUid)) { $IdentityUidToUserUids[$IdentUid] } else { $Null }
+            if (-not $UserUids -or $UserUids.Count -eq 0) { continue }
+
+            $SysKey = if ($SysUId -and $OmadaSystemMap.ContainsKey($SysUId)) { $SysUId } else { '__main__' }
+            if (-not $RaBySys.ContainsKey($SysKey)) { $RaBySys[$SysKey] = [System.Collections.Generic.List[object]]::new() }
+
+            foreach ($UserUid in $UserUids) {
+                $RaBySys[$SysKey].Add([PSCustomObject]@{
+                    resourceId         = $ResourceUid
+                    principalId        = $UserUid
+                    assignmentType     = 'Governed'
+                    extendedAttributes = @{ validFrom = $Item.VALIDFROM; validTo = $Item.VALIDTO }
+                })
+            }
+        }
+
+        Write-Step "Ingesting role assignments (Governed) across $($RaBySys.Keys.Count) system(s)..."
+        $TotalRaInserted = 0; $TotalRaUpdated = 0
+        foreach ($Key in $RaBySys.Keys) {
+            $SysId = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
+            # Deduplicate (principalId, resourceId) pairs — fanout can produce duplicates
+            # if the same identity has multiple accounts or the same resource appears twice.
+            $Seen  = [System.Collections.Generic.HashSet[string]]::new()
+            $Dedup = @($RaBySys[$Key] | Where-Object {
+                $K = "$($_.principalId)|$($_.resourceId)"
+                $Seen.Add($K)
+            })
+            $R = Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $SysId `
+                -SyncMode 'full' -Scope @{ assignmentType = 'Governed' } -Records $Dedup
+            $TotalRaInserted += ($R.inserted ?? 0); $TotalRaUpdated += ($R.updated ?? 0)
+        }
+        Write-Host "  Role assignments (Governed): +$TotalRaInserted ~$TotalRaUpdated" -ForegroundColor Green
+
+        # ── Source 2: Calculated Resource Assignments (CRA — account provisioning per connected system) ──
+        # Streamed page-by-page to avoid loading the entire dataset into memory at once.
+        # Cloud instances can have 10 000+ CRA records; accumulating them all with full expand
+        # consumes several GB of RAM and OOM-kills the worker process.
+        # Each page is processed and released before fetching the next.
+        $CaPrincipalsBySys  = @{}   # connected-system Principals derived from CRA (keyed by OmadaSystemUId)
+        $CaIdentityMembers  = [System.Collections.Generic.List[object]]::new()
+        $CaAssignmentsBySys = @{}   # Governed
+        $CaAssignmentsBysD  = @{}   # Direct
+        $CaTotalCount = 0
+        $CaSkip = 0
+        $CaPageSize = 1000
+
+        do {
+            Write-Step "Fetching CRA page (skip=$CaSkip, total so far: $CaTotalCount)..."
+            $CaPage = Invoke-OmadaGetRequest -Path '/CalculatedAssignments' `
+                -QueryParams @{ '$filter' = 'Status eq true'; '$expand' = 'Identity,Resource,System,ResourceType'
+                                '$top' = $CaPageSize; '$skip' = $CaSkip } `
+                -MaxRetries 5 -OverrideBaseUrl $BuiltinBaseUrl
+            $CaTotalCount += $CaPage.Count
+            $CaSkip += $CaPage.Count  # advance by actual received (variable page size)
+
+            foreach ($Item in $CaPage) {
+            $SysUId      = if ($Item.System)   { [string]$Item.System.UId   } else { $Null }
+            $ResourceUid = if ($Item.Resource)  { [string]$Item.Resource.UId } else { $Null }
+            $IdentityUid = if ($Item.Identity)  { [string]$Item.Identity.UId } else { $Null }
+            $AccountKey  = if ($Item.AccountKey)   { [string]$Item.AccountKey      } else { $Null }
+            $AccountName = if ($Item.AccountName)  { [string]$Item.AccountName     } else { $Null }
+            $ResType     = if ($Item.ResourceType) { $Item.ResourceType.DisplayName } else { '' }
+            if (-not $ResourceUid -or -not $IdentityUid) { continue }
+
+            $SysKey = if ($SysUId -and $OmadaSystemMap.ContainsKey($SysUId)) { $SysUId } else { '__main__' }
+            $SysId  = if ($SysKey -eq '__main__') { $SystemId } else { $OmadaSystemMap[$SysKey] }
+
+            # Resolve principalId: reuse existing Omada User for Omada Identity system;
+            # for connected systems, derive Principal from CRA using AccountKey as id.
+            $IsOmadaSys   = ($SysUId -and $SysUId -eq $OmadaIdentitySystemUId)
+            $PrincipalUid = $Null
+
+            if ($IsOmadaSys) {
+                # Reuse existing Omada User Principal (created by SyncAccounts phase)
+                if ($AccountName -and $UserNameToUid.ContainsKey($AccountName)) {
+                    $PrincipalUid = $UserNameToUid[$AccountName]
+                }
+            } else {
+                # Connected-system account — derive Principal from CRA Attributes
+                if (-not $AccountKey) { continue }
+                $PrincipalUid = $AccountKey
+
+                $Fn    = if ($Item.Attributes.'FIRSTNAME') { ($Item.Attributes.'FIRSTNAME' -join ' ').Trim() } else { '' }
+                $Ln    = if ($Item.Attributes.'LASTNAME')  { ($Item.Attributes.'LASTNAME'  -join ' ').Trim() } else { '' }
+                $Email = if ($Item.Attributes.'EMAIL')     { ($Item.Attributes.'EMAIL'     | Select-Object -First 1) } else { $Null }
+                $DName = "$Fn $Ln".Trim(); if (-not $DName) { $DName = $AccountName }
+
+                if (-not $CaPrincipalsBySys.ContainsKey($SysKey)) {
+                    $CaPrincipalsBySys[$SysKey] = [System.Collections.Generic.List[object]]::new()
+                }
+                $CaPrincipalsBySys[$SysKey].Add([PSCustomObject]@{
+                    id             = $AccountKey
+                    externalId     = $AccountName
+                    displayName    = $DName
+                    email          = $Email
+                    principalType  = 'User'
+                    accountEnabled = ($Item.Status -eq $True)
+                    extendedAttributes = @{ accountType = $ResType }
+                })
+
+                # IdentityMember: link this account to its Identity (person-type only — FK guard)
+                if ($IdentityUidInIdentitiesTable.Contains($IdentityUid)) {
+                    $CaIdentityMembers.Add([PSCustomObject]@{
+                        identityId  = $IdentityUid   # Identity.UId == Identities.id (set in SyncIdentities)
+                        principalId = $AccountKey
+                        accountType = $ResType
+                    })
+                }
+            }
+
+            if (-not $PrincipalUid) { continue }
+
+            # extendedAttributes: status, reasons, validFrom, validTo, accountType
+            $Reasons = if ($Item.Reasons) {
+                @($Item.Reasons | ForEach-Object { $_.Description }) -join '; '
+            } else { '' }
+            $ExtAttr = @{
+                validFrom   = $Item.ValidFrom
+                validTo     = $Item.ValidTo
+                status      = if ($Item.Status -eq $True) { 'Enabled' } else { 'Disabled' }
+                reasons     = $Reasons
+                accountType = $ResType
+                accountName = $AccountName
+            }
+
+            $Rec = [PSCustomObject]@{
+                resourceId         = $ResourceUid
+                principalId        = $PrincipalUid
+                assignmentType     = if ($Item.IsManaged) { 'Governed' } else { 'Direct' }
+                extendedAttributes = $ExtAttr
+            }
+            if ($Item.IsManaged) {
+                if (-not $CaAssignmentsBySys.ContainsKey($SysKey)) { $CaAssignmentsBySys[$SysKey] = [System.Collections.Generic.List[object]]::new() }
+                $CaAssignmentsBySys[$SysKey].Add($Rec)
+            } else {
+                if (-not $CaAssignmentsBysD.ContainsKey($SysKey))  { $CaAssignmentsBysD[$SysKey]  = [System.Collections.Generic.List[object]]::new() }
+                $CaAssignmentsBysD[$SysKey].Add($Rec)
+            }
+        }  # end foreach $Item in $CaPage
+        } while ($CaPage.Count -gt 0)  # fetch next page until empty
+        Write-Host "  $CaTotalCount CRA records from Omada" -ForegroundColor Gray
+
+        Write-Step "Ingesting CRA-derived principals and identity-member links..."
+        # Ingest connected-system Principals derived from CRA (delta — SyncAccounts owns full sync for Omada users)
+        $TotalCaPrincipals = 0
+        foreach ($Key in $CaPrincipalsBySys.Keys) {
+            $SysId = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
+            $Seen  = [System.Collections.Generic.HashSet[string]]::new()
+            $Dedup = @($CaPrincipalsBySys[$Key] | Where-Object { $Seen.Add($_.id) })
+        Write-Host "  CRA: $CaTotalCount records → $TotalCaPrincipals connected-system accounts, $($CaIdentityMembers.Count) identity-member links" -ForegroundColor Green
+                Send-IngestBatch -Endpoint 'ingest/principals' -SystemId $SysId `
+                    -SyncMode 'delta' -Records $Dedup | Out-Null
+                $TotalCaPrincipals += $Dedup.Count
+            }
+        }
+        # Ingest IdentityMembers for connected-system accounts (delta)
+        if ($CaIdentityMembers.Count -gt 0) {
+            $Seen  = [System.Collections.Generic.HashSet[string]]::new()
+            $Dedup = @($CaIdentityMembers | Where-Object { $Seen.Add("$($_.identityId)|$($_.principalId)") })
+            Send-IngestBatch -Endpoint 'ingest/identity-members' -SystemId $SystemId `
+                -SyncMode 'delta' -Records $Dedup | Out-Null
+        }
+        Write-Host "  CRA: $($CaItems.Count) records → $TotalCaPrincipals connected-system accounts, $($CaIdentityMembers.Count) identity-member links" -ForegroundColor Green
+
+        Write-Step "Ingesting CRA resource assignments (Governed + Direct) per system..."
+        # Ingest CRA ResourceAssignments per system
+        $TotalCaGovIns = 0; $TotalCaDirIns = 0
+        foreach ($Key in $CaAssignmentsBySys.Keys) {
+            $SysId = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
+            $Seen  = [System.Collections.Generic.HashSet[string]]::new()
+            $Dedup = @($CaAssignmentsBySys[$Key] | Where-Object { $Seen.Add("$($_.principalId)|$($_.resourceId)") })
+            $R = Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $SysId `
+                -SyncMode 'full' -Scope @{ assignmentType = 'Governed' } -Records $Dedup
+            $TotalCaGovIns += ($R.inserted ?? 0)
+        }
+        foreach ($Key in $CaAssignmentsBysD.Keys) {
+            $SysId = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
+            $Seen  = [System.Collections.Generic.HashSet[string]]::new()
+            $Dedup = @($CaAssignmentsBysD[$Key] | Where-Object { $Seen.Add("$($_.principalId)|$($_.resourceId)") })
+            $R = Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $SysId `
+                -SyncMode 'full' -Scope @{ assignmentType = 'Direct' } -Records $Dedup
+            $TotalCaDirIns += ($R.inserted ?? 0)
+        }
+        Write-Host "  CRA assignments (Governed): +$TotalCaGovIns, (Direct): +$TotalCaDirIns" -ForegroundColor Green
+
+        Write-Phase -Name 'Assignments' -Duration ([datetime]::UtcNow - $T) `
+            -Records @{ roleAssignments = ($RaBySys.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum
+                        craAssignments  = ($CaAssignmentsBySys.Values + $CaAssignmentsBysD.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum }
+    } catch {
+        $Msg = $_.Exception.Message
+        Write-Host "  Assignments phase failed: $Msg" -ForegroundColor Red
+        $Script:phaseErrors.Add("Assignments: $Msg")
+        Write-Phase -Name 'Assignments' -Duration ([datetime]::UtcNow - $T) -ErrorMsg $Msg
+    }
+}
+
+# NOTE: CertificationReviews (governance cert-review activity) is not imported —
+# that endpoint is not currently provided via OData on this Omada version.
+# "CRA" in this crawler refers to Calculated Resource Assignments (above).
+
+# ─── Refresh views ────────────────────────────────────────────────
+if ($RefreshViews) {
+    Update-CrawlerProgress -Step 'Refreshing views' -Pct 95
+    try {
+        Invoke-IngestAPI -Endpoint 'ingest/refresh-views' -Body @{} | Out-Null
+        Write-Host "`nViews refreshed." -ForegroundColor Gray
+    } catch {
+        Write-Host "  Warning: view refresh failed — $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+Update-CrawlerProgress -Step 'Complete' -Pct 100
+
+# ─── Summary ─────────────────────────────────────────────────────
+$Elapsed = [datetime]::UtcNow - $Script:startTime
+Write-Host "`n=== Omada Crawler Summary ===" -ForegroundColor Cyan
+Write-Host ("Total time: {0:mm}m {0:ss}s" -f $Elapsed) -ForegroundColor Gray
+Write-Host ""
+Write-Host ("{0,-20} {1,-10} {2}" -f 'Phase', 'Status', 'Duration') -ForegroundColor Gray
+Write-Host ("{0,-20} {1,-10} {2}" -f ('─'*20), ('─'*10), ('─'*10)) -ForegroundColor Gray
+foreach ($P in $Script:phases) {
+    $Status = if ($P.status -eq 'ok') { 'ok' } else { 'FAILED' }
+    $Color  = if ($P.status -eq 'ok') { 'Green' } else { 'Red' }
+    Write-Host ("{0,-20} {1,-10} {2}ms" -f $P.name, $Status, $P.durationMs) -ForegroundColor $Color
+}
+
+# Post per-phase results to the jobs API for the UI phase breakout.
+# Done directly from the crawler (not via the dispatcher) because PowerShell
+# child script scopes are isolated — the dispatcher cannot read our $Script: vars.
+if ($JobId -gt 0) {
+    try {
+        $PhasePayload = @{
+            phases = @($Script:phases | ForEach-Object {
+                $P = @{ name = $_.name; status = $_.status; durationMs = $_.durationMs }
+                if ($_.error)   { $P.error   = $_.error }
+                if ($_.records) { $P.records = $_.records }
+                $P
+            })
+        }
+        Invoke-RestMethod -Uri "$ApiBaseUrl/crawlers/jobs/$JobId/phases" `
+            -Method Post -TimeoutSec 15 `
+            -Headers @{ 'Authorization' = "Bearer $ApiKey"; 'Content-Type' = 'application/json' } `
+            -Body ($PhasePayload | ConvertTo-Json -Depth 5 -Compress) | Out-Null
+    } catch {
+        Write-Host "  Warning: could not post phase results — $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+if ($Script:phaseErrors.Count -gt 0) {
+    Write-Host "`nPhase errors:" -ForegroundColor Red
+    foreach ($E in $Script:phaseErrors) { Write-Host "  $E" -ForegroundColor Red }
+    throw "Omada sync completed with $($Script:phaseErrors.Count) phase error(s). See above for details."
+}
+
+Write-Host "`nOmada sync completed successfully." -ForegroundColor Green
+
+#endregion Main

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -53,9 +53,6 @@
     Sync Omada context assignments (Contextassignment) → ContextMembers table.
     Requires SyncContexts and SyncAccounts to have run in the same job.
 
-.PARAMETER SyncCRAs
-    Sync Omada certification review activities → CertificationDecisions.
-
 .PARAMETER RefreshViews
     Refresh SQL views after sync (default: true).
 
@@ -86,7 +83,6 @@ Param(
     [switch]$SyncResources       = $True,
     [switch]$SyncEntitlements    = $True,
     [switch]$SyncAssignments     = $True,
-    [switch]$SyncCRAs            = $True,
     [switch]$RefreshViews        = $True,
 
     [ValidateSet('full','delta')]
@@ -1246,7 +1242,7 @@ if ($SyncAssignments) {
             Send-IngestBatch -Endpoint 'ingest/identity-members' -SystemId $SystemId `
                 -SyncMode 'delta' -Records $Dedup | Out-Null
         }
-        Write-Host "  CRA: $($CaItems.Count) records → $TotalCaPrincipals connected-system accounts, $($CaIdentityMembers.Count) identity-member links" -ForegroundColor Green
+        Write-Host "  CRA: $CaTotalCount records → $TotalCaPrincipals connected-system accounts, $($CaIdentityMembers.Count) identity-member links" -ForegroundColor Green
 
         Write-Step "Ingesting CRA resource assignments (Governed + Direct) per system..."
         # Ingest CRA ResourceAssignments per system

--- a/tools/powershell-sdk/omada/Invoke-OmadaAuth.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaAuth.ps1
@@ -1,0 +1,279 @@
+<#
+.SYNOPSIS
+    Omada REST API authentication — multi-method session management.
+
+.DESCRIPTION
+    Provides Connect-OmadaAPI (establishes a session) and
+    Update-OmadaSessionIfExpired (refreshes before each request).
+
+    Session state lives in $script:OmadaSession (module-scoped).
+    Auth methods:
+      FormCookie  — POST /api/authenticate, capture Set-Cookie
+      OAuth2CC    — client_credentials grant → bearer token
+      OAuth2ROPC  — password grant → bearer token
+      ApiToken    — static bearer token (no refresh)
+      CookieString — pre-built semicolon-delimited cookie string
+
+.NOTES
+    WindowsAuth is intentionally not implemented — it requires a
+    domain-joined worker (Kerberos keytab on Linux) which is not
+    practical for Docker deployments. Use FormCookie or OAuth2ROPC
+    for on-premise environments instead.
+#>
+
+$script:OmadaSession = $null
+
+#region Functions
+
+function Connect-OmadaAPI {
+    <#
+    .SYNOPSIS
+        Authenticate to Omada and store the session for subsequent calls.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingUsernameAndPasswordParams', '')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory)] [string]$BaseUrl,
+        [Parameter(Mandatory)] [ValidateSet('FormCookie','OAuth2CC','OAuth2ROPC','ApiToken','CookieString','BasicAuth')]
+        [string]$AuthMethod,
+        [string]$Username          = '',
+        [string]$Password          = '',
+        [string]$ClientId          = '',
+        [string]$ClientSecret      = '',
+        [string]$TokenEndpoint     = '',
+        [string]$ApiToken          = '',
+        [string]$CookieString      = '',
+        [string]$ApiVersion        = 'v14',
+        [int]$SessionTimeoutMinutes = 30
+    )
+
+    $base = $BaseUrl.TrimEnd('/')
+
+    $script:OmadaSession = @{
+        AuthMethod            = $AuthMethod
+        BaseUrl               = $base
+        ApiVersion            = $ApiVersion
+        WebSession            = $null
+        AccessToken           = $null
+        BasicAuthHeader       = $null  # pre-computed for BasicAuth
+        CookieHeader          = $null  # raw Cookie header string for CookieString auth (cloud)
+        TokenExpiresAt        = $null
+        LastAuthAt            = $null
+        SessionTimeoutMinutes = $SessionTimeoutMinutes
+        # Stored for re-auth
+        _Username             = $Username
+        _Password             = $Password
+        _ClientId             = $ClientId
+        _ClientSecret         = $ClientSecret
+        _TokenEndpoint        = $TokenEndpoint
+        _ApiToken             = $ApiToken
+    }
+
+    switch ($AuthMethod) {
+        'FormCookie'   { Invoke-OmadaFormAuth }
+        'OAuth2CC'     { Invoke-OmadaOAuth2 -GrantType 'client_credentials' }
+        'OAuth2ROPC'   { Invoke-OmadaOAuth2 -GrantType 'password' }
+        'ApiToken'     { $script:OmadaSession.AccessToken = $ApiToken }
+        'CookieString' { Invoke-OmadaCookieStringAuth -CookieString $CookieString }
+        'BasicAuth'    {
+            if (-not $Username -or -not $Password) { throw "Omada BasicAuth: username and password are required" }
+            $encoded = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("${Username}:${Password}"))
+            $script:OmadaSession.BasicAuthHeader = "Basic $encoded"
+        }
+    }
+
+    Write-Host "  Omada: authenticated via $AuthMethod to $base" -ForegroundColor Green
+}
+
+function Get-OmadaAuthRoot {
+    # Derive the server root URL for /api/authenticate from the OData base URL.
+    # Cloud:    https://tenant.omada.cloud/odata/dataobjects  → https://tenant.omada.cloud
+    # On-prem:  http://server/odata/dataobjects               → http://server
+    # Fallback: http://server/anything-else                   → http://server/anything-else (unchanged)
+    $base     = $script:OmadaSession.BaseUrl
+    $odataIdx = $base.IndexOf('/odata/')
+    if ($odataIdx -gt 0) { return $base.Substring(0, $odataIdx) }
+    return $base
+}
+
+function Invoke-OmadaFormAuth {
+    $authRoot  = Get-OmadaAuthRoot
+    $authUri   = $authRoot + '/api/authenticate'
+    $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+    $body = @{ Username = $script:OmadaSession._Username; Password = $script:OmadaSession._Password } | ConvertTo-Json -Compress
+
+    try {
+        Invoke-RestMethod -Uri $authUri -Method Post `
+            -ContentType 'application/json' -Body $body `
+            -WebSession $webSession -ErrorAction Stop | Out-Null
+    } catch {
+        $status = $null
+        try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+        throw "Omada FormCookie auth failed (HTTP $status) at $authUri`: $($_.Exception.Message)"
+    }
+
+    $script:OmadaSession.WebSession  = $webSession
+    $script:OmadaSession.LastAuthAt  = [datetime]::UtcNow
+}
+
+function Invoke-OmadaOAuth2 {
+    param([ValidateSet('client_credentials','password')] [string]$GrantType)
+    $endpoint = $script:OmadaSession._TokenEndpoint
+    if (-not $endpoint) { throw "Omada OAuth2: tokenEndpoint is required" }
+
+    $form = @{
+        grant_type    = $GrantType
+        client_id     = $script:OmadaSession._ClientId
+        client_secret = $script:OmadaSession._ClientSecret
+    }
+    if ($GrantType -eq 'password') {
+        $form['username'] = $script:OmadaSession._Username
+        $form['password'] = $script:OmadaSession._Password
+    }
+
+    try {
+        $resp = Invoke-RestMethod -Uri $endpoint -Method Post -Body $form -ErrorAction Stop
+    } catch {
+        $status = $null
+        try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+        throw "Omada OAuth2 ($GrantType) failed (HTTP $status): $($_.Exception.Message)"
+    }
+
+    $script:OmadaSession.AccessToken    = $resp.access_token
+    $expiresIn = if ($resp.expires_in) { [int]$resp.expires_in } else { 3600 }
+    $script:OmadaSession.TokenExpiresAt = [datetime]::UtcNow.AddSeconds($expiresIn)
+}
+
+function Invoke-OmadaCookieStringAuth {
+    param([string]$CookieString)
+    if (-not $CookieString.Trim()) { throw "Omada CookieString: cookieString cannot be empty" }
+
+    $raw = $CookieString.Trim()
+
+    # If the value is just a token (no cookie name prefix like "oisauthtoken=…"),
+    # auto-prepend "oisauthtoken=". A name=value pair is detected by checking that
+    # the first '=' is followed by a non-'=' character (i.e. not base64 padding).
+    # Examples:
+    #   "MHXp1OG0seFfKwNYzQkZwA=="        → oisauthtoken=MHXp1OG0seFfKwNYzQkZwA==
+    #   "oisauthtoken=MHXp1OG0seFfKwNYzQkZwA==" → sent as-is (already name=value)
+    #   "ASP.NET_SessionId=abc; Auth=xyz"  → sent as-is (multi-cookie, on-prem)
+    if ($raw -notmatch '^[A-Za-z][A-Za-z0-9_.%-]*=[^=]') {
+        $raw = 'oisauthtoken=' + $raw
+    }
+
+    # Cloud Omada requires an explicit Cookie request header; WebSession cookie-domain
+    # matching is unreliable for cloud/HTTPS URLs.
+    $script:OmadaSession.CookieHeader = $raw
+    # No LastAuthAt — CookieString has no auto re-auth capability
+}
+
+function Update-OmadaSessionIfExpired {
+    <#
+    .SYNOPSIS
+        Re-authenticate if the session/token is about to expire.
+        Call before every HTTP request.
+    #>
+    if ($null -eq $script:OmadaSession) { throw "Omada: not connected. Call Connect-OmadaAPI first." }
+
+    $margin = [timespan]::FromMinutes(2)
+
+    switch ($script:OmadaSession.AuthMethod) {
+        'OAuth2CC' {
+            if ($script:OmadaSession.TokenExpiresAt -and [datetime]::UtcNow -ge ($script:OmadaSession.TokenExpiresAt - $margin)) {
+                Write-Host "  Omada: refreshing OAuth2CC token..." -ForegroundColor Gray
+                Invoke-OmadaOAuth2 -GrantType 'client_credentials'
+            }
+        }
+        'OAuth2ROPC' {
+            if ($script:OmadaSession.TokenExpiresAt -and [datetime]::UtcNow -ge ($script:OmadaSession.TokenExpiresAt - $margin)) {
+                Write-Host "  Omada: refreshing OAuth2ROPC token..." -ForegroundColor Gray
+                Invoke-OmadaOAuth2 -GrantType 'password'
+            }
+        }
+        'FormCookie' {
+            $timeout = [timespan]::FromMinutes($script:OmadaSession.SessionTimeoutMinutes)
+            if ($script:OmadaSession.LastAuthAt -and [datetime]::UtcNow -ge ($script:OmadaSession.LastAuthAt + $timeout - $margin)) {
+                Write-Host "  Omada: re-authenticating (FormCookie session expiry)..." -ForegroundColor Gray
+                Invoke-OmadaFormAuth
+            }
+        }
+        # CookieString and ApiToken: no-op (static)
+    }
+}
+
+function Get-OmadaRefValue {
+    <#
+    .SYNOPSIS
+        Extract the display value from an Omada reference object or return a string as-is.
+    .DESCRIPTION
+        OData 4.0 (on-prem/cloud): OIS.SetValue has .Value (string label);
+        OIS.ReferenceValue has .DisplayName (string label).
+        CSV export fallback: column_VALUE, column_ENGLISH, _DISPLAYNAME.
+    #>
+    param($Ref, [string]$Fallback = '')
+    if ($null -eq $Ref)           { return $Fallback }
+    if ($Ref -is [string])        { return $Ref }
+    if ($Ref.Value)               { return [string]$Ref.Value }       # OIS.SetValue
+    if ($Ref.DisplayName)         { return [string]$Ref.DisplayName } # OIS.ReferenceValue (OData)
+    if ($Ref.english)             { return [string]$Ref.english }
+    if ($Ref._DISPLAYNAME)        { return [string]$Ref._DISPLAYNAME }
+    if ($Ref.displayName)         { return [string]$Ref.displayName }
+    return $Fallback
+}
+
+function Get-OmadaRefUid {
+    <#
+    .SYNOPSIS
+        Extract the UId (Guid) from an Omada reference object or return the string as-is.
+    .DESCRIPTION
+        OData 4.0: OIS.ReferenceValue has .UId (Guid). Legacy: ._UID.
+    #>
+    param($Ref, [string]$Fallback = '')
+    if ($null -eq $Ref)    { return $Fallback }
+    if ($Ref -is [string]) { return $Ref }
+    if ($Ref.UId)          { return [string]$Ref.UId }  # OIS.ReferenceValue (OData)
+    if ($Ref._UID)         { return [string]$Ref._UID }
+    if ($Ref.uid)          { return [string]$Ref.uid }
+    if ($Ref.id)           { return [string]$Ref.id }
+    return $Fallback
+}
+
+function Get-OmadaEntitySets {
+    <#
+    .SYNOPSIS
+        Fetch the OData $metadata document and return the list of entity set names.
+        Returns an empty array if the fetch fails (non-blocking — caller decides how to handle).
+    #>
+    if ($null -eq $script:OmadaSession) { return @() }
+    # Build URI via string concat — NOT interpolation — to keep the literal '$metadata' intact
+    $metaUri = $script:OmadaSession.BaseUrl.TrimEnd('/') + '/$metadata'
+    $reqParams = @{ Uri = $metaUri; Method = 'Get'; ErrorAction = 'Stop' }
+    switch ($script:OmadaSession.AuthMethod) {
+        { $_ -in 'OAuth2CC','OAuth2ROPC','ApiToken' } {
+            $reqParams['Headers'] = @{ Authorization = "Bearer $($script:OmadaSession.AccessToken)" }
+        }
+        'CookieString' {
+            # $metadata returns XML — do NOT send Accept: application/json or Content-Type
+            # here; those headers cause a 500 on cloud instances when the server tries to
+            # serialize the metadata as JSON (which it does not support on this endpoint).
+            $reqParams['Headers'] = @{ Cookie = $script:OmadaSession.CookieHeader }
+        }
+        'FormCookie' {
+            $reqParams['WebSession'] = $script:OmadaSession.WebSession
+        }
+        'BasicAuth' {
+            $reqParams['Headers'] = @{ Authorization = $script:OmadaSession.BasicAuthHeader }
+        }
+    }
+    try {
+        $content = (Invoke-WebRequest @reqParams).Content
+        return @([regex]::Matches($content, 'EntitySet\s+Name="([^"]+)"') |
+                 ForEach-Object { $_.Groups[1].Value } |
+                 Where-Object { $_ })
+    } catch {
+        Write-Host "  Warning: OData metadata fetch failed — $($_.Exception.Message)" -ForegroundColor Yellow
+        return @()
+    }
+}
+
+#endregion Functions

--- a/tools/powershell-sdk/omada/Invoke-OmadaGetRequest.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaGetRequest.ps1
@@ -23,7 +23,6 @@ function Invoke-OmadaGetRequest {
     param(
         [Parameter(Mandatory)] [string]$Path,
         [hashtable]$QueryParams = @{},
-        [int]$PageSize  = 100,
         [int]$MaxRetries = 5,
         [string]$OverrideBaseUrl = ''  # use session BaseUrl when empty; pass Builtin URL for CalculatedAssignments
     )
@@ -113,7 +112,8 @@ function Invoke-OmadaGetRequest {
                     throw "Omada GET $nextUri failed (HTTP $status): $($_.Exception.Message)"
                 }
 
-                $wait = if ($retryAfter -gt 0) { $retryAfter } else { $delays[$attempt] }
+                $delayIdx = [Math]::Min($attempt, $delays.Count - 1)
+                $wait = if ($retryAfter -gt 0) { $retryAfter } else { $delays[$delayIdx] }
                 Write-Host "  Omada: retrying in ${wait}s (HTTP $status, attempt $($attempt+1)/$MaxRetries)..." -ForegroundColor Yellow
                 Start-Sleep -Seconds $wait
                 $attempt++

--- a/tools/powershell-sdk/omada/Invoke-OmadaGetRequest.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaGetRequest.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Authenticated GET against the Omada REST API with retry and OData pagination.
+#>
+
+#region Functions
+
+function Invoke-OmadaGetRequest {
+    <#
+    .SYNOPSIS
+        GET a path relative to the Omada baseUrl.
+    .DESCRIPTION
+        Handles two cases transparently:
+          OData  (Cloud)  — follows @odata.nextLink until exhausted
+          Single response — returns as-is when nextLink is absent
+        Numeric page-by-page walking is handled by Invoke-OmadaPagedRequest.
+        Refreshes the session/token before each attempt.
+    .OUTPUTS
+        Array of records (from .value or the full response).
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [hashtable]$QueryParams = @{},
+        [int]$PageSize  = 100,
+        [int]$MaxRetries = 5,
+        [string]$OverrideBaseUrl = ''  # use session BaseUrl when empty; pass Builtin URL for CalculatedAssignments
+    )
+
+    if ($null -eq $script:OmadaSession) { throw "Omada: not connected. Call Connect-OmadaAPI first." }
+
+    $base = if ($OverrideBaseUrl) { $OverrideBaseUrl.TrimEnd('/') } else { $script:OmadaSession.BaseUrl }
+    if (-not $base) { throw "Omada: session BaseUrl is empty — was Connect-OmadaAPI called successfully?" }
+
+    # Build initial URI — use concatenation (not double-quoted interpolation) because
+    # PowerShell 7 parses "$var?$other" as ${var?} (null variable named "var?"), dropping
+    # the URL. Using + avoids the ambiguity.
+    $startUri = $base + $Path
+    if ($QueryParams.Count -gt 0) {
+        $qs = ($QueryParams.GetEnumerator() |
+               ForEach-Object { "$($_.Key)=$([uri]::EscapeDataString([string]$_.Value))" }) -join '&'
+        $startUri = $startUri + '?' + $qs
+    }
+
+    $collected = [System.Collections.Generic.List[object]]::new()
+    $nextUri   = $startUri
+
+    while ($nextUri) {
+        Update-OmadaSessionIfExpired
+
+        $reqParams = @{ Uri = $nextUri; Method = 'Get'; ErrorAction = 'Stop' }
+        switch ($script:OmadaSession.AuthMethod) {
+            { $_ -in 'OAuth2CC','OAuth2ROPC','ApiToken' } {
+                $reqParams['Headers'] = @{ Authorization = "Bearer $($script:OmadaSession.AccessToken)"
+                                           Accept = 'application/json' }
+            }
+            'CookieString' {
+                # Cloud Omada requires an explicit Cookie header — WebSession domain
+                # matching is unreliable for cloud/HTTPS and the cookie would not be sent.
+                $reqParams['Headers'] = @{
+                    Cookie         = $script:OmadaSession.CookieHeader
+                    Accept         = 'application/json'
+                    'Content-Type' = 'application/json'
+                }
+            }
+            'FormCookie' {
+                $reqParams['WebSession'] = $script:OmadaSession.WebSession
+                $reqParams['Headers']    = @{ Accept = 'application/json' }
+            }
+            'BasicAuth' {
+                $reqParams['Headers'] = @{ Authorization = $script:OmadaSession.BasicAuthHeader
+                                           Accept = 'application/json' }
+            }
+        }
+
+        # Retry loop
+        $attempt = 0
+        $delays  = @(2, 4, 8, 16, 32)
+        $resp    = $null
+        while ($attempt -le $MaxRetries) {
+            try {
+                $resp = Invoke-RestMethod @reqParams
+                break
+            } catch {
+                $status = $null
+                try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+
+                if ($status -in @(401, 403)) {
+                    if ($script:OmadaSession.AuthMethod -eq 'CookieString') {
+                        throw "Omada authentication failed (HTTP $status). The cookie may have expired or been rejected by the server. Retrieve a fresh oisauthtoken cookie from your browser and update the crawler config."
+                    }
+                    if ($script:OmadaSession.AuthMethod -eq 'FormCookie' -and $attempt -lt $MaxRetries) {
+                        # Server-side session expired — re-authenticate and retry with the new cookie.
+                        Write-Host "  Omada: session expired (HTTP $status) — re-authenticating..." -ForegroundColor Yellow
+                        try { Invoke-OmadaFormAuth } catch {
+                            throw "Omada session expired and re-authentication failed: $($_.Exception.Message)"
+                        }
+                        $reqParams['WebSession'] = $script:OmadaSession.WebSession
+                        $attempt++
+                        continue
+                    }
+                }
+
+                $retryAfter = 0
+                try {
+                    $raHeader = $_.Exception.Response.Headers.GetValues('Retry-After')
+                    if ($raHeader) { $retryAfter = [int]($raHeader | Select-Object -First 1) }
+                } catch {}
+
+                $isTransient = ($null -eq $status) -or ($status -eq 429) -or ($status -ge 500 -and $status -le 504)
+                if (-not $isTransient -or $attempt -ge $MaxRetries) {
+                    throw "Omada GET $nextUri failed (HTTP $status): $($_.Exception.Message)"
+                }
+
+                $wait = if ($retryAfter -gt 0) { $retryAfter } else { $delays[$attempt] }
+                Write-Host "  Omada: retrying in ${wait}s (HTTP $status, attempt $($attempt+1)/$MaxRetries)..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $wait
+                $attempt++
+                Update-OmadaSessionIfExpired
+            }
+        }
+        if ($null -eq $resp) { break }
+
+        # Collect records
+        if ($resp.PSObject.Properties.Name -contains 'value') {
+            foreach ($r in $resp.value) { $collected.Add($r) }
+        } elseif ($resp -is [array]) {
+            foreach ($r in $resp) { $collected.Add($r) }
+        } else {
+            $collected.Add($resp)
+        }
+
+        # Follow OData nextLink; stop otherwise (numeric paging is Invoke-OmadaPagedRequest's job)
+        $nextUri = $resp.'@odata.nextLink'
+    }
+
+    return $collected
+}
+
+#endregion Functions

--- a/tools/powershell-sdk/omada/Invoke-OmadaPagedRequest.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaPagedRequest.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Thin wrapper that fetches all records from an Omada OData endpoint.
+.DESCRIPTION
+    Omada uses OData 4.0. Combines two pagination strategies:
+      1. @odata.nextLink  — standard OData cursor (Cloud / some on-prem configs)
+      2. $skip pagination — manual offset paging for servers that do not return
+                             @odata.nextLink but still honour $top and $skip.
+
+    The two strategies are complementary: each page is fetched with an explicit
+    $skip offset. Invoke-OmadaGetRequest will follow any @odata.nextLink returned
+    within a page. The loop stops when a page returns zero records.
+
+    IMPORTANT: The Builtin CalculatedAssignments endpoint returns variable-size
+    pages (fewer than $top even when more records remain), so stopping on
+    page.Count < $PageSize would cut the result short. Stopping on Count == 0
+    is the only safe termination condition for all Omada OData endpoints.
+
+    The caller gets a flat list of all records with no pagination ceremony.
+#>
+
+#region Functions
+
+function Invoke-OmadaPagedRequest {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [hashtable]$QueryParams = @{},
+        [int]$PageSize  = 100,
+        [int]$MaxRetries = 5,
+        [string]$OverrideBaseUrl = ''  # pass through to Invoke-OmadaGetRequest (e.g. Builtin URL)
+    )
+
+    if ($null -eq $script:OmadaSession) { throw "Omada: not connected. Call Connect-OmadaAPI first." }
+
+    $all  = [System.Collections.Generic.List[object]]::new()
+    $skip = 0
+
+    do {
+        # Build per-page params: merge caller params with $top and $skip.
+        # Use single-quoted keys so the literal '$top'/'$skip' strings are preserved
+        # (double-quoted would interpolate them as empty PowerShell variables).
+        $qp = @{ '$top' = $PageSize; '$skip' = $skip }
+        foreach ($kv in $QueryParams.GetEnumerator()) { $qp[$kv.Key] = $kv.Value }
+
+        $page = Invoke-OmadaGetRequest -Path $Path -QueryParams $qp `
+            -MaxRetries $MaxRetries -OverrideBaseUrl $OverrideBaseUrl
+
+        foreach ($r in $page) { $all.Add($r) }
+
+        # Advance skip by the actual number of records received, not PageSize.
+        # The Builtin endpoint can return fewer than $top records even when more
+        # remain, so we must continue until we get an empty page (Count == 0).
+        $skip += $page.Count
+
+    } while ($page.Count -gt 0)
+
+    return $all
+}
+
+#endregion Functions


### PR DESCRIPTION
- Added native Omada IGA crawler that syncs directly from the Omada OData 4.0 REST API — no manual CSV export or transform step required
- Supports six authentication methods: Form/Cookie (on-premise), HTTP Basic Auth, OAuth2 Client Credentials (cloud), OAuth2 ROPC, API Token, and Cookie String (session cookie from browser DevTools)
- Syncs systems, contexts (OrgUnits + configured types), identities, accounts/principals, resources (business roles and permissions), entitlements (CHILDROLES nesting), role assignments (Resourceassignment), and effective account assignments (CalculatedAssignments/CRA)
- Each of Omada's connected target systems (SAP, AD, Salesforce, etc.) is registered as a separate Identity Atlas System; resources and assignments are linked to their correct system
- Fetches OData `$metadata` at startup to discover available entity sets — phases that require missing sets are skipped with a warning
- Context types are configurable (`contextObjectTypes`): each entry specifies entity set, contextType label, and an optional identity reference field for direct context membership
- Resource category mapping is configurable (`resourceCategoryMapping`): maps Omada ROLECATEGORY to Identity Atlas resourceType
- CRA (CalculatedAssignments) pages are streamed one-at-a-time to prevent OOM on large cloud datasets
- Added step-by-step logging throughout the crawler — each fetch, build and ingest operation prints a `→` indicator in the job transcript
- Base URL is normalised using `System.Uri` — both root URLs and explicit OData paths are accepted; the Builtin service URL is derived automatically
- Fixed: `oisauthtoken=` prefix is auto-prepended to bare CookieString tokens for Omada Cloud
- Fixed: `$metadata` fetch no longer sends JSON Accept headers (caused HTTP 500 on cloud); XML is accepted as returned
- Added 42 Pester unit tests for the Omada SDK (auth methods, helper functions, URL normalisation, config forwarding)
- Added data model reference documentation for the Omada crawler (`docs/architecture/omada-crawler-datamodel.md`)
- Added PowerShell formatting style guide to `Functions/CLAUDE.md` (Stroustrup preset, region blocks, operator spacing)
- Fixed: Omada crawler script path in job dispatcher now respects the `IA_APP_ROOT` environment variable instead of hardcoding `/app`
- Fixed: CRA summary log line reported wrong record count (referenced a removed variable from before the streaming refactor)
- Omada post-sync now calls account correlation (cross-system identity linking with Entra and other crawlers)