### PR TITLE
feat(midpoint): map construction inducements to Contains edges (gap b, re-target to main)

### DIFF
--- a/changes/feature-midpoint-crawler-construction-relations.md
+++ b/changes/feature-midpoint-crawler-construction-relations.md
@@ -1,0 +1,2 @@
+- midPoint business roles that grant AD groups directly (via a `construction` inducement, the common pattern for birthright bundles) now show those groups as contained resources. Previously only role-to-role inducements were imported, so such roles appeared to grant nothing.
+- As a result, users holding such a role now correctly show access to the underlying AD groups in the matrix (governed access propagates through the business role).

--- a/docs/sync/midpoint.md
+++ b/docs/sync/midpoint.md
@@ -10,7 +10,7 @@ Identity Atlas can pull authorization and IGA data from a **midPoint** instance 
 |---|---|
 | `ResourceType` (connected systems with accounts) | **Systems** |
 | `OrgType` | **Contexts** (type `OrgUnit`, with hierarchy) |
-| `RoleType` | **Resources** (type `BusinessRole`); role inducements → `ResourceRelationships` (`Contains`) |
+| `RoleType` | **Resources** (type `BusinessRole`); role inducements → `ResourceRelationships` (`Contains`) — both role-to-role (`targetRef`) and role-to-AD-group (`construction`, e.g. birthright bundles) |
 | `ServiceType` | **Resources** (type `Service`) |
 | `UserType` (persons/focuses) | **Identities** + a focus Principal + `IdentityMembers` |
 | `ShadowType` `kind=account` | **Principals** (accounts on connected systems) |

--- a/test/unit/Midpoint.Tests.ps1
+++ b/test/unit/Midpoint.Tests.ps1
@@ -211,6 +211,60 @@ Describe 'Test-MidpointDefaultRelation' {
     }
 }
 
