### PR TITLE
fix(ci): repair YAML parse error blocking all PR integration tests

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -149,9 +149,7 @@ jobs:
 
           # Shared infra change → must test all crawlers
           if echo "$CHANGED" | grep -qE \
-            "^tools/crawlers/shared/|^tools/powershell-sdk/|\
-^setup/docker/Invoke-CrawlerJob\.ps1|^setup/IdentityAtlas\.psm1|\
-^setup/docker/Dockerfile\.powershell"; then
+            "^tools/crawlers/shared/|^tools/powershell-sdk/|^setup/docker/Invoke-CrawlerJob\.ps1|^setup/IdentityAtlas\.psm1|^setup/docker/Dockerfile\.powershell"; then
             echo "crawlers_to_test=" >> "$GITHUB_OUTPUT"
             echo "CRAWLERS_TO_TEST: all (shared/infra change)" >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/changes/fix-pr-integration-yaml.md
+++ b/changes/fix-pr-integration-yaml.md
@@ -1,0 +1,1 @@
+- Fixed YAML parse error in `pr-integration.yml` that caused all integration test runs to fail immediately with "workflow file issue", blocking every open PR from merging.


### PR DESCRIPTION
## Root cause

Lines 153-154 of `.github/workflows/pr-integration.yml` started at **column 0** inside a `run: |` block scalar. YAML terminates a block scalar when it encounters content with less indentation than the block level (10 spaces here), so the workflow failed to parse entirely — zero jobs ran, `Integration CI Passed` was never posted, and every open PR was blocked from merging with a "waiting for status" check.

The broken lines were shell continuation lines for a `grep -qE` regex pattern:
```
          if echo "$CHANGED" | grep -qE \
            "^tools/crawlers/shared/|^tools/powershell-sdk/|\
^setup/docker/Invoke-CrawlerJob\.ps1|^setup/IdentityAtlas\.psm1|\    ← column 0!
^setup/docker/Dockerfile\.powershell"; then                           ← column 0!
```

## Fix

Collapse the three-line continuation into a single `grep` argument — no logic change, same regex pattern.

## Impact

All 7 open PRs (#361, #364, #369, #371, #372, #374, #377) are currently blocked. This fix unblocks them by restoring `Integration CI Passed`.