### PR TITLE
chore(dependabot): pin Node to 24-slim, suppress 26+ upgrade PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
+    ignore:
+      - dependency-name: "node"
+        versions: ["26.*", ">= 27"]
 
   # Node.js API dependencies
   - package-ecosystem: "npm"

--- a/changes/pin-node-24.md
+++ b/changes/pin-node-24.md
@@ -1,0 +1,1 @@
+- Pinned Docker base image to Node 24-slim; Dependabot will no longer propose upgrades to Node 26+


### PR DESCRIPTION
- Pinned Docker base image to Node 24-slim; Dependabot will no longer propose upgrades to Node 26+

Closes the open Dependabot PR #317 (node 24→26 upgrade). Adds an `ignore` rule to the `/app/api` docker ecosystem entry so future Node 26+ proposals are suppressed automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)