### PR TITLE
Retention: purge soft-deleted tombstones on the existing retention job

### DIFF
--- a/app/api/src/bootstrap.js
+++ b/app/api/src/bootstrap.js
@@ -22,6 +22,7 @@ import { selfTest as vaultSelfTest } from './secrets/vault.js';
 import { startScheduler } from './scheduler.js';
 import { seedContextAlgorithms } from './contexts/seedAlgorithms.js';
 import { migrateCrawlerSecretsToVault } from './secrets/migrateCrawlerSecrets.js';
+import { purgeExpiredTombstones } from './ingest/tombstonePurge.js';
 
 const WORKER_KEY_FILE = process.env.WORKER_KEY_FILE || '/data/uploads/.builtin-worker-key';
 
@@ -125,10 +126,11 @@ export async function ensureBuiltinCrawler() {
   console.log(`Built-in Worker crawler created (prefix: ${prefix})`);
 }
 
-// Periodic prune of the `_history` audit table. Reads the retention setting
-// from WorkerConfig (default 180 days) and deletes anything older. Runs once
-// at startup (60s warm-up so it doesn't fight migrations) and then every 6 hours.
-// Setting retention to 0 disables pruning entirely.
+// Periodic prune of the `_history` audit table AND finalisation of soft-deleted
+// (tombstoned) rows. Reads ONE retention setting from WorkerConfig (default 180
+// days): rows soft-deleted longer ago than that are hard-deleted, and history
+// older than that is pruned. Runs once at startup (60s warm-up so it doesn't
+// fight migrations) and then every 6 hours. Setting retention to 0 disables both.
 function startHistoryPruneJob() {
   const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;
   const FIRST_RUN_DELAY_MS = 60 * 1000;
@@ -142,6 +144,14 @@ function startHistoryPruneJob() {
       );
       const days = r ? parseInt(r.configValue, 10) : DEFAULT_DAYS;
       if (days <= 0) return; // disabled
+
+      // Finalise tombstones first (the hard-delete writes the final 'D' history),
+      // then prune the history table itself to the same window.
+      const { purged } = await purgeExpiredTombstones(db, days);
+      for (const [table, n] of Object.entries(purged)) {
+        console.log(`Tombstone purge: hard-deleted ${n} ${table} soft-deleted over ${days} days ago`);
+      }
+
       const del = await db.query(
         `DELETE FROM "_history" WHERE "changedAt" < now() - ($1::int * interval '1 day')`,
         [days]
@@ -150,7 +160,7 @@ function startHistoryPruneJob() {
         console.log(`History prune: deleted ${del.rowCount} row(s) older than ${days} days`);
       }
     } catch (err) {
-      console.error('History prune failed (will retry next interval):', err.message);
+      console.error('History/tombstone prune failed (will retry next interval):', err.message);
     }
   }
 

--- a/app/api/src/ingest/tombstonePurge.js
+++ b/app/api/src/ingest/tombstonePurge.js
@@ -1,0 +1,28 @@
+// Finalize soft-deleted (tombstoned) rows once they age past the retention window.
+//
+// Soft-delete keeps a vanished entity around (stamped deletedAt) so it stays
+// auditable and cross-system references don't dangle. After the configured
+// retention it's finally hard-deleted — the _history trigger records the final
+// 'D' row, so the audit trail survives in _history (which is pruned to the same
+// window). One global value (WorkerConfig HISTORY_RETENTION_DAYS) governs both.
+//
+// Assignments are purged before principals/resources so a hard-deleted holder or
+// target doesn't briefly leave a dangling assignment. db is injected for testing.
+
+// Ordered: assignments first, then the entities they referenced.
+export const PURGE_ORDER = ['ResourceAssignments', 'Principals', 'Resources'];
+
+export async function purgeExpiredTombstones(db, days) {
+  const purged = {};
+  if (!Number.isInteger(days) || days <= 0) return { purged }; // 0/invalid disables purge
+  for (const table of PURGE_ORDER) {
+    const res = await db.query(
+      `DELETE FROM "${table}"
+        WHERE "deletedAt" IS NOT NULL
+          AND "deletedAt" < now() - ($1::int * interval '1 day')`,
+      [days]
+    );
+    if (res.rowCount) purged[table] = res.rowCount;
+  }
+  return { purged };
+}