+# ─── ConvertTo-MidpointDnKey ──────────────────────────────────────────────────
+Describe 'ConvertTo-MidpointDnKey' {
+    It 'lower-cases and trims a DN so case/whitespace differences still match' {
+        ConvertTo-MidpointDnKey '  CN=DM - Read Documents,OU=Groups,DC=corporate,DC=com  ' |
+            Should -Be 'cn=dm - read documents,ou=groups,dc=corporate,dc=com'
+    }
+    It 'returns empty for null/blank' {
+        ConvertTo-MidpointDnKey $null | Should -Be ''
+        ConvertTo-MidpointDnKey '   ' | Should -Be ''
+    }
+}
+
+# ─── Get-MidpointConstructionTargets ──────────────────────────────────────────
+Describe 'Get-MidpointConstructionTargets' {
+    It 'extracts an associationTargetSearch DN filter as a normalised search key' {
+        $con = [pscustomobject]@{ association = [pscustomobject]@{
+            ref = 'ri:group'
+            outbound = [pscustomobject]@{ expression = [pscustomobject]@{
+                associationTargetSearch = [pscustomobject]@{ filter = [pscustomobject]@{
+                    equal = [pscustomobject]@{ path = 'attributes/ri:dn'; value = 'CN=DM - Read Documents,OU=Groups,DC=corporate,DC=com' }
+                } }
+            } }
+        } }
+        $t = @(Get-MidpointConstructionTargets -Construction $con)
+        $t.Count | Should -Be 1
+        $t[0].shadowOid | Should -Be ''
+        $t[0].searchKey | Should -Be 'cn=dm - read documents,ou=groups,dc=corporate,dc=com'
+    }
+    It 'extracts a literal shadowRef oid' {
+        $con = [pscustomobject]@{ association = [pscustomobject]@{
+            ref = 'ri:group'; shadowRef = [pscustomobject]@{ oid = 'ent-9'; type = 'c:ShadowType' }
+        } }
+        $t = @(Get-MidpointConstructionTargets -Construction $con)
+        $t.Count | Should -Be 1
+        $t[0].shadowOid | Should -Be 'ent-9'
+        $t[0].searchKey | Should -Be ''
+    }
+    It 'handles multiple associations (array)' {
+        $con = [pscustomobject]@{ association = @(
+            [pscustomobject]@{ ref = 'ri:group'; shadowRef = [pscustomobject]@{ oid = 'ent-a' } }
+            [pscustomobject]@{ ref = 'ri:group'; outbound = [pscustomobject]@{ expression = [pscustomobject]@{
+                associationTargetSearch = [pscustomobject]@{ filter = [pscustomobject]@{ equal = [pscustomobject]@{ path = 'attributes/ri:dn'; value = 'CN=B,DC=x' } } } } } }
+        ) }
+        $t = @(Get-MidpointConstructionTargets -Construction $con)
+        $t.Count | Should -Be 2
+        $t[0].shadowOid | Should -Be 'ent-a'
+        $t[1].searchKey | Should -Be 'cn=b,dc=x'
+    }
+    It 'returns an empty list for a null construction or one with no association' {
+        (Get-MidpointConstructionTargets -Construction $null).Count | Should -Be 0
+        (Get-MidpointConstructionTargets -Construction ([pscustomobject]@{ kind = 'account' })).Count | Should -Be 0
+    }
+}
+
 # ─── Resolve-MidpointDepartment ───────────────────────────────────────────────
 Describe 'Resolve-MidpointDepartment' {
     BeforeAll {

--- a/tools/crawlers/midpoint/CLAUDE.md
+++ b/tools/crawlers/midpoint/CLAUDE.md
@@ -24,7 +24,7 @@ A crawler is a folder under `tools/crawlers/<type>/` with a `crawler.json` manif
 |---|---|---|
 | `ResourceType` | **Systems** | Only resources with account/entitlement shadows |
 | `OrgType` | **Contexts** (`contextType=OrgUnit`) | Hierarchy via `parentOrgRef`, topo-sorted |
-| `RoleType` | **Resources** (`resourceType=BusinessRole`) | `inducement[]` → `ResourceRelationships` (`Contains`) |
+| `RoleType` | **Resources** (`resourceType=BusinessRole`) | `inducement[]` → `ResourceRelationships` (`Contains`): `targetRef` inducements → contained Role/Service; `construction` inducements (`associationTargetSearch` DN filter or literal `shadowRef`) → contained Entitlement resource |
 | `ServiceType` | **Resources** (`resourceType=Service`) | |
 | `UserType` | **Identities** + focus **Principal** + **IdentityMembers** | One Principal per user (the midPoint focus account) |
 | `ShadowType kind=account` | **Principals** | Linked to the identity via `user.linkRef` |
@@ -48,7 +48,7 @@ midPoint OIDs are UUIDs and are reused 1-to-1 as `id`/`externalId` — every rec
 5. **Shadows** — `ShadowType` → account Principals + entitlement Resources + memberships (ResourceAssignments `Direct`)
 6. **Org membership** — `user.parentOrgRef[]` → ContextMembers
 7. **Assignments** — `user.assignment[]` (`grant=direct`) + `user.roleMembershipRef[]` (`grant=inherited`) → ResourceAssignments `Governed`. Two passes so birthright / nested / archetype-inherited memberships are captured, not just direct ones; default-relation refs only
-8. **Role nesting** — `RoleType.inducement[]` → ResourceRelationships `Contains`
+8. **Role nesting** — `RoleType.inducement[]` → ResourceRelationships `Contains`. `targetRef` inducements link to a Role/Service; `construction` inducements link to the Entitlement(s) they grant (the `associationTargetSearch` DN filter is resolved against the entitlement shadows from phase 5 via `$EntitlementByDn`, or a literal `shadowRef` is used directly). Needs the Shadows phase to have run for construction targets to resolve
 9. **Reviews** — certification campaigns → CertificationDecisions
 10. **`refresh-views`** — refreshes matrix materialized views
 
@@ -69,6 +69,8 @@ The wizard's archetype/subtype dropdowns come from `POST /api/admin/crawlers/mid
 **AD group memberships (midPoint 4.9+):** 4.9 stores account→group relationships as `shadow.referenceAttributes.group[]` (direct refs), not the legacy `association[]`. The crawler reads both forms. Shadow search requires `?options=raw`; `include=association` returns both as well.
 
 **`Invoke-MidpointSearchStream` vs `Invoke-MidpointSearch`:** Use `SearchStream` for large result sets (Shadows phase). It invokes a per-page callback and never accumulates the full result in memory. `Search` accumulates — fine for small types (Roles, Orgs), but will OOM on 300k+ shadows.
+
+**Construction inducements → Contains (birthright roles):** roles that grant AD groups via `construction` + `association` (rather than a `targetRef` to another role) are common for birthright bundles. The association target is either a literal `shadowRef` or an `associationTargetSearch` equal-filter on the group DN (`attributes/ri:dn`). The crawler resolves the DN against `$EntitlementByDn` (built during the Shadows phase, keyed by the normalised entitlement shadow name + `ri:dn`), so **the Shadows phase must run** for construction targets to resolve. `Get-MidpointConstructionTargets` + `ConvertTo-MidpointDnKey` (in `Invoke-MidpointApi.ps1`) are the pure helpers; unresolved targets are counted in the phase summary, not silently dropped.
 
 **`New-StableGuid`:** Used to derive stable UUIDs for synthetic records (e.g. the midPoint-itself system). Same input always produces the same UUID — safe for idempotent re-runs.
 

--- a/tools/crawlers/midpoint/Invoke-MidpointApi.ps1
+++ b/tools/crawlers/midpoint/Invoke-MidpointApi.ps1
@@ -421,6 +421,64 @@ function Test-MidpointDefaultRelation {
     return (-not $Relation -or $Relation -eq 'default' -or $Relation -match ':default$')
 }
 
+function ConvertTo-MidpointDnKey {
+    <#
+    .SYNOPSIS
+        Normalise an LDAP DN (or any identifier) to a stable lookup key.
+    .DESCRIPTION
+        AD distinguished names are case-insensitive and may carry incidental whitespace,
+        so a construction's associationTargetSearch filter value and an entitlement shadow's
+        name/dn are compared on their trimmed, lower-cased form. Returns '' for null/empty.
+    #>
+    [CmdletBinding()]
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    return $Value.Trim().ToLowerInvariant()
+}
+
+function Get-MidpointConstructionTargets {
+    <#
+    .SYNOPSIS
+        Extract the entitlement targets a construction inducement grants.
+    .DESCRIPTION
+        A midPoint role can grant an AD group two ways inside an inducement's
+        `construction.association[]`:
+          • a literal `shadowRef` (the entitlement shadow OID) — resolved directly, or
+          • an `outbound.expression.associationTargetSearch` equal-filter on an identifier
+            attribute (typically `attributes/ri:dn`) — resolved later by matching the filter
+            value against the entitlement shadows the crawler imported.
+        Returns a list of hashtables @{ shadowOid = <oid|''>; searchKey = <normalised value|''> }
+        — `shadowOid` set for the literal case, `searchKey` set for the search case. The caller
+        resolves `searchKey` against a DN→oid map. Returns an empty list when there is no
+        construction or it grants nothing resolvable.
+    .PARAMETER Construction
+        The `inducement.construction` object.
+    #>
+    [CmdletBinding()]
+    param($Construction)
+    $out = [System.Collections.Generic.List[object]]::new()
+    if ($null -eq $Construction) { return $out }
+    $assocs = $Construction.association
+    if (-not $assocs) { return $out }
+    foreach ($a in @($assocs)) {
+        $sref = Get-MidpointRefOid $a.shadowRef ''
+        if ($sref) { $out.Add(@{ shadowOid = $sref; searchKey = '' }); continue }
+        # associationTargetSearch → expression on the association's outbound mapping
+        $ats = $a.outbound.expression.associationTargetSearch
+        if (-not $ats) { continue }
+        foreach ($t in @($ats)) {
+            foreach ($f in @($t.filter)) {
+                $eq = $f.equal
+                if ($eq -and $null -ne $eq.value) {
+                    $key = ConvertTo-MidpointDnKey ([string]$eq.value)
+                    if ($key) { $out.Add(@{ shadowOid = ''; searchKey = $key }) }
+                }
+            }
+        }
+    }
+    return $out
+}
+
 function Resolve-MidpointDepartment {
     <#
     .SYNOPSIS

--- a/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
@@ -274,9 +274,10 @@ $ResourceOidToName       = @{}                                                  
 $UserOidToName           = @{}                                                   # user OID → display name (for readable shadow labels)
 $SyncedOrgIds            = [System.Collections.Generic.HashSet[string]]::new()  # OrgType OIDs synced as Contexts
 $OrgOidToName            = @{}                                                   # OrgType OID → display name (for the user's department)
-$SyncedResourceIds       = [System.Collections.Generic.HashSet[string]]::new()  # Role/Service OIDs synced as Resources
+$SyncedResourceIds       = [System.Collections.Generic.HashSet[string]]::new()  # Role/Service + Entitlement OIDs synced as Resources
 $AllUsers                = $null
 $ShadowOidToUserOid      = @{}                                                   # shadow OID → owning user OID (from user.linkRef)
+$EntitlementByDn         = @{}                                                   # normalised DN/name → entitlement shadow OID (for construction → Contains)
 
 # ─── Phase: Systems ──────────────────────────────────────────────────────────
 # midPoint itself + each ResourceType become Identity Atlas Systems.
@@ -633,6 +634,13 @@ if ($Sync.shadows -and $Sync.users) {
                         }
                     })
                     [void]$SyncedResourceIds.Add($shadowOid)
+                    # Index by DN so construction/associationTargetSearch inducements (which
+                    # filter on attributes/ri:dn) can later be resolved to this entitlement's
+                    # OID and emitted as Contains edges (Role nesting phase).
+                    $dnNameKey = ConvertTo-MidpointDnKey (Get-MidpointString $s.name '')
+                    if ($dnNameKey) { $EntitlementByDn[$dnNameKey] = $shadowOid }
+                    $riDnKey = ConvertTo-MidpointDnKey ([string](Get-MidpointAttrValue -Shadow $s -Keys @('dn')))
+                    if ($riDnKey) { $EntitlementByDn[$riDnKey] = $shadowOid }
                 }
                 else { if ($kind -eq 'generic') { $skipped.generic++ } else { $skipped.other++ } }
             }
