### PR TITLE
fix: mark re2 as external in node-launcher esbuild bundle

### DIFF
--- a/app/desktop/scripts/build-node-launcher.mjs
+++ b/app/desktop/scripts/build-node-launcher.mjs
@@ -84,6 +84,7 @@ run(
   ` --outfile="${BUNDLE_OUT}"` +
   ` --external:@electric-sql/pglite` +
   ` --external:pg-native` +
+  ` --external:re2` +
   ` "--banner:js=${CJS_BANNER}"`,
   { cwd: API_ROOT }
 );

--- a/changes/fix-node-launcher-re2-external.md
+++ b/changes/fix-node-launcher-re2-external.md
@@ -1,0 +1,1 @@
+- Fixed portable Windows ZIP build (cut-beta / cut-release / cut-hotfix) failing when the `re2` native addon is a dependency — marked `re2` as external in the esbuild bundle


### PR DESCRIPTION
## Summary

The portable Windows ZIP build (triggered by cut-beta, cut-release, and cut-hotfix) was failing with:

```
✘ [ERROR] No loader is configured for ".node" files: node_modules/re2/build/Release/re2.node
```

`re2` is a native Node.js addon (`.node` file) — esbuild cannot bundle it. The fix adds `--external:re2` to the esbuild command, matching the existing `--external:pg-native` pattern already in the script.

All three release workflows call the same `build-node-launcher.mjs` script, so this single fix unblocks all of them.

## Pre-Landing Review

No issues found. One-line change adds `--external:re2` to match the established `--external:pg-native` pattern.

## Test plan
- [x] Build script change is structurally correct — matches existing external pattern for pg-native
- [x] Verified against failing run 27066909709 (cut-beta 2026-06-06): esbuild error on re2.node

🤖 Generated with [Claude Code](https://claude.com/claude-code)