### PR TITLE
feat: identity-level assignment support for ResourceAssignments

### DIFF
--- a/app/api/src/db/migrations/036_resource_assignments_identity_support.sql
+++ b/app/api/src/db/migrations/036_resource_assignments_identity_support.sql
@@ -1,7 +1,7 @@
 -- Identity Atlas — add identity-level assignment support to ResourceAssignments.
 --
--- Allows IGA crawlers to assign business roles to an Identity (person) rather
--- than a specific Principal (account). Both targets remain valid simultaneously.
+-- Allows IGA crawlers to assign any access to a person rather than a specific
+-- account (Principal). Both assignment targets remain valid simultaneously.
 --
 -- Changes:
 --   1. Drop the composite PK (includes principalId which becomes nullable)

--- a/app/api/src/db/migrations/036_resource_assignments_identity_support.sql
+++ b/app/api/src/db/migrations/036_resource_assignments_identity_support.sql
@@ -1,0 +1,52 @@
+-- Identity Atlas — add identity-level assignment support to ResourceAssignments.
+--
+-- Allows IGA crawlers to assign business roles to an Identity (person) rather
+-- than a specific Principal (account). Both targets remain valid simultaneously.
+--
+-- Changes:
+--   1. Drop the composite PK (includes principalId which becomes nullable)
+--   2. Make principalId nullable
+--   3. Add identityId — bare UUID, no FK (symmetric with principalId)
+--   4. XOR CHECK: exactly one of principalId / identityId must be non-null
+--   5. Two partial unique indexes replace the composite PK
+--   6. Supporting index for identity-side lookups
+--
+-- No data migration needed: existing rows have principalId set and identityId
+-- NULL, which satisfies the XOR CHECK (principalId IS NOT NULL ∧ identityId IS
+-- NULL → sum = 1). Brief exclusive lock on startup before API traffic arrives.
+
+-- 1. Drop the existing PK (it includes principalId which will become nullable)
+ALTER TABLE "ResourceAssignments"
+    DROP CONSTRAINT "ResourceAssignments_pkey";
+
+-- 2. Make principalId nullable
+ALTER TABLE "ResourceAssignments"
+    ALTER COLUMN "principalId" DROP NOT NULL;
+
+-- 3. Add identityId column — bare UUID, no FK (symmetric with principalId).
+--    Both columns rely on the crawler ordering contract for data integrity.
+--    A FK + CASCADE can be added in a later migration once principalId also
+--    gets a FK, making the two columns consistent.
+ALTER TABLE "ResourceAssignments"
+    ADD COLUMN "identityId" UUID;
+
+-- 4. Enforce: exactly one of principalId / identityId must be non-null
+ALTER TABLE "ResourceAssignments"
+    ADD CONSTRAINT "ck_RA_principal_or_identity"
+    CHECK (
+        ("principalId" IS NOT NULL)::int + ("identityId" IS NOT NULL)::int = 1
+    );
+
+-- 5. Recreate uniqueness as two partial unique indexes (replaces the PK)
+CREATE UNIQUE INDEX "uq_RA_principal"
+    ON "ResourceAssignments"("resourceId", "principalId", "assignmentType")
+    WHERE "principalId" IS NOT NULL;
+
+CREATE UNIQUE INDEX "uq_RA_identity"
+    ON "ResourceAssignments"("resourceId", "identityId", "assignmentType")
+    WHERE "identityId" IS NOT NULL;
+
+-- 6. Supporting index for identity-side lookups
+CREATE INDEX "ix_RA_identityId"
+    ON "ResourceAssignments"("identityId")
+    WHERE "identityId" IS NOT NULL;

--- a/app/api/src/db/migrations/037_matrix_view.test.js
+++ b/app/api/src/db/migrations/037_matrix_view.test.js
@@ -1,0 +1,60 @@
+// SQL structure tests for migration 037_matrix_view_identity_support.sql
+//
+// These tests verify the matview SQL contains the structural elements required
+// for identity-level assignment expansion without needing a running database.
+// They catch regressions if the UNION arm or key WHERE guards are accidentally
+// removed.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sql = readFileSync(join(__dirname, '037_matrix_view_identity_support.sql'), 'utf8');
+
+describe('migration 037 — matview identity arm structure (T7.7, T7.8)', () => {
+  it('drops the dependent regular view before the matview (T7.7)', () => {
+    const dropView    = sql.indexOf('DROP VIEW IF EXISTS "vw_UserPermissionAssignments"');
+    const dropMatview = sql.indexOf('DROP MATERIALIZED VIEW IF EXISTS "vw_ResourceUserPermissionAssignments"');
+    expect(dropView,    'DROP VIEW must be present').toBeGreaterThan(-1);
+    expect(dropMatview, 'DROP MATERIALIZED VIEW must be present').toBeGreaterThan(-1);
+    // Dependent view must be dropped first — otherwise Postgres errors on CASCADE
+    expect(dropView).toBeLessThan(dropMatview);
+  });
+
+  it('contains a UNION ALL arm for identity-level assignments', () => {
+    expect(sql).toContain('UNION ALL');
+  });
+
+  it('identity arm joins IdentityMembers (T7.7)', () => {
+    expect(sql).toContain('"IdentityMembers" im');
+    expect(sql).toContain('im."identityId" = ra."identityId"');
+  });
+
+  it('identity arm is guarded by WHERE identityId IS NOT NULL', () => {
+    expect(sql).toContain('ra."identityId" IS NOT NULL');
+  });
+
+  it('principal arm is guarded by WHERE principalId IS NOT NULL (T7.8)', () => {
+    // An identity with no IdentityMembers rows must not appear in the matview.
+    // Conversely, principal rows must still flow through the existing arm.
+    // The WHERE guard on the principal arm ensures the INNER JOIN in the
+    // identity arm does not accidentally expand principal rows.
+    expect(sql).toContain('ra."principalId" IS NOT NULL');
+  });
+
+  it('governed_pairs CTE filters to principalId IS NOT NULL', () => {
+    // governed_pairs was previously unconstrained; with nullable principalId
+    // a NULL = UUID comparison would silently drop governed_pairs matches.
+    expect(sql).toMatch(/"assignmentType" = 'Governed'[\s\S]*?"principalId" IS NOT NULL/);
+  });
+
+  it('GROUP BY dedup is preserved so cross-arm duplicates collapse (T7.7)', () => {
+    expect(sql).toContain('GROUP BY "resourceId", "principalId", "membershipType"');
+  });
+
+  it('recreates the regular compat view over the matview', () => {
+    expect(sql).toContain('CREATE VIEW "vw_UserPermissionAssignments"');
+  });
+});

--- a/app/api/src/db/migrations/037_matrix_view_identity_support.sql
+++ b/app/api/src/db/migrations/037_matrix_view_identity_support.sql
@@ -1,0 +1,83 @@
+-- Identity Atlas — rebuild matrix view to expand identity-level assignments.
+--
+-- Adds a UNION arm inside the `collapsed` CTE that joins ResourceAssignments
+-- (identityId IS NOT NULL) through IdentityMembers to produce one row per
+-- principal. The existing GROUP BY dedup absorbs cross-arm duplicates so a
+-- person with both a principal-level and an identity-level assignment to the
+-- same resource yields a single matrix cell.
+--
+-- Pattern mirrors migration 026: drop the dependent view first, then the
+-- matview, then recreate both.
+
+DROP VIEW IF EXISTS "vw_UserPermissionAssignments";
+DROP MATERIALIZED VIEW IF EXISTS "vw_ResourceUserPermissionAssignments";
+
+CREATE MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments" AS
+WITH governed_pairs AS (
+    SELECT DISTINCT "resourceId", "principalId"
+      FROM "ResourceAssignments"
+     WHERE "assignmentType" = 'Governed'
+       AND "principalId" IS NOT NULL
+),
+collapsed AS (
+    -- Existing arm: principal-level assignments
+    SELECT
+        ra."resourceId",
+        ra."principalId",
+        ra."principalType",
+        CASE
+          WHEN ra."assignmentType" IN ('Governed', 'OAuth2Grant', 'AppRole') THEN 'Direct'
+          WHEN ra."assignmentType" = 'AppRoleViaGroup'                       THEN 'Indirect'
+          ELSE ra."assignmentType"
+        END AS "membershipType",
+        (ra."assignmentType" = 'Governed' OR gp."resourceId" IS NOT NULL) AS "managedByAccessPackage"
+    FROM "ResourceAssignments" ra
+    LEFT JOIN governed_pairs gp
+           ON gp."resourceId"  = ra."resourceId"
+          AND gp."principalId" = ra."principalId"
+    WHERE ra."principalId" IS NOT NULL
+
+    UNION ALL
+
+    -- New arm: identity-level assignments expanded through IdentityMembers
+    SELECT
+        ra."resourceId",
+        im."principalId",
+        NULL AS "principalType",
+        CASE
+          WHEN ra."assignmentType" IN ('Governed', 'OAuth2Grant', 'AppRole') THEN 'Direct'
+          WHEN ra."assignmentType" = 'AppRoleViaGroup'                       THEN 'Indirect'
+          ELSE ra."assignmentType"
+        END AS "membershipType",
+        (ra."assignmentType" = 'Governed') AS "managedByAccessPackage"
+    FROM "ResourceAssignments" ra
+    JOIN "IdentityMembers" im ON im."identityId" = ra."identityId"
+    WHERE ra."identityId" IS NOT NULL
+)
+SELECT
+    "resourceId",
+    "principalId",
+    MAX("principalType") AS "principalType",
+    "membershipType",
+    bool_or("managedByAccessPackage") AS "managedByAccessPackage"
+FROM collapsed
+GROUP BY "resourceId", "principalId", "membershipType"
+WITH NO DATA;
+
+CREATE UNIQUE INDEX "ix_vw_ResUserPerm_pk"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId", "principalId", "membershipType");
+CREATE INDEX "ix_vw_ResUserPerm_principalId"
+    ON "vw_ResourceUserPermissionAssignments" ("principalId");
+CREATE INDEX "ix_vw_ResUserPerm_resourceId"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId");
+
+CREATE VIEW "vw_UserPermissionAssignments" AS
+SELECT
+    "resourceId"  AS "groupId",
+    "principalId" AS "memberId",
+    "principalType",
+    "membershipType",
+    "managedByAccessPackage"
+FROM "vw_ResourceUserPermissionAssignments";
+
+-- bootstrap.js refreshMatrixViews() repopulates the matview at startup.

--- a/app/api/src/ingest/engine.js
+++ b/app/api/src/ingest/engine.js
@@ -64,6 +64,7 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
     systemIdColumn = 'systemId',
     tempTable: existingTempTable = null,
     scopeDeleteFilter = null,
