### PR TITLE
fix(contexts): keep the inline rename box at a readable width

### DIFF
--- a/app/ui/src/components/contexts/ContextTreeView.jsx
+++ b/app/ui/src/components/contexts/ContextTreeView.jsx
@@ -325,7 +325,7 @@ function RenameInput({ initial, placeholder, onCommit, onCancel }) {
         else if (e.key === 'Escape') onCancel();
       }}
       onBlur={() => onCommit(value.trim())}
-      className="px-2 py-1 text-sm border border-blue-400 dark:border-blue-500 rounded bg-white dark:bg-gray-800 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-400"
+      className="w-full min-w-[260px] max-w-[480px] px-2 py-1 text-sm border border-blue-400 dark:border-blue-500 rounded bg-white dark:bg-gray-800 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-400"
     />
   );
 }

--- a/changes/context-rename-input-width.md
+++ b/changes/context-rename-input-width.md
@@ -1,0 +1,1 @@
+- Fixed the context rename box shrinking to a tiny width when you double-click a context to rename it — it now stays wide enough to read and edit the full name.


### PR DESCRIPTION
## Summary

Double-clicking a context in the tree to rename it dropped in an unsized `<input>`, which collapsed to the browser's default width — much narrower than the node pill, making long names hard to read and edit.

## Fix

Give the inline rename/add-child input a sensible width (`w-full min-w-[260px] max-w-[480px]`) so it fills the row and stays readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)