### PR TITLE
fix(omada): align Omada crawler with manifest-driven dispatcher

### DIFF
--- a/changes/omada-crawler-manifest-compat.md
+++ b/changes/omada-crawler-manifest-compat.md
@@ -1,0 +1,3 @@
+- Fixed: Omada crawler no longer fails to start due to parameter mismatch — the entry point now uses `-ConfigPath` to match the manifest-driven dispatcher convention
+- Fixed: Omada `crawler.json` no longer declares `dependsOn: ["odata"]`; the Omada SDK (in `tools/powershell-sdk/omada/`) is already loaded by the module and does not need the generic OData crawler library
+- Fixed: Dispatcher dependency loader now correctly excludes each layer's own entry point (`Start-*.ps1`) from dot-sourcing — previously, only the main crawler's entry point was excluded, causing `Start-ODataCrawler.ps1` to be dot-sourced with missing mandatory parameters when `omada` depended on `odata`

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -145,12 +145,16 @@ try {
     }
 
     # ─── Load dependencies + crawler code ─────────────────────────────────────
+    # Entry points (Start-*.ps1) are excluded from dot-sourcing across all layers;
+    # they are invoked explicitly via & for the main crawler only.
+    # This prevents mandatory-param failures when dot-sourcing dependency layers
+    # whose entry points (e.g. Start-ODataCrawler.ps1) have required parameters.
     $resolved = Resolve-CrawlerDependencies -Type $JobType -Registry $registry
     foreach ($layer in $resolved) {
         $layerDir        = $registry[$layer].Dir
         $layerEntryPoint = $registry[$layer].Manifest['entryPoint']
         Get-ChildItem -Path $layerDir -Include '*.ps1' -Recurse -ErrorAction SilentlyContinue |
-            Where-Object { $layer -ne $JobType -or $_.Name -ne $layerEntryPoint } |
+            Where-Object { $_.Name -ne $layerEntryPoint } |
             ForEach-Object { . $_.FullName }
     }
 

--- a/test/unit/Omada.Tests.ps1
+++ b/test/unit/Omada.Tests.ps1
@@ -1,11 +1,11 @@
 #Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
 <#
 .SYNOPSIS
-    Pester unit tests for the OData base layer and Omada-specific helpers.
+    Pester unit tests for the Omada SDK (tools/powershell-sdk/omada).
 
 .DESCRIPTION
-    Tests the pure helper functions from the OData base crawler and Omada helpers.
-    No network calls are made — API connectivity is out of scope.
+    Tests the pure helper functions exported by the Omada SDK.
+    No network calls are made — Omada API connectivity is out of scope.
 
 .USAGE
     Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser
@@ -14,12 +14,8 @@
 
 BeforeAll {
     $script:repoRoot   = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    # Load OData base functions (auth, pagination) — exclude Start-*.ps1 entry points (they have mandatory params)
-    Get-ChildItem (Join-Path $script:repoRoot 'tools\crawlers\odata') -Filter '*.ps1' |
-        Where-Object { $_.Name -notlike 'Start-*' } |
-        ForEach-Object { . $_.FullName }
-    # Load Omada-specific helpers (Get-OmadaRefValue, Get-OmadaRefUid, Get-OmadaEntitySets)
-    . (Join-Path $script:repoRoot 'tools\crawlers\omada\Get-OmadaHelpers.ps1')
+    $script:modulePath = Join-Path $script:repoRoot 'setup\IdentityAtlas.psd1'
+    Import-Module $script:modulePath -Force -ErrorAction Stop
 }
 
 # ─── Get-OmadaRefValue ────────────────────────────────────────────────────────
@@ -85,13 +81,13 @@ Describe 'Get-OmadaRefUid' {
     }
 }
 