--- a/app/api/src/ingest/tombstonePurge.test.js
+++ b/app/api/src/ingest/tombstonePurge.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { purgeExpiredTombstones, PURGE_ORDER } from './tombstonePurge.js';
+
+describe('purgeExpiredTombstones', () => {
+  it('hard-deletes from each soft-delete table, assignments before entities', async () => {
+    const seen = [];
+    const db = {
+      query: vi.fn(async (sql, params) => {
+        seen.push({ sql, days: params[0] });
+        return { rowCount: 1 };
+      }),
+    };
+    const { purged } = await purgeExpiredTombstones(db, 180);
+    // One DELETE per table, in the safe order.
+    expect(db.query).toHaveBeenCalledTimes(PURGE_ORDER.length);
+    expect(seen.map((s) => PURGE_ORDER.find((t) => s.sql.includes(`"${t}"`)))).toEqual(PURGE_ORDER);
+    expect(seen.every((s) => s.days === 180)).toBe(true);
+    // Only deletes rows whose deletedAt is past the window.
+    expect(seen.every((s) => /deletedAt" IS NOT NULL/.test(s.sql) && /deletedAt" <\s*now\(\)/.test(s.sql))).toBe(true);
+    expect(purged).toEqual({ ResourceAssignments: 1, Principals: 1, Resources: 1 });
+  });
+
+  it('is a no-op when retention is 0, negative, or non-integer (purge disabled)', async () => {
+    const db = { query: vi.fn() };
+    for (const d of [0, -5, 1.5, NaN, undefined]) {
+      const { purged } = await purgeExpiredTombstones(db, d);
+      expect(purged).toEqual({});
+    }
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('omits tables that purged nothing from the result', async () => {
+    const db = { query: vi.fn(async () => ({ rowCount: 0 })) };
+    const { purged } = await purgeExpiredTombstones(db, 30);
+    expect(purged).toEqual({});
+  });
+});

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
 import * as db from '../db/connection.js';
 import { getAuthState } from '../config/authConfig.js';
+import { purgeExpiredTombstones } from '../ingest/tombstonePurge.js';
 import { requirePermission } from '../middleware/auth.js';
 
 // Per-handler gates for the various /admin/* endpoints. Read-only dashboards
@@ -745,12 +746,15 @@ router.post('/admin/history-retention/prune', writeSystems, adminDestructiveLimi
       [HISTORY_RETENTION_KEY]
     );
     const days = r ? parseInt(r.configValue, 10) : HISTORY_RETENTION_DEFAULT;
-    if (days <= 0) return res.json({ deleted: 0, message: 'Retention disabled (0 days) — nothing pruned' });
+    if (days <= 0) return res.json({ deleted: 0, purged: {}, message: 'Retention disabled (0 days) — nothing pruned' });
+    // Finalise tombstones (hard-delete soft-deleted rows past the window), then
+    // prune the history table — same retention governs both.
+    const { purged } = await purgeExpiredTombstones(db, days);
     const del = await db.query(
       `DELETE FROM "_history" WHERE "changedAt" < now() - ($1::int * interval '1 day')`,
       [days]
     );
-    res.json({ deleted: del.rowCount || 0, retentionDays: days });
+    res.json({ deleted: del.rowCount || 0, purged, retentionDays: days });
   } catch (err) {
     console.error('history-retention prune failed:', err.message);
     res.status(500).json({ error: 'Prune failed' });

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -887,7 +887,9 @@ function HistoryRetentionSection() {
       const r = await authFetch('/api/admin/history-retention/prune', { method: 'POST' });
       if (r.ok) {
         const j = await r.json();
-        setMessage({ kind: 'ok', text: `Pruned ${j.deleted} row(s) older than ${j.retentionDays} days` });
+        const purgedTotal = Object.values(j.purged || {}).reduce((a, b) => a + b, 0);
+        const purgedNote = purgedTotal ? `, purged ${purgedTotal} deleted record(s)` : '';
+        setMessage({ kind: 'ok', text: `Pruned ${j.deleted} history row(s)${purgedNote} (older than ${j.retentionDays} days)` });
         load();
       } else {
         setMessage({ kind: 'err', text: `Prune failed (HTTP ${r.status})` });
@@ -900,10 +902,12 @@ function HistoryRetentionSection() {
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5 mb-4">
-      <h4 className="font-semibold text-gray-900 dark:text-white mb-1">Version History Retention</h4>
+      <h4 className="font-semibold text-gray-900 dark:text-white mb-1">Deleted Data &amp; History Retention</h4>
       <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-        How long row-level change history is kept in the audit log. Older entries are pruned automatically every 6 hours.
-        Set to <code className="dark:text-gray-300">0</code> to disable pruning and keep history forever.
+        How long deleted records and row-level change history are kept. Entities removed in a source system are
+        soft-deleted (hidden but kept for audit); after this many days they&apos;re permanently purged, and audit-log
+        entries older than this are pruned too. Runs automatically every 6 hours.
+        Set to <code className="dark:text-gray-300">0</code> to disable purging and keep everything forever.
       </p>
 
       <div className="flex items-end gap-3">

--- a/changes/soft-delete-purge.md
+++ b/changes/soft-delete-purge.md
@@ -1,0 +1,2 @@
+- Soft-deleted records (users, resources and their assignments that were removed in a source system) are now **permanently purged after the retention period**, reusing the existing **Admin → Deleted Data & History Retention** setting (default 180 days). They stay auditable during the window, then the same job that prunes the audit log finalises them. One global value governs both; set it to `0` to keep everything forever.
+- The Admin retention card and its "Prune now" action now cover deleted records as well as history.


### PR DESCRIPTION
Stacked on #400 (soft-delete lifecycle). Retarget to `main` once #400 lands.

Closes the lifecycle loop: soft-deleted records are kept for the retention window, then permanently purged — **reusing the existing global `HISTORY_RETENTION_DAYS` setting** (Admin → *Deleted Data & History Retention*, default 180 days). No new config.

- The existing 6-hourly prune job (and the manual **Prune now**) now hard-delete principals/resources/assignments soft-deleted longer ago than the retention, in addition to pruning `_history`. The hard-delete writes the final `'D'` history row, so the audit trail survives in `_history` (pruned to the same window).
- Purge logic lives in `ingest/tombstonePurge.js` — db injected, unit-tested (order: assignments → principals → resources; `0`/invalid disables).
- Admin card reworded to "Deleted Data & History Retention"; one global value governs both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)