### PR TITLE
Fix: keep Authentication tab (Roles & Permissions) visible for admins on Azure

### DIFF
--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
 import { useAuth } from '../auth/AuthGate';
-import { hasPermission } from '../auth/usePermissions';
+import { ADMIN_TABS, visibleAdminTabs } from './admin/adminTabs';
 import ScheduleEditor from './ScheduleEditor';
 
 // Lazy-load the heavy sub-tab pages so they don't bloat the initial Admin bundle
@@ -1147,22 +1147,6 @@ function DangerZoneSection({ onRefresh }) {
   );
 }
 
-// ─── Admin Sub-Tabs ───────────────────────────────────────────────────────────
-// `requires` lists permissions any one of which (logical OR) grants access to
-// that sub-tab. Tabs without `requires` are visible to any authenticated user
-// (read-only stuff: Performance / About).
-const ADMIN_TABS = [
-  { key: 'crawlers',     label: 'Crawlers',            description: 'Add, configure and run identity data crawlers',                                  requires: ['admin.crawlers'] },
-  { key: 'data',         label: 'Data',                description: 'Export/import curated data and clean the database',                              requires: ['data.export.ui', 'admin.csv-import', 'admin.systems', 'admin.read-tokens', 'data.export.apikey'] },
-  { key: 'account-linking', label: 'Account Linking',  description: 'Rules for linking orphan accounts to existing identities',                        requires: ['admin.crawlers'] },
-  { key: 'risk-scoring', label: 'Risk Scoring',        description: 'Risk profile, classifiers and feature toggle',                                   requires: ['admin.llm', 'admin.crawlers'] },
-  { key: 'llm',          label: 'LLM Settings',        description: 'Configure the LLM provider used by risk scoring',                                requires: ['admin.llm'] },
-  { key: 'performance',  label: 'Performance',         description: 'API and SQL performance metrics' },
-
-  { key: 'auth',         label: 'Authentication',      description: 'Configure Entra ID single sign-on',                                              requires: ['admin.auth'] },
-  { key: 'about',        label: 'About',               description: 'License, version, and software bill of materials' },
-];
-
 // ─── LLM Settings sub-tab ────────────────────────────────────────────────────
 // Configures the LLM provider used by risk scoring, classifier generation and
 // (future) account correlation. The API key never leaves the server — the GET
@@ -1651,40 +1635,13 @@ export default function AdminPage({ onNavigate, onRefresh, onRiskScoresRefresh }
   };
   const [activeTab, setActiveTab] = useState(getInitialTab);
 
-  // On Azure App Service, auth is enforced via Bicep parameters at deploy
-  // time — there's nothing useful to do from the auth admin page (the CLI
-  // commands shown there assume Docker), so hide it when we detect Azure.
-  const { authFetch } = useAuth();
   // hasWildcard + permissions come from AuthContext (populated by AuthGateProvider
-  // after sign-in via /api/auth-me). Used to hide sub-tabs the user can't use.
-  const [platform, setPlatform] = useState(null);
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const r = await authFetch('/api/admin/auth-settings');
-        if (!r.ok || cancelled) return;
-        const data = await r.json();
-        setPlatform(data.platform || 'docker');
-      } catch {
-        // Best-effort — keep all tabs visible on detection failure.
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [authFetch]);
-  const isAzure = platform === 'azure-app-service';
+  // after sign-in via /api/auth-me). Sub-tab visibility is permission-driven only:
+  // the Authentication tab hosts Roles & Permissions, so it must stay reachable
+  // for admins on every platform. Platform-specific guidance (the Docker CLI
+  // walkthrough) is hidden inside AuthSettingsPage, not by dropping the whole tab.
   const { hasWildcard, permissions } = useAuth();
