### PR TITLE
docs: fix resourceType table and add AI configuration guide

### DIFF
--- a/changes/fix-documentation.md
+++ b/changes/fix-documentation.md
@@ -1,0 +1,4 @@
+- Fixed resourceType documentation to match what the built-in crawlers actually produce (removed non-existent types, added Application, AppRole, DelegatedPermission, Entitlement, Resource, Service)
+- Added missing assignmentType values (AppRole, AppRoleViaGroup, OAuth2Grant) to the data model reference
+- Added AI provider configuration guide to the Risk Scoring overview, including all three supported providers (Anthropic, OpenAI, Azure OpenAI), required fields per provider, and a data privacy table showing which providers are suitable for regulated environments
+- Updated config file reference to cover Azure OpenAI and correct stale model defaults

--- a/docs/concepts/data-model.md
+++ b/docs/concepts/data-model.md
@@ -359,17 +359,19 @@ The `principalType` column on the Principals table uses these standard values ac
 
 ## resourceType Values
 
-The `resourceType` column on the Resources table is a free-form string. These are the standard values used by the built-in sync functions.
+The `resourceType` column on the Resources table is a free-form string. The values below are produced by the built-in crawlers.
 
-| Value | What it covers |
-|---|---|
-| `EntraGroup` | Entra ID security groups and Microsoft 365 groups |
-| `EntraDirectoryRole` | Entra ID directory roles (Global Administrator, etc.) |
-| `EntraAppRole` | Application roles from enterprise app registrations |
-| `BusinessRole` | Named entitlement bundles from any IGA platform |
-| `SharePointSite` | SharePoint sites (via CSV import) |
-| `AzureRBACRole` | Azure RBAC role assignments (via CSV import) |
-| Custom | Any string — fully extensible for any authorization source |
+| Value | Crawler | What it represents |
+|---|---|---|
+| `EntraGroup` | Entra ID | Security group or Microsoft 365 group |
+| `Application` | Entra ID | Enterprise application / service principal. Parent of `AppRole` and `DelegatedPermission` — does not grant access on its own. |
+| `AppRole` | Entra ID | One synthetic resource per (Application, appRoleId). Linked to its parent via `relationshipType='HasAppRole'`. |
+| `DelegatedPermission` | Entra ID | One synthetic resource per (clientSP, targetAPI, OAuth2 scope). Linked to its parent via `relationshipType='DelegatesScope'`. |
+| `BusinessRole` | Entra ID, Omada, MidPoint | Entra ID access package; Omada business role; MidPoint role type. Contains child resources via `relationshipType='Contains'`; assigned via `assignmentType='Governed'`. |
+| `Entitlement` | MidPoint | AD group or other entitlement synced as a MidPoint shadow (kind=entitlement). |
+| `Resource` | Omada | Omada resource. |
+| `Service` | MidPoint | MidPoint service type. |
+| Custom | Any crawler | Any string — fully extensible for any authorization source. |
 
 !!! tip "Extending resourceType"
     You can use any string value for custom source systems. The model does not enforce an enum — `resourceType` is TEXT. Use a consistent naming convention such as `SystemPrefix_TypeName` (e.g., `SAP_Role`, `Pathlock_Permission`) so queries and views remain readable.
@@ -382,27 +384,34 @@ The `assignmentType` column on ResourceAssignments describes how the assignment 
 
 | Value | Meaning |
 |---|---|
-| `Direct` | Direct group membership |
+| `Direct` | Direct group or role membership |
 | `Owner` | Group owner relationship |
 | `Eligible` | PIM-eligible membership — granted but not yet activated |
 | `Governed` | Assigned through a business role or access package |
+| `AppRole` | Direct app role assignment to a principal |
+| `AppRoleViaGroup` | App role inherited through group membership |
+| `OAuth2Grant` | Delegated OAuth2 permission grant |
 | Custom | Any string for CSV-imported assignments |
 
 ---
 
 ## Source System Mapping
 
-The same three tables (Resources, Principals, ResourceAssignments) absorb data from any source. The crawler that writes the data and the `resourceType` / `assignmentType` values are the only things that differ.
+The same tables (Resources, Principals, ResourceAssignments) absorb data from any source. The crawler and the `resourceType` / `assignmentType` values are the only things that differ.
 
 | Source System | Crawler | resourceType | principalType | assignmentType |
 |---|---|---|---|---|
