### PR TITLE
feat(ci): automated release notes — Claude synthesis + correct CHANGES.md slicing

### DIFF
--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -85,17 +85,13 @@ jobs:
           # Latest release of any kind (beta, rc, stable) — excludes the tag just created
           PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "^${TAG}$" | head -1)
 
-          # Slice the CHANGES.md entries that are new since PREV_TAG
+          # Slice CHANGES.md to only the lines prepended since PREV_TAG.
+          # bump-version.yml always prepends — old content is the last N lines.
           if [ -n "$PREV_TAG" ]; then
-            FIRST_OLD=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | head -1)
-            if [ -n "$FIRST_OLD" ]; then
-              CUTLINE=$(grep -Fn "${FIRST_OLD}" CHANGES.md | head -1 | cut -d: -f1)
-              [ -n "$CUTLINE" ] \
-                && NEW_MD=$(head -n $((CUTLINE - 1)) CHANGES.md) \
-                || NEW_MD=$(cat CHANGES.md)
-            else
-              NEW_MD=$(cat CHANGES.md)
-            fi
+            OLD_LINES=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | wc -l)
+            TOTAL_LINES=$(wc -l < CHANGES.md)
+            NEW_LINES=$((TOTAL_LINES - OLD_LINES))
+            [ "$NEW_LINES" -gt 0 ] && NEW_MD=$(head -n "$NEW_LINES" CHANGES.md) || NEW_MD=""
           else
             NEW_MD=$(cat CHANGES.md)
           fi

--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -82,16 +82,8 @@ jobs:
 
       - name: Generate release notes
         run: |
-          # Find the previous tag to diff against:
-          #   1. Previous pre-release of this same base version (e.g. beta.1 when cutting beta.2)
-          #   2. Fall back to last stable release if this is the first pre-release for this version
-          BASE_VERSION=$(echo "${{ github.event.inputs.version }}" | sed -E 's/-(beta|rc|alpha)\.[0-9]+//')
-          PREV_TAG=$(git tag --list "v${BASE_VERSION}-*" --sort=-version:refname \
-            | grep -v "^${TAG}$" | head -1)
-          if [ -z "$PREV_TAG" ]; then
-            PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
-              | grep -v beta | grep -v rc | grep -v alpha | head -1)
-          fi
+          # Latest release of any kind (beta, rc, stable) — excludes the tag just created
+          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "^${TAG}$" | head -1)
 
           # Slice the CHANGES.md entries that are new since PREV_TAG
           if [ -n "$PREV_TAG" ]; then

--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -82,8 +82,16 @@ jobs:
 
       - name: Generate release notes
         run: |
-          # Find the previous stable release tag (excludes beta/rc/alpha)
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | head -1)
+          # Find the previous tag to diff against:
+          #   1. Previous pre-release of this same base version (e.g. beta.1 when cutting beta.2)
+          #   2. Fall back to last stable release if this is the first pre-release for this version
+          BASE_VERSION=$(echo "${{ github.event.inputs.version }}" | sed -E 's/-(beta|rc|alpha)\.[0-9]+//')
+          PREV_TAG=$(git tag --list "v${BASE_VERSION}-*" --sort=-version:refname \
+            | grep -v "^${TAG}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            PREV_TAG=$(git tag --list 'v*' --sort=-version:refname \
+              | grep -v beta | grep -v rc | grep -v alpha | head -1)
+          fi
 
           # Slice the CHANGES.md entries that are new since PREV_TAG
           if [ -n "$PREV_TAG" ]; then

--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -113,8 +113,37 @@ jobs:
             [ -n "$PREV_TAG" ] && printf '\n**Full Changelog:** https://github.com/${{ github.repository }}/compare/%s...%s\n' \
               "$PREV_TAG" "$TAG"
           } > release-notes.md
-          echo "--- release-notes.md preview ---"
+          echo "--- release-notes.md raw preview ---"
           cat release-notes.md
