### PR TITLE
fix(api): make upload-schema content-type and extension filter generic

### DIFF
--- a/app/api/src/routes/crawlerFiles.js
+++ b/app/api/src/routes/crawlerFiles.js
@@ -195,7 +195,7 @@ export function getUploadFolderPath(crawlerType, configId) {
 
 // ─── Upload schema templates ─────────────────────────────────────────────────
 // GET /api/admin/crawlers/:type/upload-schema — serves a crawler's empty
-// template files (tools/crawlers/<type>/schema/*.csv) as a single concatenated
+// template files (tools/crawlers/<type>/schema/*) as a single concatenated
 // response. The UI's "Download templates" button uses this. Mirrors the
 // discover.js loading pattern: no core file lists which crawlers have
 // templates, a missing/empty schema/ dir just 404s.
@@ -215,27 +215,59 @@ function isValidType(type) {
   return /^[a-z][a-z0-9-]*$/.test(type) && VALID_JOB_TYPES.includes(type);
 }
 
+// Which extensions a crawler's schema/ folder may contain — same manifest
+// field the upload multer filter uses, so a crawler only has to declare its
+// format once. Falls back to ['.csv'] for crawlers that don't declare it
+// (today, that's just csv itself).
+function schemaExtensionsFor(type) {
+  return _crawlerManifests[type]?.uploadFileExtensions || ['.csv'];
+}
+
+// Generic extension -> MIME type lookup for serving a single template file
+// as itself, not assuming every crawler's templates are CSV. Unknown
+// extensions fall back to a generic binary type rather than guessing.
+const MIME_BY_EXTENSION = {
+  '.csv': 'text/csv',
+  '.tsv': 'text/tab-separated-values',
+  '.txt': 'text/plain',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+};
+export function mimeTypeFor(filename) {
+  const ext = filename.slice(filename.lastIndexOf('.')).toLowerCase();
+  return MIME_BY_EXTENSION[ext] || 'application/octet-stream';
+}
+
 router.get('/admin/crawlers/:type/upload-schema', gate, (req, res) => {
   const { type } = req.params;
   if (!isValidType(type)) return res.status(404).json({ error: `Unknown crawler type: ${type}` });
 
   const schemaDir = join(CRAWLER_MANIFESTS_DIR, type, 'schema');
+  const extensions = schemaExtensionsFor(type);
   let files;
   try {
-    files = readdirSync(schemaDir).filter(f => f.toLowerCase().endsWith('.csv')).sort();
+    files = readdirSync(schemaDir)
+      .filter(f => extensions.some(ext => f.toLowerCase().endsWith(ext.toLowerCase())))
+      .sort();
   } catch {
     return res.status(404).json({ error: `Crawler '${type}' has no upload schema` });
   }
   if (files.length === 0) return res.status(404).json({ error: `Crawler '${type}' has no upload schema` });
 
+  // A human-readable digest of all templates concatenated as text — only
+  // meaningful for text-based template formats (true of every crawler with
+  // schema files today). Each template is expected to be header-only (no
+  // data rows), so including the whole trimmed file rather than "just the
+  // first line" is both more correct for a hypothetical multi-line template
+  // and produces identical output for today's single-line CSV templates.
   const slots = readSlotsManifest(type) || [];
   const lines = [];
   for (const file of files) {
     const slot = slots.find(s => s.file.toLowerCase() === file.toLowerCase());
     const label = slot ? ` — ${slot.label}${slot.required ? ' (REQUIRED)' : ' (optional)'}` : '';
-    const header = readFileSync(join(schemaDir, file), 'utf8').split('\n')[0].trim();
+    const content = readFileSync(join(schemaDir, file), 'utf8').trim();
     lines.push(`# ${file}${label}`);
-    lines.push(header);
+    lines.push(content);
     lines.push('');
   }
   res.setHeader('Content-Type', 'text/plain; charset=utf-8');
@@ -249,15 +281,17 @@ router.get('/admin/crawlers/:type/upload-schema/:filename', gate, (req, res) => 
 
   const filename = basename(req.params.filename);
   const filePath = join(CRAWLER_MANIFESTS_DIR, type, 'schema', filename);
-  let header;
+  let content;
   try {
-    header = readFileSync(filePath, 'utf8').split('\n')[0].trim();
+    // Raw bytes, no text decoding — correct for any template format, not
+    // just line-delimited text ones.
+    content = readFileSync(filePath);
   } catch {
     return res.status(404).json({ error: 'Unknown template file' });
   }
-  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Type', mimeTypeFor(filename));
   res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-  res.send(header + '\n');
+  res.send(content);
 });
 
 export default router;

--- a/app/api/src/routes/crawlerFiles.test.js
+++ b/app/api/src/routes/crawlerFiles.test.js
@@ -13,7 +13,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
-import crawlerFilesRouter, { getUploadFolderPath } from './crawlerFiles.js';
+import crawlerFilesRouter, { getUploadFolderPath, mimeTypeFor } from './crawlerFiles.js';
 
 // ─── Shared mocks ─────────────────────────────────────────────────────────────
 
@@ -103,6 +103,28 @@ describe('getUploadFolderPath', () => {
   });
 });
 
