### PR TITLE
docs: publish UX assessment & remediation page (sanitized)

### DIFF
--- a/changes/docs-ux-report.md
+++ b/changes/docs-ux-report.md
@@ -1,0 +1,1 @@
+- Published a **UX & Interface Assessment & Remediation** page in the docs (under Project → User Experience), a sanitized public summary of the June 2026 UX/GUI audit — findings by severity with status and links to the pull requests that fixed them, mirroring the existing security assessment page.

--- a/docs/ux/assessment.md
+++ b/docs/ux/assessment.md
@@ -1,0 +1,116 @@
+# UX & Interface Assessment & Remediation
+
+Identity Atlas underwent an independent **UX / GUI audit** in June 2026, conducted pentest-style: a read-only, evidence-cited review of the entire React UI (~70 components) across **twelve specialist passes** — six by *lens* and six by *region* — walking every screen, wizard step, and sub-page.
+
+This page is a **public, sanitized summary**: it records what was assessed, the findings by severity and status, and the pull requests that remediated them. Internal file/line evidence and the full twelve-pass transcripts are deliberately omitted. The full audit is kept with the project maintainers.
+
+!!! info "Why we publish this"
+    We hold our own interface to the same standard as our security posture. The audit was deliberately self-critical; every Critical and High finding is tracked openly below, and the foundational fixes (an enforced Style Guide, a design-system lint gate, an accessibility baseline) have been merged to `main`. Remaining items are listed honestly as in progress or planned.
+
+---
+
+## Scope
+
+- **The entire React UI** (`app/ui/src`, ~70 components): the dashboard, the matrix (the core analytical surface), all entity-detail variants, the crawler-configuration wizards, the Admin sub-pages, risk scoring, account correlation, contexts, and the application shell.
+- **Six lenses:** information architecture & navigation, colour & brand, component consistency, user-flow consistency, help & terminology, and accessibility.
+- **Six regions:** crawler config, Admin, entity-detail pages, the matrix end-to-end, risk/correlation/contexts, and the dashboard + list pages + shell.
+
+**Method:** manual, read-only review with every finding cited to `file:line`, deduped and rated by severity. No files were modified during the audit itself.
+
+---
+
+## Result at a glance
+
+| Severity | Found | Remediated / in progress | Open |
+|---|---|---|---|
+| Critical | 4 | 3 | 1 |
+| High | 21 | 9 | 12 |
+| Medium | ~35 | several | most |
+| Low / Informational | ~30 | several | most |
+
+The audit's headline: a **strong foundation with a missing middle** — a healthy design-*token* layer and one genuinely excellent flow (the matrix filter wizard), but no shared *component* layer, no terminology/help system, and uneven dark-mode and accessibility coverage, so the same control had drifted across colours and patterns. The remediation programme therefore prioritised **foundations** (a written Style Guide, CI enforcement, an accessibility baseline) alongside the highest-impact individual fixes.
+
+---
+
+## Findings & remediation
+
+Status legend: ✅ **Fixed** (merged) · 🟨 **Partially addressed** · 🔧 **Remediation planned**.
+
+### Critical
+
+| ID | Finding | Status | PR |
+|---|---|---|---|
+| C-01 | The matrix had no on-screen legend — its core surface (coloured single letters) was undecipherable without external docs | ✅ Fixed | [#226](https://github.com/Fortigi/IdentityAtlas/pull/226), [#250](https://github.com/Fortigi/IdentityAtlas/pull/250) |
+| C-02 | Identity Correlation is a dead-end flow: a ruleset can be saved but not run from the UI, and the review loop is half-built | 🔧 Planned | — |
+| C-03 | The matrix "governed" concept had multiple definitions that could contradict across the panel and the two grids | 🟨 Partially addressed — panel + main grid unified on business-role coverage; rotated view pending | — |
+| C-04 | Accessibility: the app was substantially keyboard- and screen-reader-inoperable (focus, reduced-motion, real controls, labels) | 🟨 Partially addressed — global focus-visible, skip link & reduced-motion baseline merged; modal focus-trap and a full real-controls sweep remain | [#229](https://github.com/Fortigi/IdentityAtlas/pull/229), [#236](https://github.com/Fortigi/IdentityAtlas/pull/236) |
+
+### High
+
+| ID | Finding | Status | PR |
+|---|---|---|---|
+| H-01 | No shared component layer — primitives quarantined; the same action rendered in several colours/styles | 🟨 Partially addressed — shared `Stepper`, unified interactive colour to blue, softened data-viz | [#241](https://github.com/Fortigi/IdentityAtlas/pull/241), [#242](https://github.com/Fortigi/IdentityAtlas/pull/242) |
+| H-02 | Detail pages are "two products in one" (shared-layout vs bespoke; a stale duplicate Group page) | 🔧 Planned | — |
+| H-03 | Entire Contexts tab broken in dark mode | ✅ Fixed | [#227](https://github.com/Fortigi/IdentityAtlas/pull/227) |
+| H-04 | Several regions light-mode only (crawler job-detail modal, compliance & account-type badges) | 🟨 Partially addressed — badges fixed; job-detail modal pending | [#232](https://github.com/Fortigi/IdentityAtlas/pull/232) |
+| H-05 | Botched automated dark-mode pass left doubled/contradictory classes | 🟨 Partially addressed | [#233](https://github.com/Fortigi/IdentityAtlas/pull/233) |
+| H-06 | Roles & Permissions is buried inside Authentication; the described self-lockout guard isn't implemented | 🔧 Planned | — |
+| H-07 | Risk Scoring can't be created/run from its own page; dead cluster code | 🔧 Planned | — |
+| H-08 | Admin → Data tab gating mismatch (sections render regardless of the entry permission) | 🔧 Planned | — |
+| H-09 | Matrix "Apply vs Save" is a trap (overlapping verbs; a scolding "Not saved" badge) | 🔧 Planned | — |
+| H-10 | Rotated matrix is a silent reduced mode while still showing the controls it drops | 🔧 Planned | — |
+| H-11 | Core concepts never defined on screen (matrix, subjects, governed, gaps) | 🟨 Partially addressed — matrix legend + Style Guide glossary | [#226](https://github.com/Fortigi/IdentityAtlas/pull/226), [#237](https://github.com/Fortigi/IdentityAtlas/pull/237) |
+| H-12 | List pages dead-end new users; Systems cited a stale CLI command | 🟨 Partially addressed — Systems onboarding fixed; remaining list pages pending | [#230](https://github.com/Fortigi/IdentityAtlas/pull/230) |
+| H-13 | Optional tabs (Risk Scores, Identities) hidden by default even when enabled | 🔧 Planned | — |
+| H-14 | List-page sort silently sorts only the current page over server pagination | 🔧 Planned | — |
+| H-15 | Dashboard backend error masqueraded as an "empty database" onboarding state | ✅ Fixed | [#235](https://github.com/Fortigi/IdentityAtlas/pull/235) |
+| H-16 | Almost no contextual help / doc links; no in-app glossary | 🔧 Planned | — |
+| H-17 | Terminology drift leaked internal jargon (SOLL/IST, "Org Unit", "Access Package") into the UI | ✅ Fixed — strings corrected + a CI rule blocks regressions | [#228](https://github.com/Fortigi/IdentityAtlas/pull/228), [#243](https://github.com/Fortigi/IdentityAtlas/pull/243), [#238](https://github.com/Fortigi/IdentityAtlas/pull/238) |
+| H-18 | CSV import validates only the filename, not headers; loose name-matching can mis-map | 🔧 Planned | — |
+| H-19 | One-time API key trivially lost; Copy reports success even when the clipboard fails | 🔧 Planned | — |
+| H-20 | Crawler "audit log" fetches data but renders nothing | 🔧 Planned | — |
+| H-21 | ~11 native `confirm()`/`alert()`/`prompt()` for important actions — unstyled, no dark mode, untestable | 🟨 Partially addressed — a CI rule blocks new ones; the existing backlog is being migrated | [#238](https://github.com/Fortigi/IdentityAtlas/pull/238) |
+
+### Medium & Low
+
+Around 35 Medium and 30 Low/Informational items were recorded — inconsistent sub-navigation, no breadcrumbs, ad-hoc empty/loading states, tag-pill contrast risks, the orphaned brand colour and button-colour drift, ad-hoc type sizes, and assorted polish. Several have already been resolved as part of the foundational work below (terminology, the brand/colour decision, the matrix Tags column, a null-guard crash); the remainder are tracked internally and scheduled alongside the High items. Technical detail is withheld here pending remediation.
+
+---
+
+## Supporting work
+
+Beyond the per-finding fixes, the remediation programme added the **foundations the audit said were missing**:
+
+- **A written, enforced UI Style Guide** — codifies the two-role colour system (green = brand, blue = interactive), dark-mode and accessibility rules, the data-viz saturation rule, component conventions, and a terminology glossary ([#237](https://github.com/Fortigi/IdentityAtlas/pull/237), [#245](https://github.com/Fortigi/IdentityAtlas/pull/245)).
+- **A CI "design-system lint" gate** — blocks native dialogs and legacy jargon in new code, on top of the existing contrast rule ([#238](https://github.com/Fortigi/IdentityAtlas/pull/238)).
+- **A visual-consistency sweep** — a shared stepper, one interactive colour, softened data-visualisation fills, and the removal of the stale matrix Tags column ([#241](https://github.com/Fortigi/IdentityAtlas/pull/241), [#242](https://github.com/Fortigi/IdentityAtlas/pull/242), [#243](https://github.com/Fortigi/IdentityAtlas/pull/243)).
+- **Documentation that matches the product** — the docs site now mirrors the app's shell and brand ([#239](https://github.com/Fortigi/IdentityAtlas/pull/239), [#244](https://github.com/Fortigi/IdentityAtlas/pull/244)).
+
+---
+
+## Strengths (confirmed)
+
+The audit confirmed real strengths, preserved throughout remediation:
+
+- **A genuine design-token layer** — centralised colour palettes and tier/badge style maps.
+- **One excellent flow** — the matrix filter wizard with live preview counts.
+- **A WCAG contrast lint rule** already in place, now joined by the broader design-system gate.
+- **Dark-mode intent** throughout, now being completed region by region.
+
+---
+
+## Remediation roadmap
+
+| Priority | Theme | Status |
+|---|---|---|
+| **P0** | Legibility & trust — matrix legend & "how to read", dashboard error ≠ empty | ✅ Complete |
+| **P1** | Design-system foundation — Style Guide, CI lint, accessibility baseline, interactive-colour unification | 🟨 In progress |
+| **P2** | Dark mode & brand — complete dark mode region by region; finish the colour decision | 🟨 In progress |
+| **P3** | IA & onboarding — unify the detail-page family, promote Roles & Permissions, guiding empty states, surface optional tabs | 🔧 Scheduled |
+| **P4** | Help & governance — per-page doc links + glossary, finish/fence half-built features | 🔧 Scheduled |
+
+A follow-up re-audit is recommended once the P2–P3 items are remediated.
+
+---
+
+*This page is a sanitized public summary. The full audit, with per-finding file/line evidence across the twelve specialist passes, is kept with the project maintainers. No files or deployments were modified during the audit itself — it was a read-only inspection.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,8 @@ nav:
       - History: history.md
       - Contributing:
           - UI Style Guide: contributing/style-guide.md
+      - User Experience:
+          - Assessment & Remediation: ux/assessment.md
       - Security:
           - Assessment & Remediation: security/assessment.md
 


### PR DESCRIPTION
Publishes the June 2026 UX/GUI audit the same way the pentest review was published — a **sanitized public summary** at `docs/ux/assessment.md`, added under **Project → User Experience**.

Mirrors `docs/security/assessment.md`:
- "Public, sanitized summary" framing + "why we publish this" (the audit is self-critical; the repo is public).
- Scope & 12-pass methodology.
- Result-at-a-glance severity table.
- **Findings & remediation** tables (Critical C-01–C-04, High H-01–H-21) with status (✅/🟨/🔧) and links to this campaign's merged PRs (#226–#245, #250).
- Supporting work (Style Guide, CI design-system lint, visual-consistency sweep, docs theme), strengths, and a P0–P4 roadmap.

Internal file/line evidence and the full twelve-pass transcripts are deliberately omitted (kept with maintainers). `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)