### PR TITLE
fix(ingest): import context-members referenced by external id (Omada CSV)

### DIFF
--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -108,6 +108,21 @@ export function normalizeRecords(records, coreColumns, options = {}) {
       if (rec.principalExternalId && !normalized.principalId) {
         normalized.principalId = deterministicGuid(`${sysPrefix}-principals`, String(rec.principalExternalId));
       }
+      // Context-member references (ingest/context-members). The context endpoint
+      // generates context IDs under "<sys>-contexts" and each member entity under
+      // "<sys>-<entity>", so re-derive the same namespaces here to make the FKs
+      // line up. The CSV crawler sends these externalIds expecting resolution
+      // here — see tools/crawlers/csv/Start-CSVCrawler.ps1 → ContextMembers.csv.
+      if (rec.contextExternalId && !normalized.contextId) {
+        normalized.contextId = deterministicGuid(`${sysPrefix}-contexts`, String(rec.contextExternalId));
+      }
+      if (rec.memberExternalId && !normalized.memberId) {
+        // memberId's namespace depends on what kind of entity the member is.
+        const memberNs = { Identity: 'identities', Principal: 'principals', Resource: 'resources' }[rec.memberType];
+        if (memberNs) {
+          normalized.memberId = deterministicGuid(`${sysPrefix}-${memberNs}`, String(rec.memberExternalId));
+        }
+      }
     }
 
     // Set systemId if provided, the record doesn't override it, AND the table has the column

--- a/app/api/src/ingest/normalization.test.js
+++ b/app/api/src/ingest/normalization.test.js
@@ -102,3 +102,59 @@ describe('normalizeRecords — boolean fields', () => {
     expect(result[0].enabled).not.toBe(1);
   });
 });
+
+describe('normalizeRecords — context-member externalId resolution', () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  // The CSV crawler sends context-members with idPrefix "<sys>-context-members".
+  const memberOpts  = { idGeneration: 'deterministic', idPrefix: 'Omada-context-members', systemId: 1 };
+  const memberCols  = ['contextId', 'memberId', 'memberType', 'addedBy'];
+
+  it('resolves contextExternalId to a deterministic UUID in contextId', () => {
+    const r = normalizeRecords(
+      [{ contextExternalId: 'OU123|JT456', memberExternalId: 'alice', memberType: 'Identity', addedBy: 'sync' }],
+      memberCols, memberOpts
+    );
+    expect(r[0].contextId).toMatch(UUID_RE);
+    expect(r[0].memberId).toMatch(UUID_RE);
+  });
+
+  it('a pipe in the context key is handled (it is hashed, not split)', () => {
+    const piped  = normalizeRecords([{ contextExternalId: 'OU|JT', memberExternalId: 'a', memberType: 'Identity' }], memberCols, memberOpts);
+    const plain  = normalizeRecords([{ contextExternalId: 'OUJT',  memberExternalId: 'a', memberType: 'Identity' }], memberCols, memberOpts);
+    expect(piped[0].contextId).toMatch(UUID_RE);
+    // Different keys → different ids (no truncation/collision on the pipe).
+    expect(piped[0].contextId).not.toBe(plain[0].contextId);
+  });
+
+  it('member contextId matches the id the Contexts endpoint generates for the same key (incl. a pipe)', () => {
+    // This is the FK that was broken: a ContextMember must resolve to the exact
+    // UUID the Position context got. Contexts are sent with idPrefix "<sys>-contexts".
+    const posKey = 'OU123|JT456';
+    const contextOpts = { idGeneration: 'deterministic', idPrefix: 'Omada-contexts', systemId: 1 };
+    const ctx = normalizeRecords(
+      [{ externalId: posKey, displayName: 'Pos', variant: 'synced', targetType: 'Identity', contextType: 'Position' }],
+      ['id', 'externalId', 'displayName', 'variant', 'targetType', 'contextType', 'systemId'], contextOpts
+    );
+    const mem = normalizeRecords(
+      [{ contextExternalId: posKey, memberExternalId: 'alice', memberType: 'Identity' }],
+      memberCols, memberOpts
+    );
+    expect(mem[0].contextId).toBe(ctx[0].id);
+  });
+
+  it('memberId namespace depends on memberType (Identity → identities)', () => {
+    const member   = normalizeRecords([{ contextExternalId: 'c', memberExternalId: 'alice', memberType: 'Identity' }], memberCols, memberOpts);
+    // An identity sent to ingest/identities (idPrefix "<sys>-identities") gets this id.
+    const identity = normalizeRecords([{ externalId: 'alice', displayName: 'A' }], ['id', 'externalId', 'displayName'], { idGeneration: 'deterministic', idPrefix: 'Omada-identities', systemId: 1 });
+    expect(member[0].memberId).toBe(identity[0].id);
+  });
+
+  it('does not overwrite an explicit contextId', () => {
+    const explicit = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    const r = normalizeRecords(
+      [{ contextId: explicit, contextExternalId: 'OU|JT', memberExternalId: 'a', memberType: 'Identity' }],
+      memberCols, memberOpts
+    );
+    expect(r[0].contextId).toBe(explicit);
+  });
+});