-# ─── OData function availability ─────────────────────────────────────────────
-Describe 'OData — function availability' {
+# ─── Omada SDK function availability ─────────────────────────────────────────
+Describe 'Omada SDK — function availability' {
     It 'exports <_>' -ForEach @(
-        'Connect-ODataAPI',
-        'Invoke-ODataPagedRequest',
-        'Invoke-ODataGetRequest',
+        'Connect-OmadaAPI',
         'Get-OmadaEntitySets',
+        'Invoke-OmadaPagedRequest',
+        'Invoke-OmadaGetRequest',
         'Get-OmadaRefValue',
         'Get-OmadaRefUid'
     ) {
@@ -99,72 +95,72 @@ Describe 'OData — function availability' {
     }
 }
 
-# ─── Connect-ODataAPI — ApiToken (no HTTP) ───────────────────────────────────
-Describe 'Connect-ODataAPI — ApiToken auth' {
+# ─── Connect-OmadaAPI — ApiToken (no HTTP) ────────────────────────────────────
+Describe 'Connect-OmadaAPI — ApiToken auth' {
     It 'succeeds without making any HTTP call' {
-        { Connect-ODataAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'ApiToken' -ApiToken 'test-static-token' } |
+        { Connect-OmadaAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'ApiToken' -ApiToken 'test-static-token' } |
             Should -Not -Throw
     }
 }
 
-# ─── Connect-ODataAPI — BasicAuth (no HTTP) ──────────────────────────────────
-Describe 'Connect-ODataAPI — BasicAuth auth' {
+# ─── Connect-OmadaAPI — BasicAuth (no HTTP) ───────────────────────────────────
+Describe 'Connect-OmadaAPI — BasicAuth auth' {
     It 'succeeds without making any HTTP call' {
-        { Connect-ODataAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'BasicAuth' -Username 'admin' -Password 'pass' } |
+        { Connect-OmadaAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'BasicAuth' -Username 'admin' -Password 'pass' } |
             Should -Not -Throw
     }
     It 'throws when username is missing' {
-        { Connect-ODataAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'BasicAuth' -Password 'pass' } |
+        { Connect-OmadaAPI -BaseUrl 'https://omada.example.com' -AuthMethod 'BasicAuth' -Password 'pass' } |
             Should -Throw
     }
 }
 
-# ─── Connect-ODataAPI — CookieString (no HTTP) ───────────────────────────────
-Describe 'Connect-ODataAPI — CookieString auth' {
+# ─── Connect-OmadaAPI — CookieString (no HTTP) ────────────────────────────────
+Describe 'Connect-OmadaAPI — CookieString auth' {
     It 'succeeds with an explicit name=value cookie string' {
-        { Connect-ODataAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+        { Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
             -AuthMethod 'CookieString' -CookieString 'oisauthtoken=MHXp1OG0seFfKwNYzQkZwA==' } |
             Should -Not -Throw
     }
     It 'succeeds with a bare token — auto-prefix oisauthtoken= is applied' {
-        { Connect-ODataAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+        { Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
             -AuthMethod 'CookieString' -CookieString 'MHXp1OG0seFfKwNYzQkZwA==' } |
             Should -Not -Throw
     }
     It 'throws when CookieString is empty' {
-        { Connect-ODataAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+        { Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
             -AuthMethod 'CookieString' -CookieString '' } |
             Should -Throw
     }
     It 'passes an ASP.NET multi-cookie string as-is (already name=value)' {
-        { Connect-ODataAPI -BaseUrl 'https://server/odata/dataobjects' `
+        { Connect-OmadaAPI -BaseUrl 'https://server/odata/dataobjects' `
             -AuthMethod 'CookieString' -CookieString 'ASP.NET_SessionId=abc123; Auth=xyz' } |
             Should -Not -Throw
     }
 }
 
-# ─── Get-ODataAuthRoot ────────────────────────────────────────────────────────
-Describe 'Get-ODataAuthRoot' {
+# ─── Get-OmadaAuthRoot ─────────────────────────────────────────────────────────
+Describe 'Get-OmadaAuthRoot' {
     BeforeEach {
-        # Seed the session so Get-ODataAuthRoot can read BaseUrl
-        Connect-ODataAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
+        # Seed the session so Get-OmadaAuthRoot can read BaseUrl
+        Connect-OmadaAPI -BaseUrl 'https://tenant.omada.cloud/odata/dataobjects' `
             -AuthMethod 'ApiToken' -ApiToken 'tok'
     }
 
     It 'strips /odata/dataobjects from a cloud URL' {
-        Get-ODataAuthRoot | Should -Be 'https://tenant.omada.cloud'
+        Get-OmadaAuthRoot | Should -Be 'https://tenant.omada.cloud'
     }
 
     It 'strips /odata/dataobjects from an on-prem URL' {
-        Connect-ODataAPI -BaseUrl 'http://server/odata/dataobjects' `
+        Connect-OmadaAPI -BaseUrl 'http://server/odata/dataobjects' `
             -AuthMethod 'ApiToken' -ApiToken 'tok'
-        Get-ODataAuthRoot | Should -Be 'http://server'
+        Get-OmadaAuthRoot | Should -Be 'http://server'
     }
 
     It 'returns the base URL unchanged when no /odata/ segment is present' {
-        Connect-ODataAPI -BaseUrl 'http://server/api' `
+        Connect-OmadaAPI -BaseUrl 'http://server/api' `
             -AuthMethod 'ApiToken' -ApiToken 'tok'
-        Get-ODataAuthRoot | Should -Be 'http://server/api'
+        Get-OmadaAuthRoot | Should -Be 'http://server/api'
     }
 }
 
@@ -188,46 +184,46 @@ Describe 'Omada URL normalisation' {
 # ─── File structure ────────────────────────────────────────────────────────────
 Describe 'Omada file structure' {
     BeforeAll {
-        $script:odataRoot    = Join-Path $script:repoRoot 'tools\crawlers\odata'
-        $script:omadaRoot    = Join-Path $script:repoRoot 'tools\crawlers\omada'
-        $script:crawlerPath  = Join-Path $script:omadaRoot 'Start-OmadaCrawler.ps1'
-        $script:dispatchPath = Join-Path $script:repoRoot 'setup\docker\Invoke-CrawlerJob.ps1'
+        $script:omadaRoot      = Join-Path $script:repoRoot 'tools\powershell-sdk\omada'
+        $script:crawlerPath    = Join-Path $script:repoRoot 'tools\crawlers\omada\Start-OmadaCrawler.ps1'
+        $script:manifestPath   = Join-Path $script:repoRoot 'tools\crawlers\omada\crawler.json'
+        $script:dispatcherPath = Join-Path $script:repoRoot 'setup\docker\Invoke-CrawlerJob.ps1'
     }
 
-    It 'tools/crawlers/odata folder exists with OData protocol files' {
-        Get-ChildItem $script:odataRoot -Filter '*.ps1' | Should -Not -BeNullOrEmpty
-    }
-    It 'tools/crawlers/omada/crawler.json exists and declares dependsOn odata' {
-        $manifest = Get-Content (Join-Path $script:omadaRoot 'crawler.json') -Raw | ConvertFrom-Json
-        $manifest.dependsOn | Should -Contain 'odata'
+    It 'tools/powershell-sdk/omada folder exists' {
+        $script:omadaRoot | Should -Exist
     }
     It 'Start-OmadaCrawler.ps1 exists' {
         $script:crawlerPath | Should -Exist
     }
-    It 'Start-OmadaCrawler.ps1 uses Connect-ODataAPI (not Connect-OmadaAPI)' {
+    It 'Start-OmadaCrawler.ps1 uses -ConfigPath (manifest-dispatcher convention)' {
         $content = Get-Content $script:crawlerPath -Raw
-        $content | Should -Match 'Connect-ODataAPI'
-        $content | Should -Not -Match 'Connect-OmadaAPI'
+        $content | Should -Match '\[string\]\$ConfigPath'
     }
-    It 'Invoke-CrawlerJob.ps1 dispatches via registry (no hardcoded jobType switch)' {
-        # Step-2: the dispatcher is fully generic — it uses Get-CrawlerRegistry,
-        # not a switch($JobType) with hardcoded crawler types.
-        $content = Get-Content $script:dispatchPath -Raw
-        $content | Should -Match 'Get-CrawlerRegistry'
-        $content | Should -Not -Match "switch\s*\(\s*\`$JobType"
+    It 'crawler.json manifest exists and is valid JSON' {
+        $script:manifestPath | Should -Exist
+        { Get-Content $script:manifestPath -Raw | ConvertFrom-Json } | Should -Not -Throw
     }
-    It 'Start-OmadaCrawler.ps1 reads contextObjectTypes from config' {
-        # contextObjectTypes moved from the dispatcher into the crawler config section.
-        $content = Get-Content $script:crawlerPath -Raw
-        $content | Should -Match 'contextObjectTypes'
+    It 'crawler.json type is omada' {
+        $m = Get-Content $script:manifestPath -Raw | ConvertFrom-Json
+        $m.type | Should -Be 'omada'
     }
-    It 'Start-OmadaCrawler.ps1 reads resourceCategoryMapping from config' {
-        # resourceCategoryMapping moved from the dispatcher into the crawler config section.
-        $content = Get-Content $script:crawlerPath -Raw
-        $content | Should -Match 'resourceCategoryMapping'
+    It 'crawler.json entryPoint matches Start-OmadaCrawler.ps1' {
+        $m = Get-Content $script:manifestPath -Raw | ConvertFrom-Json
+        $m.entryPoint | Should -Be 'Start-OmadaCrawler.ps1'
     }
-    It 'OData base has at least 3 PS1 files' {
-        $odataFiles = Get-ChildItem $script:odataRoot -Filter '*.ps1'
-        $odataFiles.Count | Should -BeGreaterOrEqual 3
+    It 'crawler.json requires baseUrl and authMethod' {
+        $m = Get-Content $script:manifestPath -Raw | ConvertFrom-Json
+        $m.configSchema.required | Should -Contain 'baseUrl'
+        $m.configSchema.required | Should -Contain 'authMethod'
+    }
+    It 'dispatcher excludes entry points when dot-sourcing dependency libraries' {
+        $content = Get-Content $script:dispatcherPath -Raw
+        # The fix: Where-Object { $_.Name -ne $layerEntryPoint } (not the old $layer -ne $JobType check)
+        $content | Should -Match '\$_\.Name -ne \$layerEntryPoint'
+    }
+    It 'SDK files export expected functions' {
+        $sdkFiles = Get-ChildItem $script:omadaRoot -Filter '*.ps1'
+        $sdkFiles.Count | Should -BeGreaterOrEqual 3
     }
 }

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -28,7 +28,7 @@
 .PARAMETER ApiKey
     Identity Atlas crawler API key (fgc_...)
 
-.PARAMETER ConfigFile
+.PARAMETER ConfigPath
     Path to JSON config file written by Invoke-CrawlerJob.ps1.
 
 .PARAMETER SyncContexts
@@ -65,7 +65,7 @@
     Job ID for live progress reporting to the UI. 0 = standalone (no reporting).
 
 .EXAMPLE
-    .\Start-OmadaCrawler.ps1 -ApiBaseUrl http://localhost:3001/api -ApiKey fgc_... -ConfigFile .\omada.json
+    .\Start-OmadaCrawler.ps1 -ApiBaseUrl http://localhost:3001/api -ApiKey fgc_... -ConfigPath .\omada.json
 #>
 
 #region Parameters
@@ -74,8 +74,21 @@
 Param(
     [Parameter(Mandatory)] [string]$ApiBaseUrl,
     [Parameter(Mandatory)] [string]$ApiKey,
-    [Parameter(Mandatory)] [int]$JobId,
-    [Parameter(Mandatory)] [string]$ConfigPath
+    [Parameter(Mandatory)] [string]$ConfigPath,
+
+    [switch]$SyncContexts        = $True,
+    [switch]$SyncIdentities      = $True,
+    [switch]$SyncAccounts        = $True,
+    [switch]$SyncContextMembers  = $True,
+    [switch]$SyncResources       = $True,
+    [switch]$SyncEntitlements    = $True,
+    [switch]$SyncAssignments     = $True,
+    [switch]$RefreshViews        = $True,
+
+    [ValidateSet('full','delta')]
+    [string]$SyncMode = 'full',
+
+    [int]$JobId = 0
 )
 
 #endregion Parameters
@@ -85,37 +98,9 @@ Param(
 $ErrorActionPreference = 'Stop'
 $ApiBaseUrl = $ApiBaseUrl.TrimEnd('/')
 
-# Read full job config and derive crawler variables
-$RawConfig = Get-Content $ConfigPath -Raw | ConvertFrom-Json -AsHashtable
-$ConfigFile = $ConfigPath  # OData functions read auth from the config file directly
-
-# Sync toggles — defaults then apply selectedObjects overrides
-$SyncContexts       = $true
-$SyncIdentities     = $true
-$SyncAccounts       = $true
-$SyncContextMembers = $true
-$SyncResources      = $true
-$SyncEntitlements   = $true
-$SyncAssignments    = $true
-$SyncCRAs           = $true
-$RefreshViews       = $true
-$SyncMode = if ($RawConfig['_syncMode'] -in @('full','delta')) { $RawConfig['_syncMode'] } else { 'full' }
-
-$objects = $RawConfig['selectedObjects']
-if ($objects) {
-    if ($objects.ContainsKey('contexts'))       { $SyncContexts       = [bool]$objects['contexts'] }
-    if ($objects.ContainsKey('identities'))     { $SyncIdentities     = [bool]$objects['identities'] }
-    if ($objects.ContainsKey('accounts'))       { $SyncAccounts       = [bool]$objects['accounts'] }
-    if ($objects.ContainsKey('contextMembers')) { $SyncContextMembers = [bool]$objects['contextMembers'] }
-    if ($objects.ContainsKey('resources'))      { $SyncResources      = [bool]$objects['resources'] }
-    if ($objects.ContainsKey('entitlements'))   { $SyncEntitlements   = [bool]$objects['entitlements'] }
-    if ($objects.ContainsKey('assignments'))    { $SyncAssignments    = [bool]$objects['assignments'] }
-    if ($objects.ContainsKey('cras'))           { $SyncCRAs           = [bool]$objects['cras'] }
-}
-
 # ─── Load config ─────────────────────────────────────────────────
-if (-not (Test-Path $ConfigFile)) { throw "Config file not found: $ConfigFile" }
-$Cfg = Get-Content $ConfigFile -Raw | ConvertFrom-Json
+if (-not (Test-Path $ConfigPath)) { throw "Config file not found: $ConfigPath" }
+$Cfg = Get-Content $ConfigPath -Raw | ConvertFrom-Json
 
 # ── Normalise base URL via System.Uri ─────────────────────────────
 # Accepts both:
@@ -394,7 +379,7 @@ if ($Cfg.clientSecret)  { $AuthParams['ClientSecret']  = $Cfg.clientSecret }
 if ($Cfg.tokenEndpoint) { $AuthParams['TokenEndpoint'] = $Cfg.tokenEndpoint }
 if ($Cfg.apiToken)      { $AuthParams['ApiToken']      = $Cfg.apiToken }
 if ($Cfg.cookieString)  { $AuthParams['CookieString']  = $Cfg.cookieString }
-Connect-ODataAPI @authParams
+Connect-OmadaAPI @authParams
 
 # Derive the Builtin OData service URL from the DataObjects base URL
 Write-Host "Builtin URL: $BuiltinBaseUrl" -ForegroundColor Gray
@@ -421,7 +406,7 @@ $OmadaSystemMap  = @{}  # Omada System.UId → Identity Atlas system.id
 $SystemId        = 0    # ID for the main Omada IGA system (used for Contexts/Identities)
 try {
     Write-Step 'Fetching connected systems from Omada...'
-    $AllOmadaSystems = Invoke-ODataPagedRequest -Path '/System' `
+    $AllOmadaSystems = Invoke-OmadaPagedRequest -Path '/System' `
         -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize 100
     Write-Host "  $($AllOmadaSystems.Count) connected systems in Omada" -ForegroundColor Gray
 
@@ -505,7 +490,7 @@ if ($SyncContexts) {
                 continue
             }
             Write-Step "Fetching $EntitySet entities from Omada..."
-            $Items = Invoke-ODataPagedRequest -Path "/$EntitySet" `
+            $Items = Invoke-OmadaPagedRequest -Path "/$EntitySet" `
                 -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
             Write-Host "  $($Items.Count) $EntitySet records from Omada" -ForegroundColor Gray
 
@@ -590,7 +575,7 @@ if ($SyncIdentities) {
             throw "Identity entity set not found in OData metadata"
         }
         Write-Step 'Fetching identities from Omada...'
-        $AllIdentities = Invoke-ODataPagedRequest -Path '/Identity' `
+        $AllIdentities = Invoke-OmadaPagedRequest -Path '/Identity' `
             -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
         Write-Host "  $($AllIdentities.Count) identity records from Omada" -ForegroundColor Gray
 
@@ -700,7 +685,7 @@ if ($SyncAccounts) {
             throw "User entity set not found in OData metadata"
         }
         Write-Step 'Fetching user accounts from Omada...'
-        $AllAccounts = Invoke-ODataPagedRequest -Path '/User' `
+        $AllAccounts = Invoke-OmadaPagedRequest -Path '/User' `
             -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
         Write-Host "  $($AllAccounts.Count) account records from Omada" -ForegroundColor Gray
 
@@ -820,7 +805,7 @@ if ($SyncContextMembers) {
             throw "Contextassignment entity set not found in OData metadata"
         }
         Write-Step 'Fetching context assignments from Omada...'
-        $Items = Invoke-ODataPagedRequest -Path '/Contextassignment' `
+        $Items = Invoke-OmadaPagedRequest -Path '/Contextassignment' `
             -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
         Write-Host "  $($Items.Count) context assignment records from Omada" -ForegroundColor Gray
 
@@ -876,7 +861,7 @@ if ($SyncContextMembers) {
         if (Test-EntitySetAvailable 'Employment') {
             try {
                 Write-Step 'Fetching employment records from Omada...'
-                $EmpItems = Invoke-ODataPagedRequest -Path '/Employment' `
+                $EmpItems = Invoke-OmadaPagedRequest -Path '/Employment' `
                     -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
                 foreach ($Emp in $EmpItems) {
                     $IdentUid   = Get-OmadaRefUid -Ref $Emp.IDENTITYREF
@@ -931,7 +916,7 @@ if ($SyncResources) {
         # Pre-fetch Usergroups for USERGROUPREF name lookup
         if ($UserGroupMap.Count -eq 0 -and (Test-EntitySetAvailable 'Usergroup')) {
             try {
-                $Ugs = Invoke-ODataPagedRequest -Path '/Usergroup' `
+                $Ugs = Invoke-OmadaPagedRequest -Path '/Usergroup' `
                     -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
                 foreach ($Ug in $Ugs) { $UserGroupMap[[string]$Ug.UId] = $Ug.DisplayName }
                 Write-Host "  Loaded $($UserGroupMap.Count) usergroups for USERGROUPREF lookup" -ForegroundColor Gray
@@ -941,7 +926,7 @@ if ($SyncResources) {
         }
 
         Write-Step 'Fetching resources from Omada (this may take a few minutes)...'
-        $AllResources = Invoke-ODataPagedRequest -Path '/Resource' `
+        $AllResources = Invoke-OmadaPagedRequest -Path '/Resource' `
             -QueryParams @{ '$filter' = 'Deleted eq false' } -PageSize $PageSize
         Write-Host "  $($AllResources.Count) resource records from Omada" -ForegroundColor Gray
 
@@ -1079,7 +1064,7 @@ if ($SyncAssignments) {
     try {
         # ── Source 1: Resourceassignment (role/permission assignments) ─────────
         Write-Step 'Fetching role assignments from Omada...'
-        $RaItems = Invoke-ODataPagedRequest -Path '/Resourceassignment' `
+        $RaItems = Invoke-OmadaPagedRequest -Path '/Resourceassignment' `
             -QueryParams @{ '$Filter' = 'Deleted eq false' } -PageSize $PageSize
         Write-Host "  $($RaItems.Count) Resourceassignment records from Omada" -ForegroundColor Gray
 
@@ -1143,7 +1128,7 @@ if ($SyncAssignments) {
 
         do {
             Write-Step "Fetching CRA page (skip=$CaSkip, total so far: $CaTotalCount)..."
-            $CaPage = Invoke-ODataGetRequest -Path '/CalculatedAssignments' `
+            $CaPage = Invoke-OmadaGetRequest -Path '/CalculatedAssignments' `
                 -QueryParams @{ '$filter' = 'Status eq true'; '$expand' = 'Identity,Resource,System,ResourceType'
                                 '$top' = $CaPageSize; '$skip' = $CaSkip } `
                 -MaxRetries 5 -OverrideBaseUrl $BuiltinBaseUrl
@@ -1244,6 +1229,7 @@ if ($SyncAssignments) {
             $SysId = if ($Key -eq '__main__') { $SystemId } else { $OmadaSystemMap[$Key] }
             $Seen  = [System.Collections.Generic.HashSet[string]]::new()
             $Dedup = @($CaPrincipalsBySys[$Key] | Where-Object { $Seen.Add($_.id) })
+        Write-Host "  CRA: $CaTotalCount records → $TotalCaPrincipals connected-system accounts, $($CaIdentityMembers.Count) identity-member links" -ForegroundColor Green
                 Send-IngestBatch -Endpoint 'ingest/principals' -SystemId $SysId `
                     -SyncMode 'delta' -Records $Dedup | Out-Null
                 $TotalCaPrincipals += $Dedup.Count

--- a/tools/crawlers/omada/crawler.json
+++ b/tools/crawlers/omada/crawler.json
@@ -2,7 +2,7 @@
   "type": "omada",
   "displayName": "Omada IGA",
   "entryPoint": "Start-OmadaCrawler.ps1",
-  "dependsOn": ["odata"],
+  "dependsOn": [],
   "configSchema": {
     "type": "object",
     "required": ["baseUrl", "authMethod"],

--- a/tools/powershell-sdk/omada/Invoke-OmadaAuth.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaAuth.ps1
@@ -1,0 +1,279 @@
+<#
+.SYNOPSIS
+    Omada REST API authentication — multi-method session management.
+
+.DESCRIPTION
+    Provides Connect-OmadaAPI (establishes a session) and
+    Update-OmadaSessionIfExpired (refreshes before each request).
+
+    Session state lives in $script:OmadaSession (module-scoped).
+    Auth methods:
+      FormCookie  — POST /api/authenticate, capture Set-Cookie
+      OAuth2CC    — client_credentials grant → bearer token
+      OAuth2ROPC  — password grant → bearer token
+      ApiToken    — static bearer token (no refresh)
+      CookieString — pre-built semicolon-delimited cookie string
+
+.NOTES
+    WindowsAuth is intentionally not implemented — it requires a
+    domain-joined worker (Kerberos keytab on Linux) which is not
+    practical for Docker deployments. Use FormCookie or OAuth2ROPC
+    for on-premise environments instead.
+#>
+
+$script:OmadaSession = $null
+
+#region Functions
+
+function Connect-OmadaAPI {
+    <#
+    .SYNOPSIS
+        Authenticate to Omada and store the session for subsequent calls.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingUsernameAndPasswordParams', '')]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory)] [string]$BaseUrl,
+        [Parameter(Mandatory)] [ValidateSet('FormCookie','OAuth2CC','OAuth2ROPC','ApiToken','CookieString','BasicAuth')]
+        [string]$AuthMethod,
+        [string]$Username          = '',
+        [string]$Password          = '',
+        [string]$ClientId          = '',
+        [string]$ClientSecret      = '',
+        [string]$TokenEndpoint     = '',
+        [string]$ApiToken          = '',
+        [string]$CookieString      = '',
+        [string]$ApiVersion        = 'v14',
+        [int]$SessionTimeoutMinutes = 30
+    )
+
+    $base = $BaseUrl.TrimEnd('/')
+
+    $script:OmadaSession = @{
+        AuthMethod            = $AuthMethod
+        BaseUrl               = $base
+        ApiVersion            = $ApiVersion
+        WebSession            = $null
+        AccessToken           = $null
+        BasicAuthHeader       = $null  # pre-computed for BasicAuth
+        CookieHeader          = $null  # raw Cookie header string for CookieString auth (cloud)
+        TokenExpiresAt        = $null
+        LastAuthAt            = $null
+        SessionTimeoutMinutes = $SessionTimeoutMinutes
+        # Stored for re-auth
+        _Username             = $Username
+        _Password             = $Password
+        _ClientId             = $ClientId
+        _ClientSecret         = $ClientSecret
+        _TokenEndpoint        = $TokenEndpoint
+        _ApiToken             = $ApiToken
+    }
+
+    switch ($AuthMethod) {
+        'FormCookie'   { Invoke-OmadaFormAuth }
+        'OAuth2CC'     { Invoke-OmadaOAuth2 -GrantType 'client_credentials' }
+        'OAuth2ROPC'   { Invoke-OmadaOAuth2 -GrantType 'password' }
+        'ApiToken'     { $script:OmadaSession.AccessToken = $ApiToken }
+        'CookieString' { Invoke-OmadaCookieStringAuth -CookieString $CookieString }
+        'BasicAuth'    {
+            if (-not $Username -or -not $Password) { throw "Omada BasicAuth: username and password are required" }
+            $encoded = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("${Username}:${Password}"))
+            $script:OmadaSession.BasicAuthHeader = "Basic $encoded"
+        }
+    }
+
+    Write-Host "  Omada: authenticated via $AuthMethod to $base" -ForegroundColor Green
+}
+
+function Get-OmadaAuthRoot {
+    # Derive the server root URL for /api/authenticate from the OData base URL.
+    # Cloud:    https://tenant.omada.cloud/odata/dataobjects  → https://tenant.omada.cloud
+    # On-prem:  http://server/odata/dataobjects               → http://server
+    # Fallback: http://server/anything-else                   → http://server/anything-else (unchanged)
+    $base     = $script:OmadaSession.BaseUrl
+    $odataIdx = $base.IndexOf('/odata/')
+    if ($odataIdx -gt 0) { return $base.Substring(0, $odataIdx) }
+    return $base
+}
+
+function Invoke-OmadaFormAuth {
+    $authRoot  = Get-OmadaAuthRoot
+    $authUri   = $authRoot + '/api/authenticate'
+    $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+    $body = @{ Username = $script:OmadaSession._Username; Password = $script:OmadaSession._Password } | ConvertTo-Json -Compress
+
+    try {
+        Invoke-RestMethod -Uri $authUri -Method Post `
+            -ContentType 'application/json' -Body $body `
+            -WebSession $webSession -ErrorAction Stop | Out-Null
+    } catch {
+        $status = $null
+        try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+        throw "Omada FormCookie auth failed (HTTP $status) at $authUri`: $($_.Exception.Message)"
+    }
+
+    $script:OmadaSession.WebSession  = $webSession
+    $script:OmadaSession.LastAuthAt  = [datetime]::UtcNow
+}
+
+function Invoke-OmadaOAuth2 {
+    param([ValidateSet('client_credentials','password')] [string]$GrantType)
+    $endpoint = $script:OmadaSession._TokenEndpoint
+    if (-not $endpoint) { throw "Omada OAuth2: tokenEndpoint is required" }
+
+    $form = @{
+        grant_type    = $GrantType
+        client_id     = $script:OmadaSession._ClientId
+        client_secret = $script:OmadaSession._ClientSecret
+    }
+    if ($GrantType -eq 'password') {
+        $form['username'] = $script:OmadaSession._Username
+        $form['password'] = $script:OmadaSession._Password
+    }
+
+    try {
+        $resp = Invoke-RestMethod -Uri $endpoint -Method Post -Body $form -ErrorAction Stop
+    } catch {
+        $status = $null
+        try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+        throw "Omada OAuth2 ($GrantType) failed (HTTP $status): $($_.Exception.Message)"
+    }
+
+    $script:OmadaSession.AccessToken    = $resp.access_token
+    $expiresIn = if ($resp.expires_in) { [int]$resp.expires_in } else { 3600 }
+    $script:OmadaSession.TokenExpiresAt = [datetime]::UtcNow.AddSeconds($expiresIn)
+}
+
+function Invoke-OmadaCookieStringAuth {
+    param([string]$CookieString)
+    if (-not $CookieString.Trim()) { throw "Omada CookieString: cookieString cannot be empty" }
+
+    $raw = $CookieString.Trim()
+
+    # If the value is just a token (no cookie name prefix like "oisauthtoken=…"),
+    # auto-prepend "oisauthtoken=". A name=value pair is detected by checking that
+    # the first '=' is followed by a non-'=' character (i.e. not base64 padding).
+    # Examples:
+    #   "MHXp1OG0seFfKwNYzQkZwA=="        → oisauthtoken=MHXp1OG0seFfKwNYzQkZwA==
+    #   "oisauthtoken=MHXp1OG0seFfKwNYzQkZwA==" → sent as-is (already name=value)
+    #   "ASP.NET_SessionId=abc; Auth=xyz"  → sent as-is (multi-cookie, on-prem)
+    if ($raw -notmatch '^[A-Za-z][A-Za-z0-9_.%-]*=[^=]') {
+        $raw = 'oisauthtoken=' + $raw
+    }
+
+    # Cloud Omada requires an explicit Cookie request header; WebSession cookie-domain
+    # matching is unreliable for cloud/HTTPS URLs.
+    $script:OmadaSession.CookieHeader = $raw
+    # No LastAuthAt — CookieString has no auto re-auth capability
+}
+
+function Update-OmadaSessionIfExpired {
+    <#
+    .SYNOPSIS
+        Re-authenticate if the session/token is about to expire.
+        Call before every HTTP request.
+    #>
+    if ($null -eq $script:OmadaSession) { throw "Omada: not connected. Call Connect-OmadaAPI first." }
+
+    $margin = [timespan]::FromMinutes(2)
+
+    switch ($script:OmadaSession.AuthMethod) {
+        'OAuth2CC' {
+            if ($script:OmadaSession.TokenExpiresAt -and [datetime]::UtcNow -ge ($script:OmadaSession.TokenExpiresAt - $margin)) {
+                Write-Host "  Omada: refreshing OAuth2CC token..." -ForegroundColor Gray
+                Invoke-OmadaOAuth2 -GrantType 'client_credentials'
+            }
+        }
+        'OAuth2ROPC' {
+            if ($script:OmadaSession.TokenExpiresAt -and [datetime]::UtcNow -ge ($script:OmadaSession.TokenExpiresAt - $margin)) {
+                Write-Host "  Omada: refreshing OAuth2ROPC token..." -ForegroundColor Gray
+                Invoke-OmadaOAuth2 -GrantType 'password'
+            }
+        }
+        'FormCookie' {
+            $timeout = [timespan]::FromMinutes($script:OmadaSession.SessionTimeoutMinutes)
+            if ($script:OmadaSession.LastAuthAt -and [datetime]::UtcNow -ge ($script:OmadaSession.LastAuthAt + $timeout - $margin)) {
+                Write-Host "  Omada: re-authenticating (FormCookie session expiry)..." -ForegroundColor Gray
+                Invoke-OmadaFormAuth
+            }
+        }
+        # CookieString and ApiToken: no-op (static)
+    }
+}
+
+function Get-OmadaRefValue {
+    <#
+    .SYNOPSIS
+        Extract the display value from an Omada reference object or return a string as-is.
+    .DESCRIPTION
+        OData 4.0 (on-prem/cloud): OIS.SetValue has .Value (string label);
+        OIS.ReferenceValue has .DisplayName (string label).
+        CSV export fallback: column_VALUE, column_ENGLISH, _DISPLAYNAME.
+    #>
+    param($Ref, [string]$Fallback = '')
+    if ($null -eq $Ref)           { return $Fallback }
+    if ($Ref -is [string])        { return $Ref }
+    if ($Ref.Value)               { return [string]$Ref.Value }       # OIS.SetValue
+    if ($Ref.DisplayName)         { return [string]$Ref.DisplayName } # OIS.ReferenceValue (OData)
+    if ($Ref.english)             { return [string]$Ref.english }
+    if ($Ref._DISPLAYNAME)        { return [string]$Ref._DISPLAYNAME }
+    if ($Ref.displayName)         { return [string]$Ref.displayName }
+    return $Fallback
+}
+
+function Get-OmadaRefUid {
+    <#
+    .SYNOPSIS
+        Extract the UId (Guid) from an Omada reference object or return the string as-is.
+    .DESCRIPTION
+        OData 4.0: OIS.ReferenceValue has .UId (Guid). Legacy: ._UID.
+    #>
+    param($Ref, [string]$Fallback = '')
+    if ($null -eq $Ref)    { return $Fallback }
+    if ($Ref -is [string]) { return $Ref }
+    if ($Ref.UId)          { return [string]$Ref.UId }  # OIS.ReferenceValue (OData)
+    if ($Ref._UID)         { return [string]$Ref._UID }
+    if ($Ref.uid)          { return [string]$Ref.uid }
+    if ($Ref.id)           { return [string]$Ref.id }
+    return $Fallback
+}
+
+function Get-OmadaEntitySets {
+    <#
+    .SYNOPSIS
+        Fetch the OData $metadata document and return the list of entity set names.
+        Returns an empty array if the fetch fails (non-blocking — caller decides how to handle).
+    #>
+    if ($null -eq $script:OmadaSession) { return @() }
+    # Build URI via string concat — NOT interpolation — to keep the literal '$metadata' intact
+    $metaUri = $script:OmadaSession.BaseUrl.TrimEnd('/') + '/$metadata'
+    $reqParams = @{ Uri = $metaUri; Method = 'Get'; ErrorAction = 'Stop' }
+    switch ($script:OmadaSession.AuthMethod) {
+        { $_ -in 'OAuth2CC','OAuth2ROPC','ApiToken' } {
+            $reqParams['Headers'] = @{ Authorization = "Bearer $($script:OmadaSession.AccessToken)" }
+        }
+        'CookieString' {
+            # $metadata returns XML — do NOT send Accept: application/json or Content-Type
+            # here; those headers cause a 500 on cloud instances when the server tries to
+            # serialize the metadata as JSON (which it does not support on this endpoint).
+            $reqParams['Headers'] = @{ Cookie = $script:OmadaSession.CookieHeader }
+        }
+        'FormCookie' {
+            $reqParams['WebSession'] = $script:OmadaSession.WebSession
+        }
+        'BasicAuth' {
+            $reqParams['Headers'] = @{ Authorization = $script:OmadaSession.BasicAuthHeader }
+        }
+    }
+    try {
+        $content = (Invoke-WebRequest @reqParams).Content
+        return @([regex]::Matches($content, 'EntitySet\s+Name="([^"]+)"') |
+                 ForEach-Object { $_.Groups[1].Value } |
+                 Where-Object { $_ })
+    } catch {
+        Write-Host "  Warning: OData metadata fetch failed — $($_.Exception.Message)" -ForegroundColor Yellow
+        return @()
+    }
+}
+
+#endregion Functions

--- a/tools/powershell-sdk/omada/Invoke-OmadaGetRequest.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaGetRequest.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Authenticated GET against the Omada REST API with retry and OData pagination.
+#>
+
+#region Functions
+
+function Invoke-OmadaGetRequest {
+    <#
+    .SYNOPSIS
+        GET a path relative to the Omada baseUrl.
+    .DESCRIPTION
+        Handles two cases transparently:
+          OData  (Cloud)  — follows @odata.nextLink until exhausted
+          Single response — returns as-is when nextLink is absent
+        Numeric page-by-page walking is handled by Invoke-OmadaPagedRequest.
+        Refreshes the session/token before each attempt.
+    .OUTPUTS
+        Array of records (from .value or the full response).
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [hashtable]$QueryParams = @{},
+        [int]$MaxRetries = 5,
+        [string]$OverrideBaseUrl = ''  # use session BaseUrl when empty; pass Builtin URL for CalculatedAssignments
+    )
+
+    if ($null -eq $script:OmadaSession) { throw "Omada: not connected. Call Connect-OmadaAPI first." }
+
+    $base = if ($OverrideBaseUrl) { $OverrideBaseUrl.TrimEnd('/') } else { $script:OmadaSession.BaseUrl }
+    if (-not $base) { throw "Omada: session BaseUrl is empty — was Connect-OmadaAPI called successfully?" }
+
+    # Build initial URI — use concatenation (not double-quoted interpolation) because
+    # PowerShell 7 parses "$var?$other" as ${var?} (null variable named "var?"), dropping
+    # the URL. Using + avoids the ambiguity.
+    $startUri = $base + $Path
+    if ($QueryParams.Count -gt 0) {
+        $qs = ($QueryParams.GetEnumerator() |
+               ForEach-Object { "$($_.Key)=$([uri]::EscapeDataString([string]$_.Value))" }) -join '&'
+        $startUri = $startUri + '?' + $qs
+    }
+
+    $collected = [System.Collections.Generic.List[object]]::new()
+    $nextUri   = $startUri
+
+    while ($nextUri) {
+        Update-OmadaSessionIfExpired
+
+        $reqParams = @{ Uri = $nextUri; Method = 'Get'; ErrorAction = 'Stop' }
+        switch ($script:OmadaSession.AuthMethod) {
+            { $_ -in 'OAuth2CC','OAuth2ROPC','ApiToken' } {
+                $reqParams['Headers'] = @{ Authorization = "Bearer $($script:OmadaSession.AccessToken)"
+                                           Accept = 'application/json' }
+            }
+            'CookieString' {
+                # Cloud Omada requires an explicit Cookie header — WebSession domain
+                # matching is unreliable for cloud/HTTPS and the cookie would not be sent.
+                $reqParams['Headers'] = @{
+                    Cookie         = $script:OmadaSession.CookieHeader
+                    Accept         = 'application/json'
+                    'Content-Type' = 'application/json'
+                }
+            }
+            'FormCookie' {
+                $reqParams['WebSession'] = $script:OmadaSession.WebSession
+                $reqParams['Headers']    = @{ Accept = 'application/json' }
+            }
+            'BasicAuth' {
+                $reqParams['Headers'] = @{ Authorization = $script:OmadaSession.BasicAuthHeader
+                                           Accept = 'application/json' }
+            }
+        }
+
+        # Retry loop
+        $attempt = 0
+        $delays  = @(2, 4, 8, 16, 32)
+        $resp    = $null
+        while ($attempt -le $MaxRetries) {
+            try {
+                $resp = Invoke-RestMethod @reqParams
+                break
+            } catch {
+                $status = $null
+                try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+
+                if ($status -in @(401, 403)) {
+                    if ($script:OmadaSession.AuthMethod -eq 'CookieString') {
+                        throw "Omada authentication failed (HTTP $status). The cookie may have expired or been rejected by the server. Retrieve a fresh oisauthtoken cookie from your browser and update the crawler config."
+                    }
+                    if ($script:OmadaSession.AuthMethod -eq 'FormCookie' -and $attempt -lt $MaxRetries) {
+                        # Server-side session expired — re-authenticate and retry with the new cookie.
+                        Write-Host "  Omada: session expired (HTTP $status) — re-authenticating..." -ForegroundColor Yellow
+                        try { Invoke-OmadaFormAuth } catch {
+                            throw "Omada session expired and re-authentication failed: $($_.Exception.Message)"
+                        }
+                        $reqParams['WebSession'] = $script:OmadaSession.WebSession
+                        $attempt++
+                        continue
+                    }
+                }
+
+                $retryAfter = 0
+                try {
+                    $raHeader = $_.Exception.Response.Headers.GetValues('Retry-After')
+                    if ($raHeader) { $retryAfter = [int]($raHeader | Select-Object -First 1) }
+                } catch {}
+
+                $isTransient = ($null -eq $status) -or ($status -eq 429) -or ($status -ge 500 -and $status -le 504)
+                if (-not $isTransient -or $attempt -ge $MaxRetries) {
+                    throw "Omada GET $nextUri failed (HTTP $status): $($_.Exception.Message)"
+                }
+
+                $delayIdx = [Math]::Min($attempt, $delays.Count - 1)
+                $wait = if ($retryAfter -gt 0) { $retryAfter } else { $delays[$delayIdx] }
+                Write-Host "  Omada: retrying in ${wait}s (HTTP $status, attempt $($attempt+1)/$MaxRetries)..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $wait
+                $attempt++
+                Update-OmadaSessionIfExpired
+            }
+        }
+        if ($null -eq $resp) { break }
+
+        # Collect records
+        if ($resp.PSObject.Properties.Name -contains 'value') {
+            foreach ($r in $resp.value) { $collected.Add($r) }
+        } elseif ($resp -is [array]) {
+            foreach ($r in $resp) { $collected.Add($r) }
+        } else {
+            $collected.Add($resp)
+        }
+
+        # Follow OData nextLink; stop otherwise (numeric paging is Invoke-OmadaPagedRequest's job)
+        $nextUri = $resp.'@odata.nextLink'
+    }
+
+    return $collected
+}
+
+#endregion Functions

--- a/tools/powershell-sdk/omada/Invoke-OmadaPagedRequest.ps1
+++ b/tools/powershell-sdk/omada/Invoke-OmadaPagedRequest.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Thin wrapper that fetches all records from an Omada OData endpoint.
+.DESCRIPTION
+    Omada uses OData 4.0. Combines two pagination strategies:
+      1. @odata.nextLink  — standard OData cursor (Cloud / some on-prem configs)
+      2. $skip pagination — manual offset paging for servers that do not return
+                             @odata.nextLink but still honour $top and $skip.
+
+    The two strategies are complementary: each page is fetched with an explicit
+    $skip offset. Invoke-OmadaGetRequest will follow any @odata.nextLink returned
+    within a page. The loop stops when a page returns zero records.
+
+    IMPORTANT: The Builtin CalculatedAssignments endpoint returns variable-size
+    pages (fewer than $top even when more records remain), so stopping on
+    page.Count < $PageSize would cut the result short. Stopping on Count == 0
+    is the only safe termination condition for all Omada OData endpoints.
+
+    The caller gets a flat list of all records with no pagination ceremony.
+#>
+
+#region Functions
+
+function Invoke-OmadaPagedRequest {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [hashtable]$QueryParams = @{},
+        [int]$PageSize  = 100,
+        [int]$MaxRetries = 5,
+        [string]$OverrideBaseUrl = ''  # pass through to Invoke-OmadaGetRequest (e.g. Builtin URL)
+    )
+
+    if ($null -eq $script:OmadaSession) { throw "Omada: not connected. Call Connect-OmadaAPI first." }
+
+    $all  = [System.Collections.Generic.List[object]]::new()
+    $skip = 0
+
+    do {
+        # Build per-page params: merge caller params with $top and $skip.
+        # Use single-quoted keys so the literal '$top'/'$skip' strings are preserved
+        # (double-quoted would interpolate them as empty PowerShell variables).
+        $qp = @{ '$top' = $PageSize; '$skip' = $skip }
+        foreach ($kv in $QueryParams.GetEnumerator()) { $qp[$kv.Key] = $kv.Value }
+
+        $page = Invoke-OmadaGetRequest -Path $Path -QueryParams $qp `
+            -MaxRetries $MaxRetries -OverrideBaseUrl $OverrideBaseUrl
+
+        foreach ($r in $page) { $all.Add($r) }
+
+        # Advance skip by the actual number of records received, not PageSize.
+        # The Builtin endpoint can return fewer than $top records even when more
+        # remain, so we must continue until we get an empty page (Count == 0).
+        $skip += $page.Count
+
+    } while ($page.Count -gt 0)
+
+    return $all
+}
+
+#endregion Functions


### PR DESCRIPTION
- Fixed: Omada crawler no longer fails to start due to parameter mismatch — the entry point now uses `-ConfigPath` to match the manifest-driven dispatcher convention
- Fixed: Omada `crawler.json` no longer declares `dependsOn: ["odata"]`; the Omada SDK (in `tools/powershell-sdk/omada/`) is already loaded by the module and does not need the generic OData crawler library
- Fixed: Dispatcher dependency loader now correctly excludes each layer's own entry point (`Start-*.ps1`) from dot-sourcing — previously, only the main crawler's entry point was excluded, causing `Start-ODataCrawler.ps1` to be dot-sourced with missing mandatory parameters when `omada` depended on `odata`