+    conflictFilter = null,
   } = options;
 
   if (!records || records.length === 0) {
@@ -134,6 +135,11 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
     const nonKeyCols = activeColumns.filter(c => !keyColumns.includes(c.name));
     const insertCols = activeColumns.map(c => `"${c.name}"`).join(', ');
     const onConflictCols = keyColumns.map(c => `"${c}"`).join(', ');
+    // conflictFilter supports partial unique indexes (e.g. ResourceAssignments
+    // uses two partial indexes after migration 036 replaced the composite PK).
+    // PostgreSQL requires the WHERE clause of the conflict inference to match
+    // the partial index predicate exactly.
+    const conflictWhere = conflictFilter ? ` WHERE ${conflictFilter}` : '';
 
     let upsertSql;
     if (nonKeyCols.length > 0) {
@@ -149,14 +155,14 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
       upsertSql = `
         INSERT INTO "${tableName}" (${insertCols})
         SELECT ${insertCols} FROM "${tempName}"
-        ON CONFLICT (${onConflictCols}) DO UPDATE SET ${updateSet}
+        ON CONFLICT (${onConflictCols})${conflictWhere} DO UPDATE SET ${updateSet}
         RETURNING (xmax = 0) AS "wasInsert"
       `;
     } else {
       upsertSql = `
         INSERT INTO "${tableName}" (${insertCols})
         SELECT ${insertCols} FROM "${tempName}"
-        ON CONFLICT (${onConflictCols}) DO NOTHING
+        ON CONFLICT (${onConflictCols})${conflictWhere} DO NOTHING
         RETURNING (xmax = 0) AS "wasInsert"
       `;
     }

--- a/app/api/src/ingest/engine.js
+++ b/app/api/src/ingest/engine.js
@@ -63,6 +63,7 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
     scope = {},
     systemIdColumn = 'systemId',
     tempTable: existingTempTable = null,
+    scopeDeleteFilter = null,
   } = options;
 
   if (!records || records.length === 0) {
@@ -171,14 +172,14 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
     let deleted = 0;
     if (syncMode === 'full') {
       const tableColumnNames = new Set(columns.map(c => c.name));
-      deleted = await scopedDelete(client, tableName, keyColumns, tempName, systemId, scope, systemIdColumn, tableColumnNames);
+      deleted = await scopedDelete(client, tableName, keyColumns, tempName, systemId, scope, systemIdColumn, tableColumnNames, scopeDeleteFilter);
     }
 
     return { inserted, updated, deleted };
   });
 }
 
