### PR TITLE
refactor(api): extract shared query and ingest helpers (dedup phase 1)

### DIFF
--- a/app/api/src/db/matrixHelpers.js
+++ b/app/api/src/db/matrixHelpers.js
@@ -1,0 +1,72 @@
+/**
+ * Shared SQL expression builders for matrix.js.
+ * Each function encapsulates a rowType === 'identity' ? ... : ... branch that
+ * appeared 2-4 times across the matrix route handler.
+ */
+
+/** Preview and scope-stats assignment filter expressions (uses vw_ResourceUserPermissionAssignments alias p). */
+export function buildAssignmentExprs(rowType, built) {
+  const subjectIdExpr = rowType === 'identity' ? 'im."identityId"' : 'p."principalId"';
+  const assignmentJoin = rowType === 'identity'
+    ? `INNER JOIN "IdentityMembers" im ON im."principalId" = p."principalId"`
+    : '';
+  const assignmentWhere = [`(p."principalType" IS NULL OR p."principalType" != '#microsoft.graph.group')`];
+  if (built.subjectSql)  assignmentWhere.push(`${subjectIdExpr} IN ${built.subjectSql}`);
+  if (built.resourceSql) assignmentWhere.push(`p."resourceId" IN ${built.resourceSql}`);
+  return { subjectIdExpr, assignmentJoin, assignmentWhere };
+}
+
+/** Identity join expressions for context-rollup branches (source alias: nm.pid). */
+export function buildIdentityJoinExprs(rowType) {
+  const join = rowType === 'identity'
+    ? `JOIN "IdentityMembers" im ON im."principalId" = nm.pid
+       JOIN "Identities" i ON i.id = im."identityId"`
+    : '';
+  const subjectId = rowType === 'identity' ? 'i.id' : 'nm.pid';
+  return { join, subjectId };
+}
+
+/** Subject join/id/name/type expressions for business-role drill (source: br."userId"). */
+export function buildRoleSubjectJoinExprs(rowType) {
+  const join = rowType === 'identity'
+    ? `INNER JOIN "Principals" u ON u.id = br."userId"
+       INNER JOIN "IdentityMembers" im ON im."principalId" = u.id
+       INNER JOIN "Identities" i ON i.id = im."identityId"`
+    : `INNER JOIN "Principals" u ON u.id = br."userId"`;
+  return {
+    join,
+    id:   rowType === 'identity' ? 'i.id'             : 'u.id',
+    name: rowType === 'identity' ? 'i."displayName"'  : 'u."displayName"',
+    type: rowType === 'identity' ? `'Identity'`        : `'User'`,
+  };
+}
+
+/** AP member id/join for rollup business-role count queries (source: br."userId"). */
+export function buildApMemberExprs(rowType) {
+  return {
+    memberId: rowType === 'identity' ? 'im2."identityId"' : 'br."userId"',
+    join:     rowType === 'identity'
+      ? 'INNER JOIN "IdentityMembers" im2 ON im2."principalId" = br."userId"'
+      : '',
+  };
+}
+
+/** Merge base group totals with an inherited array, summing shared groupValues. */
+export function mergeGroupTotals(base, inherited) {
+  if (!inherited?.length) return base;
+  const m = new Map(base.map(t => [t.groupValue, t.total]));
+  for (const t of inherited) m.set(t.groupValue, (m.get(t.groupValue) || 0) + t.total);
+  return [...m.entries()].map(([groupValue, total]) => ({ groupValue, total }));
+}
+
+/** Extract the standard resource-metadata shape from a query row. */
+export function resourceMeta(row) {
+  return {
+    resourceId:          row.resourceId,
+    resourceDisplayName: row.resourceDisplayName,
+    resourceType:        row.resourceType,
+    resourceDescription: row.resourceDescription,
+    systemId:            row.systemId,
+    systemName:          row.systemName,
+  };
+}

--- a/app/api/src/db/matrixHelpers.test.js
+++ b/app/api/src/db/matrixHelpers.test.js
@@ -56,6 +56,7 @@ describe('buildRoleSubjectJoinExprs', () => {
     const { join, id, name, type } = buildRoleSubjectJoinExprs('user');
     expect(join).not.toContain('Identities');
     expect(id).toBe('u.id');
+    expect(name).toBe('u."displayName"');
     expect(type).toContain('User');
   });
 });

