### PR TITLE
fix(node-launcher): self-import IdentityAtlas module in Invoke-CrawlerJob.ps1

### DIFF
--- a/changes/bugfixes-fix-crawler-module-bootstrap.md
+++ b/changes/bugfixes-fix-crawler-module-bootstrap.md
@@ -1,0 +1,1 @@
+- Fixed crawler jobs failing in the portable Windows launcher with "Get-CrawlerRegistry is not recognized" — the dispatcher now self-imports the IdentityAtlas module when running as a standalone process

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -126,6 +126,17 @@ $appRoot = if ($env:IA_APP_ROOT) { $env:IA_APP_ROOT.TrimEnd('/\') } else { '/app
 
 try {
 
+    # ─── Module bootstrap ─────────────────────────────────────────────────────
+    # Desktop worker spawns a fresh pwsh with no module pre-loaded; Docker's
+    # scheduler.ps1 imports the module in the same process before calling here.
+    if (-not (Get-Command Get-CrawlerRegistry -ErrorAction SilentlyContinue)) {
+        $modulePsd1 = Join-Path $appRoot 'setup' 'IdentityAtlas.psd1'
+        if (-not (Test-Path $modulePsd1)) {
+            throw "IdentityAtlas module not found at '$modulePsd1'. Is IA_APP_ROOT set correctly?"
+        }
+        Import-Module $modulePsd1 -Force
+    }
+
     # ─── Registry lookup ──────────────────────────────────────────────────────
     $registry = Get-CrawlerRegistry
     if (-not $registry.ContainsKey($JobType)) {

--- a/test/unit/Dispatcher.Tests.ps1
+++ b/test/unit/Dispatcher.Tests.ps1
@@ -211,24 +211,3 @@ Describe 'Dependency loader — entry points are never dot-sourced' {
         { Invoke-DependencyLoader -Resolved $resolved -Registry $script:loaderRegistry } | Should -Not -Throw
     }
 }
-
-# ─── Fresh-process bootstrap (node-launcher simulation) ──────────────────────
-
-Describe 'Invoke-CrawlerJob.ps1 — fresh-process module bootstrap (node-launcher)' {
-    It 'self-imports IdentityAtlas when spawned without a pre-loaded module' {
-        # Simulate exactly what desktop-worker.cjs does: pwsh -NonInteractive -File
-        # with no prior Import-Module. The script must self-bootstrap.
-        $dispatcherPath = Join-Path $script:repoRoot 'setup' 'docker' 'Invoke-CrawlerJob.ps1'
-        $savedRoot = $env:IA_APP_ROOT
-        try {
-            $env:IA_APP_ROOT = $script:repoRoot
-            $output = & pwsh -NonInteractive -File $dispatcherPath `
-                -JobId 0 -JobType 'entra-id' -Config '{}' -ApiKey 'test' 2>&1 |
-                Out-String
-        } finally {
-            $env:IA_APP_ROOT = $savedRoot
-        }
-
-        $output | Should -Not -Match "The term 'Get-CrawlerRegistry' is not recognized"
-    }
-}

--- a/test/unit/Dispatcher.Tests.ps1
+++ b/test/unit/Dispatcher.Tests.ps1
@@ -211,3 +211,24 @@ Describe 'Dependency loader — entry points are never dot-sourced' {
         { Invoke-DependencyLoader -Resolved $resolved -Registry $script:loaderRegistry } | Should -Not -Throw
     }
 }
+
+# ─── Fresh-process bootstrap (node-launcher simulation) ──────────────────────
+
+Describe 'Invoke-CrawlerJob.ps1 — fresh-process module bootstrap (node-launcher)' {
+    It 'self-imports IdentityAtlas when spawned without a pre-loaded module' {
+        # Simulate exactly what desktop-worker.cjs does: pwsh -NonInteractive -File
+        # with no prior Import-Module. The script must self-bootstrap.
+        $dispatcherPath = Join-Path $script:repoRoot 'setup' 'docker' 'Invoke-CrawlerJob.ps1'
+        $savedRoot = $env:IA_APP_ROOT
+        try {
+            $env:IA_APP_ROOT = $script:repoRoot
+            $output = & pwsh -NonInteractive -File $dispatcherPath `
+                -JobId 0 -JobType 'entra-id' -Config '{}' -ApiKey 'test' 2>&1 |
+                Out-String
+        } finally {
+            $env:IA_APP_ROOT = $savedRoot
+        }
+
+        $output | Should -Not -Match "The term 'Get-CrawlerRegistry' is not recognized"
+    }
+}

--- a/test/unit/NodeLauncher.Tests.ps1
+++ b/test/unit/NodeLauncher.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Verifies that every $appRoot-relative path reference in node-launcher
+    PowerShell scripts resolves to a file that exists in the repository.
+
+.DESCRIPTION
+    The node-launcher sets IA_APP_ROOT to the bundled-scripts directory, which
+    mirrors the repo layout. Scripts that reference $appRoot/... paths break at
+    runtime if those files are missing (moved, renamed, or never created).
+
+    Parses all PS1 files under setup/docker/ and tools/crawlers/ for two patterns:
+      1. "$appRoot/path/to/file"       -- string interpolation
+      2. Join-Path $appRoot 'seg' ...  -- literal-segment Join-Path
+
+    Each resolved path is asserted to exist relative to the repo root.
+    Catches: moved files, renamed scripts, dead references.
+    Does not catch: paths built from runtime variables (checked at runtime only).
+
+.USAGE
+    Invoke-Pester -Path test/unit/NodeLauncher.Tests.ps1 -Output Detailed
+#>
+
+BeforeDiscovery {
+    $root  = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $pat1  = '"\$[Aa]pp[Rr]oot[/\\]([^"]+)"'
+    $pat2  = "Join-Path\s+\`$[Aa]pp[Rr]oot\s+((?:'[^']+'\s*)+)"
+
+    $refs = [System.Collections.Generic.List[hashtable]]::new()
+    foreach ($dir in @(
+        (Join-Path $root 'setup' 'docker'),
+        (Join-Path $root 'tools' 'crawlers')
+    )) {
+        Get-ChildItem -Path $dir -Recurse -Filter '*.ps1' -ErrorAction SilentlyContinue | ForEach-Object {
+            $content = Get-Content $_.FullName -Raw
+            $label   = $_.FullName.Substring($root.Length).TrimStart([char]'/', [char]'\')
+
+            # Pattern 1: "$appRoot/path/to/file"
+            [regex]::Matches($content, $pat1) | ForEach-Object {
+                $rel = $_.Groups[1].Value -replace '[/\\]', [System.IO.Path]::DirectorySeparatorChar
+                $refs.Add(@{ File = $label; Path = $rel; Root = $root })
+            }
+
+            # Pattern 2: Join-Path $appRoot 'seg1' 'seg2' (literal segments only)
+            [regex]::Matches($content, $pat2) | ForEach-Object {
+                $segs = [regex]::Matches($_.Groups[1].Value, "'([^']+)'") |
+                        ForEach-Object { $_.Groups[1].Value }
+                $refs.Add(@{ File = $label; Path = ($segs -join [System.IO.Path]::DirectorySeparatorChar); Root = $root })
+            }
+        }
+    }
+}
+
+Describe 'Node-launcher: $appRoot path references exist in repo' {
+    It 'at least one $appRoot reference found (sanity)' -ForEach @(@{ N = $refs.Count }) {
+        $N | Should -BeGreaterThan 0
+    }
+
+    It '<Path> exists (referenced in <File>)' -ForEach $refs {
+        Join-Path $Root $Path | Should -Exist -Because "'$File' references `$appRoot/$Path"
+    }
+}

--- a/test/unit/NodeLauncher.Tests.ps1
+++ b/test/unit/NodeLauncher.Tests.ps1
@@ -35,10 +35,12 @@ BeforeDiscovery {
             $content = Get-Content $_.FullName -Raw
             $label   = $_.FullName.Substring($root.Length).TrimStart([char]'/', [char]'\')
 
-            # Pattern 1: "$appRoot/path/to/file"
+            # Pattern 1: "$appRoot/path/to/file" — scripts only; data files may be generated at runtime
             [regex]::Matches($content, $pat1) | ForEach-Object {
                 $rel = $_.Groups[1].Value -replace '[/\\]', [System.IO.Path]::DirectorySeparatorChar
-                $refs.Add(@{ File = $label; Path = $rel; Root = $root })
+                if ($rel -match '\.(ps1|psd1|psm1)$') {
+                    $refs.Add(@{ File = $label; Path = $rel; Root = $root })
+                }
             }
 
             # Pattern 2: Join-Path $appRoot 'seg1' 'seg2' (literal segments only)


### PR DESCRIPTION
## Summary

- Fixed crawler jobs failing in the portable Windows launcher with \"Get-CrawlerRegistry is not recognized\" — the dispatcher now self-imports the IdentityAtlas module when running as a standalone process
- Added \`NodeLauncher.Tests.ps1\`: parses every PS1 under \`setup/docker/\` and \`tools/crawlers/\` for \`\$appRoot\`-relative file references and asserts each resolves to a real file in the repo — catches moved, renamed, or missing files on every PR without a build step

## Root cause

\`desktop-worker.cjs\` spawns \`pwsh.exe -NonInteractive -File Invoke-CrawlerJob.ps1\` as a fresh process with no module pre-loaded. \`Get-CrawlerRegistry\` is defined in \`IdentityAtlas.psm1\`, which was never imported in that context. Docker's \`scheduler.ps1\` imports the module in the same process before calling the script, so Docker was unaffected.

## Test plan

- [ ] Pester: \`NodeLauncher.Tests.ps1\` — all \`\$appRoot\` path references resolve in repo
- [ ] Build portable ZIP (\`npm run build:node-launcher\`) and trigger a crawler job — no \"not recognized\" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)