### PR TITLE
refactor(crawlers): extract shared WizardShell, credentials, and MappingRows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -586,8 +586,8 @@ jobs:
 
   # ── Stage 10: Code duplication threshold ─────────────────────────────────
   # Fails if overall duplication exceeds the threshold in .jscpd.json.
-  # Threshold starts at 3% (above the 2.95% pre-refactor baseline). Lower it
-  # progressively as the dedup refactor phases land in main.
+  # Threshold is 2% (above the 1.65% baseline after dedup phases 1-4). Lower it
+  # progressively as further dedup refactor phases land in main.
   duplication:
     name: 'Lint: Code duplication (jscpd)'
     needs: [changes]

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 3,
+  "threshold": 2,
   "minLines": 10,
   "minTokens": 50,
   "reporters": ["console"],

--- a/app/ui/CLAUDE.md
+++ b/app/ui/CLAUDE.md
@@ -100,6 +100,9 @@ Before writing any utility function, helper, constant, or component — **search
 - `components/inputs/Combobox.jsx` — free-text input with live-discovery dropdown; props: `value`, `onChange`, `options: string[]`, `defaultOption: {value,label}`, `placeholder`, `className`, `wrapperClassName`
 - `components/inputs/Select.jsx` — styled native `<select>` with `ChevronDown` overlay; props: `value`, `onChange`, `id`, `wrapperClassName`, children as `<option>` elements
 - `components/inputs/ChevronDown.jsx` — shared SVG chevron icon; used by both `Select` and `Combobox`
+- `components/WizardShell.jsx` — shared outer card/header/stepper/error wrapper for all crawler ConfigWizard components; props: `title`, `onCancel`, `steps`, `currentStep`, `onStepClick`, `allowAllSteps`, `error`, `children`
+- `components/MappingRows.jsx` — generic add/remove/update mapping-row grid for ConfigWizard components; props: `rows`, `onAdd`, `onRemove(i)`, `onUpdate(i,key,val)`, `columns: [{key, render(value,onChange)}]`, `headers?`, `addLabel?`, `minRows?`
+- `utils/crawlerCredentials.js` — `canSubmitCredentials(authMethod, fields, isEdit)`, `buildCredentialFields(authMethod, fields)`, `SECRET_PLACEHOLDER`; covers all auth methods used by crawlers
 
 If the same logic already exists in one file and you're about to write it in a second, stop and extract it instead. Three or more files with the same code is a mandatory extraction — don't leave it for later.
 

