### PR TITLE
fix(changelog): add user-facing Node 24 alignment entry

### DIFF
--- a/changes/bugfixes-node24-changelog-wording.md
+++ b/changes/bugfixes-node24-changelog-wording.md
@@ -1,0 +1,1 @@
+- Aligned Node.js to v24 (Active LTS) across all components: Docker images, portable Windows launcher, and all GitHub Actions workflows and release flows


### PR DESCRIPTION
- Aligned Node.js to v24 (Active LTS) across all components: Docker images, portable Windows launcher, and all GitHub Actions workflows and release flows