### PR TITLE
docs: add Azure deployment pages to site navigation

### DIFF
--- a/changes/azure-docs-nav.md
+++ b/changes/azure-docs-nav.md
@@ -1,0 +1,1 @@
+- Added the Azure Deployment walkthrough and Azure Deployment reference to the documentation site navigation (under Operations) so they're discoverable instead of only reachable by direct URL.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,8 @@ nav:
           - Crawler Architecture: architecture/crawler-architecture.md
           - Account Linking: architecture/account-linking.md
       - Operations:
+          - Azure Deployment: architecture/azure-deployment-walkthrough.md
+          - Azure Deployment Reference: architecture/azure-deployment.md
           - Scaling & Load Testing: architecture/scaling.md
           - Demo Dataset: architecture/demo-dataset.md
           - Nightly Review: operations/nightly-review.md


### PR DESCRIPTION
The Azure deployment walkthrough and reference pages existed in the repo but were never added to mkdocs nav, so they had no link in the published site navigation and were only reachable by direct URL. Add both under the Operations section.