### PR TITLE
fix(ci): ignore files directly in tools/crawlers/ when detecting crawler types

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -158,10 +158,12 @@ jobs:
           fi
 
           # Extract changed crawler type names from the diff.
+          # Require trailing slash to match subdirectories only —
+          # tools/crawlers/CLAUDE.md (a file) must not be treated as a type.
           # tools/crawlers/<type>/... → <type>
           LIST=$(echo "$CHANGED" \
-            | grep -oE "^tools/crawlers/[^/]+" \
-            | sed 's|tools/crawlers/||' \
+            | grep -oE "^tools/crawlers/[^/]+/" \
+            | sed 's|tools/crawlers/||;s|/$||' \
             | grep -v '^shared$' \
             | sort -u \
             | tr '\n' ',' \

--- a/changes/fix-crawler-scope-directory-filter.md
+++ b/changes/fix-crawler-scope-directory-filter.md
@@ -1,0 +1,1 @@
+- Fixed CI crawler scope detection incorrectly treating `tools/crawlers/CLAUDE.md` as a crawler type — only subdirectory paths are now matched

--- a/test/ci-scripts/test-crawler-scope.sh
+++ b/test/ci-scripts/test-crawler-scope.sh
@@ -45,8 +45,8 @@ detect_scope() {
 
   local list
   list=$(echo "$changed" \
-    | grep -oE "^tools/crawlers/[^/]+" \
-    | sed 's|tools/crawlers/||' \
+    | grep -oE "^tools/crawlers/[^/]+/" \
+    | sed 's|tools/crawlers/||;s|/$||' \
     | grep -v '^shared$' \
     | sort -u \
     | tr '\n' ',' \
@@ -116,6 +116,17 @@ assert "app/api/src/ → empty (PS runner tests all)" \
 assert "docker-compose.yml → empty" \
   "" \
   "$(detect_scope "docker-compose.ci.yml")"
+
+echo ""
+echo "── Files directly in tools/crawlers/ must not be treated as types ──"
+assert "tools/crawlers/CLAUDE.md → ignored (file, not dir)" \
+  "" \
+  "$(detect_scope "tools/crawlers/CLAUDE.md")"
+
+assert "CLAUDE.md + omada change → only omada detected" \
+  "omada" \
+  "$(detect_scope "tools/crawlers/CLAUDE.md
+tools/crawlers/omada/Start-OmadaCrawler.ps1")"
 
 echo ""
 echo "── New crawler type (future-proofing) ──"


### PR DESCRIPTION
## Summary

`tools/crawlers/CLAUDE.md` was being matched by the scope detection regex and passed as crawler type `"CLAUDE.md"` to the PS runner.

**Fix:** require a trailing `/` so only subdirectory paths (i.e. `tools/crawlers/<type>/...`) are matched — files living directly under `tools/crawlers/` are ignored.

```
Before: grep -oE "^tools/crawlers/[^/]+"   → matches tools/crawlers/CLAUDE.md
After:  grep -oE "^tools/crawlers/[^/]+/"  → requires a directory separator
```

Adds 2 test cases. Found by testing against existing PRs after Phase 2 merged.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)