### PR TITLE
fix(ui): in-app docs links match the running channel (edge vs stable)

### DIFF
--- a/app/ui/src/components/CrawlersPage.jsx
+++ b/app/ui/src/components/CrawlersPage.jsx
@@ -2,6 +2,7 @@
 import { useAuth } from '../auth/AuthGate';
 import ScheduleEditor from './ScheduleEditor';
 import Stepper from './Stepper';
+import useDocsUrl from '../hooks/useDocsUrl';
 import { formatDurationSeconds as formatDurationHMS } from '../utils/formatters';
 
 const SECRET_MASK = '••••••••';
@@ -2361,6 +2362,7 @@ $s.Cookies.GetCookies([Uri]"https://omada.example.com") |
 // ═══════════════════════════════════════════════════════════════════════════════
 
 function CustomConnectorWizard({ onComplete, onCancel, authFetch }) {
+  const docsLink = useDocsUrl();
   const [step, setStep] = useState(1);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -2571,7 +2573,7 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
               <span className="font-medium text-sm dark:text-gray-200">Download OpenAPI Spec</span>
               <span className="text-xs text-gray-500 dark:text-gray-400">JSON format</span>
             </a>
-            <a href="https://fortigi.github.io/IdentityAtlas/datasources/csv-schema/" target="_blank" rel="noopener noreferrer"
+            <a href={docsLink('/architecture/csv-import-schema/')} target="_blank" rel="noopener noreferrer"
               className="flex flex-col items-center p-4 border-2 rounded-lg hover:border-blue-400 hover:shadow-md transition-all text-center dark:border-gray-700 dark:hover:border-blue-500">
               <span className="text-2xl mb-1">📋</span>
               <span className="font-medium text-sm dark:text-gray-200">CSV Schema Reference</span>

--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -15,13 +15,13 @@ import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { useAuth } from '../auth/AuthGate';
 import { useIsDark } from '../contexts/ThemeContext';
 import { formatCompactNumber as formatNumber, formatRelativeTime } from '../utils/formatters';
+import { docsUrl } from '../utils/docsUrl';
 
 // Lazy-load Trends — keeps the dashboard's first paint cheap (chart code +
 // data hook are only needed when the user clicks the tab).
 const DashboardTrendsTab = lazy(() => import('./DashboardTrendsTab'));
 
 const GITHUB_BASE = 'https://github.com/Fortigi/IdentityAtlas';
-const DOCS_URL = 'https://fortigi.github.io/IdentityAtlas';
 const SUPPORT_EMAIL = 'support@identityatlas.io';
 
 function changesUrl(v) {
@@ -246,7 +246,7 @@ export default function DashboardPage({ onNavigate }) {
             <h3 className="text-sm font-bold text-gray-900 dark:text-white">Resources</h3>
           </div>
           <ul className="space-y-2.5 text-sm">
-            <li><a href={DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>Documentation</a></li>
+            <li><a href={docsUrl(version?.version)} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>Documentation</a></li>
             <li><a href={GITHUB_BASE} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>GitHub repository</a></li>
             <li><a href={`${GITHUB_BASE}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>License</a></li>
             <li><a href={`${GITHUB_BASE}/releases`} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>Releases</a></li>

--- a/app/ui/src/hooks/useDocsUrl.js
+++ b/app/ui/src/hooks/useDocsUrl.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { docsUrl } from '../utils/docsUrl';
+
+// Returns a `(path) => url` builder that points at the docs version matching
+// the running build (edge vs stable). Fetches /api/version once (public, like
+// useFeatures) so components without the version handy can still build a
+// channel-correct docs link. See utils/docsUrl.
+export default function useDocsUrl() {
+  const [version, setVersion] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/version')
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => { if (!cancelled) setVersion(d?.version || null); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  return (path = '') => docsUrl(version, path);
+}

--- a/app/ui/src/utils/docsUrl.js
+++ b/app/ui/src/utils/docsUrl.js
@@ -1,0 +1,25 @@
+// Build a docs-site URL that points at the version matching the running build.
+//
+// The docs site is versioned with mike: every push to main publishes the
+// `edge` alias; cutting a release publishes the version + the `stable` alias
+// (which is the site default). So an *edge* build must link to `/edge/...`,
+// otherwise the in-app "Documentation" link sends edge users to the last
+// released (stable) docs — which won't match the running features.
+//
+// Channel is derived from the version string (same edge rule as the footer's
+// "edge" badge in App.jsx):
+//   edge/dev build → Major.Minor.yyyyMMdd.HHmm  (3rd segment is an 8-digit date)
+//   anything else (release Major.Minor.Patch.0, or unknown) → stable (the
+//   site default — safer than sending users to edge when unsure)
+const DOCS_BASE = 'https://fortigi.github.io/IdentityAtlas';
+
+export function docsVersionAlias(version) {
+  const parts = (version || '').split('.');
+  const isEdge = parts.length === 4 && /^\d{8}$/.test(parts[2]);
+  return isEdge ? 'edge' : 'stable';
+}
+
+// `path` is appended after the version segment, e.g. docsUrl(v, '/concepts/data-model/').
+export function docsUrl(version, path = '') {
+  return `${DOCS_BASE}/${docsVersionAlias(version)}${path}`;
+}

--- a/app/ui/src/utils/docsUrl.test.js
+++ b/app/ui/src/utils/docsUrl.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { docsUrl, docsVersionAlias } from './docsUrl';
+
+describe('docsUrl', () => {
+  it('maps an edge/dev build (date-based version) to the edge docs', () => {
+    expect(docsVersionAlias('5.131.20260605.1037')).toBe('edge');
+    expect(docsUrl('5.131.20260605.1037', '/concepts/data-model/'))
+      .toBe('https://fortigi.github.io/IdentityAtlas/edge/concepts/data-model/');
+  });
+
+  it('maps a release build (patch-based version) to the stable docs', () => {
+    expect(docsVersionAlias('5.2.1.0')).toBe('stable');
+    expect(docsUrl('5.2.1.0')).toBe('https://fortigi.github.io/IdentityAtlas/stable');
+  });
+
+  it('defaults to stable for unknown/blank versions', () => {
+    expect(docsVersionAlias(null)).toBe('stable');
+    expect(docsVersionAlias('')).toBe('stable');
+  });
+});

--- a/changes/docs-link-channel.md
+++ b/changes/docs-link-channel.md
@@ -1,0 +1,1 @@
+- The in-app "Documentation" and "CSV Schema Reference" links now point to the docs version that matches the running build — an **edge** build links to the edge docs, a release links to the stable docs — instead of always opening the default (stable) docs.


### PR DESCRIPTION
**Bug:** on an edge build, the in-app "Documentation" link opened the **stable** docs (the site default), which don't match the running features.

**Fix:** derive the docs version from the running build and link to the matching mike alias:
- `docsVersionAlias(version)` → `edge` when the version is `Major.Minor.yyyyMMdd.HHmm` (same rule as the footer's "edge" badge), otherwise `stable` (releases + unknown → safe default).
- `docsUrl(version, path)` builds `…/edge/…` or `…/stable/…`; `useDocsUrl()` hook for components without the version handy.
- Wired into the Dashboard **Documentation** link and the Crawler **CSV Schema Reference** link (also corrected its stale path → `architecture/csv-import-schema`).

Tests: `docsUrl.test.js` (edge / release / unknown). eslint clean; `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)