### PR TITLE
fix(docker): include tools/crawlers in the frontend build stage

### DIFF
--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -2,12 +2,21 @@
 # Usage: docker build -f app/api/Dockerfile -t fortigraph-backend .
 
 # ── Stage 1: Build frontend ───────────────────────────────────────────────────
+# Layout mirrors the repo root (app/ui/ + tools/crawlers/ as siblings) because
+# CrawlersPage.jsx discovers crawler wizards via a repo-root-relative
+# import.meta.glob('../../../../tools/crawlers/*/ConfigWizard.jsx') — vite build
+# resolves that glob against the filesystem, so tools/crawlers must be present
+# four levels up from src/components at build time, not just at dev-server time.
+# node_modules is installed at /build (not app/ui/node_modules) so Node's
+# ancestor-walk module resolution can find "react" etc. from files under
+# tools/crawlers/ too — they aren't descendants of app/ui.
 FROM node:24-slim AS frontend-build
-WORKDIR /app/frontend
+WORKDIR /build
 COPY app/ui/package*.json ./
 RUN npm ci
-COPY app/ui/ .
-RUN npm run build
+COPY app/ui/ ./app/ui/
+COPY tools/crawlers ./tools/crawlers
+RUN npm --prefix app/ui run build
 
 # ── Stage 2: Backend runtime ──────────────────────────────────────────────────
 FROM node:24-slim AS runtime
@@ -29,7 +38,7 @@ COPY tools/crawlers /app/crawlers
 RUN find /app/crawlers -name "*.ps1" -delete
 ENV CRAWLER_MANIFESTS_DIR=/app/crawlers
 # Copy the compiled frontend so Express can serve it as static files
-COPY --from=frontend-build /app/frontend/dist ../frontend/dist
+COPY --from=frontend-build /build/app/ui/dist ../frontend/dist
 
 EXPOSE 3001
 # Create the uploads directory with node ownership BEFORE switching user.

--- a/app/ui/e2e/crawler-wizard-discovery.spec.js
+++ b/app/ui/e2e/crawler-wizard-discovery.spec.js
@@ -1,0 +1,80 @@
+// @ts-check
+/**
+ * Crawler wizard plugin discovery E2E test.
+ *
+ * CrawlersPage.jsx discovers crawler wizards via a repo-root-relative
+ * import.meta.glob() call targeting each crawler folder's CrawlerMeta.js file.
+ * That glob is resolved against the filesystem at build time, so a packaging
+ * mistake (e.g. a build stage that doesn't copy tools/crawlers/) silently
+ * produces zero matches with no error anywhere — see the Docker
+ * frontend-build bug fixed by app/api/Dockerfile's frontend-build stage
+ * restructuring.
+ *
+ * This test does NOT hardcode crawler names (crawlers come and go). Instead
+ * it discovers the same source of truth the production code reads from
+ * (each tools/crawlers/<type>/CrawlerMeta.js file on disk) and asserts the
+ * running app's "Add Crawler" type picker shows every one of them. Runs
+ * against the real Docker-built backend in CI (see playwright.ci.config.js),
+ * so it exercises the actual production build artifact, not just
+ * `npm run dev`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { readdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { execFileSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3001';
+const CRAWLERS_ROOT = join(__dirname, '..', '..', '..', 'tools', 'crawlers');
+
+// Playwright's own module loader intercepts dynamic import() of arbitrary
+// external files and can misclassify their module format, so the actual
+// import is done in a throwaway child Node process instead (matches plain
+// `node` behavior, which is what the real API/UI code paths use).
+function importDefaultExport(absPath) {
+  const script = `import(${JSON.stringify(pathToFileURL(absPath).href)}).then(m => process.stdout.write(JSON.stringify(m.default)));`;
+  return JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8' }));
+}
+
+function discoverCrawlerMetas() {
+  if (!existsSync(CRAWLERS_ROOT)) return [];
+  const metas = [];
+  for (const entry of readdirSync(CRAWLERS_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const metaPath = join(CRAWLERS_ROOT, entry.name, 'CrawlerMeta.js');
+    if (!existsSync(metaPath)) continue;
+    metas.push(importDefaultExport(metaPath));
+  }
+  return metas;
+}
+
+test.describe('Crawler wizard plugin discovery', () => {
+  test('every tools/crawlers/*/CrawlerMeta.js entry appears in the Add Crawler type picker', async ({ page }) => {
+    const metas = discoverCrawlerMetas();
+    test.skip(metas.length === 0, 'No file-based crawler plugins found in tools/crawlers/ — nothing to verify');
+
+    await page.goto(`${BASE}/#admin`);
+    await page.waitForLoadState('networkidle');
+
+    // .first() — an empty-data install shows a second "Add Crawler" CTA in the
+    // welcome banner alongside the toolbar button; both open the same picker.
+    const addBtn = page.locator('button:has-text("Add Crawler")').first();
+    if (!await addBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+    await addBtn.click();
+
+    for (const meta of metas) {
+      const typeBtn = page.locator('button').filter({ hasText: meta.name });
+      await expect(
+        typeBtn,
+        `Expected "${meta.name}" (tools/crawlers/${meta.id}/CrawlerMeta.js) in the type picker. If this fails, ` +
+        `the crawler-wizard plugin discovery (import.meta.glob) found nothing in the running build — check that ` +
+        `tools/crawlers/ was actually included wherever this app was built.`
+      ).toBeVisible({ timeout: 5000 });
+    }
+  });
+});

