### PR TITLE
fix(ci): restore PR Summary stub to suppress Claude app ghost check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -614,3 +614,17 @@ jobs:
             exit 1
           fi
           echo "All checks passed or were legitimately skipped." >> "$GITHUB_STEP_SUMMARY"
+
+  # ── PR Summary stub ─────────────────────────────────────────────────────────
+  # The Claude GitHub App (issue triage, autofix, release-notes synthesis) creates
+  # a check suite named "PR Summary" on every PR push. It stays queued if its
+  # auto-summary feature doesn't fire, showing as "expected" in the GitHub UI.
+  # This stub job emits a completed "PR Summary" check run that overshadows the
+  # pending app suite — same check name, workflow wins in the UI display.
+  pr-summary:
+    name: 'PR Summary'
+    needs: [ci-passed]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR Summary check satisfied by CI gate."

--- a/changes/restore-pr-summary-check.md
+++ b/changes/restore-pr-summary-check.md
@@ -1,0 +1,1 @@
+- Fixed "PR Summary expected" ghost check appearing on all PRs after Phase 1 renamed the gate job; a stub job now emits the completed check name the Claude GitHub App expects.

--- a/docs/contributing/ci-pipeline.md
+++ b/docs/contributing/ci-pipeline.md
@@ -1,0 +1,120 @@
+# CI Pipeline
+
+Two GitHub Actions workflows run on every PR targeting `main`. Both use the same two-step pattern: a **commit-range skip** job that detects housekeeping-only pushes, then **path-filter gates** that run only what actually changed.
+
+Branch protection requires two checks to pass before a PR can merge:
+
+| Required check | Workflow | What it gates |
+|---|---|---|
+| `CI Passed` | `pr.yml` | Lint, unit tests, build, hygiene |
+| `Integration CI Passed` | `pr-integration.yml` | Docker integration tests, E2E, load soak |
+
+---
+
+## pr.yml — fast checks (~5 min)
+
+### Commit-range skip
+
+The `changes` job inspects commit messages in the push range. If every commit is a housekeeping commit (`chore: bump version to …` or `Merge branch 'main' into …`), all downstream jobs are skipped and `CI Passed` reports green. This prevents re-running CI when "Update branch" imports only an automated version bump.
+
+A fresh branch push (no previous SHA) or a force-push/rebase always runs CI.
+
+### Path gates
+
+When product changes are detected, a `filter` job uses `dorny/paths-filter` to produce boolean outputs. Each job only runs if its relevant paths changed:
+
+| Job | Check name | Runs when |
+|---|---|---|
+| `lint-ps` | Lint: PSScriptAnalyzer | `tools/crawlers/**/*.ps1`, `tools/powershell-sdk/**`, `setup/**/*.ps1` |
+| `lint-js` | Lint: ESLint | `app/ui/src/**`, `tools/crawlers/**/*.jsx` |
+| `unit-tests` | Unit Tests: Pester | `tools/powershell-sdk/**`, `tools/crawlers/shared/**`, `setup/docker/Invoke-CrawlerJob.ps1`, `test/unit/**` |
+| `unit-js` | Unit Tests: Vitest (API) | `app/api/src/**` |
+| `unit-ui` | Unit Tests: Vitest (UI) | `app/ui/src/**`, `tools/crawlers/**/*.jsx` |
+| `node-launcher-ui-build` | Build: Node-launcher UI | `app/ui/src/**`, `tools/crawlers/**/*.jsx` |
+| `openapi` | Lint: OpenAPI spec | `app/api/src/openapi.yaml` |
+
+These four jobs have **no path gate** — they always run when there are product changes:
+
+| Job | Check name | Purpose |
+|---|---|---|
+| `audit` | Audit: npm audit | npm vulnerability scan |
+| `hygiene` | PR Hygiene | Branch naming, PR description checks |
+| `crawler-manifest` | Lint: Crawler manifest completeness | Every crawler has a `crawler.json` |
+| `docs-nav` | Lint: Crawler docs registered in site nav | Every crawler has a docs entry in `mkdocs.yml` |
+
+### Gate jobs
+
+`ci-passed` (`CI Passed`) wraps all of the above. It fails if any job failed or was cancelled; it passes if all jobs succeeded or were legitimately skipped. This is the check required by branch protection.
+
+`pr-summary` (`PR Summary`) is a stub that runs after `ci-passed`. It exists to suppress a ghost pending check created by the Claude GitHub App (used for issue triage, autofix, and release notes) — the app creates a "PR Summary" check suite on every PR push that would otherwise show as permanently pending.
+
+### Labels
+
+| Label | Effect |
+|---|---|
+| `skip-hygiene` | Skips the PR Hygiene job |
+
+---
+
+## pr-integration.yml — Docker integration tests (~20–50 min)
+
+### Commit-range skip
+
+Same logic as `pr.yml` — skips the entire integration suite when only housekeeping commits were pushed.
+
+### Path gates
+
+A `filter` job determines which heavy jobs need to run:
+
+| Job | Check name | Runs when |
+|---|---|---|
+| `integration` | Integration Tests | API source, crawler `.ps1`/`.js`, shared infra, Dockerfiles, compose files |
+| `e2e` | Playwright E2E | UI source, crawler `.jsx`, API source, Dockerfile |
+| `load-soak` | Load & Soak Tests | API source, shared infra, `Start-*.ps1`, Dockerfiles, compose files |
+
+### Per-crawler scoping
+
+When the `integration` job is triggered, a `scope` step computes `CRAWLERS_TO_TEST` from the git diff against the base branch:
+
+- **Shared infra changed** (`tools/crawlers/shared/`, `tools/powershell-sdk/`, `Invoke-CrawlerJob.ps1`, `IdentityAtlas.psm1`, `Dockerfile.powershell`) → full run, all crawlers tested.
+- **Only specific crawler directories changed** → only those crawler types are listed (e.g. `csv,omada`).
+- **Integration triggered by non-crawler paths** (e.g. `app/api/src/`) → full run.
+
+The PS integration runner expands `CRAWLERS_TO_TEST` using the dependency graph:
+
+```
+testSet = changed crawler types + their transitive dependents (upward)
+runSet  = testSet + their transitive dependencies (downward, for data setup)
+```
+
+Types in `runSet` but not `testSet` run for data setup only — their exit code is ignored. Types in `testSet` must pass.
+
+Example: only `omada` changed → `testSet = [omada]`, `runSet = [odata, omada]`. The `odata` crawler runs first to seed the data omada's test needs; only omada's result is asserted.
+
+### Gate job
+
+`ci-integration-passed` (`Integration CI Passed`) wraps `integration`, `e2e`, and `load-soak`. Same logic as `CI Passed` — failure or cancellation fails the gate; success or legitimate skip passes it.
+
+### Labels
+
+| Label | Effect |
+|---|---|
+| `integration-test` | Forces full crawler run regardless of which paths changed |
+| `load-soak` | Forces load soak regardless of which paths changed |
+| `skip-load-soak` | Skips load soak even when paths would trigger it |
+| `skip-e2e` | Skips Playwright E2E |
+
+---
+
+## What runs for common change types
+
+| What changed | PS lint | Pester | API tests | UI tests | Crawler tests | E2E | Load soak |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| One crawler's `.ps1` files only | ✅ | — | — | — | that crawler + dependents | — | — |
+| `tools/crawlers/shared/` | ✅ | ✅ | — | — | all crawlers | — | ✅ |
+| `tools/powershell-sdk/` | ✅ | ✅ | — | — | all crawlers | — | ✅ |
+| `app/api/src/` | — | — | ✅ | — | all crawlers | ✅ | ✅ |
+| `app/ui/src/` | — | — | — | ✅ | — | ✅ | — |
+| Crawler `.jsx` wizard only | — | — | — | ✅ | — | — | — |
+| Dockerfiles / compose | — | — | — | — | all crawlers | ✅ | ✅ |
+| Housekeeping only | — | — | — | — | — | — | — |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - About Identity Atlas: about.md
       - History: history.md
       - Contributing:
+          - CI Pipeline: contributing/ci-pipeline.md
           - UI Style Guide: contributing/style-guide.md
       - User Experience:
           - Assessment & Remediation: ux/assessment.md


### PR DESCRIPTION
## Problem

The Claude GitHub App (used for issue triage, autofix, and release notes synthesis) creates a check suite named **"PR Summary"** on every PR push. Before Phase 1 (`#378`), `pr.yml` had a job with that same display name that always completed green — its completed check run overshadowed the app's pending suite in the GitHub UI.

Phase 1 renamed the job to `'CI Passed'`, leaving the Claude app's check suite permanently stuck in `queued` state. Every PR now shows **"PR Summary expected"** as a ghost pending check.

## Fix

Re-adds a minimal stub job `pr-summary` / `'PR Summary'` that depends on `ci-passed` and always emits a completed check run. The workflow's completed check run wins the UI display over the Claude app's pending suite.

No logic change — `ci-passed` is still the real gate for branch protection.