--- a/app/ui/src/components/MappingRows.jsx
+++ b/app/ui/src/components/MappingRows.jsx
@@ -1,0 +1,53 @@
+// Generic add/remove mapping-row grid for crawler ConfigWizard components.
+// Each column renders its own input via a `render(value, onChange)` callback.
+//
+// Props:
+//   rows      — array of row objects
+//   onAdd     — () => void          — append a blank row
+//   onRemove  — (i) => void         — remove row at index i
+//   onUpdate  — (i, key, val) => void  — update one field of row i
+//   columns   — [{ key, render(value, onChange) }]
+//   headers   — optional string[]   — column header labels
+//   addLabel  — string (default '+ Add row')
+//   minRows   — int (default 1)     — remove button disabled when rows.length ≤ minRows
+export default function MappingRows({
+  rows,
+  onAdd,
+  onRemove,
+  onUpdate,
+  columns,
+  headers,
+  addLabel = '+ Add row',
+  minRows = 1,
+}) {
+  return (
+    <div className="space-y-2">
+      {headers && (
+        <div className="flex gap-2 text-xs font-medium text-gray-500 dark:text-gray-400 pr-6 mb-1">
+          {headers.map((h, i) => <span key={i} className="flex-1 min-w-0">{h}</span>)}
+        </div>
+      )}
+      {rows.map((row, i) => (
+        <div key={i} className="flex gap-2 items-center">
+          {columns.map(col => (
+            <div key={col.key} className="flex-1 min-w-0">
+              {col.render(row[col.key], (val) => onUpdate(i, col.key, val))}
+            </div>
+          ))}
+          <button
+            onClick={() => onRemove(i)}
+            disabled={rows.length <= minRows}
+            className="text-gray-600 dark:text-gray-400 hover:text-red-500 text-lg leading-none disabled:opacity-30"
+            title="Remove">
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={onAdd}
+        className="mt-2 text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 rounded dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300">
+        {addLabel}
+      </button>
+    </div>
+  );
+}

--- a/app/ui/src/components/WizardShell.jsx
+++ b/app/ui/src/components/WizardShell.jsx
@@ -1,0 +1,55 @@
+import Stepper from '@ui/components/Stepper';
+
+/**
+ * Shared outer wrapper for all crawler ConfigWizard components.
+ * Renders the card, title bar + Cancel button, optional Stepper, and error message.
+ * Step content goes in children.
+ *
+ * Props:
+ *   title          — heading text
+ *   onCancel       — Cancel button handler
+ *   cancelDisabled — optional: disables the Cancel button (demo's loading state)
+ *   steps          — optional: array passed to Stepper; omit to hide the Stepper row
+ *   currentStep    — current step number for the Stepper
+ *   onStepClick    — optional: step-click handler for the Stepper
+ *   allowAllSteps  — optional: allow clicking any step (used when isEdit=true)
+ *   error          — optional: error string; renders a red alert when set
+ *   children       — step content
+ */
+export default function WizardShell({
+  title,
+  onCancel,
+  cancelDisabled,
+  steps,
+  currentStep,
+  onStepClick,
+  allowAllSteps,
+  error,
+  children,
+}) {
+  return (
+    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+        <button onClick={onCancel} disabled={cancelDisabled}
+          className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">
+          Cancel
+        </button>
+      </div>
+
+      {steps && (
+        <div className="mb-5">
+          <Stepper steps={steps} current={currentStep} onStepClick={onStepClick} allowAll={!!allowAllSteps} />
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {children}
+    </div>
+  );
+}

--- a/app/ui/src/utils/crawlerCredentials.js
+++ b/app/ui/src/utils/crawlerCredentials.js
@@ -1,0 +1,45 @@
+export const SECRET_PLACEHOLDER = '••••••••';
+
+// Supported auth methods across all OData/REST crawlers.
+// Each auth method has a different set of required credential fields.
+// isEdit relaxes the requirement for secret fields (blank = keep stored value).
+export function canSubmitCredentials(authMethod, fields, isEdit) {
+  const {
+    username = '', password = '', clientId = '', clientSecret = '',
+    tokenEndpoint = '', apiToken = '', cookieString = '',
+  } = fields;
+  if (authMethod === 'FormCookie' || authMethod === 'BasicAuth')
+    return !!username.trim() && !!(password.trim() || isEdit);
+  if (authMethod === 'OAuth2CC')
+    return !!tokenEndpoint.trim() && !!clientId.trim() && !!(clientSecret.trim() || isEdit);
+  if (authMethod === 'OAuth2ROPC')
+    return !!tokenEndpoint.trim() && !!clientId.trim() && !!(clientSecret.trim() || isEdit)
+      && !!username.trim() && !!(password.trim() || isEdit);
+  if (authMethod === 'ApiToken')    return !!(apiToken.trim() || isEdit);
+  if (authMethod === 'CookieString') return !!(cookieString.trim() || isEdit);
+  return true;
+}
+
+// Builds the credential payload from the active auth method's fields.
+// Only includes fields that have a value — blank means "keep the existing
+// stored value" on edit, and is unreachable on create because
+// canSubmitCredentials already requires it there.
+export function buildCredentialFields(authMethod, fields) {
+  const {
+    username = '', password = '', clientId = '', clientSecret = '',
+    tokenEndpoint = '', apiToken = '', cookieString = '',
+  } = fields;
+  const out = {};
+  if (authMethod === 'FormCookie' || authMethod === 'BasicAuth' || authMethod === 'OAuth2ROPC') {
+    out.username = username.trim();
+    if (password.trim()) out.password = password.trim();
+  }
+  if (authMethod === 'OAuth2CC' || authMethod === 'OAuth2ROPC') {
+    out.tokenEndpoint = tokenEndpoint.trim();
+    out.clientId = clientId.trim();
+    if (clientSecret.trim()) out.clientSecret = clientSecret.trim();
+  }
+  if (authMethod === 'ApiToken' && apiToken.trim()) out.apiToken = apiToken.trim();
+  if (authMethod === 'CookieString' && cookieString.trim()) out.cookieString = cookieString.trim();
+  return out;
+}

--- a/changes/dedup-crawler-wizards.md
+++ b/changes/dedup-crawler-wizards.md
@@ -1,3 +1,4 @@
 - Extracted shared `WizardShell` component from all 7 crawler ConfigWizard files, eliminating repeated card/header/stepper/error JSX
 - Extracted shared `canSubmitCredentials` and `buildCredentialFields` utilities into `crawlerCredentials.js`, covering all auth methods (FormCookie, BasicAuth, OAuth2CC, OAuth2ROPC, ApiToken, CookieString)
 - Extracted shared `MappingRows` component for the add/remove mapping-row grids used by the Omada and midPoint wizards
+- Lowered the jscpd duplication gate threshold from 3% to 2%, locking in the JS/JSX reduction (1.65% overall after this refactor phase)

--- a/changes/dedup-crawler-wizards.md
+++ b/changes/dedup-crawler-wizards.md
@@ -1,0 +1,3 @@
+- Extracted shared `WizardShell` component from all 7 crawler ConfigWizard files, eliminating repeated card/header/stepper/error JSX
+- Extracted shared `canSubmitCredentials` and `buildCredentialFields` utilities into `crawlerCredentials.js`, covering all auth methods (FormCookie, BasicAuth, OAuth2CC, OAuth2ROPC, ApiToken, CookieString)
+- Extracted shared `MappingRows` component for the add/remove mapping-row grids used by the Omada and midPoint wizards

--- a/tools/crawlers/azure-rm/ConfigWizard.jsx
+++ b/tools/crawlers/azure-rm/ConfigWizard.jsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import ScheduleEditor from '@ui/components/ScheduleEditor';
-import Stepper from '@ui/components/Stepper';
-
-const SECRET_PLACEHOLDER = '••••••••';
+import WizardShell from '@ui/components/WizardShell';
+import { SECRET_PLACEHOLDER } from '@ui/utils/crawlerCredentials';
 
 // Pure, independently-testable credential gate. The client secret is required on create but
 // optional on edit (blank = keep the stored value). See credentialGating.test.js.
@@ -141,15 +140,15 @@ export default function AzureRmConfigWizard({ onComplete, onCancel, initialConfi
   const inputCls = 'w-full border border-gray-200 rounded px-3 py-2 text-sm bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200';
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold dark:text-white">{isEdit ? 'Edit' : 'Add'} Azure Resource Manager Crawler</h3>
-        <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
-      </div>
-
-      <div className="mb-5"><Stepper steps={steps} current={step} onStepClick={goToStep} allowAll={!!isEdit} /></div>
-
-      {error && <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm dark:bg-red-900/20 dark:border-red-800 dark:text-red-400">{error}</div>}
+    <WizardShell
+      title={`${isEdit ? 'Edit' : 'Add'} Azure Resource Manager Crawler`}
+      onCancel={onCancel}
+      steps={steps}
+      currentStep={step}
+      onStepClick={goToStep}
+      allowAllSteps={isEdit}
+      error={error}
+    >
 
       {/* Step 1 — Service Principal */}
       {step === 1 && (
@@ -318,6 +317,6 @@ export default function AzureRmConfigWizard({ onComplete, onCancel, initialConfi
           </div>
         </div>
       )}
-    </div>
+    </WizardShell>
   );
 }

--- a/tools/crawlers/csv/ConfigWizard.jsx
+++ b/tools/crawlers/csv/ConfigWizard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import Stepper from '@ui/components/Stepper';
+import WizardShell from '@ui/components/WizardShell';
 import CSV_SLOTS from './csv-slots.json';
 
 export const MAX_FILE_BYTES = 1024 * 1024 * 1024; // 1 GB — must match crawlerFiles.js
@@ -168,19 +168,15 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
   ];
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold dark:text-white">{isEdit ? 'Edit CSV Crawler' : 'Add CSV Crawler'}</h3>
-        <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
-      </div>
-
-      <div className="mb-5"><Stepper steps={csvSteps} current={step} onStepClick={setStep} allowAll={!!isEdit} /></div>
-
-      {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700 dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
+    <WizardShell
+      title={isEdit ? 'Edit CSV Crawler' : 'Add CSV Crawler'}
+      onCancel={onCancel}
+      steps={csvSteps}
+      currentStep={step}
+      onStepClick={setStep}
+      allowAllSteps={isEdit}
+      error={error}
+    >
 
       {/* ── Step 1: System info ──────────────────────────────────────────── */}
       {step === 1 && (
@@ -361,6 +357,6 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
           </div>
         </div>
       )}
-    </div>
+    </WizardShell>
   );
 }

--- a/tools/crawlers/custom-connector/ConfigWizard.jsx
+++ b/tools/crawlers/custom-connector/ConfigWizard.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Stepper from '@ui/components/Stepper';
+import WizardShell from '@ui/components/WizardShell';
 import useDocsUrl from '@ui/hooks/useDocsUrl';
 
 export default function ConfigWizard({ onComplete, onCancel, authFetch }) {
@@ -122,17 +122,13 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
   ];
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold dark:text-white">Custom Connector</h3>
-        <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
-      </div>
-
-      <div className="mb-5"><Stepper steps={connectorSteps} current={step} /></div>
-
-      {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">{error}</div>
-      )}
+    <WizardShell
+      title="Custom Connector"
+      onCancel={onCancel}
+      steps={connectorSteps}
+      currentStep={step}
+      error={error}
+    >
 
       {/* Step 1: Name + register */}
       {step === 1 && (
@@ -257,7 +253,7 @@ Invoke-RestMethod -Uri "$api/ingest/principals" -Method Post -Headers $headers -
           </div>
         </div>
       )}
-    </div>
+    </WizardShell>
   );
 }
 

--- a/tools/crawlers/demo/ConfigWizard.jsx
+++ b/tools/crawlers/demo/ConfigWizard.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import WizardShell from '@ui/components/WizardShell';
 
 export default function DemoConfigWizard({ onComplete, onCancel, authFetch }) {
   const [loading, setLoading] = useState(false);
@@ -25,18 +26,7 @@ export default function DemoConfigWizard({ onComplete, onCancel, authFetch }) {
   };
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Load Demo Data</h3>
-        <button
-          onClick={onCancel}
-          disabled={loading}
-          className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200"
-        >
-          Cancel
-        </button>
-      </div>
-
+    <WizardShell title="Load Demo Data" onCancel={onCancel} cancelDisabled={loading} error={error}>
       <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
         Loads a synthetic dataset so you can explore the platform without connecting a live system.
         The import takes approximately 30 seconds.
@@ -51,12 +41,6 @@ export default function DemoConfigWizard({ onComplete, onCancel, authFetch }) {
           <li>Business roles with governed assignments</li>
         </ul>
       </div>
-
-      {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
 
       <div className="flex gap-3">
         <button
@@ -74,6 +58,6 @@ export default function DemoConfigWizard({ onComplete, onCancel, authFetch }) {
           Cancel
         </button>
       </div>
-    </div>
+    </WizardShell>
   );
 }

--- a/tools/crawlers/entra-id/ConfigWizard.jsx
+++ b/tools/crawlers/entra-id/ConfigWizard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import ScheduleEditor from '@ui/components/ScheduleEditor';
-import Stepper from '@ui/components/Stepper';
+import WizardShell from '@ui/components/WizardShell';
 
 // ─── Attribute Picker ───────────────────────────────────────────────────────
 function AttributePicker({ title, available, selected, onChange, coreAttrs = [] }) {
@@ -436,17 +436,15 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
   ];
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold dark:text-white">{isEdit ? 'Edit' : 'Add'} Microsoft Graph Crawler</h3>
-        <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
-      </div>
-
-      <div className="mb-5"><Stepper steps={entraSteps} current={step} onStepClick={setStep} allowAll={!!isEdit} /></div>
-
-      {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm dark:bg-red-900/20 dark:border-red-800 dark:text-red-400">{error}</div>
-      )}
+    <WizardShell
+      title={`${isEdit ? 'Edit' : 'Add'} Microsoft Graph Crawler`}
+      onCancel={onCancel}
+      steps={entraSteps}
+      currentStep={step}
+      onStepClick={setStep}
+      allowAllSteps={isEdit}
+      error={error}
+    >
 
       {/* ─── Step 1: Name + Credentials ─────────────────────────── */}
       {step === 1 && (
@@ -755,6 +753,6 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
           </div>
         </div>
       )}
-    </div>
+    </WizardShell>
   );
 }

--- a/tools/crawlers/midpoint/ConfigWizard.jsx
+++ b/tools/crawlers/midpoint/ConfigWizard.jsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import ScheduleEditor from '@ui/components/ScheduleEditor';
-import Stepper from '@ui/components/Stepper';
+import MappingRows from '@ui/components/MappingRows';
+import WizardShell from '@ui/components/WizardShell';
 import Combobox from '@ui/components/inputs/Combobox';
 import Select from '@ui/components/inputs/Select';
+import { SECRET_PLACEHOLDER, canSubmitCredentials, buildCredentialFields } from '@ui/utils/crawlerCredentials';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-const SECRET_PLACEHOLDER = '••••••••';
 
 const AUTH_METHODS = [
   { id: 'BasicAuth',  label: 'HTTP Basic Auth',           description: 'username + password (Authorization: Basic)' },
@@ -31,40 +31,6 @@ const SYNC_OPTIONS = [
 const RESOURCE_TYPE_OPTIONS  = ['BusinessRole', 'Service', 'Resource', 'Application', 'AppRole', 'Entitlement', 'DelegatedPermission'];
 const PRINCIPAL_TYPE_OPTIONS = ['User', 'ServicePrincipal', 'ManagedIdentity', 'WorkloadIdentity', 'AIAgent', 'ExternalUser', 'SharedMailbox'];
 const FIELD_CLS = 'text-sm border border-gray-300 rounded px-2 py-1 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200';
-
-// ─── Credential validation + payload helpers ───────────────────────────────────
-// Pure functions (no closure over component state) so they're independently
-// unit-testable — see credentialGating.test.js. Each auth method needs a
-// different subset of fields; isEdit relaxes the requirement for secret
-// fields only (blank in edit mode means "keep the stored value").
-
-export function canSubmitCredentials(authMethod, fields, isEdit) {
-  const { username, password, clientId, clientSecret, tokenEndpoint, apiToken } = fields;
-  if (authMethod === 'BasicAuth')  return !!username.trim() && !!(password.trim() || isEdit);
-  if (authMethod === 'ApiToken')   return !!(apiToken.trim() || isEdit);
-  if (authMethod === 'OAuth2CC')   return !!tokenEndpoint.trim() && !!clientId.trim() && !!(clientSecret.trim() || isEdit);
-  if (authMethod === 'OAuth2ROPC') return !!tokenEndpoint.trim() && !!clientId.trim() && !!(clientSecret.trim() || isEdit) && !!username.trim() && !!(password.trim() || isEdit);
-  return true;
-}
-
-// Only includes credential fields that have a value — blank means "keep the
-// existing stored value" on edit, and is unreachable on create because
-// canSubmitCredentials already requires it there.
-export function buildCredentialFields(authMethod, fields) {
-  const { username, password, clientId, clientSecret, tokenEndpoint, apiToken } = fields;
-  const out = {};
-  if (authMethod === 'BasicAuth' || authMethod === 'OAuth2ROPC') {
-    out.username = username.trim();
-    if (password.trim()) out.password = password.trim();
-  }
-  if (authMethod === 'ApiToken' && apiToken.trim()) out.apiToken = apiToken.trim();
-  if (authMethod === 'OAuth2CC' || authMethod === 'OAuth2ROPC') {
-    out.tokenEndpoint = tokenEndpoint.trim();
-    out.clientId = clientId.trim();
-    if (clientSecret.trim()) out.clientSecret = clientSecret.trim();
-  }
-  return out;
-}
 
 // ─── Wizard ───────────────────────────────────────────────────────────────────
 
@@ -207,15 +173,15 @@ export default function MidpointConfigWizard({ onComplete, onCancel, initialConf
   const handleStepClick = (n) => { setStep(n); if (n === 3) fetchDiscovery(); };
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold dark:text-white">{isEdit ? 'Edit' : 'Add'} midPoint Crawler</h3>
-        <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
-      </div>
-
-      <div className="mb-5"><Stepper steps={steps} current={step} onStepClick={handleStepClick} allowAll={!!isEdit} /></div>
-
-      {error && <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm dark:bg-red-900/20 dark:border-red-800 dark:text-red-400">{error}</div>}
+    <WizardShell
+      title={`${isEdit ? 'Edit' : 'Add'} midPoint Crawler`}
+      onCancel={onCancel}
+      steps={steps}
+      currentStep={step}
+      onStepClick={handleStepClick}
+      allowAllSteps={isEdit}
+      error={error}
+    >
 
       {/* Step 1 — Connection */}
       {step === 1 && (
@@ -334,32 +300,36 @@ export default function MidpointConfigWizard({ onComplete, onCancel, initialConf
               Dropdowns are populated live from the midPoint server. Default: every role → BusinessRole.
             </p>
             {discoError && <p className="text-xs text-amber-600 dark:text-amber-400 mb-2">{discoError}</p>}
-            <div className="space-y-2">
-              <div className="grid grid-cols-3 gap-2 text-xs font-medium text-gray-500 dark:text-gray-400 pr-6">
-                <span>Archetype</span><span>Subtype (fallback)</span><span>Identity Atlas type</span>
-              </div>
-              {archetypeMapping.map((m, i) => (
-                <div key={i} className="flex gap-2 items-center">
-                  <Combobox value={m.archetype} onChange={v => upArch(i, 'archetype', v)}
+            <MappingRows
+              rows={archetypeMapping}
+              onAdd={addArch}
+              onRemove={rmArch}
+              onUpdate={upArch}
+              headers={['Archetype', 'Subtype (fallback)', 'Identity Atlas type']}
+              addLabel="+ Add rule"
+              columns={[
+                { key: 'archetype', render: (v, onChange) => (
+                  <Combobox value={v} onChange={onChange}
                     options={(disco?.archetypes || []).map(a => a.name)}
                     defaultOption={{ value: '', label: '(any / catch-all)' }}
                     placeholder="(any / catch-all)"
-                    wrapperClassName="flex-1 min-w-0" className={FIELD_CLS} />
-                  <Combobox value={m.subtype} onChange={v => upArch(i, 'subtype', v)}
+                    className={FIELD_CLS} />
+                )},
+                { key: 'subtype', render: (v, onChange) => (
+                  <Combobox value={v} onChange={onChange}
                     options={disco?.roleSubtypes || []}
                     defaultOption={{ value: '', label: '(none)' }}
                     placeholder="(optional)"
-                    wrapperClassName="flex-1 min-w-0" className={FIELD_CLS} />
-                  <Select value={m.resourceType} onChange={e => upArch(i, 'resourceType', e.target.value)}
-                    wrapperClassName="flex-1 min-w-0" className={FIELD_CLS + ' bg-white'}>
+                    className={FIELD_CLS} />
+                )},
+                { key: 'resourceType', render: (v, onChange) => (
+                  <Select value={v} onChange={e => onChange(e.target.value)}
+                    className={FIELD_CLS + ' bg-white'}>
                     {RESOURCE_TYPE_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
                   </Select>
-                  <button onClick={() => rmArch(i)} disabled={archetypeMapping.length === 1}
-                    className="text-gray-600 dark:text-gray-400 hover:text-red-500 text-lg leading-none disabled:opacity-30" title="Remove">×</button>
-                </div>
-              ))}
-            </div>
-            <button onClick={addArch} className="mt-2 text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 rounded dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300">+ Add rule</button>
+                )},
+              ]}
+            />
           </div>
 
           <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
@@ -371,42 +341,54 @@ export default function MidpointConfigWizard({ onComplete, onCancel, initialConf
                 <div>
                   <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Org → context type</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Map an OrgType subtype to a context type. Blank subtype = catch-all (default OrgUnit).</p>
-                  <div className="grid grid-cols-2 gap-2 text-xs font-medium text-gray-500 dark:text-gray-400 pr-6 mb-1"><span>Org subtype</span><span>Context type</span></div>
-                  {orgMapping.map((m, i) => (
-                    <div key={i} className="flex gap-2 items-center mb-1">
-                      <Combobox value={m.orgSubtype} onChange={v => upOrg(i, 'orgSubtype', v)}
-                        options={disco?.orgSubtypes || []}
-                        defaultOption={{ value: '', label: '(any / catch-all)' }}
-                        placeholder="(any / catch-all)"
-                        wrapperClassName="flex-1 min-w-0" className={FIELD_CLS} />
-                      <input value={m.contextType} onChange={e => upOrg(i, 'contextType', e.target.value)} placeholder="OrgUnit"
-                        className={'flex-1 min-w-0 ' + FIELD_CLS} />
-                      <button onClick={() => rmOrg(i)} disabled={orgMapping.length === 1}
-                        className="text-gray-600 dark:text-gray-400 hover:text-red-500 text-lg leading-none disabled:opacity-30" title="Remove">×</button>
-                    </div>
-                  ))}
-                  <button onClick={addOrg} className="mt-1 text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 rounded dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300">+ Add rule</button>
+                  <MappingRows
+                    rows={orgMapping}
+                    onAdd={addOrg}
+                    onRemove={rmOrg}
+                    onUpdate={upOrg}
+                    headers={['Org subtype', 'Context type']}
+                    addLabel="+ Add rule"
+                    columns={[
+                      { key: 'orgSubtype', render: (v, onChange) => (
+                        <Combobox value={v} onChange={onChange}
+                          options={disco?.orgSubtypes || []}
+                          defaultOption={{ value: '', label: '(any / catch-all)' }}
+                          placeholder="(any / catch-all)"
+                          className={FIELD_CLS} />
+                      )},
+                      { key: 'contextType', render: (v, onChange) => (
+                        <input value={v} onChange={e => onChange(e.target.value)} placeholder="OrgUnit"
+                          className={'w-full ' + FIELD_CLS} />
+                      )},
+                    ]}
+                  />
                 </div>
                 <div>
                   <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">User → principal type</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Map a UserType subtype/employeeType to a principal type. Blank = catch-all (default User).</p>
-                  <div className="grid grid-cols-2 gap-2 text-xs font-medium text-gray-500 dark:text-gray-400 pr-6 mb-1"><span>User subtype</span><span>Principal type</span></div>
-                  {idMapping.map((m, i) => (
-                    <div key={i} className="flex gap-2 items-center mb-1">
-                      <Combobox value={m.userType} onChange={v => upId(i, 'userType', v)}
-                        options={disco?.userTypes || []}
-                        defaultOption={{ value: '', label: '(any / catch-all)' }}
-                        placeholder="(any / catch-all)"
-                        wrapperClassName="flex-1 min-w-0" className={FIELD_CLS} />
-                      <Select value={m.principalType} onChange={e => upId(i, 'principalType', e.target.value)}
-                        wrapperClassName="flex-1 min-w-0" className={FIELD_CLS + ' bg-white'}>
-                        {PRINCIPAL_TYPE_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
-                      </Select>
-                      <button onClick={() => rmId(i)} disabled={idMapping.length === 1}
-                        className="text-gray-600 dark:text-gray-400 hover:text-red-500 text-lg leading-none disabled:opacity-30" title="Remove">×</button>
-                    </div>
-                  ))}
-                  <button onClick={addId} className="mt-1 text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 rounded dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300">+ Add rule</button>
+                  <MappingRows
+                    rows={idMapping}
+                    onAdd={addId}
+                    onRemove={rmId}
+                    onUpdate={upId}
+                    headers={['User subtype', 'Principal type']}
+                    addLabel="+ Add rule"
+                    columns={[
+                      { key: 'userType', render: (v, onChange) => (
+                        <Combobox value={v} onChange={onChange}
+                          options={disco?.userTypes || []}
+                          defaultOption={{ value: '', label: '(any / catch-all)' }}
+                          placeholder="(any / catch-all)"
+                          className={FIELD_CLS} />
+                      )},
+                      { key: 'principalType', render: (v, onChange) => (
+                        <Select value={v} onChange={e => onChange(e.target.value)}
+                          className={FIELD_CLS + ' bg-white'}>
+                          {PRINCIPAL_TYPE_OPTIONS.map(o => <option key={o} value={o}>{o}</option>)}
+                        </Select>
+                      )},
+                    ]}
+                  />
                 </div>
               </div>
             )}
@@ -446,6 +428,6 @@ export default function MidpointConfigWizard({ onComplete, onCancel, initialConf
           </div>
         </div>
       )}
-    </div>
+    </WizardShell>
   );
 }

--- a/tools/crawlers/midpoint/credentialGating.test.js
+++ b/tools/crawlers/midpoint/credentialGating.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canSubmitCredentials, buildCredentialFields } from './ConfigWizard.jsx';
+import { canSubmitCredentials, buildCredentialFields } from '@ui/utils/crawlerCredentials';
 
 const blank = { username: '', password: '', clientId: '', clientSecret: '', tokenEndpoint: '', apiToken: '' };
 

--- a/tools/crawlers/omada/ConfigWizard.jsx
+++ b/tools/crawlers/omada/ConfigWizard.jsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import ScheduleEditor from '@ui/components/ScheduleEditor';
-import Stepper from '@ui/components/Stepper';
+import MappingRows from '@ui/components/MappingRows';
+import WizardShell from '@ui/components/WizardShell';
+import { SECRET_PLACEHOLDER, canSubmitCredentials, buildCredentialFields } from '@ui/utils/crawlerCredentials';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-const SECRET_PLACEHOLDER = '••••••••';
 
 const AUTH_METHODS = [
   { id: 'FormCookie',   label: 'Form / Cookie',              description: 'POST username+password to /api/authenticate (on-premise)' },
@@ -32,57 +32,7 @@ const SYNC_OPTIONS = [
 ];
 
 const RESOURCE_TYPE_OPTIONS = ['BusinessRole', 'Resource', 'AppRole', 'DelegatedPermission'];
-
-// ─── Credential validation + payload helpers ───────────────────────────────────
-// Pure functions (no closure over component state) so they're independently
-// unit-testable — see credentialGating.test.js. Each auth method needs a
-// different subset of fields; isEdit relaxes the requirement for secret
-// fields only (blank in edit mode means "keep the stored value").
-
-export function canSubmitCredentials(authMethod, fields, isEdit) {
-  const { username, password, clientId, clientSecret, tokenEndpoint, apiToken, cookieString } = fields;
-  if (authMethod === 'FormCookie') {
-    return !!username.trim() && !!(password.trim() || isEdit);
-  }
-  if (authMethod === 'OAuth2CC') {
-    return !!tokenEndpoint.trim() && !!clientId.trim() && !!(clientSecret.trim() || isEdit);
-  }
-  if (authMethod === 'OAuth2ROPC') {
-    return !!tokenEndpoint.trim() && !!clientId.trim() && !!(clientSecret.trim() || isEdit) && !!username.trim() && !!(password.trim() || isEdit);
-  }
-  if (authMethod === 'ApiToken') return !!(apiToken.trim() || isEdit);
-  if (authMethod === 'CookieString') return !!(cookieString.trim() || isEdit);
-  if (authMethod === 'BasicAuth') return !!username.trim() && !!(password.trim() || isEdit);
-  return true;
-}
-
-// Only includes credential fields that have a value — blank means "keep the
-// existing stored value" on edit, and is unreachable on create because
-// canSubmitCredentials already requires it there.
-export function buildCredentialFields(authMethod, fields) {
-  const { username, password, clientId, clientSecret, tokenEndpoint, apiToken, cookieString } = fields;
-  const out = {};
-  if (authMethod === 'FormCookie' || authMethod === 'OAuth2ROPC') {
-    out.username = username.trim();
-    if (password.trim()) out.password = password.trim();
-  }
-  if (authMethod === 'OAuth2CC' || authMethod === 'OAuth2ROPC') {
-    out.tokenEndpoint = tokenEndpoint.trim();
-    out.clientId = clientId.trim();
-    if (clientSecret.trim()) out.clientSecret = clientSecret.trim();
-  }
-  if (authMethod === 'ApiToken') {
-    if (apiToken.trim()) out.apiToken = apiToken.trim();
-  }
-  if (authMethod === 'CookieString') {
-    if (cookieString.trim()) out.cookieString = cookieString.trim();
-  }
-  if (authMethod === 'BasicAuth') {
-    out.username = username.trim();
-    if (password.trim()) out.password = password.trim();
-  }
-  return out;
-}
+const FIELD_CLS = 'w-full text-sm border border-gray-300 rounded px-2 py-1 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200';
 
 // Validates one contextObjectTypes row's entitySet/identityField against the
 // live $metadata lists fetched from the Omada server. Pure function (no
@@ -273,15 +223,15 @@ export default function OmadaConfigWizard({ onComplete, onCancel, initialConfig,
   const handleStepClick = (n) => { setStep(n); if (n === 3) fetchMetadata(); };
 
   return (
-    <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold dark:text-white">{isEdit ? 'Edit' : 'Add'} Omada IGA Crawler</h3>
-        <button onClick={onCancel} className="text-gray-500 hover:text-gray-700 text-sm dark:text-gray-400 dark:hover:text-gray-200">Cancel</button>
-      </div>
-
-      <div className="mb-5"><Stepper steps={steps} current={step} onStepClick={handleStepClick} allowAll={!!isEdit} /></div>
-
-      {error && <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm dark:bg-red-900/20 dark:border-red-800 dark:text-red-400">{error}</div>}
+    <WizardShell
+      title={`${isEdit ? 'Edit' : 'Add'} Omada IGA Crawler`}
+      onCancel={onCancel}
+      steps={steps}
+      currentStep={step}
+      onStepClick={handleStepClick}
+      allowAllSteps={isEdit}
+      error={error}
+    >
 
       {/* Step 1 — Connection */}
       {step === 1 && (
@@ -540,30 +490,27 @@ $s.Cookies.GetCookies([Uri]"https://omada.example.com") |
               Maps Omada <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">ROLECATEGORY</code> to an
               Identity Atlas resource type. Leave <em>ROLECATEGORY</em> blank for the default/catch-all row (must be last).
             </p>
-            <div className="space-y-2">
-              <div className="grid grid-cols-2 gap-2 text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 pr-6">
-                <span>ROLECATEGORY value</span><span>Identity Atlas type</span>
-              </div>
-              {resCategoryMapping.map((m, i) => (
-                <div key={i} className="flex gap-2 items-center">
-                  <input value={m.category} onChange={e => updateResMapping(i, 'category', e.target.value)}
+            <MappingRows
+              rows={resCategoryMapping}
+              onAdd={addResMapping}
+              onRemove={removeResMapping}
+              onUpdate={updateResMapping}
+              headers={['ROLECATEGORY value', 'Identity Atlas type']}
+              addLabel="+ Add mapping row"
+              columns={[
+                { key: 'category', render: (v, onChange) => (
+                  <input value={v} onChange={e => onChange(e.target.value)}
                     placeholder="e.g. Role  (blank = default)"
-                    className="flex-1 min-w-0 text-sm border border-gray-300 rounded px-2 py-1 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
-                  <select value={m.resourceType} onChange={e => updateResMapping(i, 'resourceType', e.target.value)}
-                    className="flex-1 min-w-0 text-sm border border-gray-300 rounded px-2 py-1 bg-white dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                    {RESOURCE_TYPE_OPTIONS.map(opt => (
-                      <option key={opt} value={opt}>{opt}</option>
-                    ))}
+                    className={FIELD_CLS} />
+                )},
+                { key: 'resourceType', render: (v, onChange) => (
+                  <select value={v} onChange={e => onChange(e.target.value)}
+                    className={FIELD_CLS + ' bg-white'}>
+                    {RESOURCE_TYPE_OPTIONS.map(opt => <option key={opt} value={opt}>{opt}</option>)}
                   </select>
-                  <button onClick={() => removeResMapping(i)} disabled={resCategoryMapping.length === 1}
-                    className="text-gray-600 dark:text-gray-400 hover:text-red-500 text-lg leading-none disabled:opacity-30" title="Remove">×</button>
-                </div>
-              ))}
-            </div>
-            <button onClick={addResMapping}
-              className="mt-2 text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 rounded dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300">
-              + Add mapping row
-            </button>
+                )},
+              ]}
+            />
           </div>
 
           <div className="flex justify-between">
@@ -604,6 +551,6 @@ $s.Cookies.GetCookies([Uri]"https://omada.example.com") |
           </div>
         </div>
       )}
-    </div>
+    </WizardShell>
   );
 }

--- a/tools/crawlers/omada/credentialGating.test.js
+++ b/tools/crawlers/omada/credentialGating.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canSubmitCredentials, buildCredentialFields } from './ConfigWizard.jsx';
+import { canSubmitCredentials, buildCredentialFields } from '@ui/utils/crawlerCredentials';
 
 const blank = { username: '', password: '', clientId: '', clientSecret: '', tokenEndpoint: '', apiToken: '', cookieString: '' };
 


### PR DESCRIPTION
## Summary

- Extracted `WizardShell` from all 7 crawler ConfigWizard files — shared card/header/Stepper/error banner, eliminating ~25 lines of boilerplate per wizard
- Extracted `canSubmitCredentials`, `buildCredentialFields`, and `SECRET_PLACEHOLDER` into `app/ui/src/utils/crawlerCredentials.js` — covers all auth methods (FormCookie, BasicAuth, OAuth2CC, OAuth2ROPC, ApiToken, CookieString); all credential gating tests updated to import from the shared location
- Extracted `MappingRows` — generic add/remove mapping-row grid used by Omada (resource category mapping) and midPoint (archetype, org, and user type mappings)
- Net: 258 lines removed, 319 added (the additions are the shared files themselves); all 7 wizards are thinner wrappers

## Test plan

- [ ] All 273 unit tests pass (`npm test` in `app/ui/`)
- [ ] 0 lint errors (`npm run lint` in `app/ui/`)
- [ ] Open Admin → Crawlers → Add Crawler for Omada: walk all 4 steps, verify stepper, credentials gating, context type rows, resource category mapping rows, schedule
- [ ] Open Admin → Crawlers → Add Crawler for midPoint: walk all 4 steps, verify archetype/org/user mapping rows with live discovery dropdowns
- [ ] Edit an existing Omada or midPoint crawler: verify cancel/save, secret-field placeholders, step jumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)