### PR TITLE
feat(midpoint): sync department from user's primary org-unit

### DIFF
--- a/changes/feature-midpoint-department-sync.md
+++ b/changes/feature-midpoint-department-sync.md
@@ -1,0 +1,1 @@
+- The midPoint crawler now fills the **department** field on both identities and their midPoint accounts, derived from the user's primary organizational unit (org membership).

--- a/test/unit/Midpoint.Tests.ps1
+++ b/test/unit/Midpoint.Tests.ps1
@@ -101,6 +101,55 @@ Describe 'Get-MidpointRefType' {
     }
 }
 
+# ─── Resolve-MidpointDepartment ───────────────────────────────────────────────
+Describe 'Resolve-MidpointDepartment' {
+    BeforeAll {
+        $script:orgMap = @{
+            'org-hr'    = 'HR'
+            'org-it'    = 'IT'
+            'org-board' = 'Board'
+        }
+    }
+    It 'resolves a single org membership to its display name' {
+        $u = [pscustomobject]@{ parentOrgRef = [pscustomobject]@{ oid = 'org-hr'; type = 'c:OrgType' } }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be 'HR'
+    }
+    It 'treats an absent relation as the default org' {
+        $u = [pscustomobject]@{ parentOrgRef = [pscustomobject]@{ oid = 'org-it' } }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be 'IT'
+    }
+    It 'prefers the org:default ref over a manager/meta ref' {
+        $u = [pscustomobject]@{ parentOrgRef = @(
+            [pscustomobject]@{ oid = 'org-board'; relation = 'org:manager' },
+            [pscustomobject]@{ oid = 'org-hr';    relation = 'org:default' }
+        ) }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be 'HR'
+    }
+    It 'matches a bare "default" relation too' {
+        $u = [pscustomobject]@{ parentOrgRef = [pscustomobject]@{ oid = 'org-it'; relation = 'default' } }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be 'IT'
+    }
+    It 'falls back to the first ref when no default-relation org is present' {
+        $u = [pscustomobject]@{ parentOrgRef = @(
+            [pscustomobject]@{ oid = 'org-it';    relation = 'org:manager' },
+            [pscustomobject]@{ oid = 'org-board'; relation = 'org:meta' }
+        ) }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be 'IT'
+    }
+    It 'returns empty when the user has no org membership' {
+        $u = [pscustomobject]@{ name = 'lonely' }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be ''
+    }
+    It 'returns empty when the org was not synced (not in the map)' {
+        $u = [pscustomobject]@{ parentOrgRef = [pscustomobject]@{ oid = 'org-unknown'; relation = 'org:default' } }
+        Resolve-MidpointDepartment -User $u -OrgMap $script:orgMap | Should -Be ''
+    }
+    It 'returns empty for a null user without throwing' {
+        { Resolve-MidpointDepartment -User $null -OrgMap $script:orgMap } | Should -Not -Throw
+        Resolve-MidpointDepartment -User $null -OrgMap $script:orgMap | Should -Be ''
+    }
+}
+
 # ─── Test-MidpointEnabled ─────────────────────────────────────────────────────
 Describe 'Test-MidpointEnabled' {
     It 'returns true when activation.effectiveStatus is enabled' {

--- a/tools/crawlers/midpoint/CLAUDE.md
+++ b/tools/crawlers/midpoint/CLAUDE.md
@@ -32,7 +32,8 @@ A crawler is a folder under `tools/crawlers/<type>/` with a `crawler.json` manif
 | `ShadowType kind=generic`/other | **Skipped** | OU/container/DB rows — no user account |
 | Account → entitlement membership | **ResourceAssignments** (`assignmentType=Direct`) | Via `association[]` or (4.9+) `referenceAttributes.<name>[]`, consolidated on the owner focus principal, `viaAccount` in `extendedAttributes` |
 | `user.assignment[]` → Role/Service | **ResourceAssignments** (`assignmentType=Governed`) | |
-| `user.parentOrgRef[]` | **ContextMembers** | |
+| `user.parentOrgRef[]` | **ContextMembers** | All org memberships |
+| `user.parentOrgRef` (default relation) | **Identity.department** + focus **Principal.department** | The user's primary org-unit name; see `Resolve-MidpointDepartment` |
 | `accessCertificationCampaigns` | **CertificationDecisions** | Requires `?include=case` |
 
 midPoint OIDs are UUIDs and are reused 1-to-1 as `id`/`externalId` — every record is traceable to the source object.

--- a/tools/crawlers/midpoint/Invoke-MidpointApi.ps1
+++ b/tools/crawlers/midpoint/Invoke-MidpointApi.ps1
@@ -403,6 +403,41 @@ function Get-MidpointRefRelation {
     return $Fallback
 }
 
+function Resolve-MidpointDepartment {
+    <#
+    .SYNOPSIS
+        Derive a user's department from its org membership. A midPoint user can sit in
+        several orgs via parentOrgRef[], each carrying a relation (org:default,
+        org:manager, org:meta, …). The "department" is the user's PRIMARY org — the ref
+        whose relation is the default (org:default, or absent — midPoint's implied default).
+        Other relations (manager/meta/owner/approver) are ignored. Falls back to the first
+        ref when no default-relation ref is present. The chosen org OID is resolved to its
+        display name via $OrgMap (OrgType OID → display name). Returns '' when the user has
+        no org or the org wasn't synced.
+    .PARAMETER User
+        The midPoint UserType object (must expose .parentOrgRef).
+    .PARAMETER OrgMap
+        Hashtable of org OID → display name, built during the Orgs phase.
+    #>
+    [CmdletBinding()]
+    param($User, $OrgMap)
+    if ($null -eq $User -or $null -eq $OrgMap) { return '' }
+    $refs = @($User.parentOrgRef) | Where-Object { $_ }
+    if ($refs.Count -eq 0) { return '' }
+
+    $chosen = $null
+    foreach ($ref in $refs) {
+        $rel = Get-MidpointRefRelation $ref ''
+        # Default relation = empty (implied) or any QName ending in ":default" / equal to "default".
+        if (-not $rel -or $rel -eq 'default' -or $rel -match ':default$') { $chosen = $ref; break }
+    }
+    if (-not $chosen) { $chosen = $refs[0] }   # no default-relation org → first ref
+
+    $oid = Get-MidpointRefOid $chosen $null
+    if ($oid -and $OrgMap.ContainsKey($oid)) { return [string]$OrgMap[$oid] }
+    return ''
+}
+
 function Get-MidpointString {
     <#
     .SYNOPSIS

--- a/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
@@ -257,6 +257,7 @@ $ResourceSystemId        = @{}                                                  
 $ResourceOidToName       = @{}                                                   # resource OID → display name (for readable shadow labels)
 $UserOidToName           = @{}                                                   # user OID → display name (for readable shadow labels)
 $SyncedOrgIds            = [System.Collections.Generic.HashSet[string]]::new()  # OrgType OIDs synced as Contexts
+$OrgOidToName            = @{}                                                   # OrgType OID → display name (for the user's department)
 $SyncedResourceIds       = [System.Collections.Generic.HashSet[string]]::new()  # Role/Service OIDs synced as Resources
 $AllUsers                = $null
 $ShadowOidToUserOid      = @{}                                                   # shadow OID → owning user OID (from user.linkRef)
@@ -367,7 +368,7 @@ if ($Sync.orgs) {
 
         $R = Send-IngestBatch -Endpoint 'ingest/contexts' -SystemId $MidpointSystemId `
             -Scope @{ variant = 'synced'; contextType = 'OrgUnit'; scopeSystemId = $MidpointSystemId } -Records @($records)
-        $records | ForEach-Object { [void]$SyncedOrgIds.Add($_.id) }
+        $records | ForEach-Object { [void]$SyncedOrgIds.Add($_.id); $OrgOidToName[$_.id] = $_.displayName }
         Write-Host "  Contexts: +$($R.inserted) ~$($R.updated) -$($R.deleted)" -ForegroundColor Green
     } catch { Add-PhaseError 'Orgs' $_.Exception.Message }
 }
@@ -441,6 +442,8 @@ if ($Sync.users) {
             $oid  = [string]$u.oid
             $name = (Get-MidpointString $u.fullName (Get-MidpointString $u.name $oid))
             $UserOidToName[$oid] = $name
+            # Department = the user's primary org-unit (parentOrgRef, default relation).
+            $department = (Resolve-MidpointDepartment -User $u -OrgMap $OrgOidToName)
             $identRecs.Add([PSCustomObject]@{
                 id          = $oid
                 externalId  = $oid
@@ -450,6 +453,7 @@ if ($Sync.users) {
                 email       = (Get-MidpointString $u.emailAddress '')
                 employeeId  = (Get-MidpointString $u.employeeNumber '')
                 jobTitle    = (Get-MidpointString $u.title '')
+                department  = $department
                 extendedAttributes = @{
                     name           = (Get-MidpointString $u.name '')
                     lifecycleState = (Get-MidpointString $u.lifecycleState '')
@@ -464,6 +468,7 @@ if ($Sync.users) {
                 principalType  = 'User'
                 accountEnabled = (Test-MidpointEnabled $u)
                 jobTitle       = (Get-MidpointString $u.title '')
+                department     = $department
                 extendedAttributes = @{ name = (Get-MidpointString $u.name ''); source = 'midpoint-focus' }
             })
             $memberRecs.Add([PSCustomObject]@{ identityId = $oid; principalId = $oid; accountType = 'Primary'; isPrimary = $true })

--- a/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
@@ -124,6 +124,18 @@ try {
         Report-Result 'Midpoint/Data — user principal ingested' ($cnt -ge 1) "($cnt matching 'midpoint.citest')"
     } catch { Report-Result 'Midpoint/Data — user principal ingested' $false $_.Exception.Message }
 
+    # ── Assert: department derived from the user's org membership (parentOrgRef → org name) ──
+    # The mock user sits in 'midPoint CI Org' via parentOrgRef; Resolve-MidpointDepartment
+    # must have stamped that org's display name onto both the Identity and its focus Principal.
+    try {
+        $ident    = Invoke-RestMethod -Uri "$ApiBaseUrl/identities/$userOid" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
+        $identDept = $ident.identity.department
+        $focus     = @($ident.members) | Where-Object { $_.principalId -eq $userOid } | Select-Object -First 1
+        $princDept = if ($focus) { $focus.department } else { $null }
+        $ok = ($identDept -eq 'midPoint CI Org') -and ($princDept -eq 'midPoint CI Org')
+        Report-Result 'Midpoint/Data — department from org membership (Identity + Principal)' $ok "(identity: '$identDept', principal: '$princDept'; expected 'midPoint CI Org')"
+    } catch { Report-Result 'Midpoint/Data — department from org membership (Identity + Principal)' $false $_.Exception.Message }
+
     # ── Assert: role resource ingested (scoped to this run's system) ──
     try {
         $sid = if ($thisSystem) { $thisSystem.id } else { 0 }


### PR DESCRIPTION
## Summary
The midPoint crawler now fills the **department** field on both identities and their midPoint accounts, derived from the user's primary organizational unit (org membership).

## How it works
- New helper `Resolve-MidpointDepartment` picks the user's **primary** org from `parentOrgRef[]` — the ref with the default relation (`org:default`, or absent = midPoint's implied default). Other relations (manager/meta/owner/approver) are ignored; falls back to the first ref when no default-relation org exists.
- A new `$OrgOidToName` map is built during the Orgs phase to resolve the chosen org OID to its display name.
- The resolved name is set as `department` on both the Identity and the focus Principal in the Users phase.
- No schema or API change needed — the `department` columns already exist on `Identities` and `Principals`, and the ingest engine maps the field automatically.

## Testing
- 8 new Pester unit tests for `Resolve-MidpointDepartment` — 61/61 green.
- New assertion in the integration test verifying department lands on both Identity and Principal.
- **Live-verified** on the edge VM against midpoint-dev: department went from 0 → 311 populated identities/principals; multi-org users resolve to a single correct value (e.g. a user in 22 org-units → one primary department); confirmed visible in the Identities list and detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)