--- a/app/api/src/db/matrixHelpers.test.js
+++ b/app/api/src/db/matrixHelpers.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAssignmentExprs,
+  buildIdentityJoinExprs,
+  buildRoleSubjectJoinExprs,
+  buildApMemberExprs,
+  mergeGroupTotals,
+  resourceMeta,
+} from './matrixHelpers.js';
+
+describe('buildAssignmentExprs', () => {
+  it('identity rowType: uses identityId and adds IdentityMembers join', () => {
+    const result = buildAssignmentExprs('identity', {});
+    expect(result.subjectIdExpr).toBe('im."identityId"');
+    expect(result.assignmentJoin).toContain('IdentityMembers');
+    expect(result.assignmentWhere).toHaveLength(1);
+  });
+
+  it('user rowType: uses principalId and no join', () => {
+    const result = buildAssignmentExprs('user', {});
+    expect(result.subjectIdExpr).toBe('p."principalId"');
+    expect(result.assignmentJoin).toBe('');
+  });
+
+  it('adds subjectSql and resourceSql to where clause when provided', () => {
+    const result = buildAssignmentExprs('user', { subjectSql: '(SELECT 1)', resourceSql: '(SELECT 2)' });
+    expect(result.assignmentWhere).toHaveLength(3);
+  });
+});
+
+describe('buildIdentityJoinExprs', () => {
+  it('identity rowType: adds IdentityMembers + Identities join and uses i.id', () => {
+    const { join, subjectId } = buildIdentityJoinExprs('identity');
+    expect(join).toContain('IdentityMembers');
+    expect(join).toContain('Identities');
+    expect(subjectId).toBe('i.id');
+  });
+
+  it('user rowType: no join, subjectId is nm.pid', () => {
+    const { join, subjectId } = buildIdentityJoinExprs('user');
+    expect(join).toBe('');
+    expect(subjectId).toBe('nm.pid');
+  });
+});
+
+describe('buildRoleSubjectJoinExprs', () => {
+  it('identity rowType: three-way join and uses identity columns', () => {
+    const { join, id, name, type } = buildRoleSubjectJoinExprs('identity');
+    expect(join).toContain('Identities');
+    expect(id).toBe('i.id');
+    expect(name).toBe('i."displayName"');
+    expect(type).toContain('Identity');
+  });
+
+  it('user rowType: single principal join and uses principal columns', () => {
+    const { join, id, name, type } = buildRoleSubjectJoinExprs('user');
+    expect(join).not.toContain('Identities');
+    expect(id).toBe('u.id');
+    expect(type).toContain('User');
+  });
+});
+
+describe('buildApMemberExprs', () => {
+  it('identity rowType: uses identityId and adds IdentityMembers join', () => {
+    const { memberId, join } = buildApMemberExprs('identity');
+    expect(memberId).toBe('im2."identityId"');
+    expect(join).toContain('IdentityMembers');
+  });
+
+  it('user rowType: uses userId directly, no join', () => {
+    const { memberId, join } = buildApMemberExprs('user');
+    expect(memberId).toBe('br."userId"');
+    expect(join).toBe('');
+  });
+});
+
+describe('mergeGroupTotals', () => {
+  it('returns base unchanged when inherited is empty', () => {
+    const base = [{ groupValue: 'a', total: 5 }];
+    expect(mergeGroupTotals(base, [])).toEqual(base);
+  });
+
+  it('returns base unchanged when inherited is null/undefined', () => {
+    const base = [{ groupValue: 'a', total: 5 }];
+    expect(mergeGroupTotals(base, null)).toEqual(base);
+  });
+
+  it('sums totals for matching groupValues', () => {
+    const base = [{ groupValue: 'a', total: 5 }, { groupValue: 'b', total: 3 }];
+    const inherited = [{ groupValue: 'a', total: 2 }, { groupValue: 'c', total: 7 }];
+    const result = mergeGroupTotals(base, inherited);
+    expect(result.find(r => r.groupValue === 'a').total).toBe(7);
+    expect(result.find(r => r.groupValue === 'b').total).toBe(3);
+    expect(result.find(r => r.groupValue === 'c').total).toBe(7);
+  });
+});
+
+describe('resourceMeta', () => {
+  it('extracts the standard 6-field resource metadata shape', () => {
+    const row = {
+      resourceId: 'r1', resourceDisplayName: 'My Role', resourceType: 'BusinessRole',
+      resourceDescription: 'desc', systemId: 42, systemName: 'Entra',
+      irrelevantField: 'ignored',
+    };
+    const meta = resourceMeta(row);
+    expect(meta).toEqual({
+      resourceId: 'r1', resourceDisplayName: 'My Role', resourceType: 'BusinessRole',
+      resourceDescription: 'desc', systemId: 42, systemName: 'Entra',
+    });
+    expect(meta.irrelevantField).toBeUndefined();
+  });
+});

--- a/app/api/src/db/queryHelpers.js
+++ b/app/api/src/db/queryHelpers.js
@@ -1,0 +1,50 @@
+import { timedRequest } from '../perf/sqlTimer.js';
+
+/**
+ * Runs a paginated data + count query against RiskScores with a caller-supplied
+ * JOIN and WHERE clause. Returns { data: recordset[], total: number }.
+ *
+ * The caller builds whereClause and params so that entity-specific filter
+ * conditions (search column names, extra filters like department/resourceType)
+ * stay in the route handler. This helper only fires the two SQL statements.
+ */
+export async function queryRiskScoresPage(pool, res, {
+  label,        // timer label prefix, e.g. 'risk-users'
+  fromClause,   // SQL after "FROM \"RiskScores\" rs", e.g. 'INNER JOIN "Principals" p ON ...'
+  selectCols,   // additional SELECT columns beyond rs.*, e.g. 'p."displayName", p.email AS ...'
+  whereClause,  // full WHERE clause including entity-type predicate, e.g. 'WHERE rs."entityType" = \'Principal\' AND ...'
+  params,       // [{ name, value }] — bound to both data and count requests
+  limit,
+  offset,
+}) {
+  const dataReq  = timedRequest(pool, `${label}-list`,  res);
+  const countReq = timedRequest(pool, `${label}-count`, res);
+
+  for (const { name, value } of params) {
+    dataReq.input(name, value);
+    countReq.input(name, value);
+  }
+  dataReq.input('limit',  limit);
+  dataReq.input('offset', offset);
+
+  const dataResult = await dataReq.query(`
+    SELECT rs.*, ${selectCols}
+    FROM "RiskScores" rs
+    ${fromClause}
+    ${whereClause}
+    ORDER BY rs."riskScore" DESC
+    LIMIT @limit OFFSET @offset
+  `);
+
+  const countResult = await countReq.query(`
+    SELECT COUNT(*) AS total
+    FROM "RiskScores" rs
+    ${fromClause}
+    ${whereClause}
+  `);
+
+  return {
+    data:  dataResult.recordset,
+    total: countResult.recordset[0].total,
+  };
+}

--- a/app/api/src/ingest/engine.js
+++ b/app/api/src/ingest/engine.js
@@ -18,6 +18,7 @@
 
 import crypto from 'crypto';
 import * as db from '../db/connection.js';
+import { createTempTable, bulkInsertIntoTemp } from './tempTableHelpers.js';
 
 // Cache the schema per table for the lifetime of the process. v5 schema is
 // only changed by migrations at startup, so the cache is safe.
