### PR TITLE
fix: apply DB migrations before starting the server

### DIFF
--- a/app/api/src/bootstrap.js
+++ b/app/api/src/bootstrap.js
@@ -293,12 +293,23 @@ export async function getOrCreateTagRoot(targetType) {
   return id;
 }
 
+// Run database migrations as a hard startup prerequisite. This MUST complete
+// before the HTTP server binds its port: the worker container starts polling
+// the job-claim endpoint the moment the web port is up, and a crawler running
+// against a mid-migration schema deadlocks against the migration's DDL locks
+// (this is what hit a customer during a version upgrade). Migrating first
+// guarantees a newer version always upgrades the schema before anything else
+// touches the database.
+export async function migrateDatabase() {
+  if (process.env.USE_SQL !== 'true') return;
+  const pool = await db.getPool();
+  await runMigrations(pool);
+}
+
 export async function bootstrapWorker() {
   if (process.env.USE_SQL !== 'true') return;
   try {
     ensureVaultKey();
-    const pool = await db.getPool();
-    await runMigrations(pool);
     await ensureBuiltinCrawler();
     // Move any legacy plaintext crawler clientSecrets into the encrypted vault.
     try {

--- a/app/api/src/index.js
+++ b/app/api/src/index.js
@@ -10,7 +10,7 @@
 import { createApp } from './app.js';
 import { enable as enablePerf, isEnabled as isPerfEnabled } from './perf/collector.js';
 import { loadAuthConfig, isAuthEnabled } from './config/authConfig.js';
-import { bootstrapWorker } from './bootstrap.js';
+import { bootstrapWorker, migrateDatabase } from './bootstrap.js';
 
 const port       = process.env.PORT || 3001;
 // Desktop mode binds to 127.0.0.1 only — the portable is a local app and should
@@ -52,6 +52,19 @@ loadAuthConfig().catch(err => {
 });
 
 const app = createApp();
+
+// Apply database migrations BEFORE binding the port (see migrateDatabase). The
+// worker container starts polling for crawler jobs as soon as the web port is
+// up, so the schema must be fully upgraded first — otherwise a crawler can run
+// against a mid-migration schema and deadlock against the migration's locks.
+// On failure, exit non-zero: Docker restarts the container and retries, and
+// because the port never opened, no crawler ever ran against a broken schema.
+try {
+  await migrateDatabase();
+} catch (err) {
+  console.error('Database migration failed — refusing to start:', err.message);
+  process.exit(1);
+}
 
 const server = app.listen(port, host, async () => {
   console.log(`Identity Atlas running on http://localhost:${port}`);

--- a/app/api/src/index.test.js
+++ b/app/api/src/index.test.js
@@ -3,6 +3,56 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import net from 'node:net';
 
+// Shared recorder + mock fns for the startup-ordering test. vi.hoisted runs
+// before the vi.mock factories below (which are themselves hoisted above the
+// imports), so the factories can safely close over these.
+const startup = vi.hoisted(() => {
+  const calls = [];
+  return {
+    calls,
+    // migrateDatabase deliberately yields to the event loop before recording,
+    // so if a regression ever called app.listen() WITHOUT awaiting migrations
+    // first, 'listen' would be recorded before 'migrate' and the test fails.
+    migrateDatabase: vi.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      calls.push('migrate');
+    }),
+    bootstrapWorker: vi.fn(async () => { calls.push('bootstrap'); }),
+    listen: vi.fn((_port, _host, cb) => {
+      calls.push('listen');
+      if (cb) cb();
+      return { on: vi.fn() };
+    }),
+  };
+});
+
+vi.mock('./app.js', () => ({ createApp: () => ({ listen: startup.listen }) }));
+vi.mock('./bootstrap.js', () => ({
+  migrateDatabase: startup.migrateDatabase,
+  bootstrapWorker: startup.bootstrapWorker,
+}));
+vi.mock('./perf/collector.js', () => ({ enable: vi.fn(), isEnabled: () => false }));
+vi.mock('./config/authConfig.js', () => ({
+  loadAuthConfig: vi.fn(async () => {}),
+  isAuthEnabled: () => false,
+}));
+
+describe('startup ordering — migrations run first', () => {
+  it('applies migrations before the server binds its port', async () => {
+    // Importing index.js runs its top-level startup sequence. The dynamic
+    // import resolves only after index.js's top-level `await migrateDatabase()`
+    // settles, so by the time this await returns the ordering is final.
+    await import('./index.js');
+
+    // Migrations must have run, and must be the very first recorded step —
+    // guards against someone dropping `await migrateDatabase()` from index.js
+    // (the fn would never be called) or moving it after app.listen().
+    expect(startup.migrateDatabase).toHaveBeenCalledTimes(1);
+    expect(startup.calls[0]).toBe('migrate');
+    expect(startup.calls.indexOf('migrate')).toBeLessThan(startup.calls.indexOf('listen'));
+  });
+});
+
 describe('server EADDRINUSE handler', () => {
   afterEach(() => vi.restoreAllMocks());
 

--- a/changes/migrate-before-server-start.md
+++ b/changes/migrate-before-server-start.md
@@ -1,0 +1,2 @@
+- Fixed a database deadlock that could occur when upgrading to a newer version: the application now applies all pending SQL migrations before it starts accepting any requests, so a crawler can no longer run against a half-migrated schema.
+- If migrations fail on startup, the application now stops instead of serving with an outdated schema (the container restarts and retries automatically).

--- a/test/ci-scripts/events/update-branch.json
+++ b/test/ci-scripts/events/update-branch.json
@@ -1,0 +1,15 @@
+{
+  "action": "synchronize",
+  "pull_request": {
+    "number": 999,
+    "head": { "ref": "feature/ci-scope-testing", "sha": "HEAD" },
+    "base": { "ref": "main", "sha": "main" },
+    "labels": []
+  },
+  "before": "PREV_SHA",
+  "after": "HEAD_SHA",
+  "repository": {
+    "name": "IdentityAtlas",
+    "full_name": "Fortigi/IdentityAtlas"
+  }
+}


### PR DESCRIPTION
## Problem

A customer hit a **database deadlock** during a version upgrade: the PowerShell crawler was running at the same time SQL migrations were being applied.

**Root cause:** `app.listen()` bound the web port *before* `bootstrapWorker()` ran the migrations. The worker container starts polling `/crawlers/jobs/claim` the moment the web port is up (`depends_on: web → service_started`), so it could claim a job and run crawler INSERTs while migration DDL held `ACCESS EXCLUSIVE` locks on the same tables → deadlock.

## Fix

Migrate first, then serve. Migrations are split out of `bootstrapWorker()` into a dedicated `migrateDatabase()`, awaited **before** `app.listen()`:

- The port doesn't open until every pending migration is applied, so the worker can't claim a job — and no crawler can run — against a half-migrated schema.
- A newer version always upgrades the schema before anything else touches the database.
- If migrations fail, the container exits non-zero (Docker restarts and retries) instead of serving an outdated schema. Since the port never opened, no crawler ran against a broken schema.

## Testing

- Rebuilt the `web` image and restarted against the live Docker stack. Startup log order is now `Migrations: up to date (40 applied)` **then** `Identity Atlas running on http://localhost:3001` (previously reversed).
- `/api/health` → 200; web + worker healthy.
- `migrate.test.js` — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)