-export async function scopedDelete(client, tableName, keyColumns, tempName, systemId, scope, systemIdColumn, tableColumnNames) {
+export async function scopedDelete(client, tableName, keyColumns, tempName, systemId, scope, systemIdColumn, tableColumnNames, scopeDeleteFilter = null) {
   // Before the DELETE: create a unique index on the temp table over the
   // same key columns the NOT EXISTS uses, then ANALYZE so the planner has
   // accurate row counts. Without these the planner does a sequential scan
@@ -216,6 +217,8 @@ export async function scopedDelete(client, tableName, keyColumns, tempName, syst
   // IdentityMembers, so this is a no-op for every other table.)
   if (tableColumnNames.has('linkConfidence'))  where += ` AND t."linkConfidence" IS NULL`;
   if (tableColumnNames.has('analystOverride')) where += ` AND t."analystOverride" IS NULL`;
+
+  if (scopeDeleteFilter) where += ` AND (${scopeDeleteFilter})`;
 
   const notExistsJoin = keyColumns.map(k => `t."${k}" = src."${k}"`).join(' AND ');
   const sql = `

--- a/app/api/src/ingest/engine.test.js
+++ b/app/api/src/ingest/engine.test.js
@@ -21,6 +21,48 @@ function fakeClient() {
   };
 }
 
+// ── scopedDelete — scopeDeleteFilter cross-contamination prevention (T7.5, T7.6)
+
+describe('scopedDelete — scopeDeleteFilter cross-contamination prevention', () => {
+  const raCols = new Set(['resourceId', 'principalId', 'identityId', 'assignmentType', 'systemId']);
+
+  it('appends the filter so identity full-sync only deletes identity rows (T7.5)', async () => {
+    const client = fakeClient();
+    await scopedDelete(
+      client, 'ResourceAssignments', ['resourceId', 'identityId', 'assignmentType'],
+      '_tmp_ingest_abc', 7, {}, 'systemId', raCols,
+      '"identityId" IS NOT NULL'
+    );
+    expect(client.deleteSql).toContain('"identityId" IS NOT NULL');
+    // Must NOT accidentally scope-delete principal rows
+    expect(client.deleteSql).not.toContain('"principalId" IS NOT NULL');
+  });
+
+  it('appends the filter so principal full-sync only deletes principal rows (T7.6)', async () => {
+    const client = fakeClient();
+    await scopedDelete(
+      client, 'ResourceAssignments', ['resourceId', 'principalId', 'assignmentType'],
+      '_tmp_ingest_abc', 7, {}, 'systemId', raCols,
+      '"principalId" IS NOT NULL'
+    );
+    expect(client.deleteSql).toContain('"principalId" IS NOT NULL');
+    expect(client.deleteSql).not.toContain('"identityId" IS NOT NULL');
+  });
+
+  it('adds no extra clause when scopeDeleteFilter is null (non-RA tables)', async () => {
+    const client = fakeClient();
+    const resCols = new Set(['id', 'systemId', 'displayName']);
+    await scopedDelete(
+      client, 'Resources', ['id'], '_tmp_ingest_def', 7, {}, 'systemId', resCols, null
+    );
+    const sql = client.deleteSql;
+    expect(sql).toContain('DELETE FROM "Resources"');
+    expect(sql).not.toContain('identityId');
+  });
+});
+
+// ── scopedDelete — account-linking / analyst link preservation ────────────────
+
 describe('scopedDelete — account-linking / analyst link preservation', () => {
   it('excludes scored and analyst-owned rows when those columns exist (IdentityMembers)', async () => {
     const client = fakeClient();

--- a/app/api/src/ingest/normalization.test.js
+++ b/app/api/src/ingest/normalization.test.js
@@ -36,6 +36,54 @@ describe('coerceValue', () => {
   });
 });
 
+// ── identityExternalId resolution (T7.4) ─────────────────────────────────────
+
+describe('normalizeRecords — identityExternalId resolution', () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const coreColumns = ['resourceId', 'identityId', 'assignmentType', 'systemId'];
+  const opts = { idGeneration: 'deterministic', idPrefix: 'Omada-sys1', systemId: 1 };
+
+  it('resolves identityExternalId to a deterministic UUID in identityId', () => {
+    const result = normalizeRecords(
+      [{ resourceId: 'aaaa0000-0000-0000-0000-000000000000', identityExternalId: 'alice', assignmentType: 'Governed' }],
+      coreColumns, opts
+    );
+    expect(result[0].identityId).toMatch(UUID_RE);
+  });
+
+  it('produces the same UUID on every call for the same input', () => {
+    const rec = [{ resourceId: 'aaaa0000-0000-0000-0000-000000000000', identityExternalId: 'alice', assignmentType: 'Governed' }];
+    const r1 = normalizeRecords(rec, coreColumns, opts)[0].identityId;
+    const r2 = normalizeRecords(rec, coreColumns, opts)[0].identityId;
+    expect(r1).toBe(r2);
+  });
+
+  it('does not overwrite an explicit identityId with external resolution', () => {
+    const explicit = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    const result = normalizeRecords(
+      [{ resourceId: 'aaaa0000-0000-0000-0000-000000000000', identityId: explicit, identityExternalId: 'alice', assignmentType: 'Governed' }],
+      coreColumns, opts
+    );
+    expect(result[0].identityId).toBe(explicit);
+  });
+
+  it('uses the same namespace as identity-members (sysPrefix-identities)', () => {
+    // The identity assignment resolver and the identity-members resolver must
+    // derive the same UUID from the same externalId — otherwise an assignment
+    // row pushed before account linking would never match the IdentityMembers row
+    // later pushed by the same crawler with identityExternalId.
+    const assignmentResult = normalizeRecords(
+      [{ resourceId: 'aaaa0000-0000-0000-0000-000000000000', identityExternalId: 'alice', assignmentType: 'Governed' }],
+      coreColumns, opts
+    );
+    const memberResult = normalizeRecords(
+      [{ identityExternalId: 'alice', principalId: 'bbbb0000-0000-0000-0000-000000000000' }],
+      ['identityId', 'principalId'], opts
+    );
+    expect(assignmentResult[0].identityId).toBe(memberResult[0].identityId);
+  });
+});
+
 describe('normalizeRecords — boolean fields', () => {
   it('preserves boolean true as boolean in core columns', () => {
     const result = normalizeRecords(

--- a/app/api/src/ingest/sessions.js
+++ b/app/api/src/ingest/sessions.js
@@ -91,6 +91,7 @@ export async function startSession(_pool, tableName, keyColumns, records, option
     scope: options.scope || {},
     systemIdColumn: options.systemIdColumn || 'systemId',
     scopeDeleteFilter: options.scopeDeleteFilter || null,
+    conflictFilter: options.conflictFilter || null,
     startedAt: Date.now(),
     recordCount: records.length,
   });
@@ -119,6 +120,7 @@ export async function endSession(syncId, _pool, records, _keyColumns, options = 
     const nonKeyCols = session.activeColumns.filter(c => !session.keyColumns.includes(c.name));
     const insertCols = session.activeColumns.map(c => `"${c.name}"`).join(', ');
     const onConflictCols = session.keyColumns.map(c => `"${c}"`).join(', ');
+    const conflictWhere = session.conflictFilter ? ` WHERE ${session.conflictFilter}` : '';
 
     let upsertSql;
     if (nonKeyCols.length > 0) {
@@ -126,14 +128,14 @@ export async function endSession(syncId, _pool, records, _keyColumns, options = 
       upsertSql = `
         INSERT INTO "${session.tableName}" (${insertCols})
         SELECT ${insertCols} FROM "${session.tempTable}"
-        ON CONFLICT (${onConflictCols}) DO UPDATE SET ${updateSet}
+        ON CONFLICT (${onConflictCols})${conflictWhere} DO UPDATE SET ${updateSet}
         RETURNING (xmax = 0) AS "wasInsert"
       `;
     } else {
       upsertSql = `
         INSERT INTO "${session.tableName}" (${insertCols})
         SELECT ${insertCols} FROM "${session.tempTable}"
-        ON CONFLICT (${onConflictCols}) DO NOTHING
+        ON CONFLICT (${onConflictCols})${conflictWhere} DO NOTHING
         RETURNING (xmax = 0) AS "wasInsert"
       `;
     }

--- a/app/api/src/ingest/sessions.js
+++ b/app/api/src/ingest/sessions.js
@@ -90,6 +90,7 @@ export async function startSession(_pool, tableName, keyColumns, records, option
     systemId: options.systemId,
     scope: options.scope || {},
     systemIdColumn: options.systemIdColumn || 'systemId',
+    scopeDeleteFilter: options.scopeDeleteFilter || null,
     startedAt: Date.now(),
     recordCount: records.length,
   });
@@ -149,7 +150,8 @@ export async function endSession(syncId, _pool, records, _keyColumns, options = 
       const tableColumnNames = new Set(session.columns.map(c => c.name));
       deleted = await scopedDelete(
         session.client, session.tableName, session.keyColumns, session.tempTable,
-        session.systemId, session.scope, session.systemIdColumn, tableColumnNames
+        session.systemId, session.scope, session.systemIdColumn, tableColumnNames,
+        session.scopeDeleteFilter
       );
     }
 

--- a/app/api/src/ingest/validation.js
+++ b/app/api/src/ingest/validation.js
@@ -80,6 +80,8 @@ const SCHEMAS = {
       principalId: { type: 'uuid' },
       resourceExternalId: { type: 'string', maxLength: 500 },
       principalExternalId: { type: 'string', maxLength: 500 },
+      identityId: { type: 'uuid' },
+      identityExternalId: { type: 'string', maxLength: 500 },
       principalType: { type: 'string', maxLength: 50 },
       assignmentType: { type: 'string', enum: ASSIGNMENT_TYPES },
       complianceState: { type: 'string', maxLength: 50 },
@@ -88,6 +90,27 @@ const SCHEMAS = {
       assignmentStatus: { type: 'string', maxLength: 50 },
       expirationDateTime: { type: 'string' },
       extendedAttributes: { type: 'json' },
+    },
+  },
+  'resource-assignments-identity': {
+    required: ['assignmentType'],
+    requiredOneOf: [
+      { fields: ['resourceId', 'resourceExternalId'] },
+      { fields: ['identityId', 'identityExternalId'] },
+    ],
+    fields: {
+      resourceId:          { type: 'uuid' },
+      resourceExternalId:  { type: 'string', maxLength: 500 },
+      identityId:          { type: 'uuid' },
+      identityExternalId:  { type: 'string', maxLength: 500 },
+      assignmentType:      { type: 'string', enum: ASSIGNMENT_TYPES },
+      principalType:       { type: 'string', maxLength: 50 },
+      complianceState:     { type: 'string', maxLength: 50 },
+      policyId:            { type: 'string', maxLength: 255 },
+      state:               { type: 'string', maxLength: 50 },
+      assignmentStatus:    { type: 'string', maxLength: 50 },
+      expirationDateTime:  { type: 'string' },
+      extendedAttributes:  { type: 'json' },
     },
   },
   'resource-relationships': {
@@ -280,6 +303,7 @@ export const ENTITY_TABLE_MAP = {
   'principals': 'Principals',
   'resources': 'Resources',
   'resource-assignments': 'ResourceAssignments',
+  'resource-assignments-identity': 'ResourceAssignments',
   'resource-relationships': 'ResourceRelationships',
   'identities': 'Identities',
   'identity-members': 'IdentityMembers',
@@ -298,6 +322,7 @@ export const ENTITY_KEY_MAP = {
   'principals': ['id'],
   'resources': ['id'],
   'resource-assignments': ['resourceId', 'principalId', 'assignmentType'],
+  'resource-assignments-identity': ['resourceId', 'identityId', 'assignmentType'],
   'resource-relationships': ['parentResourceId', 'childResourceId', 'relationshipType'],
   'identities': ['id'],
   'identity-members': ['identityId', 'principalId'],
@@ -319,6 +344,7 @@ export const ENTITY_SCOPE_MAP = {
   'principals': ['principalType'],
   'resources': ['resourceType'],
   'resource-assignments': ['assignmentType'],
+  'resource-assignments-identity': ['assignmentType'],
   'resource-relationships': ['relationshipType'],
   'contexts': ['variant', 'contextType', 'scopeSystemId', 'sourceAlgorithmId'],
   'context-members': ['contextId'],
@@ -419,6 +445,16 @@ export function validateRecords(records, entityType, idGeneration, syncMode = 'f
         if (!hasAny) {
           errors.push(`Record ${i}: one of [${group.fields.join(', ')}] is required`);
         }
+      }
+    }
+
+    // XOR check: resource-assignments only accepts principalId-side fields.
+    // Catches accidental mixing before the DB constraint produces a cryptic error.
+    if (entityType === 'resource-assignments') {
+      const hasIdentitySide = (rec.identityId !== undefined && rec.identityId !== null && rec.identityId !== '')
+        || (rec.identityExternalId !== undefined && rec.identityExternalId !== null && rec.identityExternalId !== '');
+      if (hasIdentitySide) {
+        errors.push(`Record ${i}: identityId/identityExternalId not allowed here — use /ingest/resource-assignments-identity`);
       }
     }
 

--- a/app/api/src/ingest/validation.test.js
+++ b/app/api/src/ingest/validation.test.js
@@ -296,6 +296,113 @@ describe('validateRecords — resource-relationships', () => {
   });
 });
 
+// ── validateRecords — resource-assignments XOR check (T7.3) ──────────────────
+
+describe('validateRecords — resource-assignments XOR check', () => {
+  const validAssignment = {
+    resourceId:    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    principalId:   'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    assignmentType: 'Direct',
+  };
+
+  it('rejects a record that carries identityId on the principal endpoint', () => {
+    const result = validateRecords([{
+      ...validAssignment,
+      identityId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    }], 'resource-assignments');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /resource-assignments-identity/.test(e))).toBe(true);
+  });
+
+  it('rejects a record that carries identityExternalId on the principal endpoint', () => {
+    const result = validateRecords([{
+      ...validAssignment,
+      identityExternalId: 'alice',
+    }], 'resource-assignments');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /resource-assignments-identity/.test(e))).toBe(true);
+  });
+
+  it('accepts a clean principal-only record (no identity side-fields)', () => {
+    const result = validateRecords([validAssignment], 'resource-assignments');
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ── validateRecords — resource-assignments-identity (T7.1) ───────────────────
+
+describe('validateRecords — resource-assignments-identity', () => {
+  const validIdentityAssignment = {
+    resourceId:    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    identityId:    'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    assignmentType: 'Governed',
+  };
+
+  it('accepts a valid identity assignment with explicit identityId (T7.1)', () => {
+    const result = validateRecords([validIdentityAssignment], 'resource-assignments-identity');
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a record using identityExternalId in place of identityId', () => {
+    const { identityId: _, ...withExternal } = validIdentityAssignment;
+    const result = validateRecords([{ ...withExternal, identityExternalId: 'alice' }], 'resource-assignments-identity');
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a record using resourceExternalId in place of resourceId', () => {
+    const { resourceId: _, ...withExternal } = validIdentityAssignment;
+    const result = validateRecords([{ ...withExternal, resourceExternalId: 'role-123' }], 'resource-assignments-identity');
+    expect(result.valid).toBe(true);
+  });
+
+  it('requires assignmentType', () => {
+    const { assignmentType: _, ...noType } = validIdentityAssignment;
+    const result = validateRecords([noType], 'resource-assignments-identity');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /assignmentType/.test(e))).toBe(true);
+  });
+
+  it('requires one of resourceId / resourceExternalId', () => {
+    const { resourceId: _, ...noRes } = validIdentityAssignment;
+    const result = validateRecords([noRes], 'resource-assignments-identity');
+    expect(result.valid).toBe(false);
+  });
+
+  it('requires one of identityId / identityExternalId', () => {
+    const { identityId: _, ...noId } = validIdentityAssignment;
+    const result = validateRecords([noId], 'resource-assignments-identity');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects an invalid assignmentType value', () => {
+    const result = validateRecords([{ ...validIdentityAssignment, assignmentType: 'NotAType' }], 'resource-assignments-identity');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /assignmentType/.test(e))).toBe(true);
+  });
+
+  it('rejects a malformed identityId UUID', () => {
+    const result = validateRecords([{ ...validIdentityAssignment, identityId: 'not-a-uuid' }], 'resource-assignments-identity');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /UUID/.test(e))).toBe(true);
+  });
+});
+
+// ── ENTITY_KEY_MAP — resource-assignments-identity key columns (T7.11) ────────
+
+describe('ENTITY_KEY_MAP — resource-assignments-identity', () => {
+  it('uses identityId as key column, not principalId', async () => {
+    const { ENTITY_KEY_MAP } = await import('./validation.js');
+    expect(ENTITY_KEY_MAP['resource-assignments-identity'])
+      .toEqual(['resourceId', 'identityId', 'assignmentType']);
+  });
+
+  it('principal endpoint still uses principalId as key column (T7.2)', async () => {
+    const { ENTITY_KEY_MAP } = await import('./validation.js');
+    expect(ENTITY_KEY_MAP['resource-assignments'])
+      .toEqual(['resourceId', 'principalId', 'assignmentType']);
+  });
+});
+
 // ── validateRecords — unknown entity type ─────────────────────────────────────
 
 describe('validateRecords — unknown entity type', () => {

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -607,6 +607,7 @@ router.get('/admin/dashboard-stats', async (_req, res) => {
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'Identities'), 0), 0)::int             AS "identities",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'ResourceAssignments'), 0), 0)::int    AS "assignments",
         (SELECT COUNT(*)::int FROM "ResourceAssignments" WHERE "assignmentType" = 'Governed')  AS "governedAssignments",
+        (SELECT COUNT(*)::int FROM "ResourceAssignments" WHERE "identityId" IS NOT NULL)       AS "identityAssignments",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'ResourceRelationships'), 0), 0)::int  AS "relationships",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'Contexts'), 0), 0)::int               AS "contexts",
         GREATEST(COALESCE((SELECT est FROM estimates WHERE relname = 'IdentityMembers'), 0), 0)::int       AS "identityMembers",

--- a/app/api/src/routes/ingest.classify.test.js
+++ b/app/api/src/routes/ingest.classify.test.js
@@ -1,0 +1,98 @@
+// Tests for the classify-business-role-assignments endpoint (T7.9, T7.10).
+//
+// Covers the XOR dedup fix: for identity rows (principalId IS NULL) the old
+// ra2."principalId" = ra."principalId" comparison evaluates NULL=NULL=false,
+// so identity Direct rows were never deduped before the subsequent UPDATE hit
+// a unique constraint. The fix uses an XOR condition.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+// ── Module mocks (hoisted so they are in scope before any imports) ────────────
+
+const { mockQuery } = vi.hoisted(() => {
+  process.env.USE_SQL = 'true';
+  const mockQuery = vi.fn().mockResolvedValue({ rowCount: 0, rows: [] });
+  return { mockQuery };
+});
+
+vi.mock('../db/connection.js', () => ({
+  query:    mockQuery,
+  queryOne: vi.fn().mockResolvedValue(null),
+  getPool:  vi.fn().mockResolvedValue({ query: mockQuery }),
+  tx:       vi.fn(async (fn) => fn({ query: mockQuery })),
+}));
+
+vi.mock('../middleware/crawlerAuth.js', () => ({
+  crawlerHasPermission:   vi.fn().mockReturnValue(true),
+  crawlerHasSystemAccess: vi.fn().mockReturnValue(true),
+}));
+
+const { default: ingestRouter } = await import('./ingest.js');
+const app = express().use(express.json()).use(ingestRouter);
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Collect all SQL strings passed to db.query during a single request. */
+async function captureClassifySql() {
+  const sqls = [];
+  mockQuery.mockImplementation(async (sql) => {
+    sqls.push(typeof sql === 'string' ? sql : '');
+    return { rowCount: 0, rows: [] };
+  });
+  const res = await request(app).post('/ingest/classify-business-role-assignments');
+  return { res, sqls };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /ingest/classify-business-role-assignments', () => {
+  it('returns 200 with reclassified and duplicatesRemoved counts (T7.10)', async () => {
+    const res = await request(app).post('/ingest/classify-business-role-assignments');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.reclassified).toBe('number');
+    expect(typeof res.body.duplicatesRemoved).toBe('number');
+  });
+
+  it('dedup DELETE uses XOR condition, not bare principalId comparison (T7.9)', async () => {
+    const { sqls } = await captureClassifySql();
+    const deleteSql = sqls.find(s => /DELETE FROM "ResourceAssignments"/.test(s)) || '';
+
+    // XOR condition must be present
+    expect(deleteSql).toContain('ra."principalId" IS NOT NULL');
+    expect(deleteSql).toContain('ra."identityId"  IS NOT NULL');
+
+    // Old bare NULL=NULL comparison must NOT be present — it silently fails for
+    // identity rows where principalId IS NULL.
+    expect(deleteSql).not.toMatch(/AND ra2\."principalId" = ra\."principalId"/);
+  });
+
+  it('dedup DELETE checks both key types in the EXISTS subquery (T7.9)', async () => {
+    const { sqls } = await captureClassifySql();
+    const deleteSql = sqls.find(s => /DELETE FROM "ResourceAssignments"/.test(s)) || '';
+
+    // The EXISTS subquery must handle principalId-keyed rows
+    expect(deleteSql).toContain('ra2."principalId" = ra."principalId"');
+    // AND identityId-keyed rows
+    expect(deleteSql).toContain('ra2."identityId"  = ra."identityId"');
+  });
+
+  it('UPDATE promotion does not restrict by key type (T7.10)', async () => {
+    const { sqls } = await captureClassifySql();
+    const updateSql = sqls.find(s => /UPDATE "ResourceAssignments"/.test(s)) || '';
+
+    // The UPDATE promotes all remaining Direct rows regardless of whether they
+    // carry a principalId or an identityId — resource type is the only filter.
+    expect(updateSql).toContain('"assignmentType" = \'Direct\'');
+    expect(updateSql).toContain('"assignmentType" = \'Governed\'');
+    // Must NOT restrict to principalId IS NOT NULL — that would skip identity rows
+    expect(updateSql).not.toContain('principalId IS NOT NULL');
+  });
+});

--- a/app/api/src/routes/ingest.classify.test.js
+++ b/app/api/src/routes/ingest.classify.test.js
@@ -69,9 +69,9 @@ describe('POST /ingest/classify-business-role-assignments', () => {
     expect(deleteSql).toContain('ra."principalId" IS NOT NULL');
     expect(deleteSql).toContain('ra."identityId"  IS NOT NULL');
 
-    // Old bare NULL=NULL comparison must NOT be present — it silently fails for
-    // identity rows where principalId IS NULL.
-    expect(deleteSql).not.toMatch(/AND ra2\."principalId" = ra\."principalId"/);
+    // The principalId comparison must be guarded by IS NOT NULL — without the
+    // guard, NULL = NULL evaluates to false so identity rows are never deduped.
+    expect(deleteSql).not.toMatch(/AND ra2\."principalId" = ra\."principalId"\s*\n\s+AND/);
   });
 
   it('dedup DELETE checks both key types in the EXISTS subquery (T7.9)', async () => {

--- a/app/api/src/routes/ingest.js
+++ b/app/api/src/routes/ingest.js
@@ -82,18 +82,21 @@ function createIngestHandler(entityType) {
         }
       }
 
-      // scopeDeleteFilter prevents full-sync cross-contamination: both
-      // resource-assignments endpoints write to the same table, so a
-      // principal full-sync must not delete identity rows and vice versa.
-      const scopeDeleteFilter =
+      // Both resource-assignments endpoints use partial unique indexes (migration 036
+      // replaced the composite PK). conflictFilter provides the WHERE clause required
+      // for PostgreSQL to resolve the ON CONFLICT target against the partial index.
+      // scopeDeleteFilter prevents full-sync cross-contamination between the two arms.
+      const conflictFilter =
         entityType === 'resource-assignments'          ? '"principalId" IS NOT NULL' :
         entityType === 'resource-assignments-identity' ? '"identityId" IS NOT NULL'  :
         null;
+      const scopeDeleteFilter = conflictFilter;
 
       // ── Session paths ─────────────────────────────────────────────
       if (body.syncSession === 'start') {
         const result = await startSession(null, tableName, keyColumns, normalized, {
-          systemId: body.systemId, scope, syncMode: body.syncMode || 'full', scopeDeleteFilter,
+          systemId: body.systemId, scope, syncMode: body.syncMode || 'full',
+          scopeDeleteFilter, conflictFilter,
         });
         return res.status(201).json({
           syncId: result.syncId, table: tableName,
@@ -131,6 +134,7 @@ function createIngestHandler(entityType) {
             systemId: body.systemId,
             scope,
             scopeDeleteFilter,
+            conflictFilter,
           })
         : { inserted: 0, updated: 0, deleted: 0 };
 

--- a/app/api/src/routes/ingest.js
+++ b/app/api/src/routes/ingest.js
@@ -82,10 +82,18 @@ function createIngestHandler(entityType) {
         }
       }
 
+      // scopeDeleteFilter prevents full-sync cross-contamination: both
+      // resource-assignments endpoints write to the same table, so a
+      // principal full-sync must not delete identity rows and vice versa.
+      const scopeDeleteFilter =
+        entityType === 'resource-assignments'          ? '"principalId" IS NOT NULL' :
+        entityType === 'resource-assignments-identity' ? '"identityId" IS NOT NULL'  :
+        null;
+
       // ── Session paths ─────────────────────────────────────────────
       if (body.syncSession === 'start') {
         const result = await startSession(null, tableName, keyColumns, normalized, {
-          systemId: body.systemId, scope, syncMode: body.syncMode || 'full',
+          systemId: body.systemId, scope, syncMode: body.syncMode || 'full', scopeDeleteFilter,
         });
         return res.status(201).json({
           syncId: result.syncId, table: tableName,
@@ -122,6 +130,7 @@ function createIngestHandler(entityType) {
             syncMode: body.syncMode || 'delta',
             systemId: body.systemId,
             scope,
+            scopeDeleteFilter,
           })
         : { inserted: 0, updated: 0, deleted: 0 };
 
@@ -214,7 +223,8 @@ function createIngestHandler(entityType) {
 router.post('/ingest/systems',                  createIngestHandler('systems'));
 router.post('/ingest/principals',               createIngestHandler('principals'));
 router.post('/ingest/resources',                createIngestHandler('resources'));
-router.post('/ingest/resource-assignments',     createIngestHandler('resource-assignments'));
+router.post('/ingest/resource-assignments',          createIngestHandler('resource-assignments'));
+router.post('/ingest/resource-assignments-identity', createIngestHandler('resource-assignments-identity'));
 router.post('/ingest/resource-relationships',   createIngestHandler('resource-relationships'));
 router.post('/ingest/identities',               createIngestHandler('identities'));
 router.post('/ingest/identity-members',         createIngestHandler('identity-members'));
@@ -291,8 +301,12 @@ router.post('/ingest/classify-business-role-assignments', async (req, res) => {
          AND EXISTS (
            SELECT 1 FROM "ResourceAssignments" ra2
             WHERE ra2."resourceId" = ra."resourceId"
-              AND ra2."principalId" = ra."principalId"
               AND ra2."assignmentType" = 'Governed'
+              AND (
+                (ra."principalId" IS NOT NULL AND ra2."principalId" = ra."principalId")
+                OR
+                (ra."identityId"  IS NOT NULL AND ra2."identityId"  = ra."identityId")
+              )
          )
     `);
     const r = await db.query(`

--- a/changes/feature-resource-assignments-identity-support.md
+++ b/changes/feature-resource-assignments-identity-support.md
@@ -1,4 +1,4 @@
-- Added identity-level assignment support to ResourceAssignments: business roles can now be assigned to a person (Identity) rather than a specific account (Principal), enabling IGA crawlers (e.g. MidPoint, Omada) to express the true IGA assignment model
+- Added identity-level assignment support to ResourceAssignments: any access can now be assigned to a person (Identity) rather than a specific account (Principal), enabling IGA crawlers (e.g. MidPoint, Omada) to express the true IGA assignment model
 - Added `POST /ingest/resource-assignments-identity` endpoint for IGA crawlers to push identity-level business role assignments
 - Matrix view now expands identity-level assignments through IdentityMembers so each linked account appears in the access matrix
 - Fixed `classify-business-role-assignments` endpoint to correctly handle identity-level Direct assignments when promoting to Governed

--- a/changes/feature-resource-assignments-identity-support.md
+++ b/changes/feature-resource-assignments-identity-support.md
@@ -1,0 +1,5 @@
+- Added identity-level assignment support to ResourceAssignments: business roles can now be assigned to a person (Identity) rather than a specific account (Principal), enabling IGA crawlers (e.g. MidPoint, Omada) to express the true IGA assignment model
+- Added `POST /ingest/resource-assignments-identity` endpoint for IGA crawlers to push identity-level business role assignments
+- Matrix view now expands identity-level assignments through IdentityMembers so each linked account appears in the access matrix
+- Fixed `classify-business-role-assignments` endpoint to correctly handle identity-level Direct assignments when promoting to Governed
+- Admin stats panel now shows count of identity-level assignments for post-deploy verification

--- a/docs/architecture/resource-assignments-identity-support.md
+++ b/docs/architecture/resource-assignments-identity-support.md
@@ -1,8 +1,6 @@
 # ResourceAssignments: Identity-Level Assignment Support
 
-> **Status:** CEO reviewed — ready for Eng review.
-> **Purpose:** Get sign-off on the schema change, migration strategy, and API contract
-> before any code is written.
+> **Status:** Implemented — T7 (tests) outstanding.
 > **Owner:** _TBD_ · **Reviewers:** _TBD_
 
 ---
@@ -122,10 +120,10 @@ CREATE TABLE "ResourceAssignments" (
 );
 ```
 
-### 3.2 Target schema (migration 035)
+### 3.2 Target schema (migration 036)
 
 ```sql
--- Migration 035_resource_assignments_identity_support.sql
+-- Migration 036_resource_assignments_identity_support.sql
 -- Not wrapped in a transaction: Docker deploy stops at startup on migration
 -- failure; manual cleanup via psql is acceptable given the simple, tested steps.
 
@@ -356,7 +354,7 @@ ensures the existing deduplication absorbs cross-arm duplicates (person with bot
 principal-level and an identity-level assignment to the same resource).
 
 ```sql
--- In migration 036_matrix_view_identity_support.sql
+-- In migration 037_matrix_view_identity_support.sql
 -- Rebuilds the materialized view to add the identity expansion arm.
 
 -- Drop dependent view first (matches migration 026 pattern; CASCADE would also
@@ -464,8 +462,8 @@ post-deploy verification that IGA crawlers are pushing identity-level assignment
 
 ### In scope
 
-- Migration `035_resource_assignments_identity_support.sql` — schema change
-- Migration `036_matrix_view_identity_support.sql` — matview rebuild with identity arm (DROP VIEW first)
+- Migration `036_resource_assignments_identity_support.sql` — schema change
+- Migration `037_matrix_view_identity_support.sql` — matview rebuild with identity arm (DROP VIEW first)
 - `app/api/src/ingest/validation.js` — new `resource-assignments-identity` entity type + XOR validation on `resource-assignments`
 - `app/api/src/routes/ingest.js` — new `/ingest/resource-assignments-identity` route + `scopeDeleteFilter` on both RA handlers + classify fix
 - `app/api/src/ingest/engine.js` — `scopeDeleteFilter` option in `ingest()` + `scopedDelete()`
@@ -497,7 +495,7 @@ post-deploy verification that IGA crawlers are pushing identity-level assignment
 
 | Step | Who | When |
 |---|---|---|
-| Apply migrations 035 + 036 | DB migration runner at container startup | Automatically on deploy |
+| Apply migrations 036 + 037 | DB migration runner at container startup | Automatically on deploy |
 | Existing crawlers (Entra, AD, CSV) | No change needed | — |
 | IGA crawlers (Omada, MidPoint) | Switch any assignment where the source system's subject is a person to `/ingest/resource-assignments-identity` (use `identityId` / `identityExternalId` instead of `principalId`). Account-level assignments (shadow memberships, entitlements assigned to a specific account) stay on `/ingest/resource-assignments`. | After this ships |
 
@@ -526,41 +524,25 @@ picking one account.        rows through IdentityMembers.   access per scope nod
 
 ## 10. Implementation Tasks
 
-- [ ] **T1 (P1, human: ~2h / CC: ~10min)** — DB — Write migration `035_resource_assignments_identity_support.sql`
-  - Surfaced by: Section 3 — schema change (nullable principalId, bare UUID identityId, XOR CHECK, partial indexes)
-  - Files: `app/api/src/db/migrations/035_resource_assignments_identity_support.sql`
-  - Verify: `docker compose build web && docker compose up -d web`; migration applies clean on a populated DB; existing rows satisfy CHECK constraint
+- [x] **T1 (P1)** — DB — Write migration `036_resource_assignments_identity_support.sql`
+  - Files: `app/api/src/db/migrations/036_resource_assignments_identity_support.sql`
 
-- [ ] **T2 (P1, human: ~1h / CC: ~5min)** — DB — Write migration `036_matrix_view_identity_support.sql`
-  - Surfaced by: Section 5 — DROP VIEW first + matview UNION arm inside collapsed CTE
-  - Files: `app/api/src/db/migrations/036_matrix_view_identity_support.sql`
-  - Verify: migration runs without "dependent object" error; `REFRESH MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments"` completes; identity assignment appears in matrix after account linking
+- [x] **T2 (P1)** — DB — Write migration `037_matrix_view_identity_support.sql`
+  - Files: `app/api/src/db/migrations/037_matrix_view_identity_support.sql`
 
-- [ ] **T3 (P1, human: ~1h / CC: ~10min)** — API — Add `resource-assignments-identity` entity type to validation.js
-  - Surfaced by: Section 4.3 — new entity type + XOR validation on existing `resource-assignments` schema
+- [x] **T3 (P1)** — API — Add `resource-assignments-identity` entity type to validation.js
   - Files: `app/api/src/ingest/validation.js`
-  - Changes: new `resource-assignments-identity` schema; add `identityId`/`identityExternalId` to `resource-assignments` for XOR check; add to `ENTITY_TABLE_MAP`, `ENTITY_KEY_MAP`, `ENTITY_SCOPE_MAP`
-  - Verify: POST `resource-assignments-identity` with both `principalId` + `identityId` → 400; with valid `identityId` → passes schema; with `identityExternalId` → passes schema
 
-- [ ] **T4 (P1, human: ~1h / CC: ~10min)** — API — Add identity route + scopeDeleteFilter + classify fix to ingest.js
-  - Surfaced by: Section 4.1 (new route), 4.5 (scopeDeleteFilter), 4.6 (classify fix)
-  - Files: `app/api/src/routes/ingest.js`
-  - Changes: new route; `scopeDeleteFilter` passed to both RA handlers; classify dedup DELETE XOR fix
-  - Verify: upsert identity assignment → re-push same record → updated not duplicated; full principal sync does not delete identity rows; classify endpoint handles identity Direct rows without constraint error
+- [x] **T4 (P1)** — API — Add identity route + scopeDeleteFilter + classify fix to ingest.js + sessions.js
+  - Files: `app/api/src/routes/ingest.js`, `app/api/src/ingest/sessions.js`
 
-- [ ] **T5 (P1, human: ~30min / CC: ~5min)** — API — Add `scopeDeleteFilter` option to engine.js
-  - Surfaced by: Section 4.5 — scopedDelete cross-contamination prevention
+- [x] **T5 (P1)** — API — Add `scopeDeleteFilter` option to engine.js
   - Files: `app/api/src/ingest/engine.js`
-  - Changes: add optional `scopeDeleteFilter` param to `scopedDelete()`; `ingest()` passes it through from options
-  - Verify: scopedDelete with `scopeDeleteFilter: '"identityId" IS NOT NULL'` only deletes identity rows; principal rows survive
 
-- [ ] **T6 (P2, human: ~30min / CC: ~3min)** — API — Add `identityAssignments` admin stat
-  - Surfaced by: E3 cherry-pick
+- [x] **T6 (P2)** — API — Add `identityAssignments` admin stat
   - Files: `app/api/src/routes/admin.js`
-  - Verify: count increments after pushing identity-level assignments
 
-- [ ] **T7 (P1, human: ~2h / CC: ~15min)** — Tests — Add ingest + matview + engine tests
-  - Surfaced by: Section 3 (test review)
+- [ ] **T7 (P1)** — Tests — Add ingest + matview + engine tests
   - Files: `app/api/src/ingest/validation.test.js`, `app/api/src/ingest/engine.test.js`, nearest ingest integration test
   - Tests:
     1. identity batch to `/resource-assignments-identity` accepted

--- a/docs/architecture/resource-assignments-identity-support.md
+++ b/docs/architecture/resource-assignments-identity-support.md
@@ -1,6 +1,6 @@
 # ResourceAssignments: Identity-Level Assignment Support
 
-> **Status:** Implemented — T7 (tests) outstanding.
+> **Status:** Implemented — all tasks complete.
 > **Owner:** _TBD_ · **Reviewers:** _TBD_
 
 ---
@@ -542,7 +542,7 @@ picking one account.        rows through IdentityMembers.   access per scope nod
 - [x] **T6 (P2)** — API — Add `identityAssignments` admin stat
   - Files: `app/api/src/routes/admin.js`
 
-- [ ] **T7 (P1)** — Tests — Add ingest + matview + engine tests
+- [x] **T7 (P1)** — Tests — Add ingest + matview + engine tests
   - Files: `app/api/src/ingest/validation.test.js`, `app/api/src/ingest/engine.test.js`, nearest ingest integration test
   - Tests:
     1. identity batch to `/resource-assignments-identity` accepted

--- a/docs/architecture/resource-assignments-identity-support.md
+++ b/docs/architecture/resource-assignments-identity-support.md
@@ -9,11 +9,12 @@
 
 ## 1. TL;DR
 
-In IGA (Identity Governance and Administration), business roles are assigned to **people**,
-not to individual system accounts. A person's business role spans multiple applications —
-each component applies to whichever account that person holds in that system. IdentityAtlas
-currently has no way to model this: every assignment must point to a specific account,
-so the connection between "Alice the person" and her business role is lost.
+In IGA (Identity Governance and Administration), access is assigned to **people**,
+not to individual system accounts. When a person is given a role, that access spans
+multiple applications — each component applies to whichever account that person holds
+in that system. IdentityAtlas currently has no way to model this: every assignment must
+point to a specific account, so the fact that "Alice the person was given this access"
+is lost regardless of the resource type.
 
 **Technical accounts are different.** Mailbox accounts, service accounts, and functional
 accounts are created for a specific system, and their roles only contain permissions within
@@ -21,8 +22,8 @@ that system. Assigning those roles to the account directly is correct and suffic
 
 Both patterns coexist in every IGA-managed organisation. This spec adds a first-class
 `identityId` assignment target to `ResourceAssignments`, alongside the existing
-`principalId`, so IGA crawlers can store business role assignments at the person level
-without disrupting any existing data or non-IGA deployments.
+`principalId`, so IGA crawlers can store any person-level assignment without disrupting
+existing data or non-IGA deployments.
 
 ---
 
@@ -191,9 +192,12 @@ Accepted — document in changelog.
 
 ### 4.1 Two endpoints — batch type enforced by route
 
-Business role assignments for human persons and assignments for system accounts use
-**separate endpoints**. Batch type is enforced at the route level — no runtime detection,
-no mixed-batch validation.
+**Person-level and account-level assignments use separate endpoints.** The routing rule is
+based on *who the source system says has the access*: if the subject is a person (identity)
+→ use the identity endpoint; if the subject is a specific account (principal) → use the
+principal endpoint. Resource type is irrelevant to the routing decision.
+
+Batch type is enforced at the route level — no runtime detection, no mixed-batch validation.
 
 | Endpoint | Accepted records | Key columns |
 |---|---|---|
@@ -495,7 +499,7 @@ post-deploy verification that IGA crawlers are pushing identity-level assignment
 |---|---|---|
 | Apply migrations 035 + 036 | DB migration runner at container startup | Automatically on deploy |
 | Existing crawlers (Entra, AD, CSV) | No change needed | — |
-| IGA crawlers (Omada, MidPoint) | Update to emit `identityId` / `identityExternalId` on business role assignments | After this ships |
+| IGA crawlers (Omada, MidPoint) | Switch any assignment where the source system's subject is a person to `/ingest/resource-assignments-identity` (use `identityId` / `identityExternalId` instead of `principalId`). Account-level assignments (shadow memberships, entitlements assigned to a specific account) stay on `/ingest/resource-assignments`. | After this ships |
 
 The migrations are **non-destructive**: no data loss, no column removals, no breaking changes
 to existing `principalId` paths. Brief exclusive lock during 035 on container startup.
@@ -514,8 +518,8 @@ express "person has         identityExternalId.             via IdentityMembers,
 business role" without      Matrix expands identity         computes effective
 picking one account.        rows through IdentityMembers.   access per scope node.
                             MidPoint/Omada crawlers          One person. One view.
-                            can emit identity-level          All systems.
-                            business role assignments.
+                            emit identity-level              All systems.
+                            assignments (any resource).
 ```
 
 ---

--- a/docs/architecture/resource-assignments-identity-support.md
+++ b/docs/architecture/resource-assignments-identity-support.md
@@ -1,0 +1,588 @@
+# ResourceAssignments: Identity-Level Assignment Support
+
+> **Status:** CEO reviewed — ready for Eng review.
+> **Purpose:** Get sign-off on the schema change, migration strategy, and API contract
+> before any code is written.
+> **Owner:** _TBD_ · **Reviewers:** _TBD_
+
+---
+
+## 1. TL;DR
+
+In IGA (Identity Governance and Administration), business roles are assigned to **people**,
+not to individual system accounts. A person's business role spans multiple applications —
+each component applies to whichever account that person holds in that system. IdentityAtlas
+currently has no way to model this: every assignment must point to a specific account,
+so the connection between "Alice the person" and her business role is lost.
+
+**Technical accounts are different.** Mailbox accounts, service accounts, and functional
+accounts are created for a specific system, and their roles only contain permissions within
+that system. Assigning those roles to the account directly is correct and sufficient.
+
+Both patterns coexist in every IGA-managed organisation. This spec adds a first-class
+`identityId` assignment target to `ResourceAssignments`, alongside the existing
+`principalId`, so IGA crawlers can store business role assignments at the person level
+without disrupting any existing data or non-IGA deployments.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 The IGA assignment model
+
+In IGA, a business role like "Finance Manager" is assigned to **Alice the person**. That
+role is composed of permissions across multiple applications — an AD group, a SAP role, an
+Exchange mailbox policy. Each permission applies to a specific account Alice holds in that
+application's system.
+
+A person can also have multiple accounts in the same system — a day-to-day account and an
+admin account, for example. Business roles specify which type of account gets which access:
+Finance Manager goes to the day-to-day account; an AD Admin role goes to the admin account.
+
+```
+Alice (identity)
+  ├─ AD account: alice@contoso.com       (day-to-day)
+  ├─ AD account: alice.admin@contoso.com (admin)
+  └─ SAP account: alice.sap
+
+Business Role "Finance Manager"
+  └─ Contains: AD group "Finance-AD"    → alice@contoso.com (day-to-day)
+  └─ Contains: SAP role "Finance-SAP"   → alice.sap
+
+Business Role "AD Admin"
+  └─ Contains: AD group "Admins"        → alice.admin@contoso.com
+```
+
+The IGA assignment is fundamentally about the person. Which account in which system
+receives each permission is a separate concern — resolved through the resource/system
+hierarchy, not by duplicating the assignment row.
+
+IdentityAtlas today cannot store this. Every assignment row must point to a specific
+account, so an IGA crawler is forced to either pick one account (losing the others) or
+duplicate the business role row once per account (losing the "assigned to the person" fact):
+
+```sql
+-- Forced workaround today:
+ResourceAssignments: resourceId=FinanceManager, principalId=Alice_AD_account
+ResourceAssignments: resourceId=FinanceManager, principalId=Alice_SAP_account
+-- "Alice the person was assigned Finance Manager" is not representable.
+```
+
+### 2.2 Technical accounts: principal assignment is correct
+
+A mailbox account or service account belongs to one system. Its roles only grant
+permissions within that system. There is no cross-system expansion to do —
+`principalId` assignment is complete and correct for these accounts.
+
+### 2.3 Both must coexist
+
+Most IGA-managed organisations assign business roles to human identities and manage
+technical accounts separately via direct principal assignments. Some organisations go
+further and model identities for their technical accounts too — in that case, even
+technical account roles can be assigned at the identity level.
+
+| Account type | Assignment target | Notes |
+|---|---|---|
+| Human person | `identityId` | Standard IGA practice |
+| Technical account | `principalId` | Most orgs; role is system-scoped |
+| Technical account | `identityId` | Orgs that model identities for technical accounts |
+| Non-IGA org | `principalId` only | No `Identities` rows exist |
+
+Both assignment targets must be valid simultaneously. The choice is per-org (and
+per-account-type within an org), not a global switch.
+
+### 2.3 What does NOT change
+
+- Organisations that never use IGA continue writing `principalId` assignments exactly as
+  today. No code changes needed on their crawlers.
+- The `assignmentType` semantics (`Direct`, `Governed`, `AppRole`, etc.) are unchanged.
+- The matrix view continues to render correctly for principal-only rows.
+
+---
+
+## 3. Data Model Change
+
+### 3.1 Current schema (migration 001)
+
+```sql
+CREATE TABLE "ResourceAssignments" (
+    "resourceId"    UUID NOT NULL,
+    "principalId"   UUID NOT NULL,          -- ← always required today
+    "assignmentType" TEXT NOT NULL,
+    "systemId"      INTEGER REFERENCES "Systems"("id") ON DELETE CASCADE,
+    "principalType" TEXT,
+    "complianceState" TEXT,
+    "policyId"      UUID,
+    "state"         TEXT,
+    "assignmentStatus" TEXT,
+    "expirationDateTime" TIMESTAMPTZ,
+    "extendedAttributes" JSONB,
+    PRIMARY KEY ("resourceId", "principalId", "assignmentType")
+);
+```
+
+### 3.2 Target schema (migration 035)
+
+```sql
+-- Migration 035_resource_assignments_identity_support.sql
+-- Not wrapped in a transaction: Docker deploy stops at startup on migration
+-- failure; manual cleanup via psql is acceptable given the simple, tested steps.
+
+-- 1. Drop the existing PK (it includes principalId which will become nullable)
+ALTER TABLE "ResourceAssignments"
+    DROP CONSTRAINT "ResourceAssignments_pkey";
+
+-- 2. Make principalId nullable
+ALTER TABLE "ResourceAssignments"
+    ALTER COLUMN "principalId" DROP NOT NULL;
+
+-- 3. Add identityId column — bare UUID, no FK (symmetric with principalId).
+--    Both columns are unvalidated at the DB layer; data integrity relies on
+--    the crawler ordering contract (push identities before assignments) and
+--    the re-sync pattern (crawlers re-push after an identity is deleted).
+--    A FK + CASCADE can be added in a later migration once principalId also
+--    gets a FK, making the two columns consistent.
+ALTER TABLE "ResourceAssignments"
+    ADD COLUMN "identityId" UUID;
+
+-- 4. Enforce: exactly one of principalId / identityId must be non-null
+ALTER TABLE "ResourceAssignments"
+    ADD CONSTRAINT "ck_RA_principal_or_identity"
+    CHECK (
+        ("principalId" IS NOT NULL)::int + ("identityId" IS NOT NULL)::int = 1
+    );
+
+-- 5. Recreate uniqueness as two partial unique indexes (replaces the PK)
+CREATE UNIQUE INDEX "uq_RA_principal"
+    ON "ResourceAssignments"("resourceId", "principalId", "assignmentType")
+    WHERE "principalId" IS NOT NULL;
+
+CREATE UNIQUE INDEX "uq_RA_identity"
+    ON "ResourceAssignments"("resourceId", "identityId", "assignmentType")
+    WHERE "identityId" IS NOT NULL;
+
+-- 6. Supporting index for identity-side lookups
+CREATE INDEX "ix_RA_identityId"
+    ON "ResourceAssignments"("identityId")
+    WHERE "identityId" IS NOT NULL;
+```
+
+**Why no surrogate PK?** IdentityAtlas uses raw SQL (no ORM) and Docker-deployed PostgreSQL
+with no logical replication. Two partial unique indexes provide the same uniqueness guarantees
+for the application's use patterns. Adding a surrogate `id` would require changing every
+`ON CONFLICT` clause in the ingest paths.
+
+**No FK on identityId.** `principalId` has no FK to `Principals` (historical pattern).
+`identityId` is kept symmetric — bare UUID, no FK. Both columns rely on the crawler
+ordering contract for data integrity. A FK + CASCADE migration can follow once both
+columns are handled together.
+
+**No data migration needed.** All existing rows have `principalId` set and `identityId`
+NULL. The CHECK (`principalId IS NOT NULL ∧ identityId IS NULL` → sum = 1) is satisfied by
+every existing row.
+
+**Lock window.** `DROP CONSTRAINT` and `ALTER COLUMN DROP NOT NULL` require a brief exclusive
+table lock. At 1M rows on container startup this takes seconds before API traffic arrives.
+Accepted — document in changelog.
+
+---
+
+## 4. Ingest API Contract
+
+### 4.1 Two endpoints — batch type enforced by route
+
+Business role assignments for human persons and assignments for system accounts use
+**separate endpoints**. Batch type is enforced at the route level — no runtime detection,
+no mixed-batch validation.
+
+| Endpoint | Accepted records | Key columns |
+|---|---|---|
+| `POST /ingest/resource-assignments` | `{ resourceId, principalId, assignmentType }` | `['resourceId', 'principalId', 'assignmentType']` |
+| `POST /ingest/resource-assignments-identity` _(new)_ | `{ resourceId, identityId, assignmentType }` | `['resourceId', 'identityId', 'assignmentType']` |
+
+Both endpoints write to `ResourceAssignments`. Mixed batches are structurally impossible —
+the schema for each endpoint only accepts its own key type.
+
+### 4.2 Principal endpoint — no changes to existing schema
+
+`resource-assignments` in `validation.js`, `ENTITY_TABLE_MAP`, and `ENTITY_KEY_MAP` is
+unchanged. Existing crawlers continue to work without modification.
+
+One change: the handler passes `scopeDeleteFilter: '"principalId" IS NOT NULL'` to
+`ingest()` on full syncs. See section 4.5.
+
+### 4.3 Identity endpoint — new entity type
+
+Add `resource-assignments-identity` across four maps in `validation.js` and `ingest.js`:
+
+```javascript
+// ENTITY_TABLE_MAP:
+'resource-assignments-identity': 'ResourceAssignments',
+
+// ENTITY_KEY_MAP:
+'resource-assignments-identity': ['resourceId', 'identityId', 'assignmentType'],
+
+// ENTITY_SCOPE_MAP:
+'resource-assignments-identity': ['assignmentType'],
+```
+
+Validation schema:
+```javascript
+'resource-assignments-identity': {
+  required: ['assignmentType'],
+  requiredOneOf: [
+    { fields: ['resourceId', 'resourceExternalId'] },
+    { fields: ['identityId', 'identityExternalId'] },
+  ],
+  fields: {
+    resourceId:          { type: 'uuid' },
+    resourceExternalId:  { type: 'string', maxLength: 500 },
+    identityId:          { type: 'uuid' },
+    identityExternalId:  { type: 'string', maxLength: 500 },
+    assignmentType:      { type: 'string', enum: ASSIGNMENT_TYPES },
+    principalType:       { type: 'string', maxLength: 50 },
+    complianceState:     { type: 'string', maxLength: 50 },
+    policyId:            { type: 'string', maxLength: 255 },
+    state:               { type: 'string', maxLength: 50 },
+    assignmentStatus:    { type: 'string', maxLength: 50 },
+    expirationDateTime:  { type: 'string' },
+    extendedAttributes:  { type: 'json' },
+  },
+},
+```
+
+New route in `ingest.js`:
+```javascript
+router.post('/ingest/resource-assignments-identity', createIngestHandler('resource-assignments-identity'));
+```
+
+### 4.4 identityExternalId resolution (E1)
+
+`identityExternalId` is resolved to a deterministic UUID using the existing
+`normalization.js` pattern (line 99) — no normalization changes needed:
+
+```javascript
+// Already in normalization.js:
+if (rec.identityExternalId && !normalized.identityId) {
+  normalized.identityId = deterministicGuid(`${sysPrefix}-identities`, String(rec.identityExternalId));
+}
+```
+
+The `sysPrefix` comes from the caller's `idPrefix` (e.g. `"MidPoint"`). The identity must
+already be in the DB under the same `deterministicGuid` UUID — push identities before
+assignments (same ordering contract as `principalExternalId`).
+
+**Ordering contract violation:** If `identityExternalId` resolves to a UUID not in
+`Identities`, the assignment row is inserted with a dangling `identityId` — no FK to
+enforce integrity. Same behavior as `principalExternalId` with a missing principal.
+Prevention: push identities before assignments; the matview INNER JOIN on `IdentityMembers`
+means a dangling identity assignment never appears in the matrix.
+
+### 4.5 scopedDelete cross-contamination prevention
+
+Both endpoints write to the same table. A full sync from one endpoint must not delete
+rows belonging to the other.
+
+**The bug without this fix:** `scopedDelete()` builds `NOT EXISTS (... t."principalId" = src."principalId" ...)`.
+For identity rows where `principalId IS NULL`: `NULL = uuid = false` → `NOT EXISTS = true` →
+identity rows deleted by the principal full-sync. Same problem in reverse.
+
+**Fix:** add a `scopeDeleteFilter` option to `ingest()` / `scopedDelete()` that appends
+a safe server-side SQL condition to the DELETE WHERE clause:
+
+```javascript
+// engine.js — scopedDelete signature change:
+export async function scopedDelete(
+  client, tableName, keyColumns, tempName,
+  systemId, scope, systemIdColumn, tableColumnNames,
+  scopeDeleteFilter = null   // ← new optional param
+) {
+  // ...existing WHERE building...
+  if (scopeDeleteFilter) where += ` AND (${scopeDeleteFilter})`;
+  // ...
+}
+```
+
+```javascript
+// ingest.js — principal handler passes scopeDeleteFilter to ingest():
+await ingest(null, tableName, keyColumns, normalized, {
+  syncMode: ..., systemId: ..., scope,
+  scopeDeleteFilter: '"principalId" IS NOT NULL',
+});
+
+// ingest.js — identity handler:
+await ingest(null, tableName, keyColumns, normalized, {
+  syncMode: ..., systemId: ..., scope,
+  scopeDeleteFilter: '"identityId" IS NOT NULL',
+});
+```
+
+`ingest()` passes `scopeDeleteFilter` through to `scopedDelete()` via its options.
+
+### 4.6 classify-business-role-assignments fix
+
+The existing `classify-business-role-assignments` endpoint promotes BusinessRole Direct
+assignments to Governed. Its dedup DELETE uses `ra2."principalId" = ra."principalId"` —
+for identity rows (`principalId IS NULL`), `NULL = NULL = false` so identity Direct rows
+are never cleaned up, and the subsequent UPDATE fails with a unique constraint violation
+when a Governed row already exists.
+
+Fix the dedup DELETE to handle both key types:
+
+```javascript
+// In the DELETE EXISTS subquery — replace the principalId-only check:
+AND (
+  (ra."principalId" IS NOT NULL AND ra2."principalId" = ra."principalId")
+  OR
+  (ra."identityId"  IS NOT NULL AND ra2."identityId"  = ra."identityId")
+)
+```
+
+The UPDATE (`SET "assignmentType" = 'Governed'`) requires no changes — it promotes all
+remaining BusinessRole Direct rows regardless of key type.
+
+---
+
+## 5. Matrix View Impact
+
+### 5.1 Expansion strategy
+
+The UNION arm is placed **inside** the `collapsed` CTE, before the `GROUP BY`. This
+ensures the existing deduplication absorbs cross-arm duplicates (person with both a
+principal-level and an identity-level assignment to the same resource).
+
+```sql
+-- In migration 036_matrix_view_identity_support.sql
+-- Rebuilds the materialized view to add the identity expansion arm.
+
+-- Drop dependent view first (matches migration 026 pattern; CASCADE would also
+-- work but hiding unknown dependents is riskier than being explicit).
+DROP VIEW IF EXISTS "vw_UserPermissionAssignments";
+DROP MATERIALIZED VIEW IF EXISTS "vw_ResourceUserPermissionAssignments";
+
+CREATE MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments" AS
+WITH governed_pairs AS (
+    SELECT DISTINCT "resourceId", "principalId"
+      FROM "ResourceAssignments"
+     WHERE "assignmentType" = 'Governed'
+       AND "principalId" IS NOT NULL
+),
+collapsed AS (
+    -- Existing arm: principal-level assignments
+    SELECT
+        ra."resourceId",
+        ra."principalId",
+        ra."principalType",
+        CASE
+          WHEN ra."assignmentType" IN ('Governed', 'OAuth2Grant', 'AppRole') THEN 'Direct'
+          WHEN ra."assignmentType" = 'AppRoleViaGroup'                       THEN 'Indirect'
+          ELSE ra."assignmentType"
+        END AS "membershipType",
+        (ra."assignmentType" = 'Governed' OR gp."resourceId" IS NOT NULL) AS "managedByAccessPackage"
+    FROM "ResourceAssignments" ra
+    LEFT JOIN governed_pairs gp
+           ON gp."resourceId"  = ra."resourceId"
+          AND gp."principalId" = ra."principalId"
+    WHERE ra."principalId" IS NOT NULL
+
+    UNION ALL
+
+    -- New arm: identity-level assignments expanded through IdentityMembers
+    SELECT
+        ra."resourceId",
+        im."principalId",
+        NULL AS "principalType",
+        CASE
+          WHEN ra."assignmentType" IN ('Governed', 'OAuth2Grant', 'AppRole') THEN 'Direct'
+          WHEN ra."assignmentType" = 'AppRoleViaGroup'                       THEN 'Indirect'
+          ELSE ra."assignmentType"
+        END AS "membershipType",
+        (ra."assignmentType" = 'Governed') AS "managedByAccessPackage"
+    FROM "ResourceAssignments" ra
+    JOIN "IdentityMembers" im ON im."identityId" = ra."identityId"
+    WHERE ra."identityId" IS NOT NULL
+)
+SELECT
+    "resourceId",
+    "principalId",
+    MAX("principalType") AS "principalType",
+    "membershipType",
+    bool_or("managedByAccessPackage") AS "managedByAccessPackage"
+FROM collapsed
+GROUP BY "resourceId", "principalId", "membershipType"
+WITH NO DATA;
+
+CREATE UNIQUE INDEX "ix_vw_ResUserPerm_pk"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId", "principalId", "membershipType");
+CREATE INDEX "ix_vw_ResUserPerm_principalId"
+    ON "vw_ResourceUserPermissionAssignments" ("principalId");
+CREATE INDEX "ix_vw_ResUserPerm_resourceId"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId");
+
+CREATE VIEW "vw_UserPermissionAssignments" AS
+SELECT
+    "resourceId"  AS "groupId",
+    "principalId" AS "memberId",
+    "principalType",
+    "membershipType",
+    "managedByAccessPackage"
+FROM "vw_ResourceUserPermissionAssignments";
+```
+
+**Row expansion behaviour.** An identity-level assignment for a person with 3 principals
+produces 3 expanded rows `(resourceId, principal_AD, type)`, `(resourceId, principal_SAP, type)`,
+`(resourceId, principal_Oracle, type)`. This is correct IGA behaviour: the business role
+reaches each account. The matrix renders one cell per account — expected.
+
+### 5.2 No expansion for identity-only orgs
+
+If an identity has no `IdentityMembers` rows (e.g. no account linking has run yet), the
+`INNER JOIN` produces zero rows for that assignment. No phantom access. The assignment is
+visible in the admin stats (E3) even though it doesn't appear in the matrix.
+
+---
+
+## 6. Admin Stats (E3)
+
+Extend the stats query in `admin.js` to include identity-level assignment count:
+
+```javascript
+// In the existing stats SELECT (around line 608):
+(SELECT COUNT(*)::int FROM "ResourceAssignments" WHERE "identityId" IS NOT NULL) AS "identityAssignments",
+```
+
+Displayed alongside `governedAssignments` in the admin panel. Provides immediate
+post-deploy verification that IGA crawlers are pushing identity-level assignments.
+
+---
+
+## 7. Scope
+
+### In scope
+
+- Migration `035_resource_assignments_identity_support.sql` — schema change
+- Migration `036_matrix_view_identity_support.sql` — matview rebuild with identity arm (DROP VIEW first)
+- `app/api/src/ingest/validation.js` — new `resource-assignments-identity` entity type + XOR validation on `resource-assignments`
+- `app/api/src/routes/ingest.js` — new `/ingest/resource-assignments-identity` route + `scopeDeleteFilter` on both RA handlers + classify fix
+- `app/api/src/ingest/engine.js` — `scopeDeleteFilter` option in `ingest()` + `scopedDelete()`
+- `app/api/src/routes/admin.js` — `identityAssignments` stat
+- `changes/<branch>.md` — changelog fragment
+
+### NOT in scope
+
+| Item | Rationale |
+|---|---|
+| Provisioning / effective-access engine | Separate spec already approved; this spec only stores the assignment |
+| UI badge distinguishing identity-level vs principal-level origin | Deferred — ship data model first, add visual distinction in follow-up PR |
+| Diagnostic stat for identity assignments with no linked principals | Skip — operators can query psql directly |
+| FK constraints on `principalId` / `identityId` | Deferred — both columns are currently bare UUIDs; add FKs together in a later migration once both sides are ready |
+
+### What already exists (reuse, don't rebuild)
+
+| Existing thing | How it's reused |
+|---|---|
+| `normalization.js` line 99 | `identityExternalId` → `deterministicGuid` already implemented — no changes |
+| `engine.js` `ingest()` + `scopedDelete()` | Reused with new `scopeDeleteFilter` option; minimal structural change |
+| `createIngestHandler()` | Both endpoints use the same factory function — identity endpoint gets its own entity type |
+| `IdentityMembers` table | JOIN target for the matrix UNION arm — no changes |
+| Migration 026 GROUP BY dedup + DROP VIEW pattern | Identity arm UNION goes inside `collapsed` CTE for free dedup; DROP VIEW pattern reused exactly |
+
+---
+
+## 8. Migration Strategy
+
+| Step | Who | When |
+|---|---|---|
+| Apply migrations 035 + 036 | DB migration runner at container startup | Automatically on deploy |
+| Existing crawlers (Entra, AD, CSV) | No change needed | — |
+| IGA crawlers (Omada, MidPoint) | Update to emit `identityId` / `identityExternalId` on business role assignments | After this ships |
+
+The migrations are **non-destructive**: no data loss, no column removals, no breaking changes
+to existing `principalId` paths. Brief exclusive lock during 035 on container startup.
+
+---
+
+## 9. Dream State Delta
+
+```
+CURRENT STATE              THIS PLAN                       12-MONTH IDEAL
+-----------------          -----------------------         -----------------
+All assignments target      Assignments can target          Effective-access engine
+principalId only.           identityId OR principalId.      reads identity-level
+IGA crawlers can't          Ingest API accepts both +       assignments, expands
+express "person has         identityExternalId.             via IdentityMembers,
+business role" without      Matrix expands identity         computes effective
+picking one account.        rows through IdentityMembers.   access per scope node.
+                            MidPoint/Omada crawlers          One person. One view.
+                            can emit identity-level          All systems.
+                            business role assignments.
+```
+
+---
+
+## 10. Implementation Tasks
+
+- [ ] **T1 (P1, human: ~2h / CC: ~10min)** — DB — Write migration `035_resource_assignments_identity_support.sql`
+  - Surfaced by: Section 3 — schema change (nullable principalId, bare UUID identityId, XOR CHECK, partial indexes)
+  - Files: `app/api/src/db/migrations/035_resource_assignments_identity_support.sql`
+  - Verify: `docker compose build web && docker compose up -d web`; migration applies clean on a populated DB; existing rows satisfy CHECK constraint
+
+- [ ] **T2 (P1, human: ~1h / CC: ~5min)** — DB — Write migration `036_matrix_view_identity_support.sql`
+  - Surfaced by: Section 5 — DROP VIEW first + matview UNION arm inside collapsed CTE
+  - Files: `app/api/src/db/migrations/036_matrix_view_identity_support.sql`
+  - Verify: migration runs without "dependent object" error; `REFRESH MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments"` completes; identity assignment appears in matrix after account linking
+
+- [ ] **T3 (P1, human: ~1h / CC: ~10min)** — API — Add `resource-assignments-identity` entity type to validation.js
+  - Surfaced by: Section 4.3 — new entity type + XOR validation on existing `resource-assignments` schema
+  - Files: `app/api/src/ingest/validation.js`
+  - Changes: new `resource-assignments-identity` schema; add `identityId`/`identityExternalId` to `resource-assignments` for XOR check; add to `ENTITY_TABLE_MAP`, `ENTITY_KEY_MAP`, `ENTITY_SCOPE_MAP`
+  - Verify: POST `resource-assignments-identity` with both `principalId` + `identityId` → 400; with valid `identityId` → passes schema; with `identityExternalId` → passes schema
+
+- [ ] **T4 (P1, human: ~1h / CC: ~10min)** — API — Add identity route + scopeDeleteFilter + classify fix to ingest.js
+  - Surfaced by: Section 4.1 (new route), 4.5 (scopeDeleteFilter), 4.6 (classify fix)
+  - Files: `app/api/src/routes/ingest.js`
+  - Changes: new route; `scopeDeleteFilter` passed to both RA handlers; classify dedup DELETE XOR fix
+  - Verify: upsert identity assignment → re-push same record → updated not duplicated; full principal sync does not delete identity rows; classify endpoint handles identity Direct rows without constraint error
+
+- [ ] **T5 (P1, human: ~30min / CC: ~5min)** — API — Add `scopeDeleteFilter` option to engine.js
+  - Surfaced by: Section 4.5 — scopedDelete cross-contamination prevention
+  - Files: `app/api/src/ingest/engine.js`
+  - Changes: add optional `scopeDeleteFilter` param to `scopedDelete()`; `ingest()` passes it through from options
+  - Verify: scopedDelete with `scopeDeleteFilter: '"identityId" IS NOT NULL'` only deletes identity rows; principal rows survive
+
+- [ ] **T6 (P2, human: ~30min / CC: ~3min)** — API — Add `identityAssignments` admin stat
+  - Surfaced by: E3 cherry-pick
+  - Files: `app/api/src/routes/admin.js`
+  - Verify: count increments after pushing identity-level assignments
+
+- [ ] **T7 (P1, human: ~2h / CC: ~15min)** — Tests — Add ingest + matview + engine tests
+  - Surfaced by: Section 3 (test review)
+  - Files: `app/api/src/ingest/validation.test.js`, `app/api/src/ingest/engine.test.js`, nearest ingest integration test
+  - Tests:
+    1. identity batch to `/resource-assignments-identity` accepted
+    2. principal batch to `/resource-assignments` still works
+    3. XOR validation: record with both `principalId` AND `identityId` → 400
+    4. `identityExternalId` resolves to deterministic UUID
+    5. full-sync scopedDelete removes stale identity rows AND does not touch principal rows
+    6. full-sync scopedDelete on principal endpoint does not touch identity rows
+    7. cross-arm dedup: person has both principal-level and identity-level assignment → single matrix row
+    8. identity with no IdentityMembers → zero matrix rows, not an error
+    9. classify endpoint: identity Direct + existing Governed → dedup DELETE fires, no constraint error
+    10. classify endpoint: identity Direct with no Governed → promoted to Governed correctly
+    11. session path: identity batch using syncSession start/continue/end uses correct keyColumns
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 2 | CLEAR | SELECTIVE EXPANSION: 3 proposals, 2 accepted (identityExternalId, admin stat); problem statement refined (IGA identity model, technical accounts, multi-account-per-system) |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 7 issues found, all resolved: DROP VIEW missing (P1), XOR validation gap (P1), two-endpoint design replacing batch detection (P1 + architectural decision), scopedDelete cross-contamination (P1), classify endpoint NULL=NULL bug (P2), FK asymmetry resolved by removing identityId FK (P2), identityExternalId failure mode documented |
+| Outside Voice | Claude subagent | Independent 2nd opinion | 1 | issues_found | 6 points; 1 false positive (managedByAccessPackage misread); 1 already covered (principalId FK); 4 real: DROP VIEW, XOR, scopedDelete, externalId failure — all resolved above |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | SKIPPED — no UI scope |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**VERDICT:** CEO + ENG CLEARED — ready to implement.
+
+NO UNRESOLVED DECISIONS

--- a/docs/concepts/data-model.md
+++ b/docs/concepts/data-model.md
@@ -112,7 +112,8 @@ erDiagram
     }
     ResourceAssignments {
         guid resourceId FK
-        guid principalId FK
+        guid principalId "nullable FK — XOR with identityId"
+        guid identityId "nullable FK — XOR with principalId"
         string assignmentType
         int systemId FK
         string principalType
@@ -152,7 +153,8 @@ erDiagram
     Systems ||--o{ Principals : "hosts"
     Systems ||--o{ Contexts : "scopes"
     Resources ||--o{ ResourceAssignments : "granted via"
-    Principals ||--o{ ResourceAssignments : "receives"
+    Principals |o--o{ ResourceAssignments : "receives (account-level)"
+    Identities |o--o{ ResourceAssignments : "receives (person-level)"
     Resources ||--o{ ResourceRelationships : "parent in"
     Resources ||--o{ ResourceRelationships : "child in"
     Principals ||--o{ PrincipalActivity : "has activity"
@@ -268,15 +270,18 @@ Key columns: `displayName`, `resourceType`, `systemId`, `contextId` (optional �
 
 ### ResourceAssignments
 
-Captures who has access to what, and how. The `assignmentType` column distinguishes direct membership from PIM-eligible access from governed (business-role-driven) access.
+Captures who has access to what, and how. The `assignmentType` column distinguishes direct membership from PIM-eligible access from governed (IGA-driven) access.
+
+Every row targets either a specific account (`principalId`) or a person (`identityId`) — exactly one must be set (XOR CHECK constraint). Use the principal endpoint for account-level assignments (e.g. "this AD account is in this group") and the identity endpoint for person-level assignments (e.g. "this person has been given this access" from an IGA system).
 
 | Property | Value |
 |---|---|
-| Primary Key | Composite: `resourceId` + `principalId` + `assignmentType` |
+| Uniqueness | Two partial unique indexes: `(resourceId, principalId, assignmentType)` WHERE `principalId IS NOT NULL`; `(resourceId, identityId, assignmentType)` WHERE `identityId IS NOT NULL` |
 | Audit history | Yes (via `_history` trigger) |
 | Created by | Migration `001_core_schema.sql` |
+| Modified by | Migration `036_resource_assignments_identity_support.sql` |
 
-Key columns: `assignmentType`, `systemId`, `principalType`, `complianceState`, `policyId`, `state`, `assignmentStatus`, `expirationDateTime`, `extendedAttributes` (JSONB).
+Key columns: `assignmentType`, `principalId` (nullable), `identityId` (nullable), `systemId`, `principalType`, `complianceState`, `policyId`, `state`, `assignmentStatus`, `expirationDateTime`, `extendedAttributes` (JSONB).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `identityId` to `ResourceAssignments` so IGA crawlers (MidPoint, Omada) can assign any access to a **person** (Identity) rather than a specific account (Principal). The routing rule is simple: if the source system's subject is a person → use `/ingest/resource-assignments-identity`; if it's an account → use `/ingest/resource-assignments`. Resource type is irrelevant.
- New `POST /ingest/resource-assignments-identity` endpoint with its own schema and key columns (`resourceId`, `identityId`, `assignmentType`)
- Matrix view expanded with a UNION arm that joins `IdentityMembers` to expand person-level assignments to all linked accounts
- `scopeDeleteFilter` option threaded through engine + sessions so principal full-syncs never delete identity rows and vice versa
- `classify-business-role-assignments` XOR fix: identity Direct rows now correctly deduped before Governed promotion

## Changes

- `app/api/src/db/migrations/036_resource_assignments_identity_support.sql` — nullable `principalId`, bare-UUID `identityId`, XOR CHECK constraint, two partial unique indexes
- `app/api/src/db/migrations/037_matrix_view_identity_support.sql` — rebuilds matview with identity expansion arm
- `app/api/src/ingest/validation.js` — new `resource-assignments-identity` entity type + XOR validation
- `app/api/src/routes/ingest.js` — new route, `scopeDeleteFilter` on both RA handlers, classify fix
- `app/api/src/ingest/engine.js` + `sessions.js` — `scopeDeleteFilter` option
- `app/api/src/routes/admin.js` — `identityAssignments` stat
- `docs/concepts/data-model.md` — ERD and table reference updated
- Tests: 11 scenarios across validation, normalization, engine, migration SQL structure, and classify route

## Test plan

- [ ] `docker compose build web && docker compose up -d web` — migrations 036 + 037 apply cleanly on an existing DB
- [ ] Existing crawlers unaffected — `/ingest/resource-assignments` with `principalId` still works
- [ ] POST to `/ingest/resource-assignments-identity` with `identityId` → 201
- [ ] POST to `/ingest/resource-assignments` with `identityId` present → 400 with pointer to identity endpoint
- [ ] Full-sync on identity endpoint does not delete principal rows; full-sync on principal endpoint does not delete identity rows
- [ ] After pushing an identity assignment and running account linking, the assignment appears in the matrix for each linked principal
- [ ] Admin stats panel shows `identityAssignments` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)