-| Entra ID groups | Entra ID crawler | `EntraGroup` | `User` | `Direct` / `Owner` / `Eligible` |
-| Entra ID directory roles | Entra ID crawler | `EntraDirectoryRole` | `User` | `Direct` |
-| Entra ID app roles | Entra ID crawler | `EntraAppRole` | `User` / `ServicePrincipal` | `Direct` |
-| Entra ID access packages | Entra ID crawler | `BusinessRole` | — | `Governed` |
-| Omada / SailPoint | CSV crawler | `BusinessRole` | Any | `Governed` |
-| SAP / Pathlock | CSV crawler | Any | Any | Any |
-| Custom system | CSV crawler (or your own via the [Ingest API](../architecture/ingest-api.md)) | Any | Any | Any |
+| Entra ID groups | Entra ID | `EntraGroup` | `User` | `Direct` / `Owner` / `Eligible` |
+| Entra ID enterprise apps | Entra ID | `Application` | — | — (parent only) |
+| Entra ID app roles | Entra ID | `AppRole` | `User` / `ServicePrincipal` | `AppRole` / `AppRoleViaGroup` |
+| Entra ID OAuth2 grants | Entra ID | `DelegatedPermission` | `User` | `OAuth2Grant` |
+| Entra ID access packages | Entra ID | `BusinessRole` | `User` | `Governed` |
+| Omada business roles | Omada | `BusinessRole` | `User` | `Governed` |
+| Omada resources | Omada | `Resource` | `User` | `Governed` |
+| MidPoint roles | MidPoint | `BusinessRole` | `User` | `Governed` |
+| MidPoint entitlements (AD groups etc.) | MidPoint | `Entitlement` | `User` | `Direct` |
+| MidPoint service types | MidPoint | `Service` | `User` | `Governed` |
+| Any system | CSV / custom crawler | Any string | Any | Any |
 
 ---
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -51,15 +51,28 @@ When using the in-browser wizard, these permissions are validated automatically 
 
 ## Section: LLM
 