@@ -810,27 +818,43 @@ if ($Sync.roleNesting -and $AllRoles) {
     try {
         $seen = [System.Collections.Generic.HashSet[string]]::new()
         $rr   = [System.Collections.Generic.List[object]]::new()
+        $nTargetRef = 0; $nConstruction = 0; $nUnresolved = 0
         foreach ($r in $AllRoles) {
             $parentOid = [string]$r.oid
             $inducements = $r.inducement
             if (-not $inducements) { continue }
             foreach ($ind in @($inducements)) {
+                # (1) targetRef inducement → Contains another Role/Service resource.
                 $tr = $ind.targetRef
-                if (-not $tr) { continue }
-                $tt = Get-MidpointRefType $tr ''
-                $childOid = Get-MidpointRefOid $tr $null
-                if (-not $childOid -or $tt -notin @('RoleType', 'ServiceType')) { continue }
-                if (-not $SyncedResourceIds.Contains($childOid)) { continue }
-                if (-not $seen.Add("$parentOid|$childOid")) { continue }
-                $rr.Add([PSCustomObject]@{
-                    parentResourceId = $parentOid
-                    childResourceId  = $childOid
-                    relationshipType = 'Contains'
-                })
+                if ($tr) {
+                    $tt = Get-MidpointRefType $tr ''
+                    $childOid = Get-MidpointRefOid $tr $null
+                    if (-not $childOid -or $tt -notin @('RoleType', 'ServiceType')) { continue }
+                    if (-not $SyncedResourceIds.Contains($childOid)) { continue }
+                    if (-not $seen.Add("$parentOid|$childOid")) { continue }
+                    $rr.Add([PSCustomObject]@{ parentResourceId = $parentOid; childResourceId = $childOid; relationshipType = 'Contains' })
+                    $nTargetRef++
+                    continue
+                }
+                # (2) construction inducement → Contains the entitlement(s) it grants (e.g. AD
+                # groups). The target is a literal shadowRef or an associationTargetSearch filter
+                # on the group DN, resolved against the entitlements imported in the Shadows phase.
+                $con = $ind.construction
+                if (-not $con) { continue }
+                foreach ($t in (Get-MidpointConstructionTargets -Construction $con)) {
+                    $entOid = if ($t.shadowOid) { $t.shadowOid }
+                              elseif ($t.searchKey -and $EntitlementByDn.ContainsKey($t.searchKey)) { $EntitlementByDn[$t.searchKey] }
+                              else { '' }
+                    if (-not $entOid) { $nUnresolved++; continue }
+                    if (-not $SyncedResourceIds.Contains($entOid)) { $nUnresolved++; continue }
+                    if (-not $seen.Add("$parentOid|$entOid")) { continue }
+                    $rr.Add([PSCustomObject]@{ parentResourceId = $parentOid; childResourceId = $entOid; relationshipType = 'Contains' })
+                    $nConstruction++
+                }
             }
         }
         $R = Send-IngestBatch -Endpoint 'ingest/resource-relationships' -SystemId $MidpointSystemId -Scope @{ relationshipType = 'Contains' } -Records @($rr)
-        Write-Host "  ResourceRelationships (Contains): +$($R.inserted) ~$($R.updated) -$($R.deleted) (from $($rr.Count) links)" -ForegroundColor Green
+        Write-Host "  ResourceRelationships (Contains): +$($R.inserted) ~$($R.updated) -$($R.deleted) (from $($rr.Count) links — $nTargetRef role/service, $nConstruction construction; $nUnresolved unresolved)" -ForegroundColor Green
     } catch { Add-PhaseError 'RoleNesting' $_.Exception.Message }
 }
 

