### PR TITLE
test(api): fix bootstrap.tagRoots flaky timeout under parallel load

### DIFF
--- a/app/api/src/bootstrap.tagRoots.test.js
+++ b/app/api/src/bootstrap.tagRoots.test.js
@@ -31,6 +31,20 @@ async function loadBootstrapWithExistingRoots(existing) {
       return { rowCount: 0 };
     }),
   }));
+
+  // Stub bootstrap's heavy sibling imports. getOrCreateTagRoot only needs the
+  // db mock above; these modules are pulled in solely by bootstrapWorker (which
+  // this test never calls) and importing their real graphs — scheduler →
+  // crawler manifests → jobs, every context plugin via seedAlgorithms, the
+  // vault, the migration runner — is what made importing bootstrap.js exceed
+  // the 5s test timeout under parallel suite load (it passed in isolation).
+  // Mocking them keeps the import cheap and the test deterministic.
+  vi.doMock('./db/migrate.js', () => ({ runMigrations: vi.fn() }));
+  vi.doMock('./secrets/vault.js', () => ({ selfTest: vi.fn(() => true) }));
+  vi.doMock('./scheduler.js', () => ({ startScheduler: vi.fn() }));
+  vi.doMock('./contexts/seedAlgorithms.js', () => ({ seedContextAlgorithms: vi.fn() }));
+  vi.doMock('./secrets/migrateCrawlerSecrets.js', () => ({ migrateCrawlerSecretsToVault: vi.fn() }));
+
   // Don't actually run runMigrations / ensureBuiltinCrawler etc. — load the
   // module fresh, then call the named export. ensureTagRoots is internal but
   // getOrCreateTagRoot is exported.


### PR DESCRIPTION
## Problem
`src/bootstrap.tagRoots.test.js` intermittently failed in the **full** Vitest suite (it passed in isolation):

```
× returns the existing id when a root already exists for the targetType  6913ms
× inserts a new root when none exists and returns its id                 7098ms
Error: Test timed out in 5000ms.
```

## Root cause
The test's `loadBootstrapWithExistingRoots` calls `vi.resetModules()` then `await import('./bootstrap.js')` on every invocation. Importing `bootstrap.js` transitively loads its whole graph — `scheduler.js` (→ crawler manifests → jobs), every context plugin (via `seedAlgorithms.js`), the vault, and the migration runner. None of that is used by `getOrCreateTagRoot` (the only thing under test). Under parallel suite load that import exceeds the 5 s test timeout; alone it's fast, which is why it looked flaky.

## Fix
Mock the heavy sibling imports (`db/migrate.js`, `secrets/vault.js`, `scheduler.js`, `contexts/seedAlgorithms.js`, `secrets/migrateCrawlerSecrets.js`) so the test loads only what it exercises (the `db` module, already mocked). Proper unit isolation — `bootstrapWorker` (the only consumer of those modules) is never called by this test.

## Result
- Timing-out cases now run in ~1 s.
- Full suite green across two consecutive runs: **68 files / 745 tests, 0 failures**.
- Test-only change — no changelog fragment required (PR Hygiene excludes `*.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)