--- a/changes/ingest-resolve-context-member-externalids.md
+++ b/changes/ingest-resolve-context-member-externalids.md
@@ -1,0 +1,2 @@
+- Fixed Context Member import from CSV (e.g. the Omada→Identity Atlas conversion script): memberships that reference their context and member by external id now import correctly instead of failing with a database error. Affected any context membership imported via CSV, including Omada Positions (whose keys contain a pipe character — the pipe was never the cause).
+- Fixed the CSV crawler collapsing all context-member rows into a single record before upload, so every membership is now imported rather than just one.

--- a/tools/crawlers/csv/Start-CSVCrawler.ps1
+++ b/tools/crawlers/csv/Start-CSVCrawler.ps1
@@ -244,7 +244,13 @@ function Send-GroupedBySystem {
                     [void]$sb.Append([string]$r['parentExternalId']).Append('|')
                     [void]$sb.Append([string]$r['childExternalId']).Append('|')
                     [void]$sb.Append([string]$r['identityExternalId']).Append('|')
-                    [void]$sb.Append([string]$r['userExternalId'])
+                    [void]$sb.Append([string]$r['userExternalId']).Append('|')
+                    # Context-member rows key on (contextExternalId, memberExternalId,
+                    # memberType) — without these every membership row hashes to the
+                    # same empty key and the whole batch collapses to one record.
+                    [void]$sb.Append([string]$r['contextExternalId']).Append('|')
+                    [void]$sb.Append([string]$r['memberExternalId']).Append('|')
+                    [void]$sb.Append([string]$r['memberType'])
                     $k = $sb.ToString()
                 }
                 $seen[$k] = $r

--- a/tools/crawlers/csv/Test-CSVCrawler.ps1
+++ b/tools/crawlers/csv/Test-CSVCrawler.ps1
@@ -263,6 +263,37 @@ try {
     }
 }
 
