### PR TITLE
feat(azure-rm): read via Azure Resource Graph (replaces per-subscription REST)

### DIFF
--- a/changes/azure-rm-arg.md
+++ b/changes/azure-rm-arg.md
@@ -1,0 +1,3 @@
+- The Azure RM crawler now reads resource groups, resources, role definitions and role assignments from Azure Resource Graph instead of one call per subscription, so it scales to tenants with hundreds of subscriptions with a fraction of the API calls and a much shorter run time. Output is unchanged — verified identical to the previous method on a live tenant before switching over.
+- Azure scope identities are now case-insensitive, so the same resource group or resource is never split into two entries because Azure returned its path with different casing.
+- Fixed crawler jobs failing when a crawler folder contains development-only scripts in a `dev/` subfolder; these are now correctly ignored at runtime as intended.

--- a/docs/sync/azure-rm.md
+++ b/docs/sync/azure-rm.md
@@ -70,8 +70,18 @@ resource group *under* Foo returns `Contributor` with badge **Indirect** — inh
 - Azure RM is a JSON REST API (not OData), so this crawler does **not** depend on the `odata`
   base layer. Auth reuses `Get-FGAccessToken` against `https://management.azure.com/`.
 - Reads honour Azure's throttling (`429` + `Retry-After`) and token refresh on long crawls.
