### PR TITLE
docs(crawlers): document dev/ subfolder convention

### DIFF
--- a/docs/sync/custom-crawlers.md
+++ b/docs/sync/custom-crawlers.md
@@ -11,8 +11,23 @@ For how the system works internally, see [`docs/architecture/crawler-architectur
 ```
 tools/crawlers/my-source/
 ├── crawler.json               ← required manifest
-└── Start-MySourceCrawler.ps1  ← entry point declared in manifest
+├── Start-MySourceCrawler.ps1  ← entry point declared in manifest
+├── CLAUDE.md                  ← developer guide (architecture, data-model mapping, gotchas)
+├── Test-MySourceCrawler.ps1   ← CI integration test (optional but recommended)
+└── dev/                       ← development and testing utilities (optional)
+    ├── README.md              ← what each tool does and how to run it
+    └── Seed-MySourceData.ps1  ← example: load-test seeder, fixture generator, etc.
 ```
+
+### The `dev/` subfolder
+
+The `dev/` folder is the home for scripts that support development and testing of the crawler but are **not part of the production image** and not loaded by the dispatcher. Use it for:
+
+- **Load-test seeders** — scripts that create large volumes of test data in the source system to validate crawler performance and memory usage
+- **Fixture generators** — one-off scripts that seed a known, repeatable dataset for manual or exploratory testing
+- **Migration helpers** — scripts useful during initial setup or version upgrades of the source system
+
+The dispatcher ignores subdirectories, so nothing in `dev/` is ever executed at runtime. Include a `dev/README.md` that describes what each tool does, how to run it, and (for seeders) how to clean up afterwards.
 
 Restart the worker container after adding the folder. The new crawler appears in the UI under **Admin → Crawlers → Add Crawler** immediately.
 

--- a/tools/crawlers/CLAUDE.md
+++ b/tools/crawlers/CLAUDE.md
@@ -7,6 +7,23 @@ Architecture internals: [`docs/architecture/crawler-architecture.md`](../../docs
 
 Drop a folder into `tools/crawlers/<type>/` with `crawler.json` + entry point. No changes to `Invoke-CrawlerJob.ps1`, `IdentityAtlas.psm1`, or `pr.yml` needed. Restart the worker to pick it up.
 
+## Folder conventions
+
+```
+tools/crawlers/<type>/
+├── crawler.json                ← required manifest
+├── Start-<Type>Crawler.ps1     ← entry point
+├── CLAUDE.md                   ← developer guide (architecture, data-model mapping, gotchas)
+├── Test-<Type>Crawler.ps1      ← CI integration test
+└── dev/                        ← development tools (not shipped, not loaded by dispatcher)
+    ├── README.md               ← run instructions and cleanup notes
+    └── Seed-<Type>*.ps1        ← load-test seeders, fixture generators, etc.
+```
+
+**`dev/` subfolder:** for scripts that support development and testing but are not part of the production image. The dispatcher ignores subdirectories entirely — nothing in `dev/` ever runs at runtime. Use it for load-test seeders, fixture generators, and migration helpers. Always include a `dev/README.md`.
+
+See `docs/sync/custom-crawlers.md` for the full authoring guide including the `dev/` folder convention.
+
 ## Rules
 
 - Every `.ps1` file must have `[CmdletBinding()]` — the Pester quality gate enforces this.


### PR DESCRIPTION
## Summary

- Adds the `dev/` subfolder convention to the canonical crawler folder structure in both the user-facing authoring guide and the developer quick-reference
- Documents what belongs in `dev/` (load-test seeders, fixture generators, migration helpers), that it is not shipped in the production image, and the README requirement
- Introduced by the midPoint crawler's `tools/crawlers/midpoint/dev/` (load-test seeder + results)

## Changes

- `docs/sync/custom-crawlers.md` — updated Folder Structure section with `dev/` entry, added "The `dev/` subfolder" explanation paragraph
- `tools/crawlers/CLAUDE.md` — added Folder conventions section with ASCII tree and `dev/` description

## Test plan

- [ ] Docs render correctly in GitHub
- [ ] No existing crawler behaviour changes (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)