### PR TITLE
feat(business-role): badge Overview in Attributes + access-review timeline

### DIFF
--- a/app/api/src/routes/recentChanges.js
+++ b/app/api/src/routes/recentChanges.js
@@ -562,8 +562,50 @@ async function runTimeline(res, { entityKind, id, sinceDays, limit, where }) {
   `, [sinceDays, id, limit * 2]);
   const labels = await resolveTimelineLabels(r.rows);
   const built = buildEntityTimeline(entityKind, id, r.rows, labels);
+
+  // Access-review activity isn't in _history (CertificationDecisions isn't
+  // tracked), but each review instance has real start/end dates — surface them
+  // as "Access review started/ended" events so they show on the timeline.
+  if (entityKind === 'access-package' || entityKind === 'resource') {
+    const reviewEvents = await reviewInstanceEvents(id, sinceDays);
+    if (reviewEvents.length) {
+      built.events.push(...reviewEvents);
+      built.changedCount += reviewEvents.length;
+      built.events.sort((a, b) => new Date(b.at) - new Date(a.at));
+    }
+  }
+
   built.events = built.events.slice(0, limit);
   res.json({ sinceDays, ...built });
+}
+
+// Synthesize "Access review started / ended" timeline events from a resource's
+// review instances (distinct reviewInstanceId in CertificationDecisions).
+async function reviewInstanceEvents(id, sinceDays) {
+  const cutoff = Date.now() - sinceDays * 86400000;
+  const out = [];
+  try {
+    const r = await db.query(`
+      SELECT DISTINCT "reviewInstanceId" AS ii,
+             "reviewInstanceStartDateTime" AS st,
+             "reviewInstanceEndDateTime"   AS en,
+             "reviewInstanceStatus"        AS status
+        FROM "CertificationDecisions"
+       WHERE "resourceId"::text = $1 AND "reviewInstanceId" IS NOT NULL`, [id]);
+    const now = Date.now();
+    for (const row of r.rows) {
+      if (row.st && new Date(row.st).getTime() > cutoff) {
+        out.push({ at: row.st, operation: 'added', eventKind: 'review', summary: 'Access review started',
+          counterpartyKind: null, counterpartyId: null, counterpartyLabel: null });
+      }
+      if (row.en && new Date(row.en).getTime() <= now && new Date(row.en).getTime() > cutoff) {
+        out.push({ at: row.en, operation: 'changed', eventKind: 'review',
+          summary: `Access review ${row.status === 'Completed' ? 'completed' : 'ended'}`,
+          counterpartyKind: null, counterpartyId: null, counterpartyLabel: null });
+      }
+    }
+  } catch { /* CertificationDecisions may not exist */ }
+  return out;
 }
 
 // Per-entity _history WHERE clauses ($2 = entity id).

--- a/app/api/src/routes/recentChanges.js
+++ b/app/api/src/routes/recentChanges.js
@@ -567,7 +567,7 @@ async function runTimeline(res, { entityKind, id, sinceDays, limit, where }) {
   // tracked), but each review instance has real start/end dates — surface them
   // as "Access review started/ended" events so they show on the timeline.
   if (entityKind === 'access-package' || entityKind === 'resource') {
-    const reviewEvents = await reviewInstanceEvents(id, sinceDays);
+    const reviewEvents = await reviewInstanceEvents(id);
     if (reviewEvents.length) {
       built.events.push(...reviewEvents);
       built.changedCount += reviewEvents.length;
@@ -581,8 +581,10 @@ async function runTimeline(res, { entityKind, id, sinceDays, limit, where }) {
 
 // Synthesize "Access review started / ended" timeline events from a resource's
 // review instances (distinct reviewInstanceId in CertificationDecisions).
-async function reviewInstanceEvents(id, sinceDays) {
-  const cutoff = Date.now() - sinceDays * 86400000;
+// Reviews are sparse governance milestones, so — unlike attribute/relationship
+// events — these are NOT clipped to the selected window; the most recent review
+// should always be visible on the timeline.
+async function reviewInstanceEvents(id) {
   const out = [];
   try {
     const r = await db.query(`
@@ -594,11 +596,11 @@ async function reviewInstanceEvents(id, sinceDays) {
        WHERE "resourceId"::text = $1 AND "reviewInstanceId" IS NOT NULL`, [id]);
     const now = Date.now();
     for (const row of r.rows) {
-      if (row.st && new Date(row.st).getTime() > cutoff) {
+      if (row.st) {
         out.push({ at: row.st, operation: 'added', eventKind: 'review', summary: 'Access review started',
           counterpartyKind: null, counterpartyId: null, counterpartyLabel: null });
       }
-      if (row.en && new Date(row.en).getTime() <= now && new Date(row.en).getTime() > cutoff) {
+      if (row.en && new Date(row.en).getTime() <= now) {
         out.push({ at: row.en, operation: 'changed', eventKind: 'review',
           summary: `Access review ${row.status === 'Completed' ? 'completed' : 'ended'}`,
           counterpartyKind: null, counterpartyId: null, counterpartyLabel: null });

--- a/app/ui/src/components/AccessPackageDetailPage.jsx
+++ b/app/ui/src/components/AccessPackageDetailPage.jsx
@@ -13,7 +13,7 @@ import useExpandableGraph from '../hooks/useExpandableGraph';
 import useTimeline from '../hooks/useTimeline';
 import useFeatures from '../hooks/useFeatures';
 import { getRootNodes } from './entityGraphShape';
-import { ASSIGNMENT_TYPE_STYLES } from '../utils/accessPackageStyles';
+import { ASSIGNMENT_TYPE_STYLES, COMPLIANCE_STYLES } from '../utils/accessPackageStyles';
 
 const HEADER_FIELDS = ['catalogName', 'catalogId', 'description'];
 const HIDDEN_FIELDS = new Set([
@@ -95,30 +95,12 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
   }
   if (!data) return null;
 
-  const { attributes, lastReviewDate, lastReviewedBy, complianceStatus, daysOverdue, assignmentType, category, policyCount, reviewCount, pendingRequestCount } = data;
+  const { attributes, lastReviewDate, lastReviewedBy, complianceStatus, daysOverdue, assignmentType, category } = data;
   const attributeEntries = buildAttributeEntries(
     attributes,
     attributes.extendedAttributesParsed || (typeof attributes.extendedAttributes === 'object' ? attributes.extendedAttributes : null),
     HIDDEN_FIELDS,
   );
-
-  // Calculated / overview fields — the same values shown in the Business Roles
-  // list (Type, Review Status, Reviewed By …). Surfaced here so the data
-  // behind the overview is visible on the detail page itself.
-  const reviewStatusText = complianceStatus
-    ? complianceStatus + (daysOverdue ? ` — ${daysOverdue}d overdue` : '')
-    : null;
-  const overviewEntries = [
-    ['Type', assignmentType],
-    ['Review status', reviewStatusText],
-    ['Last review', lastReviewDate ? formatDate(lastReviewDate) : null],
-    ['Reviewed by', lastReviewedBy],
-    ['Catalog', attributes.catalogName],
-    ['Category', category?.name],
-    ['Policies', policyCount],
-    ['Access reviews', reviewCount],
-    ['Pending requests', pendingRequestCount],
-  ].filter(([, v]) => v != null && v !== '');
 
   const hasRisk = features.riskScoring && riskData && riskData.riskScore != null;
   const tabs = [
@@ -180,8 +162,19 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
       <div className="mt-4">
         {activeTab === 'attributes' && (
           <div className="space-y-4">
-            {overviewEntries.length > 0 && <AttributesTable title="Overview (calculated)" entries={overviewEntries} />}
+            <OverviewPanel
+              assignmentType={assignmentType}
+              complianceStatus={complianceStatus}
+              daysOverdue={daysOverdue}
+              lastReviewDate={lastReviewDate}
+              lastReviewedBy={lastReviewedBy}
+              category={category}
+            />
             <AttributesTable entries={attributeEntries} />
+            {/* Governance records (policies, access reviews, requests) live at
+                the bottom of Attributes — they describe this role, not a graph
+                relationship. */}
+            <AccessPackageGovernance accessPackageId={accessPackageId} authFetch={authFetch} />
           </div>
         )}
 
@@ -216,10 +209,6 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
                 <p className="text-sm text-gray-600 dark:text-gray-500">Click a node in the graph to fan it out; click again to collapse.</p>
               </div>
             )}
-
-            {/* Governance references — the records behind the review-status /
-                type overview: policies, access reviews, pending requests. */}
-            <AccessPackageGovernance accessPackageId={accessPackageId} authFetch={authFetch} />
           </div>
         )}
 
@@ -235,6 +224,51 @@ export default function AccessPackageDetailPage({ accessPackageId, cachedData, o
 
         {activeTab === 'risk' && riskData && (
           <RiskScoreSection attributes={riskData} entityType="business-roles" entityId={accessPackageId} authFetch={authFetch} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Overview — the list's calculated fields, with the same badges/colours ──
+function OverviewRow({ label, children }) {
+  return (
+    <div className="flex items-baseline gap-3 py-1.5 border-b border-gray-50 dark:border-gray-700/50 last:border-b-0">
+      <span className="text-xs text-gray-500 dark:text-gray-400 w-32 shrink-0">{label}</span>
+      <span className="text-sm text-gray-900 dark:text-gray-100">{children}</span>
+    </div>
+  );
+}
+
+const BADGE = 'inline-block px-2 py-0.5 rounded-full text-xs font-medium border';
+const NEUTRAL = 'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600';
+
+function OverviewPanel({ assignmentType, complianceStatus, daysOverdue, lastReviewDate, lastReviewedBy, category }) {
+  if (!(assignmentType || complianceStatus || lastReviewDate || lastReviewedBy || category)) return null;
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      <div className="px-4 py-2.5 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Overview</h3>
+      </div>
+      <div className="px-4 py-2">
+        {assignmentType && (
+          <OverviewRow label="Type">
+            <span className={`${BADGE} ${ASSIGNMENT_TYPE_STYLES[assignmentType] || NEUTRAL}`}>{assignmentType}</span>
+          </OverviewRow>
+        )}
+        {complianceStatus && (
+          <OverviewRow label="Review status">
+            <span className={`${BADGE} ${COMPLIANCE_STYLES[complianceStatus] || NEUTRAL}`}>
+              {complianceStatus}{daysOverdue ? ` (${daysOverdue}d ago)` : ''}
+            </span>
+          </OverviewRow>
+        )}
+        {lastReviewDate && <OverviewRow label="Review date">{formatDate(lastReviewDate)}</OverviewRow>}
+        {lastReviewedBy && <OverviewRow label="Reviewed by">{lastReviewedBy}</OverviewRow>}
+        {category && (
+          <OverviewRow label="Category">
+            <span className={BADGE} style={{ backgroundColor: category.color + '20', borderColor: category.color, color: category.color }}>{category.name}</span>
+          </OverviewRow>
         )}
       </div>
     </div>

--- a/app/ui/src/components/EntityTimeline.jsx
+++ b/app/ui/src/components/EntityTimeline.jsx
@@ -19,7 +19,7 @@ const RANGES = [
   { days: 1095, label: 'All' },
 ];
 
-const REL_KINDS = new Set(['assignment', 'relationship', 'identity-member', 'manager']);
+const REL_KINDS = new Set(['assignment', 'relationship', 'identity-member', 'manager', 'review']);
 
 function summarize(moment) {
   let attr = 0, rel = 0, created = false;

--- a/app/ui/src/components/EntityTimeline.test.jsx
+++ b/app/ui/src/components/EntityTimeline.test.jsx
@@ -22,6 +22,15 @@ describe('EntityTimeline (horizontal)', () => {
     expect(html).not.toContain('indigo'); // interactive colour is blue
   });
 
+  it('renders access-review events', () => {
+    const reviewEvents = [
+      { at: '2026-06-04T10:00:00Z', operation: 'added', eventKind: 'review', summary: 'Access review started' },
+    ];
+    const html = renderToStaticMarkup(h(EntityTimeline, { events: reviewEvents, loading: false, sinceDays: 90 }));
+    expect(html).toContain('Access review started');
+    expect(html).toContain('1 rel'); // a review counts as a relationship-kind event
+  });
+
   it('shows an empty state when there are no events', () => {
     const html = renderToStaticMarkup(h(EntityTimeline, { events: [], loading: false, sinceDays: 90 }));
     expect(html).toContain('No changes recorded');

--- a/app/ui/src/components/entityGraphShape.js
+++ b/app/ui/src/components/entityGraphShape.js
@@ -185,12 +185,11 @@ async function fetchResourceItems(resourceId, categoryKey, authFetch, _extras = 
 
 function accessPackageRootNodes(core) {
   const a = core.attributes || {};
+  // Governance metadata (policies / reviews / requests) is shown on the
+  // Attributes tab, not as graph nodes — the graph is for real relationships.
   return [
     { key: 'assignments', label: 'Assignments',      count: +core.assignmentCount || 0,    kind: 'category' },
     { key: 'resources',   label: 'Resources',        count: +core.groupCount || 0,         kind: 'category' },
-    { key: 'policies',    label: 'Policies',         count: +core.policyCount || 0,        kind: 'category' },
-    { key: 'reviews',     label: 'Reviews',          count: +core.reviewCount || 0,        kind: 'category' },
-    { key: 'requests',    label: 'Pending Requests', count: +core.pendingRequestCount || 0, kind: 'category' },
     { key: 'catalog',     label: 'Catalog',          count: a.catalogId ? 1 : 0,           kind: 'category' },
   ];
 }

--- a/app/ui/src/utils/accessPackageStyles.js
+++ b/app/ui/src/utils/accessPackageStyles.js
@@ -4,3 +4,12 @@ export const ASSIGNMENT_TYPE_STYLES = {
   'Request-based with auto-removal':  'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300 border-orange-200 dark:border-orange-700',
   'Both':                             'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300 border-purple-200 dark:border-purple-700',
 };
+
+// Review-compliance badge styles — shared by the Business Roles list and the
+// detail page's Overview so the badge/colour is identical in both.
+export const COMPLIANCE_STYLES = {
+  'Compliant':     'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700',
+  'In Progress':   'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700',
+  'Missed':        'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700',
+  'Reviewed Late': 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700',
+};

--- a/changes/business-role-governance.md
+++ b/changes/business-role-governance.md
@@ -1,0 +1,2 @@
+- Business Role detail page: the Attributes tab now opens with an **Overview** panel showing Type, Review status, Review date, Reviewed by and Category using the same badges and colours as the Business Roles list; the governance records (policies, access reviews grouped by review instance, pending requests) now sit at the bottom of the Attributes tab; and the Relationships tab is back to just the relationship graph.
+- The Business Role **Timeline** now shows access-review activity ("Access review started" / "ended").


### PR DESCRIPTION
Follow-up to the entity-detail rollout (#257), addressing review feedback on the **Business Role** page.

## Attributes tab
- Leads with an **Overview** panel: **Type**, **Review status**, **Review date**, **Reviewed by**, **Category** — with the **same badges + colours** as the Business Roles list (shared `COMPLIANCE_STYLES` extracted to `utils/accessPackageStyles.js`). Replaces the earlier plain "calculated fields" text panel.
- The **governance records** (assignment policies with review cadence, access reviews grouped by **review instance**, pending requests) now sit at the **bottom of the Attributes tab** — they describe the role, not a graph relationship.

## Relationships tab
- Reverted to **just the relationship graph** (the governance block didn't belong here).

## Timeline
- Now includes **access-review activity** — "Access review started" / "ended" — synthesized from each review instance's start/end dates (`CertificationDecisions` isn't in `_history`, so these are derived directly).

Builds on the data model: AssignmentPolicy (cadence via `reviewSettings`) → review campaign (`reviewDefinitionId`) → review instance (`reviewInstanceId`) → decisions.

eslint/WCAG clean; API + UI tests pass; `vite build` passes. Already live on SK1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)