-Configures the AI provider used by `New-FGRiskProfile` and `New-FGRiskClassifiers`. Only anonymized structural data is sent to the LLM — no user names, emails, or identity data. (Account Linking does **not** use the LLM — it is deterministic.)
+!!! info "Docker deployments: configure AI in the UI"
+    In the Docker deployment the AI provider is configured at **Admin → LLM Settings**, not via a config file. The API key is stored encrypted in the built-in secrets vault. The config file approach below is only relevant when running the PowerShell risk-profile scripts outside Docker.
+
+Supported providers: `anthropic`, `openai`, `azure-openai`. Only public organisational context (domain, industry) is sent to the AI — no user names, emails, or identity data. See [Risk Scoring → Data Privacy](../risk-scoring/overview.md#data-privacy) for details.
+
+**Anthropic / OpenAI:**
 
 | Key | Type | Description |
 |---|---|---|
-| `Provider` | string | `Anthropic` or `OpenAI`. |
-| `Model` | string | Optional model override (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). |
-| `ApiKey` | string | API key. |
+| `Provider` | string | `Anthropic` or `OpenAI` |
+| `Model` | string | Optional model override. Defaults: Anthropic → `claude-sonnet-4-6`, OpenAI → `gpt-4o`. |
+| `ApiKey` | string | API key. Can also be supplied via `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` env vars. |
 
-The LLM key can also be supplied via environment variables: `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`.
+**Azure OpenAI** (additional keys):
+
+| Key | Type | Description |
+|---|---|---|
+| `Provider` | string | `azure-openai` |
+| `ApiKey` | string | Azure OpenAI resource key. |
+| `Endpoint` | string | Resource endpoint, e.g. `https://my-resource.openai.azure.com` |
+| `Deployment` | string | Deployment name as configured in Azure. |
+| `ApiVersion` | string | Optional. Defaults to `2024-08-01-preview`. |
 
 ---
 

--- a/docs/risk-scoring/overview.md
+++ b/docs/risk-scoring/overview.md
@@ -86,13 +86,47 @@ Analysts can adjust any entity's score by −50 to +50 points with a required ju
 - Overrides are stored in `RiskScores` and preserved across re-scoring runs
 - Override history is preserved across re-scoring runs
 
+## Configuring the AI provider
+
+The AI provider is configured in **Admin → LLM Settings**. Three providers are supported:
+
+| Provider | `provider` value | Default model | Notes |
+|---|---|---|---|
+| Anthropic | `anthropic` | `claude-sonnet-4-6` | API key required |
+| OpenAI | `openai` | `gpt-4o` | API key required |
+| Azure OpenAI | `azure-openai` | _(deployment name required)_ | Also requires endpoint URL and deployment name |
+
+Once you enter the API key and click **Test**, IdentityAtlas verifies the connection and populates the model dropdown from the provider's API. The key is stored encrypted in the built-in secrets vault — it is never stored as plain text.
+
+For Azure OpenAI the endpoint must be a valid Azure OpenAI hostname (`*.openai.azure.com`, `.us`, or `.cn`). The deployment name is the name you gave the deployment in Azure, not the underlying model name.
+
 ## Data Privacy
 
-!!! success "No sensitive data leaves your infrastructure"
-    - **Phase 1 only** contacts an LLM — sends only public organizational context (domain, industry, known systems)
-    - **No identity data** (user names, email addresses, group memberships) is ever sent to external services
-    - All scoring runs locally against your SQL database
-    - Supported LLM providers: Anthropic Claude (default: `claude-sonnet-4-20250514`), OpenAI (default: `gpt-4o`)
+!!! success "No identity data ever leaves your infrastructure"
+    - **Phase 1 only** contacts an LLM — the prompt contains only public organisational context: the domain name, optional organisation name, optional free-text hints you type, and any text you paste from internal documents.
+    - **No identity data** — no user names, email addresses, group names, or access assignments — is ever sent to the AI provider.
+    - All scoring (matching classifiers against your data) runs locally against your database with no network calls.
+
+**What is sent to the AI, exactly:**
+
+| What | Example |
+|---|---|
+| Domain name | `contoso.com` |
+| Organisation name (optional) | `Contoso Ltd` |
+| Free-text hints (optional) | `We operate in the Netherlands under NIS2` |
+| Text from URLs you add (optional) | Scraped text from public or internal pages |
+
+Nothing else. The AI generates regex patterns from this context; those patterns are then stored locally and applied against your data entirely on-premises.
+
+**Provider security comparison:**
+
+| Provider | Data stays in your region? | Used for AI training? |
+|---|---|---|
+| Anthropic API | No — routed to `api.anthropic.com` | Depends on your plan. Paid API plans include a no-training clause; verify your agreement. |
+| OpenAI API | No — routed to `api.openai.com` | Consumer tier: opt-out required in account settings. Enterprise agreement: excluded by contract. |
+| Azure OpenAI | Yes — stays within your Azure subscription | No — Microsoft Azure terms contractually exclude customer prompts from model training. |
+
+For regulated environments or when in doubt, use **Azure OpenAI**: the data stays within your Azure tenant and training exclusion is contractual by default.
 
 ## RiskScores Table
 


### PR DESCRIPTION
## Summary

- Corrected the `resourceType` reference table in the data model docs — removed four types that no crawler produces (`EntraDirectoryRole`, `EntraAppRole`, `SharePointSite`, `AzureRBACRole`) and replaced with what the built-in crawlers actually emit (`Application`, `AppRole`, `DelegatedPermission`, `Entitlement`, `Resource`, `Service`). Added missing `assignmentType` values (`AppRole`, `AppRoleViaGroup`, `OAuth2Grant`).
- Added **AI provider configuration guide** to the Risk Scoring overview: provider table, required fields per provider (including Azure OpenAI), what exactly is sent to the AI, and a data privacy comparison table showing training risk per provider.
- Updated config file reference: added Azure OpenAI fields, corrected stale default model names, added note directing Docker users to Admin → LLM Settings.

## Test plan

- [ ] Docs render correctly (no broken links or Mermaid errors)
- [ ] resourceType table matches what crawlers produce
- [ ] AI configuration section covers all three providers with correct field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)