### PR TITLE
fix(ci): use client-id instead of deprecated app-id in bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -35,7 +35,7 @@ jobs:
         id: bot-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/changes/bump-version-client-id.md
+++ b/changes/bump-version-client-id.md
@@ -1,0 +1,1 @@
+- Fixed `bump-version` workflow failing to push to `main` by updating the deprecated `app-id` parameter to `client-id` in `actions/create-github-app-token`, matching `cut-release` and `cut-hotfix`


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token` v3 deprecated the `app-id` input in favour of `client-id`
- `cut-release.yml` and `cut-hotfix.yml` already use `client-id`; `bump-version.yml` was the odd one out still using `app-id`
- This aligns all three workflows and eliminates the deprecation warning in CI logs

## Test plan
- [ ] Merge this PR and verify the next `bump-version` run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)