### PR TITLE
Hide Systems and Sync Log tabs by default (opt-in per user)

### DIFF
--- a/app/api/src/routes/preferences.js
+++ b/app/api/src/routes/preferences.js
@@ -7,7 +7,10 @@ import * as db from '../db/connection.js';
 const router = Router();
 const useSql = process.env.USE_SQL === 'true';
 
-const OPTIONAL_TABS = ['risk-scores', 'identities', 'performance', 'admin'];
+// Keys of tabs a user may show/hide. Must stay in sync with the `optional`
+// tabs in the UI's utils/navTabs.js. Systems and Sync Log are opt-in (off by
+// default); Risk Scores / Identities / Performance / Admin remain optional too.
+const OPTIONAL_TABS = ['systems', 'sync-log', 'risk-scores', 'identities', 'performance', 'admin'];
 
 function getUserId(req) {
   if (req.user?.oid) return req.user.oid;

--- a/app/api/src/routes/preferences.test.js
+++ b/app/api/src/routes/preferences.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { OPTIONAL_TABS } from './preferences.js';
+
+// The preferences route filters a user's saved visibleTabs against this
+// allowlist on both read and write — a tab key not in the list can never be
+// persisted as "enabled". It must stay in sync with the `optional` tabs in the
+// UI's utils/navTabs.js, or a user could toggle a tab on but never have it stick.
+describe('preferences OPTIONAL_TABS allowlist', () => {
+  it('lets users enable the Systems and Sync Log tabs', () => {
+    expect(OPTIONAL_TABS).toEqual(expect.arrayContaining(['systems', 'sync-log']));
+  });
+
+  it('keeps the previously-optional tabs enable-able', () => {
+    expect(OPTIONAL_TABS).toEqual(expect.arrayContaining(['risk-scores', 'identities', 'performance', 'admin']));
+  });
+});

--- a/app/ui/e2e/global-setup.js
+++ b/app/ui/e2e/global-setup.js
@@ -2,15 +2,15 @@
 /**
  * Global setup for Playwright E2E tests.
  *
- * Runs once before all specs. Enables all optional tabs (Identities,
- * Org Chart, Risk Scores, Performance, Admin) via the preferences API
- * so every spec can navigate to every page without skipping.
+ * Runs once before all specs. Enables all optional tabs (Systems, Sync Log,
+ * Identities, Org Chart, Risk Scores, Performance, Admin) via the preferences
+ * API so every spec can navigate to every page without skipping.
  */
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:3001';
 
 async function globalSetup() {
-  const allTabs = ['risk-scores', 'identities', 'org-chart', 'performance', 'admin'];
+  const allTabs = ['systems', 'sync-log', 'risk-scores', 'identities', 'org-chart', 'performance', 'admin'];
 
   const res = await fetch(`${BASE}/api/preferences`, {
     method: 'PUT',

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -4,6 +4,7 @@ import { useAuth } from './auth/AuthGate';
 import { useCanSeeAdminTab } from './auth/usePermissions';
 import { useTheme } from './hooks/useTheme';
 import { ThemeContext } from './contexts/ThemeContext';
+import { computeNavTabs, availableOptionalTabs } from './utils/navTabs';
 import ErrorBoundary from './components/ErrorBoundary';
 
 // Lazy-load page components (route-based code splitting)
@@ -89,20 +90,6 @@ function useHashRoute() {
   return [page, navigate];
 }
 
-const ALL_NAV_TABS = [
-  { key: 'dashboard',        label: 'Dashboard' },
-  { key: 'matrix',           label: 'Matrix' },
-  { key: 'users',            label: 'Users' },
-  { key: 'resources',        label: 'Resources' },
-  { key: 'systems',          label: 'Systems' },
-  { key: 'access-packages',  label: 'Business Roles' },
-  { key: 'sync-log',         label: 'Sync Log' },
-  { key: 'risk-scores',      label: 'Risk Scores',  feature: 'riskScoring',        optional: true },
-  { key: 'identities',       label: 'Identities',   feature: 'accountLinking', optional: true },
-  { key: 'contexts',         label: 'Contexts' },
-  { key: 'admin',            label: 'Admin' },
-];
-
 export default function App() {
   // Parse initial state from URL (runs once — empty deps intentional)
   // eslint-disable-next-line react-hooks/preserve-manual-memoization
@@ -134,21 +121,13 @@ export default function App() {
   // page inside Admin further self-gates by admin.auth.
   const canSeeAdmin = useCanSeeAdminTab();
 
-  const navTabs = useMemo(() =>
-    ALL_NAV_TABS.filter(tab => {
-      if (tab.feature && !features[tab.feature]) return false;
-      if (tab.optional && visibleTabs && !visibleTabs.includes(tab.key)) return false;
-      if (tab.key === 'admin' && !canSeeAdmin) return false;
-      return true;
-    }),
+  const navTabs = useMemo(
+    () => computeNavTabs({ features, visibleTabs, canSeeAdmin }),
     [features, visibleTabs, canSeeAdmin]
   );
 
   // Available optional tabs (respecting feature flags)
-  const optionalTabs = useMemo(() =>
-    ALL_NAV_TABS.filter(tab => tab.optional && (!tab.feature || features[tab.feature])),
-    [features]
-  );
+  const optionalTabs = useMemo(() => availableOptionalTabs(features), [features]);
 
   // The Dashboard page handles the no-data case with its own "Configure a
   // crawler" CTA. In v5 the default landing page is the Dashboard — the old

--- a/app/ui/src/utils/navTabs.js
+++ b/app/ui/src/utils/navTabs.js
@@ -1,0 +1,45 @@
+// Top-nav tab definitions + visibility rules. Kept out of App.jsx so the
+// filtering can be unit-tested without rendering the whole app.
+//
+// Tab flags:
+//   feature   — only shown when that feature flag is enabled server-side.
+//   optional  — hidden by default; the user opts in via Settings → tabs, which
+//               adds the tab key to their `visibleTabs` preference.
+//
+// Systems and Sync Log are optional: most users live in the Matrix / Users /
+// Contexts surfaces, so these admin-leaning views are off by default and can be
+// switched on per-user when needed.
+
+export const ALL_NAV_TABS = [
+  { key: 'dashboard',        label: 'Dashboard' },
+  { key: 'matrix',           label: 'Matrix' },
+  { key: 'users',            label: 'Users' },
+  { key: 'resources',        label: 'Resources' },
+  { key: 'systems',          label: 'Systems',      optional: true },
+  { key: 'access-packages',  label: 'Business Roles' },
+  { key: 'sync-log',         label: 'Sync Log',     optional: true },
+  { key: 'risk-scores',      label: 'Risk Scores',  feature: 'riskScoring',    optional: true },
+  { key: 'identities',       label: 'Identities',   feature: 'accountLinking', optional: true },
+  { key: 'contexts',         label: 'Contexts' },
+  { key: 'admin',            label: 'Admin' },
+];
+
+// Tabs to render in the nav bar.
+//   - feature-gated tabs drop out when their flag is off
+//   - optional tabs drop out unless the user has enabled them (once preferences
+//     have loaded; while `visibleTabs` is null we don't hide them, to avoid a
+//     flash of removal before prefs arrive)
+//   - Admin drops out for users without admin permission
+export function computeNavTabs({ features = {}, visibleTabs = null, canSeeAdmin = true } = {}) {
+  return ALL_NAV_TABS.filter(tab => {
+    if (tab.feature && !features[tab.feature]) return false;
+    if (tab.optional && visibleTabs && !visibleTabs.includes(tab.key)) return false;
+    if (tab.key === 'admin' && !canSeeAdmin) return false;
+    return true;
+  });
+}
+
+// Optional tabs the user is allowed to toggle on/off (respecting feature flags).
+export function availableOptionalTabs(features = {}) {
+  return ALL_NAV_TABS.filter(tab => tab.optional && (!tab.feature || features[tab.feature]));
+}

--- a/app/ui/src/utils/navTabs.test.js
+++ b/app/ui/src/utils/navTabs.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { ALL_NAV_TABS, computeNavTabs, availableOptionalTabs } from './navTabs';
+
+const keys = (tabs) => tabs.map(t => t.key);
+const ENABLE_ALL_FEATURES = { riskScoring: true, accountLinking: true };
+
+describe('navTabs', () => {
+  it('marks Systems and Sync Log as optional', () => {
+    for (const key of ['systems', 'sync-log']) {
+      const tab = ALL_NAV_TABS.find(t => t.key === key);
+      expect(tab, key).toBeTruthy();
+      expect(tab.optional, `${key} should be optional`).toBe(true);
+    }
+  });
+
+  it('hides Systems and Sync Log by default (empty visibleTabs)', () => {
+    const shown = keys(computeNavTabs({ features: ENABLE_ALL_FEATURES, visibleTabs: [], canSeeAdmin: true }));
+    expect(shown).not.toContain('systems');
+    expect(shown).not.toContain('sync-log');
+  });
+
+  it('shows them once the user enables them', () => {
+    const shown = keys(computeNavTabs({
+      features: ENABLE_ALL_FEATURES,
+      visibleTabs: ['systems', 'sync-log'],
+      canSeeAdmin: true,
+    }));
+    expect(shown).toContain('systems');
+    expect(shown).toContain('sync-log');
+  });
+
+  it('offers Systems and Sync Log among the toggleable optional tabs', () => {
+    const optional = keys(availableOptionalTabs(ENABLE_ALL_FEATURES));
+    expect(optional).toEqual(expect.arrayContaining(['systems', 'sync-log']));
+  });
+
+  it('keeps non-optional tabs visible regardless of preferences', () => {
+    const shown = keys(computeNavTabs({ features: ENABLE_ALL_FEATURES, visibleTabs: [], canSeeAdmin: true }));
+    expect(shown).toEqual(expect.arrayContaining(['dashboard', 'matrix', 'users', 'resources', 'access-packages', 'contexts']));
+  });
+
+  it('does not hide optional tabs while preferences are still loading (visibleTabs null)', () => {
+    const shown = keys(computeNavTabs({ features: ENABLE_ALL_FEATURES, visibleTabs: null, canSeeAdmin: true }));
+    // Before prefs load we don't yet know the user's choice, so we don't remove
+    // optional tabs — avoids a flash of them disappearing.
+    expect(shown).toContain('systems');
+    expect(shown).toContain('sync-log');
+  });
+
+  it('still gates the Admin tab on permission and feature flags', () => {
+    const noAdmin = keys(computeNavTabs({ features: ENABLE_ALL_FEATURES, visibleTabs: [], canSeeAdmin: false }));
+    expect(noAdmin).not.toContain('admin');
+
+    const noRisk = keys(computeNavTabs({ features: { riskScoring: false, accountLinking: false }, visibleTabs: ['risk-scores', 'identities'], canSeeAdmin: true }));
+    expect(noRisk).not.toContain('risk-scores');
+    expect(noRisk).not.toContain('identities');
+  });
+});

--- a/changes/hide-systems-synclog-tabs.md
+++ b/changes/hide-systems-synclog-tabs.md
@@ -1,0 +1,1 @@
+- The Systems and Sync Log tabs are now hidden by default. Enable either of them per user from Settings → Visible Tabs when you need them.


### PR DESCRIPTION
## Hide Systems and Sync Log tabs by default

Both tabs are now **optional** — off by default, and each can be switched on per user from **Settings → Visible Tabs** (the same toggle mechanism already used for Risk Scores / Identities). Their routes still work if navigated to directly; only the nav-bar entries are hidden until enabled.

### Implementation
- Extracted the nav-tab list and visibility rules out of `App.jsx` into `utils/navTabs.js` (`ALL_NAV_TABS`, `computeNavTabs`, `availableOptionalTabs`) so the filtering is testable without rendering the app.
- Flipped `systems` and `sync-log` to `optional: true`.

### Testing
- New `utils/navTabs.test.js` asserts: Systems/Sync Log are optional, hidden with empty `visibleTabs`, shown when enabled, present in the toggle list, non-optional tabs always visible, no flash while prefs load, and Admin/feature gating still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
