### PR TITLE
fix: crawler manifest discovery, validation, and entra-id schema

### DIFF
--- a/app/api/CLAUDE.md
+++ b/app/api/CLAUDE.md
@@ -70,6 +70,7 @@ Crawler types and their config schemas are auto-discovered from `tools/crawlers/
 **Manifest discovery path** (checked in order):
 1. `CRAWLER_MANIFESTS_DIR` env var (set to `/app/crawlers` in Docker, `bundled-scripts/tools/crawlers` in node-launcher)
 2. Relative to `src/routes/`: `../../../../tools/crawlers` (works in local dev)
-3. Hardcoded fallback list if directory is unreachable
+
+If the directory is unreachable, an error is logged and `VALID_JOB_TYPES` is empty — there is no hardcoded fallback list.
 
 **`scheduler.js`** fires scheduled crawler jobs. It imports `VALID_JOB_TYPES` and `validateCrawlerConfig` from `routes/jobs.js` — do not duplicate that logic here.

--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -27,6 +27,7 @@ COPY app/api/src ./src
 # Node.js only; scripts belong in the worker image.
 COPY tools/crawlers /app/crawlers
 RUN find /app/crawlers -name "*.ps1" -delete
+ENV CRAWLER_MANIFESTS_DIR=/app/crawlers
 # Copy the compiled frontend so Express can serve it as static files
 COPY --from=frontend-build /app/frontend/dist ../frontend/dist
 

--- a/app/api/src/routes/jobs.js
+++ b/app/api/src/routes/jobs.js
@@ -53,11 +53,9 @@ try {
         ? _ajv.compile(manifest.configSchema) : null;
     } catch (e) { console.warn(`Crawler manifest skipped (${mPath}): ${e.message}`); }
   }
-} catch { /* crawlers directory not accessible — fall through to hardcoded list */ }
+} catch (e) { console.error(`Crawler manifests directory not accessible (${CRAWLER_MANIFESTS_DIR}): ${e.message}`); }
 
-export const VALID_JOB_TYPES = Object.keys(_crawlerManifests).length > 0
-  ? Object.keys(_crawlerManifests)
-  : ['demo', 'entra-id', 'csv', 'omada'];  // fallback if manifests unavailable
+export const VALID_JOB_TYPES = Object.keys(_crawlerManifests);
 
 export function validateCrawlerConfig(type, config) {
   const validate = _configValidators[type];

--- a/app/api/src/routes/jobs.js
+++ b/app/api/src/routes/jobs.js
@@ -60,7 +60,7 @@ export const VALID_JOB_TYPES = Object.keys(_crawlerManifests);
 export function validateCrawlerConfig(type, config) {
   const validate = _configValidators[type];
   if (!validate) return null;
-  if (validate(config)) return null;
+  if (validate(config ?? {})) return null;
   return _ajv.errorsText(validate.errors, { separator: '; ' });
 }
 const MAX_RECENT_JOBS = 50;

--- a/changes/bugfixes-crawler-manifest-and-validation-fixes.md
+++ b/changes/bugfixes-crawler-manifest-and-validation-fixes.md
@@ -1,0 +1,4 @@
+- Fixed crawler manifest discovery in Docker: the API container now automatically discovers all installed crawlers at startup, so newly added crawlers are recognised without requiring code changes.
+- Removed the hardcoded crawler-type allowlist (`demo`, `entra-id`, `csv`, `omada`). The list is now built entirely from the manifest files — any crawler not present in the container is no longer silently accepted.
+- Fixed a validation error that caused the demo crawler job to be rejected when submitted without a config body.
+- Fixed the Entra ID crawler config schema so that `clientSecret` is no longer required when credentials are stored in the vault.

--- a/tools/crawlers/entra-id/crawler.json
+++ b/tools/crawlers/entra-id/crawler.json
@@ -5,7 +5,7 @@
   "dependsOn": [],
   "configSchema": {
     "type": "object",
-    "required": ["tenantId", "clientId", "clientSecret"],
+    "required": ["tenantId", "clientId"],
     "properties": {
       "tenantId":     { "type": "string" },
       "clientId":     { "type": "string" },


### PR DESCRIPTION
- Fixed crawler manifest discovery in Docker: the API container now automatically discovers all installed crawlers at startup, so newly added crawlers are recognised without requiring code changes.
- Removed the hardcoded crawler-type allowlist (`demo`, `entra-id`, `csv`, `omada`). The list is now built entirely from the manifest files — any crawler not present in the container is no longer silently accepted.
- Fixed a validation error that caused the demo crawler job to be rejected when submitted without a config body.
- Fixed the Entra ID crawler config schema so that `clientSecret` is no longer required when credentials are stored in the vault.

## Test plan
- [ ] Start the Docker stack with a new crawler added — verify it appears in the Add Crawler dropdown without touching `jobs.js`
- [ ] Queue a demo job with no config body — should succeed (200)
- [ ] Queue an Entra ID job with vault-backed clientSecret (no secret in config body) — should succeed (200)
- [ ] Verify `VALID_JOB_TYPES` logged at startup reflects manifest-discovered types only

🤖 Generated with [Claude Code](https://claude.com/claude-code)