### PR TITLE
refactor(ui): extract EntityListPage from Resources/Users/Identities list pages

### DIFF
--- a/app/ui/src/components/EntityListPage.jsx
+++ b/app/ui/src/components/EntityListPage.jsx
@@ -1,0 +1,347 @@
+import { useMemo } from 'react';
+import { useAuth } from '@ui/auth/AuthGate';
+import useEntityPage from '@ui/hooks/useEntityPage';
+import FilterBar from './FilterBar';
+import { TAG_COLORS } from '@ui/utils/colors';
+
+/**
+ * Shared scaffold for Resources, Users, and Identities list pages.
+ *
+ * Props:
+ *   title, entityType, listEndpoint, columnsEndpoint, tagFilterKey
+ *   tableColumns        [{key, label}] — sortable header columns (entity name + tags are added automatically)
+ *   fieldLabels         {column: 'Human Label'} — passed to getFilterFields
+ *   renderEntityCell    (item, onOpenDetail) => <td> — the entity-name link cell
+ *   renderDataCells     (item) => <td>…</td> — data cells between entity name and tags
+ *   searchPlaceholder   string
+ *   showIncludeDeleted  boolean (default false)
+ *   subTabBar           JSX rendered between header and tag bar (optional)
+ *   baseFilters         object passed to useEntityPage (optional, for sub-tab driven filters)
+ *   customizeFilterFields  (fields) => fields — optional callback to filter/sort the filter dropdown
+ *   onOpenDetail        (kind, id, name) => void
+ */
+export default function EntityListPage({
+  title,
+  entityType,
+  listEndpoint,
+  columnsEndpoint,
+  tagFilterKey,
+  tableColumns,
+  fieldLabels,
+  renderEntityCell,
+  renderDataCells,
+  searchPlaceholder,
+  showIncludeDeleted = false,
+  subTabBar = null,
+  baseFilters = null,
+  customizeFilterFields = null,
+  onOpenDetail,
+}) {
+  const { authFetch } = useAuth();
+
+  const ep = useEntityPage({
+    authFetch,
+    entityType,
+    listEndpoint,
+    columnsEndpoint,
+    tagFilterKey,
+    baseFilters,
+  });
+
+  const filterFields = useMemo(() => {
+    const fields = ep.getFilterFields(fieldLabels);
+    return customizeFilterFields ? customizeFilterFields(fields) : fields;
+  }, [ep, fieldLabels, customizeFilterFields]);
+
+  const label = title.toLowerCase();
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-4 mb-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+        <span className="text-sm text-gray-500 dark:text-gray-400">{ep.total.toLocaleString()} total</span>
+      </div>
+
+      {subTabBar}
+
+      {/* Tag management bar */}
+      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
+        <span className="font-medium text-gray-600 dark:text-gray-400">Tags:</span>
+        {ep.tags.map(t => (
+          <span
+            key={t.id}
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer border ${
+              ep.activeTagFilter === t.name
+                ? 'ring-2 ring-offset-1 ring-blue-400'
+                : 'hover:opacity-80'
+            }`}
+            style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
+            onClick={() => {
+              if (ep.activeTagFilter === t.name) {
+                ep.removeFilter(tagFilterKey);
+              } else {
+                ep.addFilter(tagFilterKey, t.name);
+              }
+            }}
+            title={`${t.assignmentCount} ${label} tagged — click to filter`}
+          >
+            {t.name}
+            <span className="text-[10px] opacity-70">({t.assignmentCount})</span>
+            <button
+              onClick={(e) => { e.stopPropagation(); ep.deleteTag(t.id); }}
+              className="ml-0.5 hover:opacity-100 opacity-50"
+              title="Delete tag"
+            >
+              &times;
+            </button>
+          </span>
+        ))}
+        <button
+          onClick={() => ep.setShowCreateTag(!ep.showCreateTag)}
+          className="px-2 py-0.5 rounded text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 border border-blue-200 dark:border-blue-700 border-dashed"
+        >
+          + New Tag
+        </button>
+      </div>
+
+      {/* Create tag form */}
+      {ep.showCreateTag && (
+        <div className="flex items-center gap-2 mb-3 p-3 bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
+          <input
+            type="text"
+            value={ep.newTagName}
+            onChange={e => ep.setNewTagName(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && ep.createTag()}
+            placeholder="Tag name..."
+            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm w-48 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
+            autoFocus
+          />
+          <div className="flex items-center gap-1">
+            {TAG_COLORS.map(c => (
+              <button
+                key={c}
+                onClick={() => ep.setNewTagColor(c)}
+                className={`w-5 h-5 rounded-full border-2 ${ep.newTagColor === c ? 'border-gray-800 scale-110' : 'border-transparent'}`}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+          <button
+            onClick={ep.createTag}
+            disabled={!ep.newTagName.trim() || ep.busy}
+            className="px-3 py-1 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+          >
+            Create
+          </button>
+          <button
+            onClick={() => ep.setShowCreateTag(false)}
+            className="px-2 py-1 rounded text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Filter bar + search */}
+      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
+        <FilterBar
+          label="Filters:"
+          filterFields={filterFields}
+          activeFilters={ep.activeFilters}
+          getOptionsForField={ep.getOptionsForField}
+          onAddFilter={ep.addFilter}
+          onRemoveFilter={ep.removeFilter}
+          loading={ep.columnsLoading}
+        />
+
+        <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
+
+        <input
+          type="text"
+          value={ep.search}
+          onChange={e => ep.setSearch(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-xs w-64 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
+        />
+
+        {showIncludeDeleted && (
+          <label
+            className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-pointer select-none"
+            title={`Also show ${label} that were deleted in the source system`}
+          >
+            <input type="checkbox" checked={ep.includeDeleted} onChange={e => ep.setIncludeDeleted(e.target.checked)} />
+            Include deleted
+          </label>
+        )}
+
+        {ep.hasAnyFilter && (
+          <>
+            <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
+            <button
+              onClick={ep.clearAllFilters}
+              className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
+            >
+              Clear all
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Action bar */}
+      {ep.selected.size > 0 && (
+        <div className="flex items-center gap-3 mb-3 p-2 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-sm">
+          <span className="font-medium text-blue-700 dark:text-blue-300">{ep.selected.size} selected</span>
+          <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
+          <select
+            value={ep.actionTag}
+            onChange={e => ep.setActionTag(e.target.value)}
+            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-200"
+          >
+            <option value="">Select tag...</option>
+            {ep.tags.map(t => (
+              <option key={t.id} value={t.id}>{t.name}</option>
+            ))}
+          </select>
+          <button
+            onClick={ep.assignTag}
+            disabled={!ep.actionTag || ep.busy}
+            className="px-3 py-1 rounded text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
+          >
+            Assign Tag
+          </button>
+          <button
+            onClick={ep.removeTagFromSelected}
+            disabled={!ep.actionTag || ep.busy}
+            className="px-3 py-1 rounded text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 border border-red-200 dark:border-red-700 disabled:opacity-50"
+          >
+            Remove Tag
+          </button>
+          {ep.hasAnyFilter && ep.total > ep.selected.size && (
+            <>
+              <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
+              <button
+                onClick={ep.assignTagToAll}
+                disabled={!ep.actionTag || ep.busy}
+                className="px-3 py-1 rounded text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/30 border border-blue-300 dark:border-blue-700 disabled:opacity-50"
+                title={`Tag all ${ep.total} ${label} matching current filters`}
+              >
+                Tag all {ep.total} matching
+              </button>
+            </>
+          )}
+          <button
+            onClick={() => ep.setSelected(new Set())}
+            className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 ml-auto"
+          >
+            Clear selection
+          </button>
+        </div>
+      )}
+
+      {/* Table */}
+      {ep.loading ? (
+        <div className="text-center text-gray-500 dark:text-gray-400 py-12">Loading {label}...</div>
+      ) : ep.items.length === 0 ? (
+        <div className="text-center text-gray-500 dark:text-gray-400 py-12">
+          {ep.hasAnyFilter ? `No ${label} match the current filters.` : `No ${label} found.`}
+        </div>
+      ) : (
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-700">
+                <th className="w-10 px-3 py-2">
+                  <input
+                    type="checkbox"
+                    checked={ep.allOnPageSelected}
+                    onChange={ep.toggleSelectAll}
+                    className="rounded"
+                  />
+                </th>
+                {tableColumns.map(col => (
+                  <th
+                    key={col.key}
+                    onClick={() => ep.toggleSort(col.key)}
+                    className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {col.label}
+                      {ep.sortCol === col.key ? (
+                        <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
+                      ) : (
+                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
+                      )}
+                    </span>
+                  </th>
+                ))}
+                <th className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300">Tags</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ep.sortedItems.map(item => (
+                <tr
+                  key={item.id}
+                  className={`border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer ${
+                    ep.selected.has(item.id) ? 'bg-blue-50 dark:bg-blue-900/30' : ''
+                  }`}
+                  onClick={() => ep.toggleSelect(item.id)}
+                >
+                  <td className="px-3 py-2 text-center" onClick={e => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={ep.selected.has(item.id)}
+                      onChange={() => ep.toggleSelect(item.id)}
+                      className="rounded"
+                    />
+                  </td>
+                  {renderEntityCell(item, onOpenDetail)}
+                  {renderDataCells(item)}
+                  <td className="px-3 py-2">
+                    <div className="flex flex-wrap gap-1">
+                      {(item.tags || []).map(t => (
+                        <span
+                          key={t.id}
+                          className="inline-block px-1.5 py-0.5 rounded-full text-[10px] font-medium border"
+                          style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
+                        >
+                          {t.name}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {ep.totalPages > 1 && (
+        <div className="flex items-center justify-between mt-3 text-sm text-gray-600 dark:text-gray-400">
+          <span>
+            Showing {ep.page * ep.PAGE_SIZE + 1}&ndash;{Math.min((ep.page + 1) * ep.PAGE_SIZE, ep.total)} of {ep.total.toLocaleString()}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => ep.setPage(p => Math.max(0, p - 1))}
+              disabled={ep.page === 0}
+              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
+            >
+              Prev
+            </button>
+            <span>Page {ep.page + 1} of {ep.totalPages}</span>
+            <button
+              onClick={() => ep.setPage(p => Math.min(ep.totalPages - 1, p + 1))}
+              disabled={ep.page >= ep.totalPages - 1}
+              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/ui/src/components/EntityListPage.test.js
+++ b/app/ui/src/components/EntityListPage.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src  = readFileSync(join(here, 'EntityListPage.jsx'), 'utf8');
+
+describe('EntityListPage scaffold', () => {
+  it('delegates state management to useEntityPage', () => {
+    expect(src).toContain('useEntityPage');
+  });
+
+  it('accepts subTabBar, tableColumns, fieldLabels, and search placeholder props', () => {
+    expect(src).toContain('subTabBar');
+    expect(src).toContain('tableColumns');
+    expect(src).toContain('fieldLabels');
+    expect(src).toContain('searchPlaceholder');
+  });
+
+  it('renders a table calling renderEntityCell and renderDataCells per row', () => {
+    expect(src).toContain('renderEntityCell');
+    expect(src).toContain('renderDataCells');
+  });
+
+  it('consumers (GroupsPage, UsersPage, IdentitiesPage) no longer contain pagination logic', () => {
+    const groupsSrc      = readFileSync(join(here, 'GroupsPage.jsx'), 'utf8');
+    const usersSrc       = readFileSync(join(here, 'UsersPage.jsx'), 'utf8');
+    const identitiesSrc  = readFileSync(join(here, 'IdentitiesPage.jsx'), 'utf8');
+    // Each page now delegates to EntityListPage rather than owning pagination state
+    for (const s of [groupsSrc, usersSrc, identitiesSrc]) {
+      expect(s).toContain('EntityListPage');
+    }
+  });
+});

--- a/app/ui/src/components/GroupsPage.jsx
+++ b/app/ui/src/components/GroupsPage.jsx
@@ -1,9 +1,5 @@
-﻿import { useMemo } from 'react';
-import { useAuth } from '@ui/auth/AuthGate';
-import useEntityPage from '@ui/hooks/useEntityPage';
-import FilterBar from './FilterBar';
+import EntityListPage from './EntityListPage';
 import DeletedBadge from './DeletedBadge';
-import { TAG_COLORS } from '@ui/utils/colors';
 
 const FIELD_LABELS = {
   displayName: 'Name',
@@ -30,305 +26,31 @@ const TABLE_COLUMNS = [
 
 // Exported as both ResourcesPage (new) and GroupsPage (backward compat)
 export default function ResourcesPage({ onOpenDetail }) {
-  const { authFetch } = useAuth();
-
-  const ep = useEntityPage({
-    authFetch,
-    entityType: 'resource',
-    listEndpoint: '/api/resources',
-    columnsEndpoint: '/api/resource-columns',
-    tagFilterKey: '__resourceTag',
-  });
-
-  const filterFields = useMemo(() => ep.getFilterFields(FIELD_LABELS), [ep]);
-
   return (
-    <div className="max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center gap-4 mb-4">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Resources</h2>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{ep.total.toLocaleString()} total</span>
-      </div>
-
-      {/* Tag management bar */}
-      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
-        <span className="font-medium text-gray-600 dark:text-gray-400">Tags:</span>
-        {ep.tags.map(t => (
-          <span
-            key={t.id}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer border ${
-              ep.activeTagFilter === t.name
-                ? 'ring-2 ring-offset-1 ring-blue-400'
-                : 'hover:opacity-80'
-            }`}
-            style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-            onClick={() => {
-              if (ep.activeTagFilter === t.name) {
-                ep.removeFilter('__resourceTag');
-              } else {
-                ep.addFilter('__resourceTag', t.name);
-              }
-            }}
-            title={`${t.assignmentCount} resources tagged -- click to filter`}
-          >
-            {t.name}
-            <span className="text-[10px] opacity-70">({t.assignmentCount})</span>
-            <button
-              onClick={(e) => { e.stopPropagation(); ep.deleteTag(t.id); }}
-              className="ml-0.5 hover:opacity-100 opacity-50"
-              title="Delete tag"
-            >
-              &times;
-            </button>
-          </span>
-        ))}
-        <button
-          onClick={() => ep.setShowCreateTag(!ep.showCreateTag)}
-          className="px-2 py-0.5 rounded text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 border border-blue-200 dark:border-blue-700 border-dashed"
-        >
-          + New Tag
-        </button>
-      </div>
-
-      {/* Create tag form */}
-      {ep.showCreateTag && (
-        <div className="flex items-center gap-2 mb-3 p-3 bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
-          <input
-            type="text"
-            value={ep.newTagName}
-            onChange={e => ep.setNewTagName(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && ep.createTag()}
-            placeholder="Tag name..."
-            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm w-48 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
-            autoFocus
-          />
-          <div className="flex items-center gap-1">
-            {TAG_COLORS.map(c => (
-              <button
-                key={c}
-                onClick={() => ep.setNewTagColor(c)}
-                className={`w-5 h-5 rounded-full border-2 ${ep.newTagColor === c ? 'border-gray-800 scale-110' : 'border-transparent'}`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
-          </div>
-          <button
-            onClick={ep.createTag}
-            disabled={!ep.newTagName.trim() || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
-          >
-            Create
-          </button>
-          <button
-            onClick={() => ep.setShowCreateTag(false)}
-            className="px-2 py-1 rounded text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-          >
-            Cancel
-          </button>
-        </div>
+    <EntityListPage
+      title="Resources"
+      entityType="resource"
+      listEndpoint="/api/resources"
+      columnsEndpoint="/api/resource-columns"
+      tagFilterKey="__resourceTag"
+      tableColumns={TABLE_COLUMNS}
+      fieldLabels={FIELD_LABELS}
+      renderEntityCell={(g, openDetail) => (
+        <td className="px-3 py-2 font-medium text-blue-600 hover:text-blue-800 cursor-pointer"
+          onClick={() => openDetail?.('resource', g.id, g.displayName)}>
+          {g.displayName}{g.deletedAt && <> <DeletedBadge at={g.deletedAt} /></>}
+        </td>
       )}
-
-      {/* Filter bar + search */}
-      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
-        <FilterBar
-          label="Filters:"
-          filterFields={filterFields}
-          activeFilters={ep.activeFilters}
-          getOptionsForField={ep.getOptionsForField}
-          onAddFilter={ep.addFilter}
-          onRemoveFilter={ep.removeFilter}
-          loading={ep.columnsLoading}
-        />
-
-        <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
-
-        <input
-          type="text"
-          value={ep.search}
-          onChange={e => ep.setSearch(e.target.value)}
-          placeholder="Search by resource name or description..."
-          className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-xs w-64 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
-        />
-
-        <label className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-pointer select-none" title="Also show resources that were deleted in the source system">
-          <input type="checkbox" checked={ep.includeDeleted} onChange={e => ep.setIncludeDeleted(e.target.checked)} />
-          Include deleted
-        </label>
-
-        {ep.hasAnyFilter && (
-          <>
-            <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
-            <button
-              onClick={ep.clearAllFilters}
-              className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
-            >
-              Clear all
-            </button>
-          </>
-        )}
-      </div>
-
-      {/* Action bar */}
-      {ep.selected.size > 0 && (
-        <div className="flex items-center gap-3 mb-3 p-2 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-sm">
-          <span className="font-medium text-blue-700 dark:text-blue-300">{ep.selected.size} selected</span>
-          <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
-          <select
-            value={ep.actionTag}
-            onChange={e => ep.setActionTag(e.target.value)}
-            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-200"
-          >
-            <option value="">Select tag...</option>
-            {ep.tags.map(t => (
-              <option key={t.id} value={t.id}>{t.name}</option>
-            ))}
-          </select>
-          <button
-            onClick={ep.assignTag}
-            disabled={!ep.actionTag || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
-          >
-            Assign Tag
-          </button>
-          <button
-            onClick={ep.removeTagFromSelected}
-            disabled={!ep.actionTag || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 border border-red-200 dark:border-red-700 disabled:opacity-50"
-          >
-            Remove Tag
-          </button>
-          {ep.hasAnyFilter && ep.total > ep.selected.size && (
-            <>
-              <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
-              <button
-                onClick={ep.assignTagToAll}
-                disabled={!ep.actionTag || ep.busy}
-                className="px-3 py-1 rounded text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/30 border border-blue-300 dark:border-blue-700 disabled:opacity-50"
-                title={`Tag all ${ep.total} resources matching current filters`}
-              >
-                Tag all {ep.total} matching
-              </button>
-            </>
-          )}
-          <button
-            onClick={() => ep.setSelected(new Set())}
-            className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 ml-auto"
-          >
-            Clear selection
-          </button>
-        </div>
+      renderDataCells={(g) => (
+        <>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{g.resourceType || g.groupTypeCalculated || ''}</td>
+          <td className="px-3 py-2 text-gray-500 dark:text-gray-400 text-xs max-w-xs truncate" title={g.description || ''}>{g.description || ''}</td>
+        </>
       )}
-
-      {/* Table */}
-      {ep.loading ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">Loading resources...</div>
-      ) : ep.items.length === 0 ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          {ep.hasAnyFilter ? 'No resources match the current filters.' : 'No resources found.'}
-        </div>
-      ) : (
-        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-700">
-                <th className="w-10 px-3 py-2">
-                  <input
-                    type="checkbox"
-                    checked={ep.allOnPageSelected}
-                    onChange={ep.toggleSelectAll}
-                    className="rounded"
-                  />
-                </th>
-                {TABLE_COLUMNS.map(col => (
-                  <th
-                    key={col.key}
-                    onClick={() => ep.toggleSort(col.key)}
-                    className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-gray-700"
-                  >
-                    <span className="inline-flex items-center gap-1">
-                      {col.label}
-                      {ep.sortCol === col.key ? (
-                        <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
-                      ) : (
-                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
-                      )}
-                    </span>
-                  </th>
-                ))}
-                <th className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300">Tags</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ep.sortedItems.map(g => (
-                <tr
-                  key={g.id}
-                  className={`border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer ${
-                    ep.selected.has(g.id) ? 'bg-blue-50 dark:bg-blue-900/30' : ''
-                  }`}
-                  onClick={() => ep.toggleSelect(g.id)}
-                >
-                  <td className="px-3 py-2 text-center" onClick={e => e.stopPropagation()}>
-                    <input
-                      type="checkbox"
-                      checked={ep.selected.has(g.id)}
-                      onChange={() => ep.toggleSelect(g.id)}
-                      className="rounded"
-                    />
-                  </td>
-                  <td className="px-3 py-2 font-medium text-blue-600 hover:text-blue-800 cursor-pointer"
-                    onClick={() => onOpenDetail?.('resource', g.id, g.displayName)}>
-                    {g.displayName}{g.deletedAt && <> <DeletedBadge at={g.deletedAt} /></>}
-                  </td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{g.resourceType || g.groupTypeCalculated || ''}</td>
-                  <td className="px-3 py-2 text-gray-500 dark:text-gray-400 text-xs max-w-xs truncate" title={g.description || ''}>
-                    {g.description || ''}
-                  </td>
-                  <td className="px-3 py-2">
-                    <div className="flex flex-wrap gap-1">
-                      {g.tags.map(t => (
-                        <span
-                          key={t.id}
-                          className="inline-block px-1.5 py-0.5 rounded-full text-[10px] font-medium border"
-                          style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-                        >
-                          {t.name}
-                        </span>
-                      ))}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {/* Pagination */}
-      {ep.totalPages > 1 && (
-        <div className="flex items-center justify-between mt-3 text-sm text-gray-600 dark:text-gray-400">
-          <span>
-            Showing {ep.page * ep.PAGE_SIZE + 1}&ndash;{Math.min((ep.page + 1) * ep.PAGE_SIZE, ep.total)} of {ep.total.toLocaleString()}
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => ep.setPage(p => Math.max(0, p - 1))}
-              disabled={ep.page === 0}
-              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
-            >
-              Prev
-            </button>
-            <span>Page {ep.page + 1} of {ep.totalPages}</span>
-            <button
-              onClick={() => ep.setPage(p => Math.min(ep.totalPages - 1, p + 1))}
-              disabled={ep.page >= ep.totalPages - 1}
-              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
-            >
-              Next
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+      searchPlaceholder="Search by resource name or description..."
+      showIncludeDeleted
+      onOpenDetail={onOpenDetail}
+    />
   );
 }
 

--- a/app/ui/src/components/IdentitiesPage.jsx
+++ b/app/ui/src/components/IdentitiesPage.jsx
@@ -1,8 +1,4 @@
-﻿import { useMemo } from 'react';
-import { useAuth } from '@ui/auth/AuthGate';
-import useEntityPage from '@ui/hooks/useEntityPage';
-import FilterBar from './FilterBar';
-import { TAG_COLORS } from '@ui/utils/colors';
+import EntityListPage from './EntityListPage';
 
 // Identities list — intentionally a stripped-down Resources-style table.
 // Account-correlation controls (verify / confirm / reject, correlation
@@ -10,16 +6,16 @@ import { TAG_COLORS } from '@ui/utils/colors';
 // their own dedicated UI later; this page is just "flat list + tags".
 
 const FIELD_LABELS = {
-  displayName:      'Name',
-  email:            'Email',
-  department:       'Department',
-  jobTitle:         'Job Title',
-  companyName:      'Company',
-  city:             'City',
-  country:          'Country',
-  employeeId:       'Employee ID',
-  accountCount:     'Accounts',
-  __identityTag:    'Identity Tag',
+  displayName:   'Name',
+  email:         'Email',
+  department:    'Department',
+  jobTitle:      'Job Title',
+  companyName:   'Company',
+  city:          'City',
+  country:       'Country',
+  employeeId:    'Employee ID',
+  accountCount:  'Accounts',
+  __identityTag: 'Identity Tag',
 };
 
 const TABLE_COLUMNS = [
@@ -31,299 +27,31 @@ const TABLE_COLUMNS = [
 ];
 
 export default function IdentitiesPage({ onOpenDetail }) {
-  const { authFetch } = useAuth();
-
-  const ep = useEntityPage({
-    authFetch,
-    entityType: 'identity',
-    listEndpoint: '/api/identities',
-    columnsEndpoint: '/api/identity-columns',
-    tagFilterKey: '__identityTag',
-  });
-
-  const filterFields = useMemo(() => ep.getFilterFields(FIELD_LABELS), [ep]);
-
   return (
-    <div className="max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center gap-4 mb-4">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Identities</h2>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{ep.total.toLocaleString()} total</span>
-      </div>
-
-      {/* Tag management bar */}
-      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
-        <span className="font-medium text-gray-600 dark:text-gray-400">Tags:</span>
-        {ep.tags.map(t => (
-          <span
-            key={t.id}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer border ${
-              ep.activeTagFilter === t.name
-                ? 'ring-2 ring-offset-1 ring-blue-400'
-                : 'hover:opacity-80'
-            }`}
-            style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-            onClick={() => {
-              if (ep.activeTagFilter === t.name) {
-                ep.removeFilter('__identityTag');
-              } else {
-                ep.addFilter('__identityTag', t.name);
-              }
-            }}
-            title={`${t.assignmentCount} identities tagged -- click to filter`}
-          >
-            {t.name}
-            <span className="text-[10px] opacity-70">({t.assignmentCount})</span>
-            <button
-              onClick={(e) => { e.stopPropagation(); ep.deleteTag(t.id); }}
-              className="ml-0.5 hover:opacity-100 opacity-50"
-              title="Delete tag"
-            >
-              &times;
-            </button>
-          </span>
-        ))}
-        <button
-          onClick={() => ep.setShowCreateTag(!ep.showCreateTag)}
-          className="px-2 py-0.5 rounded text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 border border-blue-200 dark:border-blue-700 border-dashed"
-        >
-          + New Tag
-        </button>
-      </div>
-
-      {/* Create tag form */}
-      {ep.showCreateTag && (
-        <div className="flex items-center gap-2 mb-3 p-3 bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
-          <input
-            type="text"
-            value={ep.newTagName}
-            onChange={e => ep.setNewTagName(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && ep.createTag()}
-            placeholder="Tag name..."
-            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm w-48 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
-            autoFocus
-          />
-          <div className="flex items-center gap-1">
-            {TAG_COLORS.map(c => (
-              <button
-                key={c}
-                onClick={() => ep.setNewTagColor(c)}
-                className={`w-5 h-5 rounded-full border-2 ${ep.newTagColor === c ? 'border-gray-800 scale-110' : 'border-transparent'}`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
-          </div>
-          <button
-            onClick={ep.createTag}
-            disabled={!ep.newTagName.trim() || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
-          >
-            Create
-          </button>
-          <button
-            onClick={() => ep.setShowCreateTag(false)}
-            className="px-2 py-1 rounded text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-          >
-            Cancel
-          </button>
-        </div>
+    <EntityListPage
+      title="Identities"
+      entityType="identity"
+      listEndpoint="/api/identities"
+      columnsEndpoint="/api/identity-columns"
+      tagFilterKey="__identityTag"
+      tableColumns={TABLE_COLUMNS}
+      fieldLabels={FIELD_LABELS}
+      renderEntityCell={(i, openDetail) => (
+        <td className="px-3 py-2 font-medium text-blue-600 hover:text-blue-800 cursor-pointer"
+          onClick={() => openDetail?.('identity', i.id, i.displayName)}>
+          {i.displayName}
+        </td>
       )}
-
-      {/* Filter bar + search */}
-      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
-        <FilterBar
-          label="Filters:"
-          filterFields={filterFields}
-          activeFilters={ep.activeFilters}
-          getOptionsForField={ep.getOptionsForField}
-          onAddFilter={ep.addFilter}
-          onRemoveFilter={ep.removeFilter}
-          loading={ep.columnsLoading}
-        />
-
-        <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
-
-        <input
-          type="text"
-          value={ep.search}
-          onChange={e => ep.setSearch(e.target.value)}
-          placeholder="Search by name, email, job title, employee ID..."
-          className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-xs w-64 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
-        />
-
-        {ep.hasAnyFilter && (
-          <>
-            <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
-            <button
-              onClick={ep.clearAllFilters}
-              className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
-            >
-              Clear all
-            </button>
-          </>
-        )}
-      </div>
-
-      {/* Action bar */}
-      {ep.selected.size > 0 && (
-        <div className="flex items-center gap-3 mb-3 p-2 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-sm">
-          <span className="font-medium text-blue-700 dark:text-blue-300">{ep.selected.size} selected</span>
-          <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
-          <select
-            value={ep.actionTag}
-            onChange={e => ep.setActionTag(e.target.value)}
-            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-200"
-          >
-            <option value="">Select tag...</option>
-            {ep.tags.map(t => (
-              <option key={t.id} value={t.id}>{t.name}</option>
-            ))}
-          </select>
-          <button
-            onClick={ep.assignTag}
-            disabled={!ep.actionTag || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
-          >
-            Assign Tag
-          </button>
-          <button
-            onClick={ep.removeTagFromSelected}
-            disabled={!ep.actionTag || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 border border-red-200 dark:border-red-700 disabled:opacity-50"
-          >
-            Remove Tag
-          </button>
-          {ep.hasAnyFilter && ep.total > ep.selected.size && (
-            <>
-              <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
-              <button
-                onClick={ep.assignTagToAll}
-                disabled={!ep.actionTag || ep.busy}
-                className="px-3 py-1 rounded text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/30 border border-blue-300 dark:border-blue-700 disabled:opacity-50"
-                title={`Tag all ${ep.total} identities matching current filters`}
-              >
-                Tag all {ep.total} matching
-              </button>
-            </>
-          )}
-          <button
-            onClick={() => ep.setSelected(new Set())}
-            className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 ml-auto"
-          >
-            Clear selection
-          </button>
-        </div>
+      renderDataCells={(i) => (
+        <>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs font-mono">{i.primaryAccountUpn || ''}</td>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{i.accountCount ?? ''}</td>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{i.department || ''}</td>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{i.jobTitle || ''}</td>
+        </>
       )}
-
-      {/* Table */}
-      {ep.loading ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">Loading identities...</div>
-      ) : ep.items.length === 0 ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          {ep.hasAnyFilter ? 'No identities match the current filters.' : 'No identities found.'}
-        </div>
-      ) : (
-        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-700">
-                <th className="w-10 px-3 py-2">
-                  <input
-                    type="checkbox"
-                    checked={ep.allOnPageSelected}
-                    onChange={ep.toggleSelectAll}
-                    className="rounded"
-                  />
-                </th>
-                {TABLE_COLUMNS.map(col => (
-                  <th
-                    key={col.key}
-                    onClick={() => ep.toggleSort(col.key)}
-                    className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-gray-700"
-                  >
-                    <span className="inline-flex items-center gap-1">
-                      {col.label}
-                      {ep.sortCol === col.key ? (
-                        <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
-                      ) : (
-                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
-                      )}
-                    </span>
-                  </th>
-                ))}
-                <th className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300">Tags</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ep.sortedItems.map(i => (
-                <tr
-                  key={i.id}
-                  className={`border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer ${
-                    ep.selected.has(i.id) ? 'bg-blue-50 dark:bg-blue-900/30' : ''
-                  }`}
-                  onClick={() => ep.toggleSelect(i.id)}
-                >
-                  <td className="px-3 py-2 text-center" onClick={e => e.stopPropagation()}>
-                    <input
-                      type="checkbox"
-                      checked={ep.selected.has(i.id)}
-                      onChange={() => ep.toggleSelect(i.id)}
-                      className="rounded"
-                    />
-                  </td>
-                  <td className="px-3 py-2 font-medium text-blue-600 hover:text-blue-800 cursor-pointer"
-                      onClick={() => onOpenDetail?.('identity', i.id, i.displayName)}>
-                    {i.displayName}
-                  </td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs font-mono">{i.primaryAccountUpn || ''}</td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{i.accountCount ?? ''}</td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{i.department || ''}</td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{i.jobTitle || ''}</td>
-                  <td className="px-3 py-2">
-                    <div className="flex flex-wrap gap-1">
-                      {(i.tags || []).map(t => (
-                        <span
-                          key={t.id}
-                          className="inline-block px-1.5 py-0.5 rounded-full text-[10px] font-medium border"
-                          style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-                        >
-                          {t.name}
-                        </span>
-                      ))}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {/* Pagination */}
-      {ep.totalPages > 1 && (
-        <div className="flex items-center justify-between mt-3 text-sm text-gray-600 dark:text-gray-400">
-          <span>
-            Showing {ep.page * ep.PAGE_SIZE + 1}&ndash;{Math.min((ep.page + 1) * ep.PAGE_SIZE, ep.total)} of {ep.total.toLocaleString()}
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => ep.setPage(p => Math.max(0, p - 1))}
-              disabled={ep.page === 0}
-              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
-            >
-              Prev
-            </button>
-            <span>Page {ep.page + 1} of {ep.totalPages}</span>
-            <button
-              onClick={() => ep.setPage(p => Math.min(ep.totalPages - 1, p + 1))}
-              disabled={ep.page >= ep.totalPages - 1}
-              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
-            >
-              Next
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+      searchPlaceholder="Search by name, email, job title, employee ID..."
+      onOpenDetail={onOpenDetail}
+    />
   );
 }

--- a/app/ui/src/components/UsersPage.jsx
+++ b/app/ui/src/components/UsersPage.jsx
@@ -1,9 +1,6 @@
-﻿import { useMemo, useState, useEffect } from 'react';
-import { useAuth } from '@ui/auth/AuthGate';
-import useEntityPage from '@ui/hooks/useEntityPage';
-import FilterBar from './FilterBar';
+import { useMemo, useState, useEffect } from 'react';
+import EntityListPage from './EntityListPage';
 import DeletedBadge from './DeletedBadge';
-import { TAG_COLORS } from '@ui/utils/colors';
 
 const FIELD_LABELS = {
   department: 'Department',
@@ -32,8 +29,6 @@ const TABLE_COLUMNS = [
 // Sub-tabs for principalType. The Principals table is a universal identity
 // store, so the "Users" page now lists more than just humans — splitting it
 // by type keeps each view manageable when SP/MI/AIAgent sync is enabled.
-// The tab label is what's shown; the value is matched against the column.
-// 'all' is a sentinel for "no filter".
 const PRINCIPAL_TYPE_TABS = [
   { key: 'all',              label: 'All' },
   { key: 'User',             label: 'Users' },
@@ -64,343 +59,73 @@ function writeTypeToHash(tab) {
 }
 
 export default function UsersPage({ onOpenDetail }) {
-  const { authFetch } = useAuth();
   const [activeTypeTab, setActiveTypeTab] = useState(readTypeFromHash);
-
   useEffect(() => { writeTypeToHash(activeTypeTab); }, [activeTypeTab]);
 
-  // Memoise so useEntityPage's filtersObj memo isn't busted every render.
+  // Memoised so useEntityPage's filtersObj memo isn't busted every render.
   const baseFilters = useMemo(
     () => (activeTypeTab === 'all' ? null : { principalType: activeTypeTab }),
     [activeTypeTab],
   );
 
-  const ep = useEntityPage({
-    authFetch,
-    entityType: 'user',
-    listEndpoint: '/api/users',
-    columnsEndpoint: '/api/user-columns-page',
-    tagFilterKey: '__userTag',
-    baseFilters,
-  });
+  // Hide `principalType` from Filters when a specific sub-tab is active —
+  // the tab is the authoritative selector, so two controls for the same value
+  // would be confusing.
+  const customizeFilterFields = useMemo(
+    () => activeTypeTab === 'all'
+      ? null
+      : (fields) => fields.filter(f => f.key !== 'principalType'),
+    [activeTypeTab],
+  );
 
-  // Hide `principalType` from the Filters dropdown only when a specific
-  // sub-tab is active — the tab is the authoritative selector there, and
-  // having both would create two ways to set the same value. On the "All"
-  // tab no type is pinned, so leave `principalType` available as a regular
-  // filter option.
-  const filterFields = useMemo(
-    () => ep.getFilterFields(FIELD_LABELS).filter(f =>
-      !(activeTypeTab !== 'all' && f.key === 'principalType')
-    ),
-    [ep, activeTypeTab],
+  const subTabBar = (
+    <div className="border-b border-gray-200 dark:border-gray-700 mb-4">
+      <nav className="flex gap-1 -mb-px">
+        {PRINCIPAL_TYPE_TABS.map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTypeTab(tab.key)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTypeTab === tab.key
+                ? 'border-indigo-600 text-indigo-700'
+                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+    </div>
   );
 
   return (
-    <div className="max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center gap-4 mb-4">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Users</h2>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{ep.total.toLocaleString()} total</span>
-      </div>
-
-      {/* Principal-type sub-tabs. Matches the underlined-pills style used by
-          the Admin page's own sub-tab bar so the UX is consistent. */}
-      <div className="border-b border-gray-200 dark:border-gray-700 mb-4">
-        <nav className="flex gap-1 -mb-px">
-          {PRINCIPAL_TYPE_TABS.map(tab => (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTypeTab(tab.key)}
-              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-                activeTypeTab === tab.key
-                  ? 'border-indigo-600 text-indigo-700'
-                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-      </div>
-
-      {/* Tag management bar */}
-      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
-        <span className="font-medium text-gray-600 dark:text-gray-400">Tags:</span>
-        {ep.tags.map(t => (
-          <span
-            key={t.id}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer border ${
-              ep.activeTagFilter === t.name
-                ? 'ring-2 ring-offset-1 ring-blue-400'
-                : 'hover:opacity-80'
-            }`}
-            style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-            onClick={() => {
-              if (ep.activeTagFilter === t.name) {
-                ep.removeFilter('__userTag');
-              } else {
-                ep.addFilter('__userTag', t.name);
-              }
-            }}
-            title={`${t.assignmentCount} users tagged — click to filter`}
-          >
-            {t.name}
-            <span className="text-[10px] opacity-70">({t.assignmentCount})</span>
-            <button
-              onClick={(e) => { e.stopPropagation(); ep.deleteTag(t.id); }}
-              className="ml-0.5 hover:opacity-100 opacity-50"
-              title="Delete tag"
-            >
-              &times;
-            </button>
-          </span>
-        ))}
-        <button
-          onClick={() => ep.setShowCreateTag(!ep.showCreateTag)}
-          className="px-2 py-0.5 rounded text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 border border-blue-200 dark:border-blue-700 border-dashed"
-        >
-          + New Tag
-        </button>
-      </div>
-
-      {/* Create tag form */}
-      {ep.showCreateTag && (
-        <div className="flex items-center gap-2 mb-3 p-3 bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
-          <input
-            type="text"
-            value={ep.newTagName}
-            onChange={e => ep.setNewTagName(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && ep.createTag()}
-            placeholder="Tag name..."
-            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm w-48 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
-            autoFocus
-          />
-          <div className="flex items-center gap-1">
-            {TAG_COLORS.map(c => (
-              <button
-                key={c}
-                onClick={() => ep.setNewTagColor(c)}
-                className={`w-5 h-5 rounded-full border-2 ${ep.newTagColor === c ? 'border-gray-800 scale-110' : 'border-transparent'}`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
-          </div>
-          <button
-            onClick={ep.createTag}
-            disabled={!ep.newTagName.trim() || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
-          >
-            Create
-          </button>
-          <button
-            onClick={() => ep.setShowCreateTag(false)}
-            className="px-2 py-1 rounded text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-          >
-            Cancel
-          </button>
-        </div>
+    <EntityListPage
+      title="Users"
+      entityType="user"
+      listEndpoint="/api/users"
+      columnsEndpoint="/api/user-columns-page"
+      tagFilterKey="__userTag"
+      tableColumns={TABLE_COLUMNS}
+      fieldLabels={FIELD_LABELS}
+      renderEntityCell={(u, openDetail) => (
+        <td className="px-3 py-2 font-medium text-blue-600 hover:text-blue-800 cursor-pointer"
+          onClick={() => openDetail?.('user', u.id, u.displayName)}>
+          {u.displayName}{u.deletedAt && <> <DeletedBadge at={u.deletedAt} /></>}
+        </td>
       )}
-
-      {/* Filter bar + search */}
-      <div className="flex flex-wrap items-center gap-2 mb-3 text-sm">
-        <FilterBar
-          label="Filters:"
-          filterFields={filterFields}
-          activeFilters={ep.activeFilters}
-          getOptionsForField={ep.getOptionsForField}
-          onAddFilter={ep.addFilter}
-          onRemoveFilter={ep.removeFilter}
-          loading={ep.columnsLoading}
-        />
-
-        <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
-
-        <input
-          type="text"
-          value={ep.search}
-          onChange={e => ep.setSearch(e.target.value)}
-          placeholder="Search by name or UPN..."
-          className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-xs w-56 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-500"
-        />
-
-        <label className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-pointer select-none" title="Also show users that were deleted in the source system">
-          <input type="checkbox" checked={ep.includeDeleted} onChange={e => ep.setIncludeDeleted(e.target.checked)} />
-          Include deleted
-        </label>
-
-        {ep.hasAnyFilter && (
-          <>
-            <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
-            <button
-              onClick={ep.clearAllFilters}
-              className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
-            >
-              Clear all
-            </button>
-          </>
-        )}
-      </div>
-
-      {/* Action bar (visible when items selected) */}
-      {ep.selected.size > 0 && (
-        <div className="flex items-center gap-3 mb-3 p-2 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-sm">
-          <span className="font-medium text-blue-700 dark:text-blue-300">{ep.selected.size} selected</span>
-          <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
-          <select
-            value={ep.actionTag}
-            onChange={e => ep.setActionTag(e.target.value)}
-            className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-200"
-          >
-            <option value="">Select tag...</option>
-            {ep.tags.map(t => (
-              <option key={t.id} value={t.id}>{t.name}</option>
-            ))}
-          </select>
-          <button
-            onClick={ep.assignTag}
-            disabled={!ep.actionTag || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50"
-          >
-            Assign Tag
-          </button>
-          <button
-            onClick={ep.removeTagFromSelected}
-            disabled={!ep.actionTag || ep.busy}
-            className="px-3 py-1 rounded text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 border border-red-200 dark:border-red-700 disabled:opacity-50"
-          >
-            Remove Tag
-          </button>
-          {ep.hasAnyFilter && ep.total > ep.selected.size && (
-            <>
-              <div className="border-l border-blue-200 dark:border-blue-700 h-5" />
-              <button
-                onClick={ep.assignTagToAll}
-                disabled={!ep.actionTag || ep.busy}
-                className="px-3 py-1 rounded text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/30 border border-blue-300 dark:border-blue-700 disabled:opacity-50"
-                title={`Tag all ${ep.total} users matching current filters`}
-              >
-                Tag all {ep.total} matching
-              </button>
-            </>
-          )}
-          <button
-            onClick={() => ep.setSelected(new Set())}
-            className="px-2 py-1 rounded text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 ml-auto"
-          >
-            Clear selection
-          </button>
-        </div>
+      renderDataCells={(u) => (
+        <>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{u.userPrincipalName}</td>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{u.department || ''}</td>
+          <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{u.jobTitle || ''}</td>
+        </>
       )}
-
-      {/* Table */}
-      {ep.loading ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">Loading users...</div>
-      ) : ep.items.length === 0 ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          {ep.hasAnyFilter ? 'No users match the current filters.' : 'No users found.'}
-        </div>
-      ) : (
-        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-700">
-                <th className="w-10 px-3 py-2">
-                  <input
-                    type="checkbox"
-                    checked={ep.allOnPageSelected}
-                    onChange={ep.toggleSelectAll}
-                    className="rounded"
-                  />
-                </th>
-                {TABLE_COLUMNS.map(col => (
-                  <th
-                    key={col.key}
-                    onClick={() => ep.toggleSort(col.key)}
-                    className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-gray-700"
-                  >
-                    <span className="inline-flex items-center gap-1">
-                      {col.label}
-                      {ep.sortCol === col.key ? (
-                        <span className="text-blue-600 text-[10px]">{ep.sortDir === 'asc' ? '▲' : '▼'}</span>
-                      ) : (
-                        <span className="text-gray-500 dark:text-gray-500 text-[10px]">{'▴'}</span>
-                      )}
-                    </span>
-                  </th>
-                ))}
-                <th className="text-left px-3 py-2 font-medium text-gray-700 dark:text-gray-300">Tags</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ep.sortedItems.map(u => (
-                <tr
-                  key={u.id}
-                  className={`border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer ${
-                    ep.selected.has(u.id) ? 'bg-blue-50 dark:bg-blue-900/30' : ''
-                  }`}
-                  onClick={() => ep.toggleSelect(u.id)}
-                >
-                  <td className="px-3 py-2 text-center" onClick={e => e.stopPropagation()}>
-                    <input
-                      type="checkbox"
-                      checked={ep.selected.has(u.id)}
-                      onChange={() => ep.toggleSelect(u.id)}
-                      className="rounded"
-                    />
-                  </td>
-                  <td className="px-3 py-2 font-medium text-blue-600 hover:text-blue-800 cursor-pointer"
-                    onClick={() => onOpenDetail?.('user', u.id, u.displayName)}>
-                    {u.displayName}{u.deletedAt && <> <DeletedBadge at={u.deletedAt} /></>}
-                  </td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400 text-xs">{u.userPrincipalName}</td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{u.department || ''}</td>
-                  <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{u.jobTitle || ''}</td>
-                  <td className="px-3 py-2">
-                    <div className="flex flex-wrap gap-1">
-                      {u.tags.map(t => (
-                        <span
-                          key={t.id}
-                          className="inline-block px-1.5 py-0.5 rounded-full text-[10px] font-medium border"
-                          style={{ backgroundColor: t.color + '20', borderColor: t.color, color: t.color }}
-                        >
-                          {t.name}
-                        </span>
-                      ))}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {/* Pagination */}
-      {ep.totalPages > 1 && (
-        <div className="flex items-center justify-between mt-3 text-sm text-gray-600 dark:text-gray-400">
-          <span>
-            Showing {ep.page * ep.PAGE_SIZE + 1}&ndash;{Math.min((ep.page + 1) * ep.PAGE_SIZE, ep.total)} of {ep.total.toLocaleString()}
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => ep.setPage(p => Math.max(0, p - 1))}
-              disabled={ep.page === 0}
-              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
-            >
-              Prev
-            </button>
-            <span>Page {ep.page + 1} of {ep.totalPages}</span>
-            <button
-              onClick={() => ep.setPage(p => Math.min(ep.totalPages - 1, p + 1))}
-              disabled={ep.page >= ep.totalPages - 1}
-              className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-40"
-            >
-              Next
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+      searchPlaceholder="Search by name or UPN..."
+      showIncludeDeleted
+      subTabBar={subTabBar}
+      baseFilters={baseFilters}
+      customizeFilterFields={customizeFilterFields}
+      onOpenDetail={onOpenDetail}
+    />
   );
 }

--- a/changes/dedup-ui-list-pages.md
+++ b/changes/dedup-ui-list-pages.md
@@ -1,0 +1,1 @@
+- Extracted shared scaffold (`EntityListPage`) from the Resources, Users, and Identities list pages, eliminating ~700 lines of near-identical JSX while preserving all existing behavior (tag management, filter bar, sort, selection, pagination, include-deleted toggle, sub-tabs)


### PR DESCRIPTION
- Extracted shared scaffold (`EntityListPage`) from the Resources, Users, and Identities list pages, eliminating ~700 lines of near-identical JSX while preserving all existing behavior (tag management, filter bar, sort, selection, pagination, include-deleted toggle, sub-tabs)