### PR TITLE
fix(omada-transform): skip context-member rows referencing missing contexts

### DIFF
--- a/changes/fix-omada-context-member-fk.md
+++ b/changes/fix-omada-context-member-fk.md
@@ -1,0 +1,1 @@
+- Fixed FK violation in Omada → Identity Atlas transform: context-member rows for org units or job titles that don't appear in the exported Orgunits/Jobtitle files are now silently skipped instead of causing the import to fail with a `ContextMembers_contextId_fkey` constraint error.

--- a/tools/csv-templates/transforms/omada-to-identityatlas.ps1
+++ b/tools/csv-templates/transforms/omada-to-identityatlas.ps1
@@ -144,21 +144,29 @@ Write-Out 'Contexts.csv' $allContexts.ToArray()
 #   Identity → JobTitle  (via JOBTITLE_REF_ID)
 #   Identity → Position  (via the derived OrgUnit|JobTitle key)
 # All employments are included regardless of ValidFrom/ValidTo.
+#
+# Guard: only emit a membership row when the referenced ContextExternalId is
+# actually present in Contexts.csv. Employment records can reference org units
+# or job titles that were archived or excluded from the Omada export; sending
+# those would cause a FK violation (ContextMembers_contextId_fkey) in the API.
 Write-Host "Context members:" -ForegroundColor Cyan
 if ($emp) {
+    $knownContextIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($c in $allContexts) { if ($c.ExternalId) { [void]$knownContextIds.Add($c.ExternalId) } }
+
     $members = [System.Collections.Generic.List[object]]::new()
     foreach ($e in $emp) {
         $identId = $e.IDENTITYREF_ID
         if (-not $identId) { continue }
 
-        if ($e.OUREF_ID) {
+        if ($e.OUREF_ID -and $knownContextIds.Contains($e.OUREF_ID)) {
             $members.Add([PSCustomObject]@{
                 ContextExternalId = $e.OUREF_ID
                 MemberExternalId  = $identId
                 MemberType        = 'Identity'
             })
         }
-        if ($e.JOBTITLE_REF_ID) {
+        if ($e.JOBTITLE_REF_ID -and $knownContextIds.Contains($e.JOBTITLE_REF_ID)) {
             $members.Add([PSCustomObject]@{
                 ContextExternalId = $e.JOBTITLE_REF_ID
                 MemberExternalId  = $identId
@@ -166,11 +174,14 @@ if ($emp) {
             })
         }
         if ($e.OUREF_ID -and $e.JOBTITLE_REF_ID) {
-            $members.Add([PSCustomObject]@{
-                ContextExternalId = "$($e.OUREF_ID)|$($e.JOBTITLE_REF_ID)"
-                MemberExternalId  = $identId
-                MemberType        = 'Identity'
-            })
+            $posId = "$($e.OUREF_ID)|$($e.JOBTITLE_REF_ID)"
+            if ($knownContextIds.Contains($posId)) {
+                $members.Add([PSCustomObject]@{
+                    ContextExternalId = $posId
+                    MemberExternalId  = $identId
+                    MemberType        = 'Identity'
+                })
+            }
         }
     }
     Write-Out 'ContextMembers.csv' $members.ToArray()


### PR DESCRIPTION
- Fixed FK violation in Omada → Identity Atlas transform: context-member rows for org units or job titles that don't appear in the exported Orgunits/Jobtitle files are now silently skipped instead of causing the import to fail with a `ContextMembers_contextId_fkey` constraint error.

## Root cause

After #389 resolved the null-`contextId` bug, `Employment.csv` rows that reference archived or export-excluded org units / job titles now produce a resolved `contextId` that doesn't exist in the Contexts table — surfacing as a FK violation on the final (commit) batch of the context-members ingest.

The conversion script now builds a `HashSet` of all valid context `ExternalId`s from the generated `Contexts.csv` output and skips any membership row whose `ContextExternalId` isn't in that set.

## Test plan

- [ ] Run `omada-to-identityatlas.ps1` against an Omada export where `Employment.csv` contains `OUREF_ID` or `JOBTITLE_REF_ID` values absent from `Orgunits.csv` / `Jobtitle.csv` — confirm no FK error and the orphaned rows are silently dropped
- [ ] Verify normal imports (all referenced contexts present) still produce the expected `ContextMembers.csv` row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)