### PR TITLE
feat(midpoint): import inherited role memberships (gap a)

### DIFF
--- a/changes/feature-midpoint-crawler-inherited-members.md
+++ b/changes/feature-midpoint-crawler-inherited-members.md
@@ -1,0 +1,3 @@
+- midPoint crawler now imports **inherited** role and service memberships, not just directly-assigned ones. Birthright roles (assigned via an archetype), nested roles, and org-inherited roles now show all their members in Identity Atlas instead of appearing nearly empty.
+- Each governed assignment now records whether it was granted directly or inherited (`grant=direct` / `grant=inherited`).
+- Governance metadata relations (manager, owner, approver, meta) are correctly excluded — only true membership is imported as access.

--- a/docs/sync/midpoint.md
+++ b/docs/sync/midpoint.md
@@ -16,7 +16,8 @@ Identity Atlas can pull authorization and IGA data from a **midPoint** instance 
 | `ShadowType` `kind=account` | **Principals** (accounts on connected systems) |
 | `ShadowType` `kind=entitlement` | **Resources** (type `Entitlement`, e.g. AD groups) |
 | Account → entitlement membership | **ResourceAssignments** (type `Direct`) |
-| `user.assignment[]` → Role/Service | **ResourceAssignments** (type `Governed`) |
+| `user.assignment[]` → Role/Service | **ResourceAssignments** (type `Governed`, `grant=direct`) |
+| `user.roleMembershipRef[]` → Role/Service | **ResourceAssignments** (type `Governed`, `grant=inherited`) — captures birthright / nested / archetype-inherited memberships, not just directly-assigned ones |
 | `user.parentOrgRef[]` | **ContextMembers** (org unit membership) |
 | Access certification campaigns | **CertificationDecisions** |
 

--- a/test/unit/Midpoint.Tests.ps1
+++ b/test/unit/Midpoint.Tests.ps1
@@ -191,6 +191,26 @@ Describe 'Get-MidpointRefType' {
     }
 }
 
