### PR TITLE
fix(ci): switch bump-version to VERSION_BUMP_PAT instead of App token

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,17 +31,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Generate bot token
-        id: bot-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
-          token: ${{ steps.bot-token.outputs.token }}
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Merge changelog fragments and bump version
         shell: pwsh

--- a/changes/bump-version-use-pat.md
+++ b/changes/bump-version-use-pat.md
@@ -1,0 +1,1 @@
+- Fixed `bump-version` workflow repeatedly failing to push to `main` by switching back to `VERSION_BUMP_PAT` (repository admin PAT) instead of the GitHub App token whose bypass was misconfigured


### PR DESCRIPTION
## Summary
- All `bump-version` runs have been failing since PR #380 — the `fortigi-ci-bot` GitHub App token was not matching the ruleset bypass actor
- Reverts to the original `VERSION_BUMP_PAT` approach documented in CLAUDE.md
- Also updated the ruleset bypass to include `RepositoryRole: admin` (always) so the PAT from a repo admin can push directly to `main`

## Test plan
- [ ] Merge and verify the next `bump-version` run pushes `chore: bump version` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)