+
+      - name: Synthesize release notes with Claude
+        uses: anthropics/claude-code-action@41ea7642c1436fa0ee57aae58347904b71a5af27 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowedTools Read,Write"
+          prompt: |
+            Read `release-notes.md`. It contains a flat list of raw changelog bullets for
+            Identity Atlas ${{ github.event.inputs.version }}, collected from merged PRs
+            since the previous release.
+
+            Rewrite it as polished GitHub release notes following these rules:
+
+            1. Keep the blockquote banner at the top (if present) and the "Full Changelog"
+               link at the bottom unchanged.
+            2. Group bullets under `###` headings by theme (e.g. "Account Linking",
+               "Omada IGA crawler", "Security fixes", "Bug fixes", "UI & accessibility").
+               Don't create a heading for a single bullet — fold it under the closest
+               related heading or a generic "Improvements" section.
+            3. Drop bullets that fix something introduced in this same release. If one
+               bullet adds feature X and another fixes a bug in X, the fix is internal —
+               users upgrading from the previous release never saw X break.
+            4. Drop CI, tooling, and pure-implementation bullets with no user-visible
+               effect (workflow fixes, CmdletBinding additions, dependency bumps, etc.).
+            5. Merge bullets that describe the same change in different words.
+            6. Rewrite in user-facing language — focus on the effect for the user, not
+               the implementation detail.
+
+            Overwrite `release-notes.md` with the result.
 
       - name: Create GitHub pre-release with portable ZIP
         env:

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -81,33 +81,55 @@ jobs:
 
       - name: Generate release notes
         run: |
+          # Hotfix branches from a release tag, so compare against last stable.
           PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | grep -v "^${TAG}$" | head -1)
 
-          if [ -n "$PREV_TAG" ]; then
-            FIRST_OLD=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | head -1)
-            if [ -n "$FIRST_OLD" ]; then
-              CUTLINE=$(grep -Fn "${FIRST_OLD}" CHANGES.md | head -1 | cut -d: -f1)
-              [ -n "$CUTLINE" ] \
-                && NEW_MD=$(head -n $((CUTLINE - 1)) CHANGES.md) \
-                || NEW_MD=$(cat CHANGES.md)
-            else
-              NEW_MD=$(cat CHANGES.md)
-            fi
-          else
-            NEW_MD=$(cat CHANGES.md)
-          fi
-
-          BULLETS=$(printf '%s\n' "$NEW_MD" \
+          # Primary source: unmerged changes/*.md fragments on this hotfix branch.
+          # bump-version hasn't run yet so fragments aren't in CHANGES.md.
+          FRAG_BULLETS=$(find changes/ -name '*.md' -not -name 'TEMPLATE*' 2>/dev/null \
+            | sort | xargs cat 2>/dev/null \
             | grep -v '^## Changes in this PR$' \
             | awk 'BEGIN{blank=1} /^[[:space:]]*$/{if(!blank){print ""; blank=1}; next} {blank=0; print}')
+
+          # Fallback: slice CHANGES.md by line count (prepend model).
+          if [ -z "$FRAG_BULLETS" ] && [ -n "$PREV_TAG" ]; then
+            OLD_LINES=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | wc -l)
+            TOTAL_LINES=$(wc -l < CHANGES.md)
+            NEW_LINES=$((TOTAL_LINES - OLD_LINES))
+            [ "$NEW_LINES" -gt 0 ] && FRAG_BULLETS=$(head -n "$NEW_LINES" CHANGES.md \
+              | grep -v '^## Changes in this PR$' \
+              | awk 'BEGIN{blank=1} /^[[:space:]]*$/{if(!blank){print ""; blank=1}; next} {blank=0; print}')
+          fi
 
           {
             printf '## Changes'
             [ -n "$PREV_TAG" ] && printf ' since %s' "$PREV_TAG"
-            printf '\n\n%s\n' "$BULLETS"
+            printf '\n\n%s\n' "$FRAG_BULLETS"
             [ -n "$PREV_TAG" ] && printf '\n**Full Changelog:** https://github.com/${{ github.repository }}/compare/%s...%s\n' \
               "$PREV_TAG" "$TAG"
           } > release-notes.md