-- `atScope()` is used when reading role assignments, so only assignments *declared* at each
-  scope are stored — inheritance is the engine's job.
+- **Reads via Azure Resource Graph.** Resource groups, resources, role definitions and role
+  assignments are read from [Azure Resource Graph](https://learn.microsoft.com/azure/governance/resource-graph/)
+  in a few paged queries across every subscription at once, rather than one list call per
+  subscription — so the crawl scales to hundreds of subscriptions with far fewer round-trips.
+  (Subscriptions and the management-group hierarchy are still enumerated over the ARM REST API; those
+  are single calls, not per-subscription fan-out.) Two Resource Graph details: the role-assignments
+  query uses `authorizationScopeFilter=AtScopeAboveAndBelow` so management-group and tenant-root
+  declared assignments are returned (the principal still only sees what it has Reader on); and the
+  built-in role-definition catalog is fetched with `AtScopeAndAbove`, since a plain at-or-below query
+  does not surface it.
+- Only assignments *declared* at each scope are stored (at the assignment's own `properties.scope`);
+  inheritance down the `Contains` hierarchy is the effective-access engine's job, computed on demand.
 
 ## See also
 

--- a/setup/docker/Invoke-CrawlerJob.ps1
+++ b/setup/docker/Invoke-CrawlerJob.ps1
@@ -160,8 +160,12 @@ try {
     foreach ($layer in $resolved) {
         $layerDir        = $registry[$layer].Dir
         $layerEntryPoint = $registry[$layer].Manifest['entryPoint']
+        # Dot-source the crawler's library files, but never the entry point, tests, or anything under
+        # a `dev/` subfolder (load-test seeders, parity harnesses) — those are standalone scripts with
+        # their own Param() blocks; dot-sourcing one would bind/prompt for its mandatory parameters and
+        # abort the job. This matches the documented contract that nothing in dev/ runs at runtime.
         Get-ChildItem -Path $layerDir -Include '*.ps1' -Recurse -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -ne $layerEntryPoint -and $_.Name -notlike 'Test-*.ps1' } |
+            Where-Object { $_.Name -ne $layerEntryPoint -and $_.Name -notlike 'Test-*.ps1' -and $_.FullName -notmatch '[\\/]dev[\\/]' } |
             ForEach-Object { . $_.FullName }
     }
 

--- a/tools/crawlers/azure-rm/Get-AzureRGHelpers.ps1
+++ b/tools/crawlers/azure-rm/Get-AzureRGHelpers.ps1
@@ -1,0 +1,221 @@
+<#
+.SYNOPSIS
+    Azure Resource Graph (ARG) query helpers — bulk, cross-subscription reads.
+
+.DESCRIPTION
+    The Azure RM crawler reads resource groups, resources, role definitions and role assignments
+    from Azure Resource Graph rather than listing them one call per subscription — at hundreds of
+    subscriptions that turns thousands of sequential round-trips into a handful of paged KQL queries
+    across every subscription at once.
+
+    These helpers reuse the management.azure.com token already acquired by Connect-AzureRM (ARG
+    lives on the same resource) and the Update-ARMTokenIfNeeded refresh from Get-AzureRMHelpers.ps1
+    (same-folder library, dot-sourced by the dispatcher). Each typed helper returns rows shaped like
+    the equivalent ARM objects (`.name` + `.properties` for authorization resources;
+    `.id`/`.name`/`.location`/`.tags`/`.identity` for resources) so the crawler's mapping code is
+    transport-agnostic.
+
+    Three ARG behaviours the caller must know about:
+      • ARG lowercases every resource `id` and assignment `scope`. The crawler canonicalises scope
+        paths to lower-case before hashing node ids (Get-ScopeNodeId) so casing never splits a scope.
+      • Role assignments declared above a subscription (management group / tenant root) are only
+        returned when the query carries options.authorizationScopeFilter = AtScopeAboveAndBelow (and
+        the principal can see them). Get-ARGRoleAssignments sets that filter.
+      • The built-in role-definition catalog is NOT returned by an at-or-below query; it needs
+        AtScopeAndAbove (Get-ARGRoleDefinitions sets that). Output was verified byte-for-byte against
+        the previous per-subscription ARM path before it was retired.
+
+    Dot-sourced automatically by the dispatcher (same-folder library).
+#>
+
+# ARG constants. NOTE: these are inlined inside the functions below rather than read from top-level
+# variables — the dispatcher dot-sources crawler libraries inside a ForEach-Object block, where a
+# top-level (or $script:) assignment does NOT reach the scope the functions read at call time (same
+# reason Get-AzureRMHelpers.ps1 inlines its base URL). Values, for reference:
+#   api-version    2022-10-01   (supports options.authorizationScopeFilter + resultFormat)
+#   endpoint       https://management.azure.com/providers/Microsoft.ResourceGraph/resources
+#   page size      1000         (ARG hard max rows per page)
+#   sub chunk      1000         (ARG hard max subscriptions per request scope)
+
+#region Core query
+
+# POST one ARG query, following $skipToken across all pages; returns a flat array of `data` rows.
+# Honours 429/5xx with Retry-After (same contract as Invoke-ARMRequestRaw) and the ARG user-quota
+# headers (x-ms-user-quota-remaining / -resets-after) so a big crawl backs off before it is told to.
+# Subscriptions are chunked to ARG's per-request limit; each chunk is paged independently and merged.
+function Invoke-ARGQuery {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Query,
+        [string[]]$SubscriptionIds = @(),
+        [string[]]$ManagementGroups = @(),
+        [string]$ScopeFilter,
+        [int]$MaxRetries = 5
+    )
+    $pageSize     = 1000
+    $subChunkSize = 1000
+    $all = [System.Collections.Generic.List[object]]::new()
+    # Scope by management group (single query — covers the whole subtree, and surfaces the tenant
+    # role-definition catalog) or by subscriptions (chunked to ARG's per-request limit). MG scope
+    # wins when supplied.
+    $scopes = [System.Collections.Generic.List[object]]::new()
+    if ($ManagementGroups.Count -gt 0) {
+        $scopes.Add(@{ managementGroups = @($ManagementGroups) })
+    } else {
+        for ($i = 0; $i -lt $SubscriptionIds.Count; $i += $subChunkSize) {
+            $end = [Math]::Min($i + $subChunkSize, $SubscriptionIds.Count) - 1
+            $scopes.Add(@{ subscriptions = @($SubscriptionIds[$i..$end]) })
+        }
+    }
+
+    foreach ($scope in $scopes) {
+        $skipToken = $null
+        while ($true) {
+            $options = @{ '$top' = $pageSize; resultFormat = 'objectArray' }
+            if ($ScopeFilter) { $options['authorizationScopeFilter'] = $ScopeFilter }
+            if ($skipToken)   { $options['$skipToken'] = $skipToken }
+            $body = ($scope + @{ query = $Query; options = $options }) | ConvertTo-Json -Depth 6 -Compress
+
+            $resp = Invoke-ARGRequestRaw -Body $body -MaxRetries $MaxRetries
+            if ($null -ne $resp.data) { foreach ($row in $resp.data) { [void]$all.Add($row) } }
+            $skipToken = $resp.'$skipToken'
+            if (-not $skipToken) { break }
+        }
+    }
+    return $all
+}
+
+# Internal: POST the ARG endpoint once, with retry. Reuses the ARM token + refresh from
+# Get-AzureRMHelpers.ps1. Increments $Global:AzCallCount so the crawler can report round-trips.
+function Invoke-ARGRequestRaw {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Body, [int]$MaxRetries = 5)
+    $uri = 'https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01'
+    $attempt = 0
+    while ($true) {
+        $attempt++
+        Update-ARMTokenIfNeeded
+        $Global:AzCallCount = [int]$Global:AzCallCount + 1
+        try {
+            $headers = @{ Authorization = "Bearer $Global:AccessToken"; 'Content-Type' = 'application/json' }
+            $respHeaders = $null
+            $resp = Invoke-RestMethod -Uri $uri -Method Post -Body $Body -TimeoutSec 120 `
+                -Headers $headers -ResponseHeadersVariable respHeaders
+            # Proactively back off when the per-user quota is exhausted, before ARG returns a 429.
+            $remaining = 0
+            try { $remaining = [int]($respHeaders['x-ms-user-quota-remaining'] | Select-Object -First 1) } catch {}
+            if ($remaining -le 0) {
+                $resetSpan = $null
+                try { $resetSpan = [TimeSpan]::Parse(($respHeaders['x-ms-user-quota-resets-after'] | Select-Object -First 1)) } catch {}
+                $wait = if ($resetSpan) { [Math]::Ceiling($resetSpan.TotalSeconds) } else { 5 }
+                Write-Host "    ARG quota exhausted: pausing ${wait}s" -ForegroundColor DarkYellow
+                Start-Sleep -Seconds $wait
+            }
+            return $resp
+        } catch {
+            $status = $null
+            try { $status = [int]$_.Exception.Response.StatusCode } catch {}
+            $transient = ($status -eq 429) -or ($status -ge 500 -and $status -lt 600) -or (-not $status)
+            if ($transient -and $attempt -le $MaxRetries) {
+                $retryAfter = 0
+                try { $retryAfter = [int]($_.Exception.Response.Headers['Retry-After']) } catch {}
+                $wait = if ($retryAfter -gt 0) { $retryAfter } else { [Math]::Min(60, [int][Math]::Pow(2, $attempt)) }
+                Write-Host "    ARG ${status}: retry $attempt/$MaxRetries in ${wait}s" -ForegroundColor DarkYellow
+                Start-Sleep -Seconds $wait
+                continue
+            }
+            throw
+        }
+    }
+}
+
+#endregion Core query
+
+#region Typed reads
+
+# All resource groups across the given subscriptions. Shaped like the ARM `/resourcegroups` list
+# items the crawler consumes: `.id` (full ARM path, lower-cased by ARG), `.name`, `.subscriptionId`.
+function Get-ARGResourceGroups {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string[]]$SubscriptionIds)
+    $q = @'
+resourcecontainers
+| where type =~ 'microsoft.resources/subscriptions/resourcegroups'
+| project id, name, subscriptionId
+'@
+    return Invoke-ARGQuery -Query $q -SubscriptionIds $SubscriptionIds
+}
+
+# All resources across the given subscriptions, with the governance attributes the crawler lifts
+# (location, tags, managed identity). NOTE: ARG returns `identity` natively, where the ARM
+# `/resources` list omits it unless $expand=identity — so ARG may legitimately surface MORE
+# managedIdentity attributes than the REST path. That is an improvement, not a parity defect.
+function Get-ARGResources {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string[]]$SubscriptionIds)
+    $q = @'
+resources
+| project id, name, type, location, tags, identity, resourceGroup, subscriptionId
+'@
+    return Invoke-ARGQuery -Query $q -SubscriptionIds $SubscriptionIds
+}
+
+# All role definitions visible to the given subscriptions. Shaped like ARM roleDefinition objects:
+# `.name` (the role's GUID), `.properties.roleName`, `.properties.type`, `.properties.permissions[]`.
+function Get-ARGRoleDefinitions {
+    [CmdletBinding()]
+    param([string[]]$SubscriptionIds = @(), [string[]]$ManagementGroups = @())
+    $q = @'
+authorizationresources
+| where type =~ 'microsoft.authorization/roledefinitions'
+| project name, properties
+'@
+    # Built-in role definitions are a tenant catalog that a subscription-scoped query does not surface;
+    # scope by the management group (with AtScopeAndAbove to reach the tenant root) to get them.
+    if ($ManagementGroups.Count -gt 0) {
+        return Invoke-ARGQuery -Query $q -ManagementGroups $ManagementGroups -ScopeFilter 'AtScopeAndAbove'
+    }
+    return Invoke-ARGQuery -Query $q -SubscriptionIds $SubscriptionIds -ScopeFilter 'AtScopeAndAbove'
+}
+
+# All role assignments at or above/below the given subscriptions. Shaped like ARM roleAssignment
+# objects: `.name` (assignment GUID), `.properties.scope/principalId/principalType/roleDefinitionId/
+# condition/conditionVersion/createdOn/createdBy`. AtScopeAboveAndBelow is required to return
+# management-group / tenant-root declared assignments (the REST path gets these implicitly because
+# its per-subscription list includes inherited-from-above rows).
+function Get-ARGRoleAssignments {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string[]]$SubscriptionIds)
+    $q = @'
+authorizationresources
+| where type =~ 'microsoft.authorization/roleassignments'
+| project name, properties
+'@
+    return Invoke-ARGQuery -Query $q -SubscriptionIds $SubscriptionIds -ScopeFilter 'AtScopeAboveAndBelow'
+}
+
+# Map of subscriptionId → ordered management-group ancestor ids (nearest parent first, tenant root
+# last). Lets the crawler rebuild the management-group → subscription `Contains` edges that the REST
+# path derives implicitly from its per-subscription assignment lists. Subscriptions with no MG
+# ancestry (or where the chain is not exposed) map to an empty array.
+function Get-ARGSubscriptionMgChains {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string[]]$SubscriptionIds)
+    $q = @'
+resourcecontainers
+| where type =~ 'microsoft.resources/subscriptions'
+| project subscriptionId, chain = properties.managementGroupAncestorsChain
+'@
+    $rows = Invoke-ARGQuery -Query $q -SubscriptionIds $SubscriptionIds
+    $map = @{}
+    foreach ($r in $rows) {
+        $ids = [System.Collections.Generic.List[string]]::new()
+        foreach ($mg in @($r.chain)) {
+            if ($mg.name) { $ids.Add([string]$mg.name) }
+        }
+        $map[[string]$r.subscriptionId] = $ids.ToArray()
+    }
+    return $map
+}
+
+#endregion Typed reads