+// ─── mimeTypeFor — pure function, no I/O ───────────────────────────────────────
+// Not hardcoded to .csv — derives the type from whatever extension a future
+// crawler's template files use, falling back to a generic binary type for
+// anything unrecognized rather than mislabeling it as CSV.
+
+describe('mimeTypeFor', () => {
+  it('maps known extensions to their content type', () => {
+    expect(mimeTypeFor('Users.csv')).toBe('text/csv');
+    expect(mimeTypeFor('data.json')).toBe('application/json');
+    expect(mimeTypeFor('export.xml')).toBe('application/xml');
+    expect(mimeTypeFor('notes.txt')).toBe('text/plain');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(mimeTypeFor('USERS.CSV')).toBe('text/csv');
+  });
+
+  it('falls back to a generic binary type for an unrecognized extension', () => {
+    expect(mimeTypeFor('Template.xlsx')).toBe('application/octet-stream');
+  });
+});
+
 // ─── Upload schema templates ────────────────────────────────────────────────────
 
 describe('GET /admin/crawlers/:type/upload-schema', () => {
@@ -121,11 +143,13 @@ describe('GET /admin/crawlers/:type/upload-schema', () => {
     }
   });
 
-  it('serves a single real template file by name', async () => {
+  it('serves a single real template file by name with a content-type derived from its extension', async () => {
     const res = await request(makeApp()).get('/api/admin/crawlers/csv/upload-schema/ContextMembers.csv');
     expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^text\/csv/);
     expect(res.text.trim()).toBe('ContextExternalId;MemberExternalId;MemberType');
   });
+
 
   it('404s for an unknown template filename under a real type', async () => {
     const res = await request(makeApp()).get('/api/admin/crawlers/csv/upload-schema/NotARealFile.csv');

--- a/changes/feature-generic-upload-schema-mime.md
+++ b/changes/feature-generic-upload-schema-mime.md
@@ -1,0 +1,1 @@
+- Finished generalizing the crawler upload-schema endpoints: the file-extension filter and the downloaded file's content-type are now derived from each crawler's own manifest instead of being hardcoded to CSV. No user-facing change for the CSV crawler today, but removes the last CSV-specific assumptions from an otherwise generic mechanism.


### PR DESCRIPTION
## Summary

Follow-up to #356/#357 (now merged via #355). The file-upload *mechanism* was generalized out of CSV-specific core code, but the upload-schema endpoints specifically still had three CSV-shaped assumptions baked into the implementation:

- The `schema/` directory listing only matched `.csv` files (hardcoded), instead of using the crawler's own `uploadFileExtensions` manifest field — the same field the upload `multer` filter already reads.
- The single-file download always sent `Content-Type: text/csv` regardless of the actual file.
- Both routes read the file as UTF-8 text and extracted just the first line, an implicit line-delimited-text assumption.

This closes that gap:
- Extension filter and content-type are now derived from the crawler's manifest / the file's actual extension (small MIME lookup, defaults to `application/octet-stream` for anything unrecognized).
- The single-file route now serves raw bytes with no text decoding — correct for binary template formats too, not just CSV.
- The multi-file concatenated "download all" digest stays text-oriented by design (it's a human-readable reference, which only makes sense for text formats), but now includes each file's full trimmed content instead of just its first line — more correct for a hypothetical multi-line template, byte-identical output for today's single-line CSV templates.

No behavior change for CSV today — same routes, same response shape, same content for the one real consumer.

## Test plan

- [x] Existing `crawlerFiles.test.js`/`crawlerFiles.uploads.test.js` pass unchanged
- [x] Added direct unit tests for the new `mimeTypeFor()` helper (known extensions, case-insensitivity, unknown-extension fallback)
- [x] Full `npm test` — 634/636 passing (2 failures are the same pre-existing `bootstrap.tagRoots.test.js` load-dependent flake already confirmed unrelated earlier this session)
- [x] `npx eslint src/` — 0 errors
- [x] Real Docker build (full two-stage image) + live container: `curl`'d the actual endpoint, confirmed `Content-Type: text/csv` is now genuinely derived (not hardcoded) and the served bytes match the source file exactly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)