+          echo "--- release-notes.md raw preview ---"
+          cat release-notes.md
+
+      - name: Synthesize release notes with Claude
+        uses: anthropics/claude-code-action@41ea7642c1436fa0ee57aae58347904b71a5af27 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowedTools Read,Write"
+          prompt: |
+            Read `release-notes.md`. It contains raw changelog bullets for
+            Identity Atlas hotfix ${{ github.event.inputs.version }}.
+
+            Rewrite it as polished GitHub release notes following these rules:
+
+            1. Keep the "Full Changelog" link at the bottom unchanged.
+            2. Group bullets under `###` headings by theme if there are enough to
+               warrant it; otherwise a flat list under "## Bug fixes" is fine.
+            3. Drop CI, tooling, and pure-implementation bullets with no
+               user-visible effect.
+            4. Rewrite in user-facing language — focus on the effect for the user.
+
+            Overwrite `release-notes.md` with the result.
 
       - name: Create GitHub release with portable ZIP
         env:

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -81,8 +81,11 @@ jobs:
 
       - name: Generate release notes
         run: |
-          # Hotfix branches from a release tag, so compare against last stable.
-          PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | grep -v "^${TAG}$" | head -1)
+          # Compare against the previous tag in the same major.minor series
+          # (e.g. v5.7.2 when cutting v5.7.3), not the globally latest stable.
+          BASE_MINOR=$(echo "${{ github.event.inputs.version }}" | cut -d. -f1,2)
+          PREV_TAG=$(git tag --list "v${BASE_MINOR}.*" --sort=-version:refname \
+            | grep -v beta | grep -v rc | grep -v alpha | grep -v "^${TAG}$" | head -1)
 
           # Primary source: unmerged changes/*.md fragments on this hotfix branch.
           # bump-version hasn't run yet so fragments aren't in CHANGES.md.

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -116,8 +116,36 @@ jobs:
             [ -n "$PREV_TAG" ] && printf '\n**Full Changelog:** https://github.com/${{ github.repository }}/compare/%s...%s\n' \
               "$PREV_TAG" "$TAG"
           } > release-notes.md
-          echo "--- release-notes.md preview ---"
+          echo "--- release-notes.md raw preview ---"
           cat release-notes.md
+
+      - name: Synthesize release notes with Claude
+        uses: anthropics/claude-code-action@41ea7642c1436fa0ee57aae58347904b71a5af27 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowedTools Read,Write"
+          prompt: |
+            Read `release-notes.md`. It contains a flat list of raw changelog bullets for
+            Identity Atlas ${{ github.event.inputs.version }}, collected from merged PRs
+            since the previous release.
+
+            Rewrite it as polished GitHub release notes following these rules:
+
+            1. Keep the "Full Changelog" link at the bottom unchanged.
+            2. Group bullets under `###` headings by theme (e.g. "Account Linking",
+               "Omada IGA crawler", "Security fixes", "Bug fixes", "UI & accessibility").
+               Don't create a heading for a single bullet — fold it under the closest
+               related heading or a generic "Improvements" section.
+            3. Drop bullets that fix something introduced in this same release. If one
+               bullet adds feature X and another fixes a bug in X, the fix is internal —
+               users upgrading from the previous release never saw X break.
+            4. Drop CI, tooling, and pure-implementation bullets with no user-visible
+               effect (workflow fixes, CmdletBinding additions, dependency bumps, etc.).
+            5. Merge bullets that describe the same change in different words.
+            6. Rewrite in user-facing language — focus on the effect for the user, not
+               the implementation detail.
+
+            Overwrite `release-notes.md` with the result.
 
       - name: Create GitHub release with portable ZIP
         env:

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -89,17 +89,13 @@ jobs:
           # Find the previous stable release tag (excludes beta/rc/alpha)
           PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v beta | grep -v rc | grep -v alpha | grep -v "^${TAG}$" | head -1)
 
-          # Slice the CHANGES.md entries that are new since PREV_TAG
+          # Slice CHANGES.md to only the lines prepended since PREV_TAG.
+          # bump-version.yml always prepends — old content is the last N lines.
           if [ -n "$PREV_TAG" ]; then
