### PR TITLE
fix(ci): add id-token: write permission to cut-beta, cut-release, cut-hotfix

### DIFF
--- a/.github/workflows/cut-beta.yml
+++ b/.github/workflows/cut-beta.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Validate version input

--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Validate version input

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Validate version input

--- a/changes/fix-cut-workflows-oidc-permission.md
+++ b/changes/fix-cut-workflows-oidc-permission.md
@@ -1,0 +1,1 @@
+- Fixed Cut Beta, Cut Release, and Cut Hotfix workflows failing at the "Synthesize release notes with Claude" step — added `id-token: write` permission required by `claude-code-action` when using OAuth token authentication


### PR DESCRIPTION
## Summary

- **Fixed Cut Beta, Cut Release, and Cut Hotfix** failing at "Synthesize release notes with Claude" — `claude-code-action` requires `id-token: write` to fetch an OIDC token for OAuth authentication, but all three jobs only had `contents: write`.

Root cause confirmed in run [27094272376](https://github.com/Fortigi/IdentityAtlas/actions/runs/27094272376):
```
error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Attempt 1 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write`?
```

Three files, one line each.

## Test plan
- [ ] Trigger Cut Beta after merge to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)