### PR TITLE
feat(identity): "Linked from source" for crawler-linked accounts

### DIFF
--- a/app/ui/src/components/IdentityDetailPage.jsx
+++ b/app/ui/src/components/IdentityDetailPage.jsx
@@ -235,6 +235,10 @@ export default function IdentityDetailPage({ identityId, cachedData, onCacheData
                 {members.map(m => {
                   const ov = m.analystOverride;
                   const busy = busyMember === m.principalId;
+                  // A link with no confidence score came from the crawler / source
+                  // data — it's authoritative and not analyst-managed here. Only
+                  // account-linking's scored links get Confirm / Remove.
+                  const isSource = m.linkConfidence == null;
                   return (
                     <div key={m.principalId} className="flex items-center justify-between gap-3 py-2">
                       <div className="min-w-0">
@@ -249,25 +253,29 @@ export default function IdentityDetailPage({ identityId, cachedData, onCacheData
                         </div>
                       </div>
                       <div className="flex items-center gap-2 shrink-0">
-                        {m.linkConfidence != null && <ConfidenceBar confidence={m.linkConfidence} />}
-                        {ov && (
-                          <span className={`text-xs px-2 py-0.5 rounded-full border ${
-                            ov === 'confirmed' ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-300 dark:border-green-700'
-                              : ov === 'rejected' ? 'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-300 dark:border-red-700'
-                                : 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600'
-                          }`}>{ov}</span>
-                        )}
-                        {m.isPrimary ? (
-                          <span className="text-xs text-gray-500 dark:text-gray-400">source</span>
-                        ) : ov ? (
-                          <button disabled={busy} onClick={() => overrideMember(m.principalId, 'clear')}
-                            className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50">Undo</button>
+                        {isSource ? (
+                          <span className="text-xs text-gray-500 dark:text-gray-400 italic">Linked from source</span>
                         ) : (
                           <>
-                            <button disabled={busy} onClick={() => overrideMember(m.principalId, 'confirmed')}
-                              className="text-xs px-2 py-1 rounded border border-green-300 dark:border-green-700 text-green-700 dark:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/30 disabled:opacity-50">Confirm</button>
-                            <button disabled={busy} onClick={() => overrideMember(m.principalId, 'rejected')}
-                              className="text-xs px-2 py-1 rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50">Remove</button>
+                            {m.linkConfidence != null && <ConfidenceBar confidence={m.linkConfidence} />}
+                            {ov && (
+                              <span className={`text-xs px-2 py-0.5 rounded-full border ${
+                                ov === 'confirmed' ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-300 dark:border-green-700'
+                                  : ov === 'rejected' ? 'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-300 dark:border-red-700'
+                                    : 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600'
+                              }`}>{ov}</span>
+                            )}
+                            {ov ? (
+                              <button disabled={busy} onClick={() => overrideMember(m.principalId, 'clear')}
+                                className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50">Undo</button>
+                            ) : (
+                              <>
+                                <button disabled={busy} onClick={() => overrideMember(m.principalId, 'confirmed')}
+                                  className="text-xs px-2 py-1 rounded border border-green-300 dark:border-green-700 text-green-700 dark:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/30 disabled:opacity-50">Confirm</button>
+                                <button disabled={busy} onClick={() => overrideMember(m.principalId, 'rejected')}
+                                  className="text-xs px-2 py-1 rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50">Remove</button>
+                              </>
+                            )}
                           </>
                         )}
                       </div>

--- a/app/ui/src/components/IdentityDetailPage.jsx
+++ b/app/ui/src/components/IdentityDetailPage.jsx
@@ -5,6 +5,7 @@ import ConfidenceBar from './ConfidenceBar';
 import EntityGraph from './EntityGraph';
 import { AttributesTable } from './EntityDetailLayout';
 import { buildAttributeEntries } from '../utils/attributeEntries';
+import { isSourceLinkedMember } from '../utils/linkedMembers';
 import ExpandedItemsList from './ExpandedItemsList';
 import TabBar from './TabBar';
 import EntityTimeline from './EntityTimeline';
@@ -238,7 +239,7 @@ export default function IdentityDetailPage({ identityId, cachedData, onCacheData
                   // A link with no confidence score came from the crawler / source
                   // data — it's authoritative and not analyst-managed here. Only
                   // account-linking's scored links get Confirm / Remove.
-                  const isSource = m.linkConfidence == null;
+                  const isSource = isSourceLinkedMember(m);
                   return (
                     <div key={m.principalId} className="flex items-center justify-between gap-3 py-2">
                       <div className="min-w-0">

--- a/app/ui/src/utils/linkedMembers.js
+++ b/app/ui/src/utils/linkedMembers.js
@@ -1,0 +1,16 @@
+// Helpers for reasoning about an identity's linked accounts (IdentityMembers).
+
+/**
+ * A linked account is "source-linked" when it has no confidence score: it came
+ * from the crawler / source data, is authoritative, and is owned by the crawler
+ * — not by account linking. The identity UI shows "Linked from source" for these
+ * and does NOT offer Confirm / Remove (those apply only to account-linking's
+ * scored links). Mirrors the backend rule that a crawler reconcile leaves
+ * score-bearing links alone.
+ *
+ * @param {{linkConfidence?: number|null}} member
+ * @returns {boolean}
+ */
+export function isSourceLinkedMember(member) {
+  return member == null || member.linkConfidence == null;
+}

--- a/app/ui/src/utils/linkedMembers.test.js
+++ b/app/ui/src/utils/linkedMembers.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { isSourceLinkedMember } from './linkedMembers.js';
+
+describe('isSourceLinkedMember', () => {
+  it('treats a link with no confidence score as source-linked (no Confirm/Remove)', () => {
+    expect(isSourceLinkedMember({ linkConfidence: null })).toBe(true);
+    expect(isSourceLinkedMember({ linkConfidence: undefined })).toBe(true);
+    expect(isSourceLinkedMember({})).toBe(true);
+  });
+
+  it('treats a scored link as account-linking-owned (gets Confirm/Remove)', () => {
+    expect(isSourceLinkedMember({ linkConfidence: 100 })).toBe(false);
+    expect(isSourceLinkedMember({ linkConfidence: 60 })).toBe(false);
+    // A genuine 0 score is still a scored link, not source-linked.
+    expect(isSourceLinkedMember({ linkConfidence: 0 })).toBe(false);
+  });
+
+  it('is null-safe', () => {
+    expect(isSourceLinkedMember(null)).toBe(true);
+    expect(isSourceLinkedMember(undefined)).toBe(true);
+  });
+});

--- a/changes/identity-source-link-label.md
+++ b/changes/identity-source-link-label.md
@@ -1,0 +1,1 @@
+- Identity page → Linked Accounts: accounts linked by the crawler/source data (no confidence score) now show "Linked from source" instead of Confirm/Remove. Confirm/Remove apply only to account-linking's scored links, so source links can't be accidentally changed here.


### PR DESCRIPTION
Follow-up to #291. On the identity Relationships tab, accounts linked by the crawler / source data (no confidence score) now show **"Linked from source"** instead of Confirm/Remove. Those analyst actions apply only to account-linking's scored links — so source links can't be changed here, mirroring #293 (crawler owns score-less links; account linking owns scored ones).

Gate is on `linkConfidence`, not `isPrimary` (the crawler self-link isn't flagged primary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)