-            FIRST_OLD=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | head -1)
-            if [ -n "$FIRST_OLD" ]; then
-              CUTLINE=$(grep -Fn "${FIRST_OLD}" CHANGES.md | head -1 | cut -d: -f1)
-              [ -n "$CUTLINE" ] \
-                && NEW_MD=$(head -n $((CUTLINE - 1)) CHANGES.md) \
-                || NEW_MD=$(cat CHANGES.md)
-            else
-              NEW_MD=$(cat CHANGES.md)
-            fi
+            OLD_LINES=$(git show "${PREV_TAG}:CHANGES.md" 2>/dev/null | wc -l)
+            TOTAL_LINES=$(wc -l < CHANGES.md)
+            NEW_LINES=$((TOTAL_LINES - OLD_LINES))
+            [ "$NEW_LINES" -gt 0 ] && NEW_MD=$(head -n "$NEW_LINES" CHANGES.md) || NEW_MD=""
           else
             NEW_MD=$(cat CHANGES.md)
           fi

--- a/changes/feature-claude-release-notes-synthesis.md
+++ b/changes/feature-claude-release-notes-synthesis.md
@@ -1,0 +1,1 @@
+- Release notes generated at cut time are now synthesized by Claude: bullets are grouped by theme, self-fixes (bugs in features introduced in the same release) are dropped, and CI/tooling-only changes are filtered out — eliminating the need to manually rewrite release notes after each cut.


### PR DESCRIPTION
## Summary

Fixes three bugs in the cut workflows that caused release notes to be empty or wrong, and adds Claude synthesis so notes are grouped and polished automatically.

### Bug fixes

**CHANGES.md slicing was always empty** (`cut-beta`, `cut-release`, `cut-hotfix`)
The old logic anchored on the first line of `CHANGES.md` at `PREV_TAG`, which is always `## Changes in this PR` — present on line 1 of every version. `CUTLINE` resolved to 1, `head -n 0` produced nothing. Fixed by counting lines: since `bump-version.yml` always prepends, the old content is always the last N lines and the new content is the first `TOTAL - OLD` lines.

**`cut-beta` always compared against last stable** (`cut-beta`)
When cutting beta.2, `PREV_TAG` was the last stable release so notes re-listed everything from beta.1. Fixed: take the most recent tag of any kind (beta, rc, or stable), excluding the tag just created. Version sort puts v5.8.0-beta.1 above v5.7.x so a hotfix on the stable track never displaces the in-progress beta as the comparison point.

**`cut-hotfix` used the globally latest stable** (`cut-hotfix`)
With v5.8.0 and v5.9.0 already released, cutting hotfix v5.7.3 would have picked v5.9.0 as `PREV_TAG` — producing empty notes. Fixed: derive `major.minor` from the input version and search only within that series (`v5.7.*`), so v5.7.3 always compares against v5.7.2 regardless of what higher versions exist.

**`cut-hotfix` couldn't see its own fragments** (`cut-hotfix`)
Hotfix branches from a release tag, so `bump-version` hasn't run and `changes/*.md` fragments aren't in `CHANGES.md` yet. Fixed: read unmerged `changes/*.md` files first; fall back to `CHANGES.md` line-count slicing if none exist.

### Claude synthesis step

Added a `claude-code-action` step between raw bullet collection and `gh release create` in all three workflows. Claude:
- Groups bullets under `###` headings by theme
- Drops self-fixes (bugs in features introduced in the same release)
- Drops CI/tooling bullets with no user-visible effect
- Merges duplicates
- Rewrites in user-facing language

The raw bullet dump is still previewed in the workflow log for auditability.

## Test plan
- [x] Simulated locally: `v5.8.0-beta.1` raw notes (337 lines) → synthesized output (~70 lines), self-fixes dropped, 3× duplicated crawler section collapsed
- [ ] Trigger Cut Beta on next beta — verify notes are grouped and self-fixes absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)