### PR TITLE
ci: group react + react-dom in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
+    groups:
+      # react and react-dom must always be the same version — group them
+      # so Dependabot updates both in a single PR instead of independently.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
Dependabot doesn't understand that `react` and `react-dom` must always be the exact same version — to npm they're independent packages. Without grouping, Dependabot updated `react` to `^19.2.7` but left `react-dom` at `^19.2.0`, which resolved to 19.2.4 in the lockfile. React refuses to mount with a version mismatch, producing a blank white page.

The `groups.react` entry forces Dependabot to update all four React packages in a single PR: `react`, `react-dom`, `@types/react`, `@types/react-dom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)