### PR TITLE
test(api): cover the generalized crawler file-upload mechanism

### DIFF
--- a/app/api/src/routes/crawlerFiles.test.js
+++ b/app/api/src/routes/crawlerFiles.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for the generic crawler file-upload + upload-schema routes that don't
+ * need real disk I/O: type-gating (assertUploadableConfig), the schema-template
+ * routes (which read real, checked-in files under tools/crawlers/<type>/schema/),
+ * and getUploadFolderPath's pure path-naming logic.
+ *
+ * The actual upload/list/delete cycle (which needs a writable folder) is in
+ * crawlerFiles.uploads.test.js.
+ *
+ * Uses real crawler manifests (not mocked) — csv really has supportsFileUploads,
+ * entra-id really doesn't — same approach as jobs.discover.test.js.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import crawlerFilesRouter, { getUploadFolderPath } from './crawlerFiles.js';
+
+// ─── Shared mocks ─────────────────────────────────────────────────────────────
+
+const { mockPool, mockDbQuery } = vi.hoisted(() => {
+  const mockDbQuery = vi.fn();
+  const mockRequest = { input: vi.fn().mockReturnThis(), query: mockDbQuery };
+  const mockPool = { request: vi.fn(() => mockRequest) };
+  return { mockPool, mockDbQuery };
+});
+
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+vi.mock('../middleware/auth.js', () => ({
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', crawlerFilesRouter);
+  return app;
+}
+
+beforeEach(() => {
+  mockDbQuery.mockClear();
+});
+
+// ─── Type-gating (assertUploadableConfig) ──────────────────────────────────────
+
+describe('crawler-configs/:configId/files — type gating', () => {
+  it('rejects GET for a config whose type does not support file uploads', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'entra-id' }] });
+    const res = await request(makeApp()).get('/api/admin/crawler-configs/1/files');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/does not support file uploads/);
+  });
+
+  it('rejects POST (upload) for a config whose type does not support file uploads', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'entra-id' }] });
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/1/files')
+      .attach('files', Buffer.from('a,b\n1,2'), 'data.csv');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/does not support file uploads/);
+  });
+
+  it('rejects DELETE for a config whose type does not support file uploads', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'entra-id' }] });
+    const res = await request(makeApp()).delete('/api/admin/crawler-configs/1/files/data.csv');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/does not support file uploads/);
+  });
+
+  it('returns 404 when the config does not exist', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [] });
+    const res = await request(makeApp()).get('/api/admin/crawler-configs/999/files');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/Crawler config not found/);
+  });
+
+  it('rejects a non-numeric configId before touching the DB', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawler-configs/not-a-number/files');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid configId/);
+    expect(mockDbQuery).not.toHaveBeenCalled();
+  });
+
+  it('lists an empty array for a real csv config with no upload folder yet (no I/O needed)', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    // A random high id is extremely unlikely to have a real folder under the
+    // default UPLOAD_ROOT in this test environment.
+    const res = await request(makeApp()).get('/api/admin/crawler-configs/9999999/files');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ files: [] });
+  });
+});
+
+// ─── getUploadFolderPath — pure function, no I/O ───────────────────────────────
+
+describe('getUploadFolderPath', () => {
+  it('builds a {crawlerType}-{configId} folder name', () => {
+    expect(getUploadFolderPath('csv', 42)).toMatch(/csv-42$/);
+  });
+
+  it('is parameterized by crawler type, not hardcoded to csv', () => {
+    expect(getUploadFolderPath('excel', 7)).toMatch(/excel-7$/);
+    expect(getUploadFolderPath('excel', 7)).not.toMatch(/csv/);
+  });
+});
+
+// ─── Upload schema templates ────────────────────────────────────────────────────
+
+describe('GET /admin/crawlers/:type/upload-schema', () => {
+  it('serves all 10 real csv templates with label/required annotations, including ContextMembers.csv', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawlers/csv/upload-schema');
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/# ContextMembers\.csv — Context Members \(optional\)/);
+    expect(res.text).toMatch(/ContextExternalId;MemberExternalId;MemberType/);
+    expect(res.text).toMatch(/# Resources\.csv — Resources \(REQUIRED\)/);
+    for (const file of [
+      'Systems.csv', 'Contexts.csv', 'ContextMembers.csv', 'Resources.csv',
+      'ResourceRelationships.csv', 'Users.csv', 'Assignments.csv', 'Identities.csv',
+      'IdentityMembers.csv', 'Certifications.csv',
+    ]) {
+      expect(res.text).toContain(file);
+    }
+  });
+
+  it('serves a single real template file by name', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawlers/csv/upload-schema/ContextMembers.csv');
+    expect(res.status).toBe(200);
+    expect(res.text.trim()).toBe('ContextExternalId;MemberExternalId;MemberType');
+  });
+
+  it('404s for an unknown template filename under a real type', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawlers/csv/upload-schema/NotARealFile.csv');
+    expect(res.status).toBe(404);
+  });
+
+  it('404s for a real crawler type with no schema/ folder (entra-id)', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawlers/entra-id/upload-schema');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/has no upload schema/);
+  });
+
+  it('404s for an unknown crawler type', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawlers/nonexistent-type/upload-schema');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/Unknown crawler type/);
+  });
+
+  it('404s for a path-traversal-style type slug', async () => {
+    const res = await request(makeApp()).get('/api/admin/crawlers/../shared/upload-schema');
+    // Express normalises the URL so the param becomes a single segment that
+    // isn't a registered crawler type — same defense as the discover.js route.
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/src/routes/crawlerFiles.uploads.test.js
+++ b/app/api/src/routes/crawlerFiles.uploads.test.js
@@ -1,0 +1,137 @@
+/**
+ * Real upload/list/delete cycle for the generic crawler file-upload routes —
+ * needs a writable folder, unlike crawlerFiles.test.js's routing/gating tests.
+ *
+ * UPLOAD_ROOT is captured by crawlerFiles.js at module-load time, so it must
+ * be set *before* the module is imported. Same technique already proven in
+ * bootstrap.builtinKey.test.js for WORKER_KEY_FILE: real temp dir via
+ * mkdtempSync, set the env var, then dynamic `await import(...)`.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { existsSync, mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const UPLOAD_ROOT_DIR = mkdtempSync(join(tmpdir(), 'iatest-uploads-'));
+process.env.UPLOAD_ROOT = UPLOAD_ROOT_DIR;
+
+const { mockPool, mockDbQuery } = vi.hoisted(() => {
+  const mockDbQuery = vi.fn();
+  const mockRequest = { input: vi.fn().mockReturnThis(), query: mockDbQuery };
+  const mockPool = { request: vi.fn(() => mockRequest) };
+  return { mockPool, mockDbQuery };
+});
+
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+vi.mock('../middleware/auth.js', () => ({
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
+const { default: crawlerFilesRouter, deleteConfigFolder } = await import('./crawlerFiles.js');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', crawlerFilesRouter);
+  return app;
+}
+
+beforeEach(() => {
+  mockDbQuery.mockClear();
+});
+
+afterAll(() => {
+  rmSync(UPLOAD_ROOT_DIR, { recursive: true, force: true });
+});
+
+describe('crawler-configs/:configId/files — real upload/list/delete cycle', () => {
+  it('uploads a .csv file to a real csv config, landing at {UPLOAD_ROOT}/csv-{id}/', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/501/files')
+      .attach('files', Buffer.from('ExternalId;DisplayName\n1;Test'), 'Resources.csv');
+
+    expect(res.status).toBe(200);
+    expect(res.body.uploaded).toEqual([{ name: 'Resources.csv', sizeBytes: expect.any(Number) }]);
+
+    const expectedPath = join(UPLOAD_ROOT_DIR, 'csv-501', 'Resources.csv');
+    expect(existsSync(expectedPath)).toBe(true);
+    expect(readFileSync(expectedPath, 'utf8')).toBe('ExternalId;DisplayName\n1;Test');
+  });
+
+  it('lists the uploaded file back', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const res = await request(makeApp()).get('/api/admin/crawler-configs/501/files');
+    expect(res.status).toBe(200);
+    expect(res.body.files).toEqual([
+      { name: 'Resources.csv', sizeBytes: expect.any(Number), modifiedAt: expect.any(String) },
+    ]);
+  });
+
+  it('rejects a .txt file via the manifest-driven extension filter', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/501/files')
+      .attach('files', Buffer.from('not allowed'), 'notes.txt');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/File type not allowed/);
+    expect(existsSync(join(UPLOAD_ROOT_DIR, 'csv-501', 'notes.txt'))).toBe(false);
+  });
+
+  it('rejects a dotfile-style filename', async () => {
+    // A literal '..' segment never reaches the handler at all — Express's own
+    // URL normalization collapses it (one directory up) before routing, so it
+    // 404s rather than reaching sanitizeFilename. Use a dotfile name instead,
+    // which Express does NOT treat as special, to actually exercise the
+    // startsWith('.') branch of sanitizeFilename.
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const res = await request(makeApp())
+      .delete('/api/admin/crawler-configs/501/files/' + encodeURIComponent('.env'));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid filename/);
+  });
+
+  it('strips directory components from a path-traversal filename instead of escaping the config folder', async () => {
+    // basename() reduces '../../etc/passwd' to just 'passwd' — confirm the
+    // delete can only ever touch a file inside this config's own folder, by
+    // planting a decoy 'passwd' file there and confirming only THAT gets
+    // removed — the real /etc/passwd is never touched.
+    const configDir = join(UPLOAD_ROOT_DIR, 'csv-501');
+    const decoy = join(configDir, 'passwd');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(decoy, 'decoy');
+
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const res = await request(makeApp())
+      .delete('/api/admin/crawler-configs/501/files/' + encodeURIComponent('../../etc/passwd'));
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe('passwd');
+    expect(existsSync(decoy)).toBe(false);
+    expect(existsSync('/etc/passwd')).toBe(true); // the real file, untouched
+  });
+
+  it('deletes the uploaded file; subsequent list is empty', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const delRes = await request(makeApp()).delete('/api/admin/crawler-configs/501/files/Resources.csv');
+    expect(delRes.status).toBe(200);
+    expect(existsSync(join(UPLOAD_ROOT_DIR, 'csv-501', 'Resources.csv'))).toBe(false);
+
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    const listRes = await request(makeApp()).get('/api/admin/crawler-configs/501/files');
+    expect(listRes.body.files).toEqual([]);
+  });
+
+  it('deleteConfigFolder removes the whole per-config folder', async () => {
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ crawlerType: 'csv' }] });
+    await request(makeApp())
+      .post('/api/admin/crawler-configs/777/files')
+      .attach('files', Buffer.from('a;b'), 'Systems.csv');
+    const dir = join(UPLOAD_ROOT_DIR, 'csv-777');
+    expect(existsSync(dir)).toBe(true);
+
+    await deleteConfigFolder('csv', 777);
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/app/api/src/routes/jobs.fileUploads.test.js
+++ b/app/api/src/routes/jobs.fileUploads.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for the generalized file-upload dispatch block in jobs.js's
+ * POST /admin/crawler-jobs handler — replaced a hardcoded `jobType === 'csv'`
+ * check with a manifest-driven `_crawlerManifests[jobType]?.supportsFileUploads`
+ * check (PR #356). Covers: the manifest gate itself, the "folder must contain
+ * >=1 file" requirement, the csvFolder override + path-containment guard, and
+ * that non-upload types skip the whole block entirely.
+ *
+ * jobs.js captures CSV_BASE_DIR (from UPLOAD_ROOT) at module-load time, same
+ * as crawlerFiles.js — same real-temp-dir + dynamic-import technique as
+ * bootstrap.builtinKey.test.js / crawlerFiles.uploads.test.js.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const UPLOAD_ROOT_DIR = mkdtempSync(join(tmpdir(), 'iatest-jobs-uploads-'));
+process.env.UPLOAD_ROOT = UPLOAD_ROOT_DIR;
+process.env.USE_SQL = 'true'; // jobs.js captures this at module-load time too
+
+const { mockPool, mockDbQuery, mockInput } = vi.hoisted(() => {
+  const mockDbQuery = vi.fn();
+  const mockInput = vi.fn().mockReturnThis();
+  const mockRequest = { input: mockInput, query: mockDbQuery };
+  const mockPool = { request: vi.fn(() => mockRequest) };
+  return { mockPool, mockDbQuery, mockInput };
+});
+
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+vi.mock('../middleware/auth.js', () => ({
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
+const { default: jobsRouter } = await import('./jobs.js');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', jobsRouter);
+  return app;
+}
+
+// Helper: pull the JSON-stringified value passed to .input('config', ...) so
+// tests can inspect what was actually about to be stored, without needing to
+// fabricate a fake RETURNING * echo in the INSERT mock.
+function storedConfig() {
+  const call = mockInput.mock.calls.find(c => c[0] === 'config');
+  return call?.[1] ? JSON.parse(call[1]) : null;
+}
+
+beforeEach(() => {
+  mockDbQuery.mockClear();
+  mockInput.mockClear();
+});
+
+afterAll(() => {
+  rmSync(UPLOAD_ROOT_DIR, { recursive: true, force: true });
+});
+
+describe('POST /admin/crawler-jobs — generalized file-upload dispatch', () => {
+  it('queues a csv job when its upload folder has >=1 file, stamping csvFolder onto the stored config', async () => {
+    const dir = join(UPLOAD_ROOT_DIR, 'csv-501');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'Resources.csv'), 'a;b');
+
+    mockDbQuery
+      .mockResolvedValueOnce({ recordset: [{ config: {}, nextRunMode: 'delta' }] }) // config lookup
+      .mockResolvedValueOnce({ recordset: [{ id: 1 }] }) // insert
+      .mockResolvedValueOnce({ recordset: [] }); // lastRunAt update
+
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-jobs')
+      .send({ jobType: 'csv', configId: 501 });
+
+    expect(res.status).toBe(201);
+    expect(storedConfig().csvFolder).toBe(dir);
+  });
+
+  it('rejects a csv job whose upload folder is empty', async () => {
+    mkdirSync(join(UPLOAD_ROOT_DIR, 'csv-502'), { recursive: true }); // exists but empty
+    mockDbQuery.mockResolvedValueOnce({ recordset: [{ config: {}, nextRunMode: 'delta' }] });
+
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-jobs')
+      .send({ jobType: 'csv', configId: 502 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/No files found/);
+  });
+
+  it('rejects a csv job with no configId before even checking for files', async () => {
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-jobs')
+      .send({ jobType: 'csv' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/csv jobs require a configId/);
+  });
+
+  it('skips the file-upload gate entirely for a type that does not support uploads (demo)', async () => {
+    // No upload folder exists anywhere for this — if the gate ran at all for
+    // 'demo' it would 400 on a missing folder. It shouldn't even check.
+    mockDbQuery
+      .mockResolvedValueOnce({ recordset: [] }) // no duplicate demo job queued
+      .mockResolvedValueOnce({ recordset: [{ id: 2 }] }); // insert (no configId -> no lastRunAt update)
+
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-jobs')
+      .send({ jobType: 'demo' });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('accepts a csvFolder override that stays within the upload base directory', async () => {
+    const customDir = join(UPLOAD_ROOT_DIR, 'custom-csv-folder');
+    mkdirSync(customDir, { recursive: true });
+    writeFileSync(join(customDir, 'Users.csv'), 'a;b');
+    // The default csv-503 folder deliberately does NOT exist, to prove the
+    // override (not the default path) is what satisfied the file check.
+
+    mockDbQuery
+      .mockResolvedValueOnce({ recordset: [{ config: { csvFolder: customDir }, nextRunMode: 'delta' }] })
+      .mockResolvedValueOnce({ recordset: [{ id: 3 }] })
+      .mockResolvedValueOnce({ recordset: [] });
+
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-jobs')
+      .send({ jobType: 'csv', configId: 503 });
+
+    expect(res.status).toBe(201);
+    expect(storedConfig().csvFolder).toBe(customDir);
+  });
+
+  it('rejects a csvFolder override that escapes the upload base directory, falling back to the default path', async () => {
+    // The override points outside UPLOAD_ROOT entirely. The default csv-504
+    // folder also doesn't exist, so the request should 400 on "no files" —
+    // proving the malicious override was never followed, not just that it
+    // didn't grant extra access.
+    mockDbQuery.mockResolvedValueOnce({
+      recordset: [{ config: { csvFolder: '/etc' }, nextRunMode: 'delta' }],
+    });
+
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-jobs')
+      .send({ jobType: 'csv', configId: 504 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/No files found/);
+  });
+});

--- a/changes/feature-crawler-file-upload-tests.md
+++ b/changes/feature-crawler-file-upload-tests.md
@@ -1,0 +1,1 @@
+- Added automated test coverage for the generic crawler file-upload mechanism (upload/list/delete, the upload-schema templates, and the manifest-driven job-dispatch gate), which previously had none and was only verified by hand. No functional change.


### PR DESCRIPTION
## Summary

Stacked on #355 (which now also includes #356's file-upload generalization, merged into its branch).

PR #356 generalized `routes/csvUploads.js` → `routes/crawlerFiles.js` and the `jobType === 'csv'` dispatch block in `jobs.js`, verified only by hand (real Docker build + curl) during that PR. There was **zero automated test coverage** for any of it — confirmed by direct inspection, not assumption. Adds three test files:

- **`crawlerFiles.test.js`** — type-gating (`assertUploadableConfig`, using real `csv` vs `entra-id` manifest data, not mocked), the upload-schema routes (reading real files under `tools/crawlers/csv/schema/`, including the previously-missing `ContextMembers.csv`), 404s for unknown types/files, and `getUploadFolderPath`'s pure path-naming logic. No real file I/O needed.
- **`crawlerFiles.uploads.test.js`** — the real upload/list/delete cycle, needing a writable folder. `UPLOAD_ROOT` is captured by `crawlerFiles.js` at module-load time, so the test sets it via a real `mkdtempSync` temp dir and dynamically imports the module afterward — the same technique already proven in `bootstrap.builtinKey.test.js` for `WORKER_KEY_FILE`. Caught two wrong assumptions while writing this (see below).
- **`jobs.fileUploads.test.js`** — the manifest-driven `supportsFileUploads` gate, the "folder must contain ≥1 file" requirement, the `csvFolder` override + path-containment guard (both accepted-inside-base and rejected-outside-base cases), and confirms a non-upload type (`demo`) skips the gate entirely even with no upload folder anywhere.

### Two wrong assumptions caught by actually running the tests
- A literal `..` filename never reaches the route handler at all — Express's own URL normalization resolves it as "go up one directory" and 404s before routing even matches, not a 400 from the handler's own validation.
- `sanitizeFilename`'s use of `basename()` reduces `../../etc/passwd` down to the harmless `passwd` — it doesn't error, it just safely strips the traversal attempt down to a filename inside the *intended* folder. Verified this lands correctly by planting a decoy file and confirming only it (never `/etc/passwd`) gets removed.

## Test plan

- [x] All three new files pass individually and together
- [x] Full suite: 631/633 passing (the 2 failures are the same pre-existing `bootstrap.tagRoots.test.js` load-dependent flake already confirmed unrelated to this branch's work)
- [x] `npx eslint` on the new files and the full `src/` tree — 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)