### PR TITLE
fix: node-launcher re2 prebuilt + Node 24 alignment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: app/ui/package-lock.json
 
@@ -173,7 +173,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: app/api/package-lock.json
 
@@ -195,7 +195,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install Spectral
         run: npm install -g @stoplight/spectral-cli
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Audit frontend dependencies
         working-directory: app/ui

--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -2,7 +2,7 @@
 # Usage: docker build -f app/api/Dockerfile -t fortigraph-backend .
 
 # ── Stage 1: Build frontend ───────────────────────────────────────────────────
-FROM node:22-slim AS frontend-build
+FROM node:24-slim AS frontend-build
 WORKDIR /app/frontend
 COPY app/ui/package*.json ./
 RUN npm ci
@@ -10,7 +10,7 @@ COPY app/ui/ .
 RUN npm run build
 
 # ── Stage 2: Backend runtime ──────────────────────────────────────────────────
-FROM node:22-slim AS runtime
+FROM node:24-slim AS runtime
 
 # Bake the module version into the image so /api/version returns the full
 # version string (e.g. 5.0.20260414.0900) without needing the .psd1 file.

--- a/app/desktop/scripts/build-node-launcher.mjs
+++ b/app/desktop/scripts/build-node-launcher.mjs
@@ -15,10 +15,14 @@
 //
 // Requires: node 18+, PowerShell 7+ on PATH (for Invoke-WebRequest + Compress-Archive)
 
-import { execSync, execFileSync }       from 'child_process';
-import { cpSync, mkdirSync, existsSync, rmSync, copyFileSync } from 'fs';
-import { join, resolve, dirname }      from 'path';
-import { fileURLToPath }               from 'url';
+import { execSync, execFileSync }                                   from 'child_process';
+import { cpSync, mkdirSync, existsSync, rmSync, copyFileSync,
+         createReadStream, createWriteStream, readFileSync,
+         unlinkSync }                                               from 'fs';
+import { createBrotliDecompress }                                  from 'zlib';
+import { pipeline }                                                from 'stream/promises';
+import { join, resolve, dirname }                                  from 'path';
+import { fileURLToPath }                                           from 'url';
 
 const __dirname   = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT   = resolve(__dirname, '..', '..', '..');
@@ -29,9 +33,12 @@ const STAGE_DIR   = join(DIST_DIR, 'stage');
 const ZIP_PATH    = join(DIST_DIR, 'IdentityAtlas-portable.zip');
 
 const NODE_VERSION   = '24.16.0';
+// Node modules ABI for the bundled node.exe — must match NODE_VERSION.
+// Update both NODE_VERSION, NODE_ABI, and NODE_SHA256 together when bumping Node.js.
+// ABI reference: https://nodejs.org/en/download/releases (modules column)
+const NODE_ABI       = '137'; // Node 24
 const NODE_URL       = `https://nodejs.org/dist/v${NODE_VERSION}/win-x64/node.exe`;
 // SHA-256 from https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt (win-x64/node.exe)
-// Update both NODE_VERSION and NODE_SHA256 together when bumping Node.js.
 const NODE_SHA256    = 'b3094d0b49f9ad602262a9921551737bb97637c05dd357a06ae98188d7290aa3';
 
 const SKIP_UI   = process.argv.includes('--skip-ui-build');
@@ -97,12 +104,30 @@ cpSync(
   { recursive: true }
 );
 
-// ── Step 5/8 — copy PGlite ───────────────────────────────────────────────────
+// ── Step 5/8 — copy PGlite and native addons ─────────────────────────────────
 console.log('\n[6/8] Copying @electric-sql/pglite...');
 const PGLITE_SRC  = join(DESKTOP_DIR, 'node_modules', '@electric-sql', 'pglite');
 const PGLITE_DEST = join(STAGE_DIR, 'node_modules', '@electric-sql', 'pglite');
 mkdirSync(join(STAGE_DIR, 'node_modules', '@electric-sql'), { recursive: true });
 cpSync(PGLITE_SRC, PGLITE_DEST, { recursive: true });
+
+// re2 is a native addon (marked --external in esbuild).
+// Copy the package, then replace the binary with the prebuilt for the target
+// Node ABI — the host Node may differ from the bundled node.exe.
+const RE2_SRC  = join(API_ROOT, 'node_modules', 're2');
+const RE2_DEST = join(STAGE_DIR, 'node_modules', 're2');
+cpSync(RE2_SRC, RE2_DEST, { recursive: true });
+
+const RE2_VERSION   = JSON.parse(readFileSync(join(RE2_SRC, 'package.json'), 'utf8')).version;
+const RE2_BR_URL    = `https://github.com/uhop/node-re2/releases/download/${RE2_VERSION}/win32-x64-${NODE_ABI}.br`;
+const RE2_DEST_DIR  = join(RE2_DEST, 'build', 'Release');
+const RE2_BR_PATH   = join(RE2_DEST_DIR, 're2.node.br');
+const RE2_NODE_PATH = join(RE2_DEST_DIR, 're2.node');
+mkdirSync(RE2_DEST_DIR, { recursive: true });
+console.log(`  Fetching re2 prebuilt win32-x64-${NODE_ABI} (re2@${RE2_VERSION})...`);
+pwsh(`Invoke-WebRequest -Uri '${RE2_BR_URL}' -OutFile '${RE2_BR_PATH.replace(/\\/g, '\\\\')}' -UseBasicParsing`);
+await pipeline(createReadStream(RE2_BR_PATH), createBrotliDecompress(), createWriteStream(RE2_NODE_PATH));
+unlinkSync(RE2_BR_PATH);
 
 // ── Step 6/8 — copy launcher files ───────────────────────────────────────────
 console.log('\n[7/8] Copying launcher files...');

--- a/app/ui/Dockerfile
+++ b/app/ui/Dockerfile
@@ -6,7 +6,7 @@
 #   docker build -t fortigraph-frontend .
 #   docker run -p 5173:5173 -v $(pwd)/src:/app/src fortigraph-frontend
 
-FROM node:20-slim
+FROM node:24-slim
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/changes/bugfixes-node24-re2-node-launcher.md
+++ b/changes/bugfixes-node24-re2-node-launcher.md
@@ -1,0 +1,2 @@
+- Fixed portable node-launcher failing to start due to missing `re2` native addon; the correct Windows prebuilt matching the bundled Node version is now fetched at build time
+- Standardised Node.js to v24 (Active LTS) across Docker images and CI workflows


### PR DESCRIPTION
- Fixed portable node-launcher failing to start due to missing `re2` native addon; the correct Windows prebuilt matching the bundled Node version is now fetched at build time
- Standardised Node.js to v24 (Active LTS) across Docker images and CI workflows

## Root cause

The build script copied `re2` from the host's `node_modules`, which was compiled for the developer's local Node ABI. The bundled `node.exe` is Node 24 (ABI 137) — if the host runs a different Node version the binary won't load.

## Fix

The build script now downloads the `win32-x64-137.br` prebuilt directly from the re2 GitHub release and decompresses it, guaranteeing the binary always matches the bundled `node.exe` regardless of the host Node version. A `NODE_ABI` constant is added alongside `NODE_VERSION` and `NODE_SHA256` to keep them in sync.

Node 24 is Active LTS with a 16-month runway — upgraded from Node 22/20 in Docker and CI.