--- a/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
@@ -68,7 +68,21 @@ $mockObjects = @{
     resources = @(@{ oid = $resOid; name = 'midpoint-ci-resource' })
     orgs      = @(@{ oid = $orgOid; name = 'midpoint-ci-org'; displayName = 'midPoint CI Org' })
     roles     = @(
-        @{ oid = $roleOid;    name = 'midpoint-ci-role';          displayName = 'midPoint CI Role' }
+        # The main role grants two AD groups via construction inducements — one resolved by
+        # an associationTargetSearch DN filter, one by a literal shadowRef — so both
+        # construction → Contains code paths are exercised.
+        @{ oid = $roleOid;    name = 'midpoint-ci-role';          displayName = 'midPoint CI Role'
+           inducement = @(
+               @{ construction = @{
+                   resourceRef = @{ oid = $resOid; type = 'ResourceType' }; kind = 'account'; intent = 'default'
+                   association = @{ ref = 'ri:group'; outbound = @{ expression = @{
+                       associationTargetSearch = @{ filter = @{ equal = @{ path = 'attributes/ri:dn'; value = 'CN=midPoint CI Entitlement,OU=Groups' } } } } } }
+               } }
+               @{ construction = @{
+                   resourceRef = @{ oid = $resOid; type = 'ResourceType' }; kind = 'account'; intent = 'default'
+                   association = @{ ref = 'ri:group'; shadowRef = @{ oid = $entOid2; type = 'ShadowType' } }
+               } }
+           ) }
         @{ oid = $inhRoleOid; name = 'midpoint-ci-inherited-role'; displayName = 'midPoint CI Inherited Role' }
         @{ oid = $mgrRoleOid; name = 'midpoint-ci-manager-role';   displayName = 'midPoint CI Manager Role' }
     )
@@ -185,6 +199,19 @@ try {
         $ok = ($inhHit.Count -ge 1) -and ($mgrHit.Count -eq 0)
         Report-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $ok "(inherited: $($inhHit.Count) Governed; manager: $($mgrHit.Count) — expected inherited>=1, manager=0)"
     } catch { Report-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $false $_.Exception.Message }
+
+    # ── Assert: construction inducements became Contains edges (role → entitlements) ──
+    # The role grants two AD groups via construction: $entOid by associationTargetSearch DN
+    # filter, $entOid2 by literal shadowRef. Both must surface as a BusinessRole that the
+    # entitlement belongs to (vw → /resources/:id/business-roles).
+    try {
+        $brSearch = Invoke-RestMethod -Uri "$ApiBaseUrl/resources/$entOid/business-roles"  -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
+        $brLiteral = Invoke-RestMethod -Uri "$ApiBaseUrl/resources/$entOid2/business-roles" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
+        $searchHit  = @($brSearch)  | Where-Object { $_.businessRoleId -eq $roleOid }
+        $literalHit = @($brLiteral) | Where-Object { $_.businessRoleId -eq $roleOid }
+        $ok = ($searchHit.Count -ge 1) -and ($literalHit.Count -ge 1)
+        Report-Result 'Midpoint/Data — construction inducements → Contains edges (associationTargetSearch + shadowRef)' $ok "(targetSearch: $($searchHit.Count), shadowRef: $($literalHit.Count) — both expected >= 1)"
+    } catch { Report-Result 'Midpoint/Data — construction inducements → Contains edges (associationTargetSearch + shadowRef)' $false $_.Exception.Message }
 
 } catch {
     Write-Host "  Fatal test error: $($_.Exception.Message)" -ForegroundColor Red


### PR DESCRIPTION
Re-targets the construction→Contains fix to **main**. The original [#366](https://github.com/Fortigi/IdentityAtlas/pull/366) was merged into the stacked PR1 branch (`feature/midpoint-crawler-inherited-members`) rather than `main`, so its changes never reached `main`. This is the same commit, cherry-picked onto current `main` (clean — gap-a from #365 is already present).

## What changed
- midPoint business roles that grant AD groups directly (via a `construction` inducement, the common pattern for birthright bundles) now show those groups as contained resources. Previously only role-to-role inducements were imported, so such roles appeared to grant nothing.
- Users holding such a role now correctly show access to the underlying AD groups in the matrix (governed access propagates through the business role).

## How
The Role-nesting phase resolves `construction` + `association` targets — a literal `shadowRef` or an `associationTargetSearch` DN filter — against the entitlement shadows imported in the Shadows phase (`$EntitlementByDn`, keyed by normalised DN/`ri:dn`). New pure helpers `ConvertTo-MidpointDnKey` and `Get-MidpointConstructionTargets`. Unresolved targets are counted in the phase summary, not silently dropped.

## Tests / proof
- Pester: 6 new cases (87 green total).
- CI integration test: a role granting two AD groups via construction (DN filter + literal shadowRef), both asserted to produce Contains edges.
- **Live proof** against midpoint-dev: the birthright role gained its **3 Contains edges** (DM-Read, DM-Write, ODWUsers; was 0), and the via-business-role view went **0 → 954 rows** (318 users × 3 groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)