@@ -96,10 +97,7 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
 
   return await db.tx(async (client) => {
     if (!existingTempTable) {
-      const colDefs = activeColumns
-        .map(c => `"${c.name}" ${c.sqlTypeName === 'USER-DEFINED' ? 'text' : c.sqlTypeName}`)
-        .join(', ');
-      await client.query(`CREATE TEMP TABLE "${tempName}" (${colDefs}) ON COMMIT DROP`);
+      await createTempTable(client, tempName, activeColumns);
     }
 
     // Bulk insert into the temp table. We use batched INSERT ... VALUES rather
@@ -108,33 +106,13 @@ export async function ingest(_pool, tableName, keyColumns, records, options = {}
     // teardown, producing an unhandled "Cannot read properties of null (reading
     // 'stream')" that kills the Node process. The INSERT approach is ~30% slower
     // but doesn't have this failure mode.
-    const colList = activeColumns.map(c => `"${c.name}"`).join(', ');
+    //
     // 1000 rows per INSERT. We measured this on a 255k-row ResourceAssignments
     // batch: bumping from 200 → 1000 cuts round-trip count 5× and wall-clock
     // time by roughly the same factor, with no measurable increase in lock
     // hold time on Postgres (the whole batch is already one transaction, so
     // chunk size only affects statement count, not locking behaviour).
-    const INSERT_CHUNK = 1000; // rows per INSERT statement
-    for (let i = 0; i < records.length; i += INSERT_CHUNK) {
-      const chunk = records.slice(i, i + INSERT_CHUNK);
-      const placeholders = [];
-      const params = [];
-      let pi = 1;
-      for (const rec of chunk) {
-        const row = [];
-        for (const col of activeColumns) {
-          row.push(`$${pi++}`);
-          let val = rec[col.name] !== undefined ? rec[col.name] : null;
-          if (val === null && col.hasUuidDefault) val = crypto.randomUUID();
-          params.push(val);
-        }
-        placeholders.push(`(${row.join(',')})`);
-      }
-      await client.query(
-        `INSERT INTO "${tempName}" (${colList}) VALUES ${placeholders.join(',')}`,
-        params
-      );
-    }
+    await bulkInsertIntoTemp(client, tempName, activeColumns, records, 1000, true);
 
     // Upsert from temp into target. xmax = 0 detects fresh inserts.
     const nonKeyCols = activeColumns.filter(c => !keyColumns.includes(c.name));

--- a/app/api/src/ingest/sessions.js
+++ b/app/api/src/ingest/sessions.js
@@ -13,6 +13,7 @@
 import crypto from 'crypto';
 import { discoverColumns, writeSyncLog, scopedDelete } from './engine.js';
 import * as db from '../db/connection.js';
+import { createTempTable, bulkInsertIntoTemp } from './tempTableHelpers.js';
 
 const sessions = new Map();
 const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -32,30 +33,11 @@ setInterval(async () => {
 }, 5 * 60 * 1000);
 
 
-async function copyRows(client, tempTable, activeColumns, records) {
-  // Batched INSERT instead of COPY FROM STDIN. The COPY approach had a crash
-  // in pg-copy-streams at high row counts (see engine.js for details).
-  const colList = activeColumns.map(c => `"${c.name}"`).join(', ');
-  const CHUNK = 200;
-  for (let i = 0; i < records.length; i += CHUNK) {
-    const chunk = records.slice(i, i + CHUNK);
-    const placeholders = [];
-    const params = [];
-    let pi = 1;
-    for (const rec of chunk) {
-      const row = [];
-      for (const col of activeColumns) {
-        row.push(`$${pi++}`);
-        params.push(rec[col.name] !== undefined ? rec[col.name] : null);
-      }
-      placeholders.push(`(${row.join(',')})`);
-    }
-    await client.query(
-      `INSERT INTO "${tempTable}" (${colList}) VALUES ${placeholders.join(',')}`,
-      params
-    );
-  }
-}
+// Batched INSERT instead of COPY FROM STDIN (see engine.js for the reasoning).
+// Sessions use a smaller chunk size (200) because session batches are typically
+// much smaller than bulk ingest batches and are sent incrementally.
+const copyRows = (client, tempTable, activeColumns, records) =>
+  bulkInsertIntoTemp(client, tempTable, activeColumns, records, 200);
 
 export async function startSession(_pool, tableName, keyColumns, records, options = {}) {
   const syncId = crypto.randomUUID();
@@ -73,10 +55,7 @@ export async function startSession(_pool, tableName, keyColumns, records, option
   await client.query('BEGIN');
 
   const tempTable = `_tmp_session_${syncId.replace(/-/g, '').slice(0, 16)}`;
-  const colDefs = activeColumns
-    .map(c => `"${c.name}" ${c.sqlTypeName === 'USER-DEFINED' ? 'text' : c.sqlTypeName}`)
-    .join(', ');
-  await client.query(`CREATE TEMP TABLE "${tempTable}" (${colDefs}) ON COMMIT DROP`);
+  await createTempTable(client, tempTable, activeColumns);
 
   await copyRows(client, tempTable, activeColumns, records);
 

--- a/app/api/src/ingest/tempTableHelpers.js
+++ b/app/api/src/ingest/tempTableHelpers.js
@@ -1,0 +1,47 @@
+import { randomUUID } from 'crypto';
+
+/**
+ * Shared helpers for creating and bulk-loading PostgreSQL temp tables.
+ * Used by engine.js (chunkSize 1000, UUID defaults) and sessions.js (chunkSize 200).
+ */
+
+export async function createTempTable(client, tempName, activeColumns) {
+  const colDefs = activeColumns
+    .map(c => `"${c.name}" ${c.sqlTypeName === 'USER-DEFINED' ? 'text' : c.sqlTypeName}`)
+    .join(', ');
+  await client.query(`CREATE TEMP TABLE "${tempName}" (${colDefs}) ON COMMIT DROP`);
+}
+
+/**
+ * Bulk-insert records into an existing temp table using batched INSERT … VALUES.
+ *
+ * @param {object}   client          - pg client (inside a transaction)
+ * @param {string}   tempName        - temp table name
+ * @param {Array}    activeColumns   - column descriptors ({ name, hasUuidDefault? })
+ * @param {Array}    records         - plain objects to insert
+ * @param {number}   chunkSize       - rows per INSERT statement (200 for sessions, 1000 for engine)
+ * @param {boolean}  applyUuidDefaults - when true, null values for UUID-default columns get crypto.randomUUID()
+ */
+export async function bulkInsertIntoTemp(client, tempName, activeColumns, records, chunkSize, applyUuidDefaults = false) {
+  const colList = activeColumns.map(c => `"${c.name}"`).join(', ');
+  for (let i = 0; i < records.length; i += chunkSize) {
+    const chunk = records.slice(i, i + chunkSize);
+    const placeholders = [];
+    const params = [];
+    let pi = 1;
+    for (const rec of chunk) {
+      const row = [];
+      for (const col of activeColumns) {
+        row.push(`$${pi++}`);
+        let val = rec[col.name] !== undefined ? rec[col.name] : null;
+        if (applyUuidDefaults && val === null && col.hasUuidDefault) val = randomUUID();
+        params.push(val);
+      }
+      placeholders.push(`(${row.join(',')})`);
+    }
+    await client.query(
+      `INSERT INTO "${tempName}" (${colList}) VALUES ${placeholders.join(',')}`,
+      params
+    );
+  }
+}

--- a/app/api/src/routes/matrix.js
+++ b/app/api/src/routes/matrix.js
@@ -18,6 +18,14 @@ import { randomUUID } from 'crypto';
 import * as db from '../db/connection.js';
 import { timedRequest } from '../perf/sqlTimer.js';
 import {
+  buildAssignmentExprs,
+  buildIdentityJoinExprs,
+  buildRoleSubjectJoinExprs,
+  buildApMemberExprs,
+  mergeGroupTotals,
+  resourceMeta,
+} from '../db/matrixHelpers.js';
+import {
   buildEntitySubquery,
   collectContextIds,
   UUID_RE,
@@ -447,13 +455,7 @@ router.post('/matrix/preview', async (req, res) => {
     const p = await db.getPool();
     const subj = subjectScopeClauses(filter.rowType, built.subjectSql);
 
-    const subjectIdExpr = filter.rowType === 'identity' ? 'im."identityId"' : 'p."principalId"';
-    const assignmentJoin = filter.rowType === 'identity'
-      ? `INNER JOIN "IdentityMembers" im ON im."principalId" = p."principalId"`
-      : '';
-    const assignmentWhere = [`(p."principalType" IS NULL OR p."principalType" != '#microsoft.graph.group')`];
-    if (built.subjectSql)  assignmentWhere.push(`${subjectIdExpr} IN ${built.subjectSql}`);
-    if (built.resourceSql) assignmentWhere.push(`p."resourceId" IN ${built.resourceSql}`);
+    const { subjectIdExpr, assignmentJoin, assignmentWhere } = buildAssignmentExprs(filter.rowType, built);
 
     const [subjectCount, subjectTotal, resourceCount, resourceTotal, assignmentCount] = await Promise.all([
       runCount(p, 'matrix-preview-subject', res,
@@ -516,13 +518,7 @@ router.post('/matrix/scope-stats', async (req, res) => {
     const p = await db.getPool();
     const subj = subjectScopeClauses(filter.rowType, built.subjectSql);
 
-    const subjectIdExpr = filter.rowType === 'identity' ? 'im."identityId"' : 'p."principalId"';
-    const assignmentJoin = filter.rowType === 'identity'
-      ? `INNER JOIN "IdentityMembers" im ON im."principalId" = p."principalId"`
-      : '';
-    const assignmentWhere = [`(p."principalType" IS NULL OR p."principalType" != '#microsoft.graph.group')`];
-    if (built.subjectSql)  assignmentWhere.push(`${subjectIdExpr} IN ${built.subjectSql}`);
-    if (built.resourceSql) assignmentWhere.push(`p."resourceId" IN ${built.resourceSql}`);
+    const { subjectIdExpr, assignmentJoin, assignmentWhere } = buildAssignmentExprs(filter.rowType, built);
 
     // One pair-level aggregation: distinct (subject, resource) pairs, each
     // flagged governed if ANY of its assignment rows is access-package managed.
@@ -924,11 +920,7 @@ router.post('/matrix/data', async (req, res) => {
       const resMap = new Map();
       for (const row of cellRows) {
         if (!row.resourceId || resMap.has(row.resourceId)) continue;
-        resMap.set(row.resourceId, {
-          resourceId: row.resourceId, resourceDisplayName: row.resourceDisplayName,
-          resourceType: row.resourceType, resourceDescription: row.resourceDescription,
-          systemId: row.systemId, systemName: row.systemName,
-        });
+        resMap.set(row.resourceId, resourceMeta(row));
       }
       for (const r of (inhFold?.resources || [])) if (!resMap.has(r.resourceId)) resMap.set(r.resourceId, r);
 
@@ -985,10 +977,7 @@ router.post('/matrix/data', async (req, res) => {
         try { cutValues = frontierValues(frontier); }
         catch { return res.status(400).json({ error: 'Invalid frontier' }); }
 
-        const idJoin = rowType === 'identity'
-          ? `JOIN "IdentityMembers" im ON im."principalId" = nm.pid
-             JOIN "Identities" i ON i.id = im."identityId"` : '';
-        const cutSubjectId = rowType === 'identity' ? 'i.id' : 'nm.pid';
+        const { join: idJoin, subjectId: cutSubjectId } = buildIdentityJoinExprs(rowType);
 
         const layerReq = timedRequest(p, `matrix-ctx-layered[${rowType}]`, res);
         for (const [k, v] of Object.entries(built.bindings)) layerReq.input(k, v);
@@ -1000,11 +989,7 @@ router.post('/matrix/data', async (req, res) => {
         const layerResMap = new Map();
         for (const row of layerCells) {
           if (!row.resourceId || layerResMap.has(row.resourceId)) continue;
-          layerResMap.set(row.resourceId, {
-            resourceId: row.resourceId, resourceDisplayName: row.resourceDisplayName,
-            resourceType: row.resourceType, resourceDescription: row.resourceDescription,
-            systemId: row.systemId, systemName: row.systemName,
-          });
+          layerResMap.set(row.resourceId, resourceMeta(row));
         }
 
         // SCOPED member counts for the header (direct / total), so they match the
@@ -1073,26 +1058,18 @@ router.post('/matrix/data', async (req, res) => {
       try { values = frontierValues(frontier); }
       catch { return res.status(400).json({ error: 'Invalid frontier' }); }
 
-      const identityJoin = rowType === 'identity'
-        ? `JOIN "IdentityMembers" im ON im."principalId" = nm.pid
-           JOIN "Identities" i ON i.id = im."identityId"` : '';
-      const ctxSubjectId = rowType === 'identity' ? 'i.id' : 'nm.pid';
+      const { join: identityJoin, subjectId: ctxSubjectId } = buildIdentityJoinExprs(rowType);
 
       // Roles-only leaf drill: expand one org (already scoped via a subject
       // context condition) into its subjects + the business role each holds.
       if (filter.drill) {
-        const brSubjectJoin = rowType === 'identity'
-          ? `INNER JOIN "Principals" u ON u.id = br."userId"
-             INNER JOIN "IdentityMembers" im ON im."principalId" = u.id
-             INNER JOIN "Identities" i ON i.id = im."identityId"`
-          : `INNER JOIN "Principals" u ON u.id = br."userId"`;
-        const brId = rowType === 'identity' ? 'i.id' : 'u.id';
+        const { join: brSubjectJoin, id: brId, name: brName, type: brType } = buildRoleSubjectJoinExprs(rowType);
         const drillReq = timedRequest(p, `matrix-ctx-rows-drill[${rowType}]`, res);
         for (const [k, v] of Object.entries(built.bindings)) drillReq.input(k, v);
         const members = (await drillReq.query(buildRolesDrillSql({
           subjectJoin: brSubjectJoin, subjectIdExpr: brId,
-          subjectNameExpr: rowType === 'identity' ? 'i."displayName"' : 'u."displayName"',
-          subjectTypeExpr: rowType === 'identity' ? `'Identity'` : `'User'`,
+          subjectNameExpr: brName,
+          subjectTypeExpr: brType,
           subjectIdForFilter: brId, subjectSql: built.subjectSql,
         }))).recordset;
         return res.json({ rollup: 'context', rollupKind: 'context', rollupContent: 'roles-only', drill: { members } });
@@ -1195,13 +1172,7 @@ router.post('/matrix/data', async (req, res) => {
         } catch { /* business-role view may be absent */ }
       }
 
-      const mergedCtxTotals = inhCtx2?.groupTotals?.length
-        ? (() => {
-            const m = new Map(ctxTotals.map(t => [t.groupValue, t.total]));
-            for (const t of inhCtx2.groupTotals) m.set(t.groupValue, (m.get(t.groupValue) || 0) + t.total);
-            return [...m.entries()].map(([groupValue, total]) => ({ groupValue, total }));
-          })()
-        : ctxTotals;
+      const mergedCtxTotals = mergeGroupTotals(ctxTotals, inhCtx2?.groupTotals);
 
       return res.json({
         ...shared,
@@ -1242,12 +1213,7 @@ router.post('/matrix/data', async (req, res) => {
 
       // ─── Business roles as rows ───
       if (filter.rollupContent === 'roles-only') {
-        const brSubjectJoin = rowType === 'identity'
-          ? `INNER JOIN "Principals" u ON u.id = br."userId"
-             INNER JOIN "IdentityMembers" im ON im."principalId" = u.id
-             INNER JOIN "Identities" i ON i.id = im."identityId"`
-          : `INNER JOIN "Principals" u ON u.id = br."userId"`;
-        const brSubjectId = rowType === 'identity' ? 'i.id' : 'u.id';
+        const { join: brSubjectJoin, id: brSubjectId, name: brSubjectName, type: brSubjectType } = buildRoleSubjectJoinExprs(rowType);
 
         // Drill-down: expand one group column into its individual subjects +
         // which business role each holds. The group is already scoped via a
@@ -1259,8 +1225,8 @@ router.post('/matrix/data', async (req, res) => {
           const members = (await drillReq.query(buildRolesDrillSql({
             subjectJoin: brSubjectJoin,
             subjectIdExpr: brSubjectId,
-            subjectNameExpr: rowType === 'identity' ? 'i."displayName"' : 'u."displayName"',
-            subjectTypeExpr: rowType === 'identity' ? `'Identity'` : `'User'`,
+            subjectNameExpr: brSubjectName,
+            subjectTypeExpr: brSubjectType,
             subjectIdForFilter: brSubjectId,
             subjectSql: built.subjectSql,
           }))).recordset;
@@ -1353,9 +1319,7 @@ router.post('/matrix/data', async (req, res) => {
       const roleCounts = [];
       if (filter.rollupContent !== 'resources-only') {
         try {
-          const brMemberId = rowType === 'identity' ? 'im2."identityId"' : 'br."userId"';
-          const brJoin = rowType === 'identity'
-            ? 'INNER JOIN "IdentityMembers" im2 ON im2."principalId" = br."userId"' : '';
+          const { memberId: brMemberId, join: brJoin } = buildApMemberExprs(rowType);
           const brReq = timedRequest(p, 'matrix-rollup-roles', res);
           for (const [k, v] of Object.entries(built.bindings)) brReq.input(k, v);
           const brRows = (await brReq.query(buildRollupRolesSql({
@@ -1371,13 +1335,7 @@ router.post('/matrix/data', async (req, res) => {
         } catch { /* business-role view may be absent */ }
       }
 
-      const mergedGroupTotals = inhGroupTotals.length
-        ? (() => {
-            const m = new Map(groupTotals.map(t => [t.groupValue, t.total]));
-            for (const t of inhGroupTotals) m.set(t.groupValue, (m.get(t.groupValue) || 0) + t.total);
-            return [...m.entries()].map(([groupValue, total]) => ({ groupValue, total }));
-          })()
-        : groupTotals;
+      const mergedGroupTotals = mergeGroupTotals(groupTotals, inhGroupTotals);
 
       return res.json({
         rollup: filter.rollup,

--- a/app/api/src/routes/riskScores.js
+++ b/app/api/src/routes/riskScores.js
@@ -17,6 +17,7 @@
 import { Router } from 'express';
 import { timedRequest } from '../perf/sqlTimer.js';
 import { requirePermission } from '../middleware/auth.js';
+import { queryRiskScoresPage } from '../db/queryHelpers.js';
 
 const router = Router();
 const writeRisk = requirePermission('data.write.risk');
@@ -223,63 +224,30 @@ router.get('/risk-scores', async (req, res) => {
 router.get('/risk-scores/users', async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0, available: false });
-
     const p = await db.getPool();
     if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
 
-    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
     const offset = parseInt(req.query.offset, 10) || 0;
-    const tier = req.query.tier || '';
-    const search = req.query.search || '';
-    const department = req.query.department || '';
+    const tier         = req.query.tier || '';
+    const search       = req.query.search || '';
+    const department   = req.query.department || '';
     const overridesOnly = req.query.overridesOnly === 'true';
 
     let whereClause = `WHERE rs."entityType" = 'Principal'`;
-    const request = timedRequest(p, 'risk-users-list', res);
+    const params = [];
+    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                                                 params.push({ name: 'tier',       value: tier }); }
+    if (search)      { whereClause += ' AND (p."displayName" ILIKE @search OR p.email ILIKE @search OR p.department ILIKE @search)';                params.push({ name: 'search',     value: `%${search}%` }); }
+    if (department)  { whereClause += ' AND p.department = @department';                                                                            params.push({ name: 'department', value: department }); }
+    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
 
-    if (tier) {
-      whereClause += ' AND rs."riskTier" = @tier';
-      request.input('tier', tier);
-    }
-    if (search) {
-      whereClause += ' AND (p."displayName" ILIKE @search OR p.email ILIKE @search OR p.department ILIKE @search)';
-      request.input('search', `%${search}%`);
-    }
-    if (department) {
-      whereClause += ' AND p.department = @department';
-      request.input('department', department);
-    }
-    if (overridesOnly) {
-      whereClause += ' AND rs."riskOverride" IS NOT NULL';
-    }
-
-    request.input('offset', offset);
-    request.input('limit', limit);
-    const result = await request.query(`
-      SELECT rs.*, p."displayName", p.email AS "userPrincipalName", p.department, p."jobTitle", p."companyName"
-      FROM "RiskScores" rs
-      INNER JOIN "Principals" p ON rs."entityId" = p.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-      ORDER BY rs."riskScore" DESC
-      LIMIT @limit OFFSET @offset
-    `);
-
-    const countReq = timedRequest(p, 'risk-users-count', res);
-    if (tier) countReq.input('tier', tier);
-    if (search) countReq.input('search', `%${search}%`);
-    if (department) countReq.input('department', department);
-    const countResult = await countReq.query(`
-      SELECT COUNT(*) AS total
-      FROM "RiskScores" rs
-      INNER JOIN "Principals" p ON rs."entityId" = p.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-    `);
-
-    return res.json({
-      data: result.recordset.map(parseJsonColumns),
-      total: countResult.recordset[0].total,
-      available: true,
+    const { data, total } = await queryRiskScoresPage(p, res, {
+      label:      'risk-users',
+      fromClause: `INNER JOIN "Principals" p ON rs."entityId" = p.id AND ${TEMPORAL_FILTER}`,
+      selectCols: `p."displayName", p.email AS "userPrincipalName", p.department, p."jobTitle", p."companyName"`,
+      whereClause, params, limit, offset,
     });
+    return res.json({ data: data.map(parseJsonColumns), total, available: true });
   } catch (err) {
     console.error('Risk users query failed:', err.message);
     return res.status(500).json({ error: 'Failed to load risk scores' });
@@ -290,64 +258,30 @@ router.get('/risk-scores/users', async (req, res) => {
 router.get('/risk-scores/groups', async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0, available: false });
-
     const p = await db.getPool();
     if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
 
-    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
     const offset = parseInt(req.query.offset, 10) || 0;
-    const tier = req.query.tier || '';
-    const search = req.query.search || '';
-    const resourceType = req.query.resourceType || '';
+    const tier          = req.query.tier || '';
+    const search        = req.query.search || '';
+    const resourceType  = req.query.resourceType || '';
     const overridesOnly = req.query.overridesOnly === 'true';
 
     let whereClause = `WHERE rs."entityType" = 'Resource'`;
-    const request = timedRequest(p, 'risk-groups-list', res);
+    const params = [];
+    if (tier)          { whereClause += ' AND rs."riskTier" = @tier';                                              params.push({ name: 'tier',          value: tier }); }
+    if (search)        { whereClause += ' AND (r."displayName" ILIKE @search OR r.description ILIKE @search)';    params.push({ name: 'search',        value: `%${search}%` }); }
+    if (resourceType)  { whereClause += ' AND r.resourceType = @resourceType';                                     params.push({ name: 'resourceType',  value: resourceType }); }
+    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
 
-    if (tier) {
-      whereClause += ' AND rs."riskTier" = @tier';
-      request.input('tier', tier);
-    }
-    if (search) {
-      whereClause += ' AND (r."displayName" ILIKE @search OR r.description ILIKE @search)';
-      request.input('search', `%${search}%`);
-    }
-    if (resourceType) {
-      whereClause += ' AND r.resourceType = @resourceType';
-      request.input('resourceType', resourceType);
-    }
-    if (overridesOnly) {
-      whereClause += ' AND rs."riskOverride" IS NOT NULL';
-    }
-
-    request.input('offset', offset);
-    request.input('limit', limit);
-    const result = await request.query(`
-      SELECT rs.*, r."displayName", r.description, r."resourceType", r.mail
-      FROM "RiskScores" rs
-      INNER JOIN "Resources" r ON rs."entityId" = r.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-      ORDER BY rs."riskScore" DESC
-      LIMIT @limit OFFSET @offset
-    `);
-
-    const countReq = timedRequest(p, 'risk-groups-count', res);
-    if (tier) countReq.input('tier', tier);
-    if (search) countReq.input('search', `%${search}%`);
-    if (resourceType) countReq.input('resourceType', resourceType);
-    const countResult = await countReq.query(`
-      SELECT COUNT(*) AS total
-      FROM "RiskScores" rs
-      INNER JOIN "Resources" r ON rs."entityId" = r.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-    `);
-
-    return res.json({
-      data: result.recordset.map(parseJsonColumns),
-      total: countResult.recordset[0].total,
-      available: true,
-      useResources: true,
+    const { data, total } = await queryRiskScoresPage(p, res, {
+      label:      'risk-groups',
+      fromClause: `INNER JOIN "Resources" r ON rs."entityId" = r.id AND ${TEMPORAL_FILTER}`,
+      selectCols: `r."displayName", r.description, r."resourceType", r.mail`,
+      whereClause, params, limit, offset,
     });
+    return res.json({ data: data.map(parseJsonColumns), total, available: true, useResources: true });
   } catch (err) {
     console.error('Risk groups query failed:', err.message);
     return res.status(500).json({ error: 'Failed to load risk scores' });
@@ -358,60 +292,29 @@ router.get('/risk-scores/groups', async (req, res) => {
 router.get('/risk-scores/business-roles', async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0, available: false });
-
     const p = await db.getPool();
     if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
 
-    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
     const offset = parseInt(req.query.offset, 10) || 0;
-    const tier = req.query.tier || '';
-    const search = req.query.search || '';
+    const tier          = req.query.tier || '';
+    const search        = req.query.search || '';
     const overridesOnly = req.query.overridesOnly === 'true';
 
     let whereClause = `WHERE rs."entityType" = 'BusinessRole'`;
-    const request = timedRequest(p, 'risk-business-roles-list', res);
+    const params = [];
+    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                params.push({ name: 'tier',    value: tier }); }
+    if (search)      { whereClause += ' AND (br."displayName" ILIKE @search OR br.description ILIKE @search)';    params.push({ name: 'search',  value: `%${search}%` }); }
+    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
 
-    if (tier) {
-      whereClause += ' AND rs."riskTier" = @tier';
-      request.input('tier', tier);
-    }
-    if (search) {
-      whereClause += ' AND (br."displayName" ILIKE @search OR br.description ILIKE @search)';
-      request.input('search', `%${search}%`);
-    }
-    if (overridesOnly) {
-      whereClause += ' AND rs."riskOverride" IS NOT NULL';
-    }
-
-    request.input('offset', offset);
-    request.input('limit', limit);
-    const result = await request.query(`
-      SELECT rs.*, br."displayName", br.description, br."catalogId",
-             c."displayName" AS "catalogName"
-      FROM "RiskScores" rs
-      INNER JOIN "Resources" br ON rs."entityId" = br.id AND br."resourceType" = 'BusinessRole' AND ${TEMPORAL_FILTER}
-      LEFT JOIN "GovernanceCatalogs" c ON br."catalogId" = c.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-      ORDER BY rs."riskScore" DESC
-      LIMIT @limit OFFSET @offset
-    `);
-
-    const countReq = timedRequest(p, 'risk-business-roles-count', res);
-    if (tier) countReq.input('tier', tier);
-    if (search) countReq.input('search', `%${search}%`);
-    const countResult = await countReq.query(`
-      SELECT COUNT(*) AS total
-      FROM "RiskScores" rs
-      INNER JOIN "Resources" br ON rs."entityId" = br.id AND br."resourceType" = 'BusinessRole' AND ${TEMPORAL_FILTER}
-      LEFT JOIN "GovernanceCatalogs" c ON br."catalogId" = c.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-    `);
-
-    return res.json({
-      data: result.recordset.map(parseJsonColumns),
-      total: countResult.recordset[0].total,
-      available: true,
+    const { data, total } = await queryRiskScoresPage(p, res, {
+      label:      'risk-business-roles',
+      fromClause: `INNER JOIN "Resources" br ON rs."entityId" = br.id AND br."resourceType" = 'BusinessRole' AND ${TEMPORAL_FILTER}
+      LEFT JOIN "GovernanceCatalogs" c ON br."catalogId" = c.id AND ${TEMPORAL_FILTER}`,
+      selectCols: `br."displayName", br.description, br."catalogId", c."displayName" AS "catalogName"`,
+      whereClause, params, limit, offset,
     });
+    return res.json({ data: data.map(parseJsonColumns), total, available: true });
   } catch (err) {
     console.error('Risk business-roles query failed:', err.message);
     return res.status(500).json({ error: 'Failed to load risk scores' });
@@ -422,60 +325,29 @@ router.get('/risk-scores/business-roles', async (req, res) => {
 router.get('/risk-scores/contexts', async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0, available: false });
-
     const p = await db.getPool();
     if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
 
-    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
     const offset = parseInt(req.query.offset, 10) || 0;
-    const tier = req.query.tier || '';
-    const search = req.query.search || '';
+    const tier          = req.query.tier || '';
+    const search        = req.query.search || '';
     const overridesOnly = req.query.overridesOnly === 'true';
 
     let whereClause = `WHERE rs."entityType" = 'Context'`;
-    const request = timedRequest(p, 'risk-contexts-list', res);
+    const params = [];
+    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                    params.push({ name: 'tier',   value: tier }); }
+    if (search)      { whereClause += ' AND (ou."displayName" ILIKE @search OR ou.department ILIKE @search)';          params.push({ name: 'search', value: `%${search}%` }); }
+    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
 
-    if (tier) {
-      whereClause += ' AND rs."riskTier" = @tier';
-      request.input('tier', tier);
-    }
-    if (search) {
-      whereClause += ' AND (ou."displayName" ILIKE @search OR ou.department ILIKE @search)';
-      request.input('search', `%${search}%`);
-    }
-    if (overridesOnly) {
-      whereClause += ' AND rs."riskOverride" IS NOT NULL';
-    }
-
-    request.input('offset', offset);
-    request.input('limit', limit);
-    const result = await request.query(`
-      SELECT rs.*, ou."displayName", ou.department, ou."memberCount", ou."managerId",
-             p."displayName" AS "managerName"
-      FROM "RiskScores" rs
-      INNER JOIN "Contexts" ou ON rs."entityId" = ou.id AND ${TEMPORAL_FILTER}
-      LEFT JOIN "Principals" p ON ou."managerId" = p.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-      ORDER BY rs."riskScore" DESC
-      LIMIT @limit OFFSET @offset
-    `);
-
-    const countReq = timedRequest(p, 'risk-contexts-count', res);
-    if (tier) countReq.input('tier', tier);
-    if (search) countReq.input('search', `%${search}%`);
-    const countResult = await countReq.query(`
-      SELECT COUNT(*) AS total
-      FROM "RiskScores" rs
-      INNER JOIN "Contexts" ou ON rs."entityId" = ou.id AND ${TEMPORAL_FILTER}
-      LEFT JOIN "Principals" p ON ou."managerId" = p.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-    `);
-
-    return res.json({
-      data: result.recordset.map(parseJsonColumns),
-      total: countResult.recordset[0].total,
-      available: true,
+    const { data, total } = await queryRiskScoresPage(p, res, {
+      label:      'risk-contexts',
+      fromClause: `INNER JOIN "Contexts" ou ON rs."entityId" = ou.id AND ${TEMPORAL_FILTER}
+      LEFT JOIN "Principals" p ON ou."managerId" = p.id AND ${TEMPORAL_FILTER}`,
+      selectCols: `ou."displayName", ou.department, ou."memberCount", ou."managerId", p."displayName" AS "managerName"`,
+      whereClause, params, limit, offset,
     });
+    return res.json({ data: data.map(parseJsonColumns), total, available: true });
   } catch (err) {
     console.error('Risk contexts query failed:', err.message);
     return res.status(500).json({ error: 'Failed to load risk scores' });
@@ -486,58 +358,28 @@ router.get('/risk-scores/contexts', async (req, res) => {
 router.get('/risk-scores/identities', async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0, available: false });
-
     const p = await db.getPool();
     if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
 
-    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
     const offset = parseInt(req.query.offset, 10) || 0;
-    const tier = req.query.tier || '';
-    const search = req.query.search || '';
+    const tier          = req.query.tier || '';
+    const search        = req.query.search || '';
     const overridesOnly = req.query.overridesOnly === 'true';
 
     let whereClause = `WHERE rs."entityType" = 'Identity'`;
-    const request = timedRequest(p, 'risk-identities-list', res);
+    const params = [];
+    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                                             params.push({ name: 'tier',   value: tier }); }
+    if (search)      { whereClause += ' AND (i."displayName" ILIKE @search OR i.department ILIKE @search OR i.email ILIKE @search)';            params.push({ name: 'search', value: `%${search}%` }); }
+    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
 
-    if (tier) {
-      whereClause += ' AND rs."riskTier" = @tier';
-      request.input('tier', tier);
-    }
-    if (search) {
-      whereClause += ' AND (i."displayName" ILIKE @search OR i.department ILIKE @search OR i.email ILIKE @search)';
-      request.input('search', `%${search}%`);
-    }
-    if (overridesOnly) {
-      whereClause += ' AND rs."riskOverride" IS NOT NULL';
-    }
-
-    request.input('offset', offset);
-    request.input('limit', limit);
-    const result = await request.query(`
-      SELECT rs.*, i."displayName", i."accountCount", i."linkConfidence", i.department,
-             i."jobTitle", i.email
-      FROM "RiskScores" rs
-      INNER JOIN "Identities" i ON rs."entityId" = i.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-      ORDER BY rs."riskScore" DESC
-      LIMIT @limit OFFSET @offset
-    `);
-
-    const countReq = timedRequest(p, 'risk-identities-count', res);
-    if (tier) countReq.input('tier', tier);
-    if (search) countReq.input('search', `%${search}%`);
-    const countResult = await countReq.query(`
-      SELECT COUNT(*) AS total
-      FROM "RiskScores" rs
-      INNER JOIN "Identities" i ON rs."entityId" = i.id AND ${TEMPORAL_FILTER}
-      ${whereClause}
-    `);
-
-    return res.json({
-      data: result.recordset.map(parseJsonColumns),
-      total: countResult.recordset[0].total,
-      available: true,
+    const { data, total } = await queryRiskScoresPage(p, res, {
+      label:      'risk-identities',
+      fromClause: `INNER JOIN "Identities" i ON rs."entityId" = i.id AND ${TEMPORAL_FILTER}`,
+      selectCols: `i."displayName", i."accountCount", i."linkConfidence", i.department, i."jobTitle", i.email`,
+      whereClause, params, limit, offset,
     });
+    return res.json({ data: data.map(parseJsonColumns), total, available: true });
   } catch (err) {
     console.error('Risk identities query failed:', err.message);
     return res.status(500).json({ error: 'Failed to load risk scores' });

--- a/changes/dedup-api-helpers.md
+++ b/changes/dedup-api-helpers.md
@@ -1,0 +1,3 @@
+- Extracted shared `queryRiskScoresPage` helper to eliminate duplicated list+count query pattern across all five risk score list endpoints (`/users`, `/groups`, `/business-roles`, `/contexts`, `/identities`)
+- Extracted shared matrix SQL expression builders (`buildAssignmentExprs`, `buildIdentityJoinExprs`, `buildRoleSubjectJoinExprs`, `buildApMemberExprs`, `mergeGroupTotals`, `resourceMeta`) to remove repeated identity/principal conditional blocks in matrix route
+- Extracted shared `createTempTable` and `bulkInsertIntoTemp` helpers to remove duplicated temp-table creation and batch-insert logic shared between ingest engine and sync sessions


### PR DESCRIPTION
- Extracted `queryRiskScoresPage` helper to eliminate duplicated list+count query pattern across all five risk score list endpoints (`/users`, `/groups`, `/business-roles`, `/contexts`, `/identities`)
- Extracted six matrix SQL expression builders (`buildAssignmentExprs`, `buildIdentityJoinExprs`, `buildRoleSubjectJoinExprs`, `buildApMemberExprs`, `mergeGroupTotals`, `resourceMeta`) to remove repeated identity/principal conditional blocks in the matrix route
- Extracted `createTempTable` and `bulkInsertIntoTemp` helpers to remove duplicated temp-table creation and batch-insert logic shared between ingest engine and sync sessions

Part of a broader de-duplication effort (131 clone pairs, 2.95% overall duplication found by jscpd). This is phase 1 — API helpers only, self-contained and low risk.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)