+# ─── Test-MidpointDefaultRelation ─────────────────────────────────────────────
+Describe 'Test-MidpointDefaultRelation' {
+    It 'treats an absent/empty relation as default (full membership)' {
+        Test-MidpointDefaultRelation '' | Should -BeTrue
+        Test-MidpointDefaultRelation $null | Should -BeTrue
+    }
+    It 'treats the bare token "default" as default' {
+        Test-MidpointDefaultRelation 'default' | Should -BeTrue
+    }
+    It 'treats any QName ending in :default as default' {
+        Test-MidpointDefaultRelation 'org:default' | Should -BeTrue
+    }
+    It 'rejects governance relations (manager/owner/approver/meta)' {
+        Test-MidpointDefaultRelation 'org:manager'  | Should -BeFalse
+        Test-MidpointDefaultRelation 'org:owner'    | Should -BeFalse
+        Test-MidpointDefaultRelation 'org:approver' | Should -BeFalse
+        Test-MidpointDefaultRelation 'org:meta'     | Should -BeFalse
+    }
+}
+
 # ─── Resolve-MidpointDepartment ───────────────────────────────────────────────
 Describe 'Resolve-MidpointDepartment' {
     BeforeAll {

--- a/tools/crawlers/midpoint/CLAUDE.md
+++ b/tools/crawlers/midpoint/CLAUDE.md
@@ -31,7 +31,8 @@ A crawler is a folder under `tools/crawlers/<type>/` with a `crawler.json` manif
 | `ShadowType kind=entitlement` | **Resources** (`resourceType=Entitlement`) | e.g. AD groups |
 | `ShadowType kind=generic`/other | **Skipped** | OU/container/DB rows — no user account |
 | Account → entitlement membership | **ResourceAssignments** (`assignmentType=Direct`) | Via `association[]` or (4.9+) `referenceAttributes.<name>[]`, consolidated on the owner focus principal, `viaAccount` in `extendedAttributes` |
-| `user.assignment[]` → Role/Service | **ResourceAssignments** (`assignmentType=Governed`) | |
+| `user.assignment[]` → Role/Service | **ResourceAssignments** (`assignmentType=Governed`, `extendedAttributes.grant=direct`) | Directly-assigned roles/services |
+| `user.roleMembershipRef[]` → Role/Service | **ResourceAssignments** (`assignmentType=Governed`, `extendedAttributes.grant=inherited`) | midPoint's fully-computed membership (role nesting, archetype/org inducements, …). Default-relation refs only — manager/owner/approver/meta are governance, not access. Direct OIDs keep `grant=direct` (first-pass wins) |
 | `user.parentOrgRef[]` | **ContextMembers** | All org memberships |
 | `user.parentOrgRef` (default relation) | **Identity.department** + focus **Principal.department** | The user's primary org-unit name; see `Resolve-MidpointDepartment` |
 | `accessCertificationCampaigns` | **CertificationDecisions** | Requires `?include=case` |
@@ -46,7 +47,7 @@ midPoint OIDs are UUIDs and are reused 1-to-1 as `id`/`externalId` — every rec
 4. **Users** — `UserType` → Identities + focus Principals + IdentityMembers
 5. **Shadows** — `ShadowType` → account Principals + entitlement Resources + memberships (ResourceAssignments `Direct`)
 6. **Org membership** — `user.parentOrgRef[]` → ContextMembers
-7. **Assignments** — `user.assignment[]` → ResourceAssignments `Governed`
+7. **Assignments** — `user.assignment[]` (`grant=direct`) + `user.roleMembershipRef[]` (`grant=inherited`) → ResourceAssignments `Governed`. Two passes so birthright / nested / archetype-inherited memberships are captured, not just direct ones; default-relation refs only
 8. **Role nesting** — `RoleType.inducement[]` → ResourceRelationships `Contains`
 9. **Reviews** — certification campaigns → CertificationDecisions
 10. **`refresh-views`** — refreshes matrix materialized views

--- a/tools/crawlers/midpoint/Invoke-MidpointApi.ps1
+++ b/tools/crawlers/midpoint/Invoke-MidpointApi.ps1
@@ -403,6 +403,24 @@ function Get-MidpointRefRelation {
     return $Fallback
 }
 
+function Test-MidpointDefaultRelation {
+    <#
+    .SYNOPSIS
+        Test whether a midPoint relation QName denotes the *default* (full-membership) relation.
+    .DESCRIPTION
+        midPoint references (roleMembershipRef, parentOrgRef, …) carry a relation that says
+        WHY the subject is linked to the target. The default relation — an empty/absent value,
+        the bare token "default", or any namespaced QName ending in ":default" (e.g.
+        "org:default") — means an actual membership grant. All other relations (manager,
+        owner, approver, meta, …) are governance metadata, NOT access, and return $false.
+    .PARAMETER Relation
+        The relation string (e.g. from Get-MidpointRefRelation). $null/'' counts as default.
+    #>
+    [CmdletBinding()]
+    param([string]$Relation)
+    return (-not $Relation -or $Relation -eq 'default' -or $Relation -match ':default$')
+}
+
 function Resolve-MidpointDepartment {
     <#
     .SYNOPSIS
@@ -428,8 +446,7 @@ function Resolve-MidpointDepartment {
     $chosen = $null
     foreach ($ref in $refs) {
         $rel = Get-MidpointRefRelation $ref ''
-        # Default relation = empty (implied) or any QName ending in ":default" / equal to "default".
-        if (-not $rel -or $rel -eq 'default' -or $rel -match ':default$') { $chosen = $ref; break }
+        if (Test-MidpointDefaultRelation $rel) { $chosen = $ref; break }
     }
     if (-not $chosen) { $chosen = $refs[0] }   # no default-relation org → first ref
 

--- a/tools/crawlers/midpoint/Seed-MidpointTestData.ps1
+++ b/tools/crawlers/midpoint/Seed-MidpointTestData.ps1
@@ -87,7 +87,7 @@ function Get-MidpointFixtureSpec {
             identities          = 3   # Alice, Bob, Carol
             focusPrincipals     = 3   # midPoint user accounts
             shadowPrincipals    = 2   # Alice + Bob CSV accounts
-            governedAssignments = 3   # Alice→Role-A, Bob→Service-1, Carol→Role-B
+            governedAssignments = 4   # direct: Alice→Role-A, Bob→Service-1, Carol→Role-B; inherited: Alice→Role-B (Role-A induces Role-B, via roleMembershipRef)
             containsRelations   = 1   # Role-A → Role-B
             contextMembers      = 3   # Alice∈ChildA, Bob∈ChildB, Carol∈Root
             certificationDecisions = 3 # Alice/Role-A accept, Carol/Role-B revoke, Bob/Service-1 accept

--- a/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
@@ -740,8 +740,18 @@ if ($Sync.assignments -and $Sync.users -and $AllUsers) {
     Write-Host "`nAssignments (Governed):" -ForegroundColor Cyan
     Update-CrawlerProgress -Step 'Syncing assignments' -Pct 82
     try {
+        # Two passes per user so birthright/nested/org-inherited memberships are captured,
+        # not just the directly-assigned ones:
+        #   Pass 1 — user.assignment[]: the roles/services the user is DIRECTLY assigned.
+        #   Pass 2 — user.roleMembershipRef[]: midPoint's fully-computed membership set
+        #            (direct + inherited via role nesting, archetype/org inducements, …).
+        #            Default-relation refs only — manager/owner/approver/meta carry the
+        #            role for governance, not access, so they are excluded.
+        # Pass 1 wins ties: an OID seen as direct stays grant='direct'; only the OIDs that
+        # appear *solely* in roleMembershipRef are emitted as grant='inherited'.
         $seen = [System.Collections.Generic.HashSet[string]]::new()
         $ra   = [System.Collections.Generic.List[object]]::new()
+
         foreach ($u in $AllUsers) {
             $uoid = [string]$u.oid
             $assignments = $u.assignment
@@ -759,9 +769,32 @@ if ($Sync.assignments -and $Sync.users -and $AllUsers) {
                 # Resources.id = role/service oid and Principals.id = user oid (native-id
                 # ingest), so reference them directly by id — no externalId resolution needed.
                 $ra.Add([PSCustomObject]@{
-                    resourceId     = $targetOid
-                    principalId    = $uoid
-                    assignmentType = 'Governed'
+                    resourceId         = $targetOid
+                    principalId        = $uoid
+                    assignmentType     = 'Governed'
+                    extendedAttributes = @{ grant = 'direct' }
+                })
+            }
+        }
+
+        foreach ($u in $AllUsers) {
+            $uoid = [string]$u.oid
+            $memberships = $u.roleMembershipRef
+            if (-not $memberships) { continue }
+            foreach ($m in @($memberships)) {
+                $targetType = Get-MidpointRefType $m ''
+                $targetOid  = Get-MidpointRefOid $m $null
+                if (-not $targetOid) { continue }
+                if ($targetType -notin @('RoleType', 'ServiceType')) { continue }
+                # Only true membership (default relation); skip manager/owner/approver/meta.
+                if (-not (Test-MidpointDefaultRelation (Get-MidpointRefRelation $m ''))) { continue }
+                if (-not $SyncedResourceIds.Contains($targetOid)) { continue }
+                if (-not $seen.Add("$targetOid|$uoid")) { continue }   # already emitted as direct → keep that
+                $ra.Add([PSCustomObject]@{
+                    resourceId         = $targetOid
+                    principalId        = $uoid
+                    assignmentType     = 'Governed'
+                    extendedAttributes = @{ grant = 'inherited' }
                 })
             }
         }

--- a/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
@@ -61,17 +61,31 @@ $resOid  = 'aaaa1111-0000-4000-8000-000000000005'
 $acctOid = 'aaaa1111-0000-4000-8000-000000000006'
 $entOid  = 'aaaa1111-0000-4000-8000-000000000007'   # reached via legacy association[]
 $entOid2 = 'aaaa1111-0000-4000-8000-000000000009'   # reached via 4.9 referenceAttributes.group[]
+$inhRoleOid = 'aaaa1111-0000-4000-8000-00000000000a' # NOT directly assigned — only via roleMembershipRef
+$mgrRoleOid = 'aaaa1111-0000-4000-8000-00000000000b' # only a manager-relation membership → must be ignored
 
 $mockObjects = @{
     resources = @(@{ oid = $resOid; name = 'midpoint-ci-resource' })
     orgs      = @(@{ oid = $orgOid; name = 'midpoint-ci-org'; displayName = 'midPoint CI Org' })
-    roles     = @(@{ oid = $roleOid; name = 'midpoint-ci-role'; displayName = 'midPoint CI Role' })
+    roles     = @(
+        @{ oid = $roleOid;    name = 'midpoint-ci-role';          displayName = 'midPoint CI Role' }
+        @{ oid = $inhRoleOid; name = 'midpoint-ci-inherited-role'; displayName = 'midPoint CI Inherited Role' }
+        @{ oid = $mgrRoleOid; name = 'midpoint-ci-manager-role';   displayName = 'midPoint CI Manager Role' }
+    )
     services  = @(@{ oid = $svcOid; name = 'midpoint-ci-service'; displayName = 'midPoint CI Service' })
     users     = @(@{
         oid = $userOid; name = 'midpoint.citest'; fullName = 'midPoint CITest'
         givenName = 'midPoint'; familyName = 'CITest'; emailAddress = 'midpoint.citest@example.com'
         activation = @{ effectiveStatus = 'enabled' }
         assignment   = @( @{ targetRef = @{ oid = $roleOid; type = 'RoleType' } } )
+        # midPoint's fully-computed membership set: the directly-assigned role plus an
+        # INHERITED role (e.g. via nesting/archetype) — both default relation — and a
+        # manager-relation entry that grants the role for governance, not access.
+        roleMembershipRef = @(
+            @{ oid = $roleOid;    relation = 'org:default'; type = 'RoleType' }   # = direct (also in assignment[])
+            @{ oid = $inhRoleOid; relation = 'org:default'; type = 'RoleType' }   # inherited → grant=inherited
+            @{ oid = $mgrRoleOid; relation = 'org:manager'; type = 'RoleType' }   # manager → excluded
+        )
         parentOrgRef = @{ oid = $orgOid; type = 'OrgType' }
         linkRef      = @{ oid = $acctOid; type = 'ShadowType' }
     })
@@ -157,6 +171,20 @@ try {
         # referenceAttributes.group[]. Both code paths must have produced a resource.
         Report-Result 'Midpoint/Data — entitlements mapped as resources (assoc + referenceAttributes)' ($ents.Count -ge 2) "($($ents.Count) Entitlement resource(s) in system $resSid; expected >= 2)"
     } catch { Report-Result 'Midpoint/Data — entitlement mapped as resource' $false $_.Exception.Message }
+
+    # ── Assert: inherited role membership imported as a Governed assignment ──
+    # The user is only DIRECTLY assigned $roleOid, but midPoint's roleMembershipRef also
+    # lists $inhRoleOid (default relation, inherited) and $mgrRoleOid (manager relation).
+    # The crawler's two-pass Assignments phase must import the inherited role as a Governed
+    # assignment, while excluding the manager-relation one.
+    try {
+        $inhAssign = Invoke-RestMethod -Uri "$ApiBaseUrl/resources/$inhRoleOid/assignments" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
+        $mgrAssign = Invoke-RestMethod -Uri "$ApiBaseUrl/resources/$mgrRoleOid/assignments" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
+        $inhHit = @($inhAssign) | Where-Object { $_.principalId -eq $userOid -and $_.assignmentType -eq 'Governed' }
+        $mgrHit = @($mgrAssign) | Where-Object { $_.principalId -eq $userOid }
+        $ok = ($inhHit.Count -ge 1) -and ($mgrHit.Count -eq 0)
+        Report-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $ok "(inherited: $($inhHit.Count) Governed; manager: $($mgrHit.Count) — expected inherited>=1, manager=0)"
+    } catch { Report-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $false $_.Exception.Message }
 
 } catch {
     Write-Host "  Fatal test error: $($_.Exception.Message)" -ForegroundColor Red


### PR DESCRIPTION
Fixes the first of two midPoint-crawler gaps where a birthright role appeared nearly empty in Identity Atlas.

## What changed
- The midPoint crawler now imports **inherited** role and service memberships, not just directly-assigned ones. Birthright roles (assigned via an archetype), nested roles, and org-inherited roles now show all their members instead of appearing nearly empty.
- Each governed assignment records whether it was granted directly or inherited (`grant=direct` / `grant=inherited`).
- Governance metadata relations (manager, owner, approver, meta) are correctly excluded — only true membership is imported as access.

## How
Two-pass Assignments phase: direct `user.assignment[]` plus the fully-computed `user.roleMembershipRef[]` (default-relation only), deduped so direct OIDs keep `grant=direct`. New pure helper `Test-MidpointDefaultRelation`.

## Tests / proof
- Pester: 4 new cases (81 green total).
- CI integration test: mock role reached only via `roleMembershipRef` (inherited) plus a manager-relation entry that must be excluded.
- Functional fixture exercises the natural Alice→Role-B inheritance.
- **Live proof** against midpoint-dev: birthright role went from **1 → 318 members** (1 direct + 317 inherited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)