--- a/tools/crawlers/azure-rm/Get-AzureRMHelpers.ps1
+++ b/tools/crawlers/azure-rm/Get-AzureRMHelpers.ps1
@@ -63,6 +63,7 @@ function Invoke-ARMRequestRaw {
     while ($true) {
         $attempt++
         Update-ARMTokenIfNeeded
+        $Global:AzCallCount = [int]$Global:AzCallCount + 1
         try {
             return Invoke-RestMethod -Uri $Uri -Method Get -TimeoutSec 120 `
                 -Headers @{ Authorization = "Bearer $Global:AccessToken" }

--- a/tools/crawlers/azure-rm/Start-AzureRMCrawler.ps1
+++ b/tools/crawlers/azure-rm/Start-AzureRMCrawler.ps1
@@ -34,17 +34,20 @@ $OnlyEntraPrincipals  = if ($null -ne $Cfg.onlyEntraPrincipals) { [bool]$Cfg.onl
 $SubscriptionFilter   = if ($Cfg.subscriptionIds) { @($Cfg.subscriptionIds) } else { @() }
 $ManagementGroupId    = if ($Cfg.managementGroupId) { [string]$Cfg.managementGroupId } else { $null }
 
+# Round-trip counter (bumped by the request helpers) for the per-phase timing report.
+$Global:AzCallCount = 0
+
 # ─── Shared helpers ──────────────────────────────────────────────
 . (Join-Path $PSScriptRoot '..' 'shared' 'Invoke-CrawlerIngest.ps1')
 . (Join-Path $PSScriptRoot '..' 'shared' 'Get-CapabilityId.ps1')
-# Get-AzureRMHelpers.ps1 is dot-sourced automatically by the dispatcher (same-folder library).
+# Get-AzureRMHelpers.ps1 (ARM auth + enumeration) and Get-AzureRGHelpers.ps1 (Resource Graph reads)
+# are dot-sourced automatically by the dispatcher (same-folder libraries).
 
-# ARM api-versions (pinned).
-$API_SUBS    = '2022-12-01'
-$API_RG      = '2021-04-01'
-$API_RES     = '2021-04-01'
-$API_MG      = '2021-04-01'
-$API_AUTH    = '2022-04-01'   # roleAssignments + roleDefinitions
+# ARM api-versions (pinned). Subscriptions and the management-group hierarchy are still read over the
+# ARM REST API — single enumeration calls, not per-subscription fan-out. Resource groups, resources,
+# role definitions and role assignments all come from Azure Resource Graph.
+$API_SUBS = '2022-12-01'
+$API_MG   = '2021-04-01'
 
 # A scope's stable Identity Atlas node id = deterministic UUID of its ARM path.
 # ARM resource IDs can legitimately contain '|' (e.g. some Insights / alert resources), which
@@ -53,7 +56,13 @@ $API_AUTH    = '2022-04-01'   # roleAssignments + roleDefinitions
 # is encoded — the raw armPath / externalId is stored unchanged. Subscription/RG/MG paths never
 # contain either character, so their ids are unaffected.
 function Get-ScopeNodeId { param([string]$ArmScopePath)
-    $safe = $ArmScopePath -replace '%', '%25' -replace '\|', '%7C'
+    # Lower-case the path before hashing so the node id is stable regardless of casing. Azure Resource
+    # Graph lower-cases every id, and Azure itself is inconsistent about ARM-path casing (a role
+    # assignment's properties.scope may read ".../resourceGroups/Foo" while a resource id reads
+    # ".../resourcegroups/foo"). Canonicalising here means the same physical scope never splits into
+    # two nodes because of casing. Only the hash input is canonicalised; the raw armPath / externalId
+    # is still stored as received.
+    $safe = $ArmScopePath.ToLowerInvariant() -replace '%', '%25' -replace '\|', '%7C'
     Get-CapabilityId -TargetNodeId $safe -CapabilityId 'azure-scope'
 }
 
@@ -72,7 +81,14 @@ function Send-IngestBatch {
     Invoke-IngestAPI -Endpoint $Endpoint -Body $body
 }
 
-Write-Host "`n=== Azure RM Crawler ===" -ForegroundColor Cyan
+# Per-phase wall-clock + round-trip report — the call counts make the cross-subscription savings of
+# the Resource Graph queries visible (a few paged queries instead of per-subscription fan-out).
+function Write-PhaseTiming {
+    param([string]$Name, [System.Diagnostics.Stopwatch]$Sw, [int]$CallsBefore)
+    Write-Host ("  [timing] {0}: {1:n1}s, {2} Azure call(s)" -f $Name, $Sw.Elapsed.TotalSeconds, ($Global:AzCallCount - $CallsBefore)) -ForegroundColor DarkGray
+}
+
+Write-Host "`n=== Azure RM Crawler (Resource Graph) ===" -ForegroundColor Cyan
 
 # ─── Connectivity + auth ─────────────────────────────────────────
 Update-CrawlerProgress -Step 'Authenticating to Azure RM' -Pct 2
@@ -116,7 +132,7 @@ function Get-AzureResourceType { param([string]$ArmPath)
     return ''
 }
 
-# Governance/filtering attributes lifted off an ARM resource object (from the /resources list):
+# Governance/filtering attributes lifted off a resource object (from the Resource Graph resources query):
 #   azureLocation              – region, e.g. "westeurope"  -> "access to any resource in West Europe"
 #   tag.<Key>                  – each portal tag as its own key -> "access to anything tagged Prio High"
 #   managedIdentity            – identity type (SystemAssigned/UserAssigned) when the resource has one
@@ -164,30 +180,58 @@ function Add-Scope {
 
 # ─── Phase: Scope discovery ──────────────────────────────────────
 Update-CrawlerProgress -Step 'Discovering scopes' -Pct 8
+$swDisc = [System.Diagnostics.Stopwatch]::StartNew()
+$callsDisc = $Global:AzCallCount
 
-# Subscriptions (auto-discover all accessible, or the configured subset).
+# Subscriptions (auto-discover all accessible, or the configured subset). Always one ARM list call —
+# subscription enumeration is not the fan-out problem, and its ids scope the ARG queries below.
 $subs = Invoke-ARMList -Path "/subscriptions?api-version=$API_SUBS"
 if ($SubscriptionFilter.Count -gt 0) {
     $subs = @($subs | Where-Object { $SubscriptionFilter -contains $_.subscriptionId })
 }
+$subIds = @($subs | ForEach-Object { [string]$_.subscriptionId })
 Write-Host "  $($subs.Count) subscription(s)" -ForegroundColor Gray
+
+# Pull every resource group (and, if requested, every resource) for the whole tenant up front in a
+# handful of paged Resource Graph queries, then index them by parent so the loop below does no
+# per-subscription / per-resource-group network calls.
+$argRgsBySub = @{}
+$argResByRg  = @{}
+if ($subIds.Count -gt 0) {
+    foreach ($rg in (Get-ARGResourceGroups -SubscriptionIds $subIds)) {
+        $k = [string]$rg.subscriptionId
+        if (-not $argRgsBySub.ContainsKey($k)) { $argRgsBySub[$k] = [System.Collections.Generic.List[object]]::new() }
+        $argRgsBySub[$k].Add($rg)
+    }
+    if ($IncludeResourceLevel) {
+        foreach ($r in (Get-ARGResources -SubscriptionIds $subIds)) {
+            # Index by the resource's parent resource-group path (lower-cased — Resource Graph ids are
+            # already lower-case, and Get-ScopeNodeId canonicalises the same way).
+            $rgKey = "/subscriptions/$($r.subscriptionId)/resourcegroups/$($r.resourceGroup)".ToLowerInvariant()
+            if (-not $argResByRg.ContainsKey($rgKey)) { $argResByRg[$rgKey] = [System.Collections.Generic.List[object]]::new() }
+            $argResByRg[$rgKey].Add($r)
+        }
+    }
+}
 
 foreach ($sub in $subs) {
     $subPath = "/subscriptions/$($sub.subscriptionId)"
     Add-Scope -ArmPath $subPath -DisplayName $sub.displayName -ResourceType 'AzureSubscription' -ParentArmPath $null -ScopeKind 'Subscription' | Out-Null
 
-    # Resource groups.
-    $rgs = Invoke-ARMList -Path "$subPath/resourcegroups?api-version=$API_RG"
+    $rgs = if ($argRgsBySub.ContainsKey([string]$sub.subscriptionId)) { $argRgsBySub[[string]$sub.subscriptionId] } else { @() }
     foreach ($rg in $rgs) {
         Add-Scope -ArmPath $rg.id -DisplayName $rg.name -ResourceType 'AzureResourceGroup' -ParentArmPath $subPath -ScopeKind 'ResourceGroup' | Out-Null
         if ($IncludeResourceLevel) {
-            $resources = Invoke-ARMList -Path "$($rg.id)/resources?api-version=$API_RES"
+            $rgKey = ([string]$rg.id).ToLowerInvariant()
+            $resources = if ($argResByRg.ContainsKey($rgKey)) { $argResByRg[$rgKey] } else { @() }
             foreach ($r in $resources) {
                 Add-Scope -ArmPath $r.id -DisplayName $r.name -ResourceType 'AzureResource' -ParentArmPath $rg.id -ScopeKind 'Resource' -ExtraExt (Get-ResourceAttributes -Resource $r) | Out-Null
             }
         }
     }
 }
+$swDisc.Stop()
+Write-PhaseTiming -Name 'scope discovery' -Sw $swDisc -CallsBefore $callsDisc
 
 # Management groups (only when explicitly configured — walks the tree beneath it).
 if ($ManagementGroupId) {
@@ -221,28 +265,34 @@ Write-Host "  $($ScopeResources.Count) scope nodes, $($ContainsEdges.Count) Cont
 
 # ─── Phase: Role definitions ─────────────────────────────────────
 Update-CrawlerProgress -Step 'Fetching role definitions' -Pct 35
-# Role definitions are visible at any subscription scope; fetch once per subscription and merge.
+$swDefs = [System.Diagnostics.Stopwatch]::StartNew()
+$callsDefs = $Global:AzCallCount
 $roleDefs = @{}   # roleDefId (GUID) → @{ name; isCustom; plane }
-foreach ($sub in $subs) {
-    $defs = Invoke-ARMList -Path "/subscriptions/$($sub.subscriptionId)/providers/Microsoft.Authorization/roleDefinitions?api-version=$API_AUTH"
-    foreach ($d in $defs) {
-        $guid = $d.name   # the roleDefinition's GUID
-        if (-not $roleDefs.ContainsKey($guid)) {
-            $isCustom = ($d.properties.type -eq 'CustomRole')
-            if ($isCustom -and -not $IncludeCustomRoles) { continue }
-            # Plane classification: control-plane `actions` (manage the resource) vs
-            # data-plane `dataActions` (read/write the data inside it). Owner/Contributor
-            # are control; "Storage Blob Data Reader", "Key Vault Secrets User" etc. are
-            # data. A role can grant both. Lets you ask "who has any data-plane access?".
-            $ctlActions  = @($d.properties.permissions | ForEach-Object { $_.actions }     | Where-Object { $_ })
-            $dataActions = @($d.properties.permissions | ForEach-Object { $_.dataActions } | Where-Object { $_ })
-            $plane = if ($dataActions.Count -gt 0 -and $ctlActions.Count -gt 0) { 'both' }
-                     elseif ($dataActions.Count -gt 0) { 'data' } else { 'control' }
-            $roleDefs[$guid] = @{ name = $d.properties.roleName; isCustom = $isCustom; plane = $plane }
-        }
+
+# Resource Graph returns every visible role definition (built-in catalog included, via AtScopeAndAbove)
+# in one paged query. Deduped below by GUID.
+$allDefs = if ($ManagementGroupId) { Get-ARGRoleDefinitions -ManagementGroups @($ManagementGroupId) }
+           else { Get-ARGRoleDefinitions -SubscriptionIds $subIds }
+
+foreach ($d in $allDefs) {
+    $guid = $d.name   # the roleDefinition's GUID
+    if (-not $roleDefs.ContainsKey($guid)) {
+        $isCustom = ($d.properties.type -eq 'CustomRole')
+        if ($isCustom -and -not $IncludeCustomRoles) { continue }
+        # Plane classification: control-plane `actions` (manage the resource) vs
+        # data-plane `dataActions` (read/write the data inside it). Owner/Contributor
+        # are control; "Storage Blob Data Reader", "Key Vault Secrets User" etc. are
+        # data. A role can grant both. Lets you ask "who has any data-plane access?".
+        $ctlActions  = @($d.properties.permissions | ForEach-Object { $_.actions }     | Where-Object { $_ })
+        $dataActions = @($d.properties.permissions | ForEach-Object { $_.dataActions } | Where-Object { $_ })
+        $plane = if ($dataActions.Count -gt 0 -and $ctlActions.Count -gt 0) { 'both' }
+                 elseif ($dataActions.Count -gt 0) { 'data' } else { 'control' }
+        $roleDefs[$guid] = @{ name = $d.properties.roleName; isCustom = $isCustom; plane = $plane }
     }
 }
+$swDefs.Stop()
 Write-Host "  $($roleDefs.Count) role definitions" -ForegroundColor Gray
+Write-PhaseTiming -Name 'role definitions' -Sw $swDefs -CallsBefore $callsDefs
 
 # ─── Phase: Role assignments ─────────────────────────────────────
 Update-CrawlerProgress -Step 'Fetching role assignments' -Pct 55
@@ -329,15 +379,51 @@ function Ensure-AssignmentScope { param([string]$ScopePath, [string]$OwningSubPa
     return Get-ScopeNodeId -ArmScopePath $ScopePath
 }
 
-# One un-filtered roleAssignments list per subscription returns every assignment in that
-# subscription's subtree PLUS those inherited from above (management groups / tenant root). We store
-# each at its OWN declared scope (properties.scope) and let the engine compute inheritance — never
-# materialising an inherited assignment as Direct on the scopes below it. (atScope() is NOT used: it
-# means "effective at this scope", i.e. this scope AND everything inherited from above.)
+# Every role assignment is stored at its OWN declared scope (properties.scope); the engine computes
+# inheritance on demand from the Contains hierarchy — we never materialise an inherited assignment as
+# Direct on the scopes below it.
+$swAssign = [System.Diagnostics.Stopwatch]::StartNew()
+$callsAssign = $Global:AzCallCount
+
+# Fetch every assignment once (AtScopeAboveAndBelow, so management-group / tenant-root rows come too),
+# then rebuild each subscription's "visible set": an assignment in a subscription's own subtree is seen
+# only by that subscription; one declared at a management-group ancestor is seen by every subscription
+# beneath that MG; one at the tenant root ('/') by all. Driving the per-subscription loop below this
+# way produces the scope nodes, grants AND the implicit management-group → subscription Contains edges.
+$argAssignBySub = @{}
+if ($subIds.Count -gt 0) {
+    $allAssign = Get-ARGRoleAssignments -SubscriptionIds $subIds
+    $mgChains  = Get-ARGSubscriptionMgChains -SubscriptionIds $subIds   # subId → [mg ancestor ids]
+    $subsByMg  = @{}
+    foreach ($sid in $subIds) {
+        foreach ($mg in @($mgChains[$sid])) {
+            $mgKey = ([string]$mg).ToLowerInvariant()
+            if (-not $subsByMg.ContainsKey($mgKey)) { $subsByMg[$mgKey] = [System.Collections.Generic.List[string]]::new() }
+            $subsByMg[$mgKey].Add($sid)
+        }
+    }
+    foreach ($sid in $subIds) { $argAssignBySub[([string]$sid).ToLowerInvariant()] = [System.Collections.Generic.List[object]]::new() }
+    foreach ($a in $allAssign) {
+        $scope = [string]$a.properties.scope
+        if ($scope -match '^/subscriptions/([^/]+)') {
+            $owner = $matches[1].ToLowerInvariant()
+            if ($argAssignBySub.ContainsKey($owner)) { $argAssignBySub[$owner].Add($a) }
+        } elseif ($scope -eq '/') {
+            foreach ($k in $argAssignBySub.Keys) { $argAssignBySub[$k].Add($a) }
+        } elseif ($scope -match '^/providers/[Mm]icrosoft\.[Mm]anagement/managementGroups/([^/]+)') {
+            $mgKey = $matches[1].ToLowerInvariant()
+            if ($subsByMg.ContainsKey($mgKey)) {
+                foreach ($sid in $subsByMg[$mgKey]) { $argAssignBySub[([string]$sid).ToLowerInvariant()].Add($a) }
+            }
+        }
+    }
+}
+
 $assignSeen = [System.Collections.Generic.HashSet[string]]::new()
 foreach ($sub in $subs) {
     $subPath = "/subscriptions/$($sub.subscriptionId)"
-    $assignments = Invoke-ARMList -Path "$subPath/providers/Microsoft.Authorization/roleAssignments?api-version=$API_AUTH"
+    $sk = ([string]$sub.subscriptionId).ToLowerInvariant()
+    $assignments = if ($argAssignBySub.ContainsKey($sk)) { $argAssignBySub[$sk] } else { @() }
     foreach ($a in $assignments) {
         $declaredScope = [string]$a.properties.scope
         if (-not $declaredScope) { continue }
@@ -391,16 +477,23 @@ foreach ($sub in $subs) {
         }
     }
 }
+$swAssign.Stop()
 Write-Host "  $($RoleResources.Count) role-at-scope resources, $($Grants.Count) assignments" -ForegroundColor Gray
+Write-PhaseTiming -Name 'role assignments' -Sw $swAssign -CallsBefore $callsAssign
 
-# The assignment phase may have added management-group / resource scope nodes on demand, so dedup and
-# ingest the scope nodes + Contains edges now — before the capability-resources and grants below that
-# reference them. Dedup by primary key — the ingest engine's ON CONFLICT can't touch a row twice.
+# The assignment phase may have added management-group / resource scope nodes on demand, so dedup the
+# scope nodes + Contains edges now — before the capability-resources and grants that reference them.
+# Dedup by primary key — the ingest engine's ON CONFLICT can't touch a row twice.
 $sSeen = [System.Collections.Generic.HashSet[string]]::new()
 $ScopeResources = @($ScopeResources | Where-Object { $sSeen.Add([string]$_.id) })
 $eSeen = [System.Collections.Generic.HashSet[string]]::new()
 $ContainsEdges = @($ContainsEdges | Where-Object { $eSeen.Add("$($_.parentResourceId)|$($_.childResourceId)|$($_.relationshipType)") })
+# Dedup grants on their PK (resourceId, principalId, assignmentType) — Azure can declare the same
+# principal+role at one scope more than once, which would touch the same upsert row twice.
+$gSeen = [System.Collections.Generic.HashSet[string]]::new()
+$Grants = @($Grants | Where-Object { $gSeen.Add("$($_.resourceId)|$($_.principalId)|$($_.assignmentType)") })
 Write-Host "  $($ScopeResources.Count) scope nodes, $($ContainsEdges.Count) Contains edges (final)" -ForegroundColor Gray
+
 Send-IngestBatch -Endpoint 'ingest/resources' -SystemId $SystemId -SyncMode $SyncMode -Scope @{ resourceType = 'AzureScope' } -Records $ScopeResources | Out-Null
 Send-IngestBatch -Endpoint 'ingest/resource-relationships' -SystemId $SystemId -SyncMode $SyncMode -Scope @{ relationshipType = 'Contains' } -Records $ContainsEdges | Out-Null
 
@@ -459,10 +552,6 @@ foreach ($pt in $PrincipalStubs.Keys) {
     }
 }
 Send-IngestBatch -Endpoint 'ingest/resources' -SystemId $SystemId -SyncMode $SyncMode -Scope @{ resourceType = 'AzureRoleAssignment' } -Records $RoleResources | Out-Null
-# Dedup grants on their PK (resourceId, principalId, assignmentType) — Azure can declare the same
-# principal+role at one scope more than once, which would touch the same upsert row twice.
-$gSeen = [System.Collections.Generic.HashSet[string]]::new()
-$Grants = @($Grants | Where-Object { $gSeen.Add("$($_.resourceId)|$($_.principalId)|$($_.assignmentType)") })
 Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $SystemId -SyncMode $SyncMode -Scope @{ assignmentType = 'Direct' } -Records $Grants | Out-Null
 
 # Contexts are NOT emitted here — they are derived data. Context trees (scope hierarchy, resource

--- a/tools/crawlers/azure-rm/Test-AzureRMCrawler.ps1
+++ b/tools/crawlers/azure-rm/Test-AzureRMCrawler.ps1
@@ -32,6 +32,34 @@ foreach ($fn in 'Connect-AzureRM', 'Invoke-ARMList', 'Invoke-ARMGet') {
     Report "function $fn defined" ([bool](Get-Command $fn -ErrorAction SilentlyContinue))
 }
 
+# 2b. Resource Graph helpers dot-source and expose the expected typed reads.
+. (Join-Path $here 'Get-AzureRGHelpers.ps1')
+foreach ($fn in 'Invoke-ARGQuery', 'Get-ARGResourceGroups', 'Get-ARGResources', 'Get-ARGRoleDefinitions', 'Get-ARGRoleAssignments', 'Get-ARGSubscriptionMgChains') {
+    Report "function $fn defined" ([bool](Get-Command $fn -ErrorAction SilentlyContinue))
+}
+
+# 2c. Invoke-ARGQuery paging + request body (network-free — stub the raw POST). Returns two pages
+# (first carries a $skipToken, second clears it) so we assert the loop follows the token, concatenates
+# rows, and sends a well-formed body (subscriptions scope + objectArray result format).
+$script:argBodies = [System.Collections.Generic.List[string]]::new()
+function Invoke-ARGRequestRaw { param([string]$Body, [int]$MaxRetries = 5)
+    $script:argBodies.Add($Body)
+    if ($script:argBodies.Count -eq 1) {
+        return [pscustomobject]@{ data = @([pscustomobject]@{ id = 'a' }); '$skipToken' = 'TOK'; count = 1; totalRecords = 2 }
+    }
+    return [pscustomobject]@{ data = @([pscustomobject]@{ id = 'b' }); '$skipToken' = $null; count = 1; totalRecords = 2 }
+}
+$argRows = Invoke-ARGQuery -Query 'resources | project id' -SubscriptionIds @('sub-1')
+Report 'ARG query concatenates all pages' (@($argRows).Count -eq 2)
+Report 'ARG query follows $skipToken (2 requests)' ($script:argBodies.Count -eq 2)
+$argBody1 = $script:argBodies[0] | ConvertFrom-Json
+Report 'ARG body scopes by subscriptions' (@($argBody1.subscriptions) -contains 'sub-1')
+Report 'ARG body requests objectArray' ($argBody1.options.resultFormat -eq 'objectArray')
+Report 'ARG page 2 carries the skipToken' ((($script:argBodies[1] | ConvertFrom-Json).options.'$skipToken') -eq 'TOK')
+Get-ARGRoleDefinitions -SubscriptionIds @('sub-1') | Out-Null
+$argDefBody = $script:argBodies[-1] | ConvertFrom-Json
+Report 'ARG role-definitions query uses AtScopeAndAbove' ($argDefBody.options.authorizationScopeFilter -eq 'AtScopeAndAbove')
+
 # 3. Deterministic capability/scope ids — shared with the engine (must match across runs).
 . (Join-Path $here '..' 'shared' 'Get-CapabilityId.ps1')
 $id1 = Get-CapabilityId -TargetNodeId '/subscriptions/abc' -CapabilityId 'azure-scope'


### PR DESCRIPTION
Switches the Azure RM crawler from per-subscription ARM list calls to **Azure Resource Graph** for resource groups, resources, role definitions and role assignments — a handful of paged queries across every subscription at once instead of thousands of sequential round-trips, so it scales to tenants with hundreds of subscriptions.

Rebased onto current `main`, so this is now an **ARG-only diff** (6 files) on top of the existing crawler — it preserves main's orphan-principal handling, wizard option, and context plugins untouched.

## Changes
- New `Get-AzureRGHelpers.ps1`: ARG POST + `$skipToken` paging, 429/quota backoff, typed reads returning ARM-shaped rows so the mapping code is transport-agnostic.
- `Start-AzureRMCrawler.ps1`: the three data-fetch phases now read from Resource Graph; per-phase timing/round-trip counts added; scope node ids canonicalised to lower-case so casing never splits a scope.
- Subscriptions and the management-group hierarchy are still enumerated over the ARM REST API (single calls, not fan-out); auth unchanged.
- Role assignments use `authorizationScopeFilter=AtScopeAboveAndBelow` (MG/tenant-root rows included); the built-in role-definition catalog uses `AtScopeAndAbove`.
- Dispatcher no longer dot-sources `dev/` scripts at runtime (matches the documented contract).

## Validation
Verified on a live tenant that ARG output is **byte-for-byte identical** to the previous per-subscription REST path — scope nodes, `Contains` edges, role-at-scope resources, grants, and principal stubs, including ABAC condition/provenance and plane classification. The rebased version was then re-run end-to-end on the same tenant: ARG fetch + main's orphan-handling compose cleanly (same 18 scopes / 17 edges / 17 role resources / 32 assignments, orphan step runs without error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)