### PR TITLE
fix: guard re-entrant SIGINT shutdown + force-exit after 5s

### DIFF
--- a/app/api/src/index.js
+++ b/app/api/src/index.js
@@ -72,8 +72,14 @@ server.on('error', (err) => {
   throw err;
 });
 
-// Graceful shutdown: close SQL pool before exiting
+// Graceful shutdown: close SQL pool before exiting.
+// Guard flag prevents re-entrant calls (multiple Ctrl+C presses each add a
+// server 'close' listener, causing MaxListenersExceededWarning and the loop
+// of repeated "SIGINT received" messages).
+let shuttingDown = false;
 async function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log(`${signal} received, shutting down...`);
   server.close(async () => {
     if (process.env.USE_SQL === 'true') {
@@ -82,6 +88,9 @@ async function shutdown(signal) {
     }
     process.exit(0);
   });
+  // Force exit after 5 s — keep-alive browser connections would otherwise
+  // prevent server.close() from firing indefinitely.
+  setTimeout(() => process.exit(0), 5000).unref();
 }
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 process.on('SIGINT', () => shutdown('SIGINT'));

--- a/app/api/src/index.test.js
+++ b/app/api/src/index.test.js
@@ -1,4 +1,4 @@
-// Tests for index.js startup behaviour: EADDRINUSE handler and host binding.
+// Tests for index.js startup behaviour: EADDRINUSE handler, host binding, and graceful shutdown.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import net from 'node:net';
@@ -32,6 +32,60 @@ describe('server EADDRINUSE handler', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already in use'));
 
     blocker.close();
+  });
+});
+
+describe('graceful shutdown', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('logs and closes server only once when SIGINT fires multiple times', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});
+    const logSpy  = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mockServer = { close: vi.fn(cb => cb()) };
+
+    // Inline simulation of index.js shutdown logic
+    let shuttingDown = false;
+    function shutdown(signal) {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.log(`${signal} received, shutting down...`);
+      mockServer.close(() => process.exit(0));
+      setTimeout(() => process.exit(0), 5000).unref();
+    }
+
+    shutdown('SIGINT');
+    shutdown('SIGINT');
+    shutdown('SIGINT');
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(mockServer.close).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('force-exits after 5 s when server has lingering connections', () => {
+    vi.useFakeTimers();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mockServer = { close: vi.fn() }; // never calls its callback
+
+    let shuttingDown = false;
+    function shutdown(signal) {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.log(`${signal} received, shutting down...`);
+      mockServer.close(() => process.exit(0));
+      setTimeout(() => process.exit(0), 5000).unref();
+    }
+
+    shutdown('SIGINT');
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5000);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 });
 

--- a/changes/bugfixes-graceful-shutdown-sigint.md
+++ b/changes/bugfixes-graceful-shutdown-sigint.md
@@ -1,0 +1,2 @@
+- Fixed repeated "SIGINT received, shutting down..." loop when pressing Ctrl+C multiple times in the portable node-launcher
+- Fixed process hanging indefinitely after Ctrl+C due to keep-alive browser connections blocking shutdown


### PR DESCRIPTION
- Fixed repeated \"SIGINT received, shutting down...\" loop when pressing Ctrl+C multiple times
- Fixed `MaxListenersExceededWarning` (11 close listeners) caused by each keypress adding a new `server.close()` listener
- Fixed process hanging indefinitely due to keep-alive browser connections blocking `server.close()` callback

## Root cause

`shutdown()` had no re-entrancy guard. Each Ctrl+C fired a new `SIGINT`, called `server.close()` again, and added another `close` listener. `server.close()` also waits for all connections to drain — keep-alive browser connections never close, so the process would hang forever.

## Fix

- `shuttingDown` flag: first signal triggers shutdown, subsequent ones are no-ops
- 5 s `setTimeout(...).unref()` force-exit so the process always terminates even with open connections