--- a/changes/bugfixes-fix-crawler-wizard-docker-build.md
+++ b/changes/bugfixes-fix-crawler-wizard-docker-build.md
@@ -1,1 +1,2 @@
 - Fixed: crawler configuration wizards (e.g. the midPoint wizard) and their type-picker entries were silently missing from the production Docker image — the frontend build stage didn't include the `tools/crawlers` folder that the wizard plugin system discovers wizards from. They now appear correctly in the deployed app, not just in local dev.
+- Added an automated check that catches this exact class of regression going forward: an E2E test that dynamically discovers every crawler with a UI wizard and verifies it actually appears in the "Add Crawler" list of the running app.

--- a/changes/bugfixes-fix-crawler-wizard-docker-build.md
+++ b/changes/bugfixes-fix-crawler-wizard-docker-build.md
@@ -1,0 +1,1 @@
+- Fixed: crawler configuration wizards (e.g. the midPoint wizard) and their type-picker entries were silently missing from the production Docker image — the frontend build stage didn't include the `tools/crawlers` folder that the wizard plugin system discovers wizards from. They now appear correctly in the deployed app, not just in local dev.


### PR DESCRIPTION
## Summary
- The production Docker image's frontend build stage only copied `app/ui/`, never `tools/crawlers/`. `CrawlersPage.jsx` discovers crawler wizards via `import.meta.glob('../../../../tools/crawlers/*/ConfigWizard.jsx')`, which is resolved against the filesystem at `vite build` time — so in the actual shipped image this glob matched **zero** files. The midPoint crawler's wizard (and its "midPoint (Evolveum)" type-picker entry) has been silently invisible in production since PR #336/#338 merged, even though it worked fine under `npm run dev`.
- Fixed by restructuring the frontend build stage to mirror the repo's directory layout (`app/ui/` + `tools/crawlers/` as siblings under one root) and hoisting `node_modules` to that shared root so bundler module resolution (`react`, etc.) works for files under `tools/crawlers/` too — they aren't descendants of `app/ui`.
- Verified with a real `docker build` (not just `npm run dev`): before the fix, `dist/assets/` contained no `ConfigWizard` chunk; after the fix, it does, and the chunk contains the actual midPoint wizard code.

## Test plan
- [x] `docker build -f app/api/Dockerfile --target frontend-build` succeeds and produces a `ConfigWizard-*.js` chunk containing `midPoint`-specific strings
- [x] Full two-stage `docker build -f app/api/Dockerfile` succeeds; runtime image serves `/app/frontend/dist/assets/ConfigWizard-*.js`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)