-  // Reuse the shared pure check (can't use the useHasPermission hook here —
-  // this runs inside a .filter() callback). Tabs with no `requires` are always
-  // visible; everything else delegates to the same logic the hook uses.
-  const hasAnyPerm = (required) => {
-    if (!required) return true;             // no `requires` → always visible
-    return hasPermission(permissions, hasWildcard, ...required);
-  };
-  const visibleTabs = ADMIN_TABS.filter(t => {
-    if (isAzure && t.key === 'auth') return false;
-    return hasAnyPerm(t.requires);
-  });
+  const visibleTabs = visibleAdminTabs(permissions, hasWildcard);
 
   // If the user was on a now-hidden tab, bounce them to the first visible one.
   useEffect(() => {

--- a/app/ui/src/components/AuthSettingsPage.jsx
+++ b/app/ui/src/components/AuthSettingsPage.jsx
@@ -56,6 +56,10 @@ export default function AuthSettingsPage() {
   const tenantId = state?.tenantId || '';
   const clientId = state?.clientId || '';
   const requiredRoles = state?.requiredRoles || [];
+  // On Azure App Service the Docker CLI walkthrough doesn't apply (auth is set
+  // via app settings at deploy time). Hide just those sections — never the whole
+  // tab, which also hosts Roles & Permissions.
+  const isAzure = state?.platform === 'azure-app-service';
 
   const exampleTenant = tenantId || '<tenant-guid>';
   const exampleClient = clientId || '<client-guid>';
@@ -114,7 +118,16 @@ export default function AuthSettingsPage() {
       {/* ─── Roles & Permissions (visible only with admin.auth) ─── */}
       {isAdmin && <RolesPermissionsSection />}
 
-      {/* ─── How to change it ──────────────────────────────── */}
+      {isAzure && (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 text-sm text-gray-600 dark:text-gray-400">
+          This deployment runs on Azure App Service. Single sign-on is configured through the
+          app's deployment settings (tenant / client / roles), not from here. Manage roles and
+          permissions above.
+        </div>
+      )}
+
+      {/* ─── How to change it (Docker only) ──────────────────────── */}
+      {!isAzure && (
       <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
         <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-3">Changing authentication settings</h3>
         <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
@@ -140,8 +153,10 @@ export default function AuthSettingsPage() {
         <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">After any change, restart the web container so the API picks up the new state:</p>
         <CopyableCommand command={restartCmd} />
       </div>
+      )}
 
-      {/* ─── Setup walkthrough ──────────────────────────────── */}
+      {/* ─── Setup walkthrough (Docker only) ─────────────────── */}
+      {!isAzure && (
       <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
         <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-3">Entra ID app registration walkthrough</h3>
         <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
@@ -222,6 +237,7 @@ export default function AuthSettingsPage() {
           </li>
         </ol>
       </div>
+      )}
     </div>
   );
 }

--- a/app/ui/src/components/admin/adminTabs.js
+++ b/app/ui/src/components/admin/adminTabs.js
@@ -1,0 +1,30 @@
+// Admin sub-tab definitions + visibility.
+//
+// `requires` lists permissions any one of which (logical OR) grants access to
+// that sub-tab. Tabs without `requires` are visible to any authenticated user
+// (read-only stuff: Performance / About).
+//
+// NOTE: visibility is permission-driven ONLY. It must NOT depend on the
+// deployment platform — the Authentication tab hosts Roles & Permissions, so
+// hiding it on (e.g.) Azure App Service would lock admins out of managing roles.
+// Platform-specific guidance (the Docker CLI walkthrough) is hidden inside
+// AuthSettingsPage instead, leaving Roles & Permissions reachable everywhere.
+
+import { hasPermission } from '../../auth/usePermissions';
+
+export const ADMIN_TABS = [
+  { key: 'crawlers',        label: 'Crawlers',         description: 'Add, configure and run identity data crawlers',                        requires: ['admin.crawlers'] },
+  { key: 'data',            label: 'Data',             description: 'Export/import curated data and clean the database',                    requires: ['data.export.ui', 'admin.csv-import', 'admin.systems', 'admin.read-tokens', 'data.export.apikey'] },
+  { key: 'account-linking', label: 'Account Linking',  description: 'Rules for linking orphan accounts to existing identities',             requires: ['admin.crawlers'] },
+  { key: 'risk-scoring',    label: 'Risk Scoring',     description: 'Risk profile, classifiers and feature toggle',                         requires: ['admin.llm', 'admin.crawlers'] },
+  { key: 'llm',             label: 'LLM Settings',     description: 'Configure the LLM provider used by risk scoring',                      requires: ['admin.llm'] },
+  { key: 'performance',     label: 'Performance',      description: 'API and SQL performance metrics' },
+
+  { key: 'auth',            label: 'Authentication',   description: 'Single sign-on and role / permission management',                      requires: ['admin.auth'] },
+  { key: 'about',           label: 'About',            description: 'License, version, and software bill of materials' },
+];
+
+// Filter the admin sub-tabs to the ones the current user may use.
+export function visibleAdminTabs(permissions, hasWildcard, tabs = ADMIN_TABS) {
+  return tabs.filter(t => !t.requires || hasPermission(permissions, hasWildcard, ...t.requires));
+}

--- a/app/ui/src/components/admin/adminTabs.test.js
+++ b/app/ui/src/components/admin/adminTabs.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { ADMIN_TABS, visibleAdminTabs } from './adminTabs.js';
+
+describe('adminTabs', () => {
+  it('keeps the Authentication tab, gated on admin.auth (it hosts Roles & Permissions)', () => {
+    const auth = ADMIN_TABS.find(t => t.key === 'auth');
+    expect(auth).toBeTruthy();
+    expect(auth.requires).toEqual(['admin.auth']);
+  });
+
+  it('shows the Authentication tab to a user with admin.auth — on any platform', () => {
+    // The whole point of the fix: visibility is permission-driven only, never
+    // suppressed by the deployment platform.
+    const tabs = visibleAdminTabs(new Set(['admin.auth']), false);
+    expect(tabs.map(t => t.key)).toContain('auth');
+  });
+
+  it('hides the Authentication tab from a user without admin.auth', () => {
+    const tabs = visibleAdminTabs(new Set(['admin.crawlers']), false);
+    expect(tabs.map(t => t.key)).not.toContain('auth');
+  });
+
+  it('a wildcard user sees every tab', () => {
+    const tabs = visibleAdminTabs(new Set(), true);
+    expect(tabs).toHaveLength(ADMIN_TABS.length);
+  });
+
+  it('always shows tabs with no `requires` (Performance, About)', () => {
+    const tabs = visibleAdminTabs(new Set(), false);
+    expect(tabs.map(t => t.key)).toEqual(expect.arrayContaining(['performance', 'about']));
+  });
+});

--- a/changes/auth-tab-visible.md
+++ b/changes/auth-tab-visible.md
@@ -1,0 +1,1 @@
+- Fixed the Admin → Authentication tab disappearing on Azure App Service deployments. Because that tab also hosts Roles & Permissions management, hiding it locked admins out of editing role permissions. The tab now stays visible to anyone with the `admin.auth` permission on every platform; only the Docker-specific setup walkthrough is hidden on Azure.


### PR DESCRIPTION
## Fix: Authentication tab disappears on Azure (locks admins out of Roles & Permissions)

### Problem
With authentication enabled and roles in use, an admin couldn't see the **Admin → Authentication** tab, so they couldn't adjust role permissions. Root cause: `AdminPage` hid the whole Authentication sub-tab whenever the deployment platform was Azure App Service:

```js
if (isAzure && t.key === 'auth') return false;
```

That was meant to hide the Docker-CLI SSO walkthrough — but the same tab also hosts **`RolesPermissionsSection`** (role/permission management), so hiding it locked admins out.

### Fix
- Admin sub-tab visibility is now **permission-driven only** (`admin.auth`), on every platform — the Authentication tab no longer depends on the platform.
- The Docker-specific setup walkthrough is hidden **inside `AuthSettingsPage`** when on Azure App Service (with a short note), leaving the status card and Roles & Permissions visible.
- Extracted `ADMIN_TABS` + `visibleAdminTabs()` into `components/admin/adminTabs.js`.

### Test
`adminTabs.test.js`: the Authentication tab is shown to anyone with `admin.auth` (regardless of platform), hidden without it, wildcard sees all, and no-`requires` tabs always show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