+# ─── Context-member externalId resolution ───────────────────────
+# Regression test: a ContextMember referenced by contextExternalId /
+# memberExternalId (the shape the CSV crawler sends) must resolve to the same
+# deterministic UUIDs the contexts/identities endpoints generate. This used to
+# 500 with 'null value in column "contextId"' because the ingest never resolved
+# those external IDs. The context key deliberately contains a pipe to prove the
+# pipe is hashed, not split.
+try {
+    $posKey = 'edge-OU1|edge-JT1'
+    Invoke-LocalApi -Path '/ingest/contexts' -Method Post -Body @{
+        systemId = $testSystemId; idGeneration = 'deterministic'; idPrefix = 'CSVTest-contexts'
+        records  = @(@{ externalId = $posKey; displayName = 'Edge Position'; contextType = 'Position'; targetType = 'Identity'; variant = 'synced' })
+    } | Out-Null
+    Invoke-LocalApi -Path '/ingest/identities' -Method Post -Body @{
+        systemId = $testSystemId; idGeneration = 'deterministic'; idPrefix = 'CSVTest-identities'
+        records  = @(@{ externalId = 'edge-ID1'; displayName = 'Edge Person' })
+    } | Out-Null
+    $r = Invoke-LocalApi -Path '/ingest/context-members' -Method Post -Body @{
+        systemId = $testSystemId; idGeneration = 'deterministic'; idPrefix = 'CSVTest-context-members'
+        records  = @(@{ contextExternalId = $posKey; memberExternalId = 'edge-ID1'; memberType = 'Identity'; addedBy = 'sync' })
+    }
+    if ($r.inserted -ge 1 -or $r.updated -ge 1) {
+        Report-Result 'CSV/ContextMemberExternalId' $true "context-member resolved by externalId (inserted=$($r.inserted) updated=$($r.updated))"
+    } else {
+        Report-Result 'CSV/ContextMemberExternalId' $false "call succeeded but nothing written: $($r | ConvertTo-Json -Compress)"
+    }
+} catch {
+    $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+    Report-Result 'CSV/ContextMemberExternalId' $false "context-member by externalId failed (status $statusCode) — externalId resolution regression: $($_.Exception.Message)"
+}
+
 # ─── Cleanup ─────────────────────────────────────────────────────
 # Best-effort removal of temp CSV files
 try {


### PR DESCRIPTION
## Problem
A colleague's Omada import via the **PowerShell conversion script** (`tools/csv-templates/transforms/omada-to-identityatlas.ps1`) failed. The transcript:

```
ContextMembers.csv: 37635 rows
  Deduped: 37635 → 1
Sending 1 records to ingest/context-members...
  ERROR: ingest/context-members returned 500
  "message": "null value in column \"contextId\" of relation \"ContextMembers\" violates not-null constraint"
```

The reported suspicion was the **pipe** in Position keys. It's not — the pipe is a deliberate `OrgUnit|JobTitle` separator and is MD5-hashed into the deterministic id, never split. There were two real bugs in the context-member path:

### 1. Ingest never resolved `contextExternalId` / `memberExternalId`
`ingest/validation.js` *accepts* those fields and the CSV crawler sends them expecting resolution, but `ingest/normalization.js` only resolved `resourceExternalId`/`principalExternalId`/… — so `contextId` stayed null → NOT-NULL violation. Added resolution mirroring the existing pattern, deriving the same `<sys>-contexts` / `<sys>-<member-entity>` deterministic-GUID namespaces so the FKs match the contexts/identities endpoints.

### 2. CSV crawler collapsed all memberships into one row
The dedup key (`Start-CSVCrawler.ps1`) was built from `externalId` or `resource/principal/parent/child/identity/userExternalId` — **none of the context-member fields**. Every membership row hashed to the same empty key, so 37,635 rows deduped to **1**. Added `contextExternalId`/`memberExternalId`/`memberType` to the key.

Both are unrelated to the pipe.

## Testing
- **Unit** (`normalization.test.js`): resolution of both fields; namespace-by-`memberType`; explicit-id not overwritten; and the key FK test — a membership's `contextId` equals the Position context's `id` **with a pipe in the key**.
- **Integration** (`Test-CSVCrawler.ps1`): new `CSV/ContextMemberExternalId` case reproduces the previously-failing import → now `inserted=1`.
- **End-to-end on the Docker stack**: reproduced the exact 500, applied the fix, re-ran → `201`; verified the membership joins to the right context + identity. Dedup fix verified by simulation (4 rows, 1 true dup → 3 unique; was 1).
- PowerShell files parse clean under pwsh 7.

Note: the transform script itself needs no changes — `variant`/`targetType`/`addedBy` are supplied by the CSV crawler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)