### PR TITLE
fix(security): enforce authorization on crawler protocol + perf mutations

### DIFF
--- a/app/api/src/routes/crawlers.js
+++ b/app/api/src/routes/crawlers.js
@@ -5,6 +5,7 @@ import * as db from '../db/connection.js';
 import { injectJobSecret, deleteJobSecret } from '../secrets/crawlerSecrets.js';
 import { getPushModeType } from '../crawlerManifests.js';
 import { runPostCrawlJobs } from '../postCrawlJobs.js';
+import { crawlerHasPermission, crawlerHasSystemAccess } from '../middleware/crawlerAuth.js';
 
 const adminCrawlersRouter = Router();
 const gate = requirePermission('admin.crawlers');
@@ -382,8 +383,23 @@ selfServiceCrawlersRouter.post('/crawlers/job-progress', async (req, res) => {
 // to claim and complete jobs. The web container handles all SQL.
 //
 // Auth: crawler API key (the built-in worker holds the only valid one).
+//
+// Security (SEC-NEW-2): these job-orchestration endpoints are the web<->worker
+// protocol. /claim in particular returns the vaulted clientSecret (injectJobSecret),
+// so any valid fgc_ key could otherwise drain the queue and harvest another
+// system's Graph credentials. Restrict them to the privileged worker: the
+// built-in worker holds the 'admin' crawler permission; external ingest-only
+// keys (default ['ingest']) are rejected. Crawlers that only push data use
+// /api/ingest, not this protocol.
+function requireWorkerCrawler(req, res, next) {
+  if (!req.crawler) return res.status(401).json({ error: 'Not authenticated' });
+  if (!crawlerHasPermission(req, 'admin')) {
+    return res.status(403).json({ error: 'This endpoint requires a worker crawler key' });
+  }
+  next();
+}
 
-selfServiceCrawlersRouter.post('/crawlers/jobs/claim', async (req, res) => {
+selfServiceCrawlersRouter.post('/crawlers/jobs/claim', requireWorkerCrawler, async (req, res) => {
   if (!req.crawler) return res.status(401).json({ error: 'Not authenticated' });
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
 
@@ -424,7 +440,7 @@ selfServiceCrawlersRouter.post('/crawlers/jobs/claim', async (req, res) => {
 // delta-mode-next-run. Operators explicitly request a full sync via the
 // UI (setting nextRunMode='full'); once that full run lands successfully,
 // we auto-reset so the subsequent scheduled run uses the fast delta path.
-selfServiceCrawlersRouter.post('/crawlers/configs/:id/mark-delta-mode', async (req, res) => {
+selfServiceCrawlersRouter.post('/crawlers/configs/:id/mark-delta-mode', requireWorkerCrawler, async (req, res) => {
   if (!req.crawler) return res.status(401).json({ error: 'Not authenticated' });
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const id = parseInt(req.params.id, 10);
@@ -461,6 +477,12 @@ selfServiceCrawlersRouter.get('/crawlers/delta-tokens/:endpoint', async (req, re
   if (!Number.isInteger(systemId) || systemId <= 0) {
     return res.status(400).json({ error: 'systemId query param required' });
   }
+  // Security (SEC-NEW-3): scope delta tokens to systems this crawler may access.
+  // The built-in worker (systemIds=null) keeps full access; a system-scoped
+  // external crawler can no longer read another system's token.
+  if (!crawlerHasSystemAccess(req, systemId)) {
+    return res.status(403).json({ error: 'Crawler not authorized for this system' });
+  }
   // Permit alphanumerics + / - . : _ — matches Graph endpoint path fragments.
   const endpoint = String(req.params.endpoint || '');
   if (!/^[a-zA-Z0-9/_\-.:]+$/.test(endpoint) || endpoint.length > 200) {
@@ -491,6 +513,8 @@ selfServiceCrawlersRouter.put('/crawlers/delta-tokens/:endpoint', async (req, re
   const { systemId, token, recordsLastSeen } = req.body || {};
   const sid = parseInt(systemId, 10);
   if (!Number.isInteger(sid) || sid <= 0) return res.status(400).json({ error: 'systemId is required' });
+  // Security (SEC-NEW-3): scope delta-token writes to systems this crawler may access.
+  if (!crawlerHasSystemAccess(req, sid)) return res.status(403).json({ error: 'Crawler not authorized for this system' });
   if (!token || typeof token !== 'string') return res.status(400).json({ error: 'token is required' });
   // Graph delta tokens run a few KB. Cap at 64 KB to catch runaway payloads
   // while still accommodating the nested $select/$filter tokens Graph hands out.
@@ -518,6 +542,8 @@ selfServiceCrawlersRouter.delete('/crawlers/delta-tokens/:endpoint', async (req,
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const systemId = parseInt(req.query.systemId, 10);
   if (!Number.isInteger(systemId) || systemId <= 0) return res.status(400).json({ error: 'systemId query param required' });
+  // Security (SEC-NEW-3): scope delta-token deletes to systems this crawler may access.
+  if (!crawlerHasSystemAccess(req, systemId)) return res.status(403).json({ error: 'Crawler not authorized for this system' });
   const endpoint = String(req.params.endpoint || '');
   if (!/^[a-zA-Z0-9/_\-.:]+$/.test(endpoint) || endpoint.length > 200) {
     return res.status(400).json({ error: 'Invalid endpoint format' });
@@ -539,7 +565,7 @@ selfServiceCrawlersRouter.delete('/crawlers/delta-tokens/:endpoint', async (req,
 // Sync Log / Jobs UI. Called once just before the crawler returns (or throws)
 // so the data lands regardless of whether the scheduler ends up in `/complete`
 // or `/fail`. Idempotent: a re-call replaces the previous phases array.
-selfServiceCrawlersRouter.post('/crawlers/jobs/:id/phases', async (req, res) => {
+selfServiceCrawlersRouter.post('/crawlers/jobs/:id/phases', requireWorkerCrawler, async (req, res) => {
   if (!req.crawler) return res.status(401).json({ error: 'Not authenticated' });
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const id = parseInt(req.params.id, 10);
@@ -568,7 +594,7 @@ selfServiceCrawlersRouter.post('/crawlers/jobs/:id/phases', async (req, res) => 
   }
 });
 
-selfServiceCrawlersRouter.post('/crawlers/jobs/:id/complete', async (req, res) => {
+selfServiceCrawlersRouter.post('/crawlers/jobs/:id/complete', requireWorkerCrawler, async (req, res) => {
   if (!req.crawler) return res.status(401).json({ error: 'Not authenticated' });
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const id = parseInt(req.params.id, 10);
@@ -596,7 +622,7 @@ selfServiceCrawlersRouter.post('/crawlers/jobs/:id/complete', async (req, res) =
   }
 });
 
-selfServiceCrawlersRouter.post('/crawlers/jobs/:id/fail', async (req, res) => {
+selfServiceCrawlersRouter.post('/crawlers/jobs/:id/fail', requireWorkerCrawler, async (req, res) => {
   if (!req.crawler) return res.status(401).json({ error: 'Not authenticated' });
   if (!useSql) return res.status(503).json({ error: 'SQL not configured' });
   const id = parseInt(req.params.id, 10);

--- a/app/api/src/routes/crawlers.selfservice.authz.test.js
+++ b/app/api/src/routes/crawlers.selfservice.authz.test.js
@@ -1,0 +1,102 @@
+/**
+ * Authorization tests for the self-service crawler protocol (fgc_ key auth).
+ *
+ * SEC-NEW-2: the job-orchestration endpoints (/crawlers/jobs/claim, complete,
+ * fail, phases, /crawlers/configs/:id/mark-delta-mode) are the web<->worker
+ * protocol. /claim returns the vaulted clientSecret, so any valid crawler key
+ * could otherwise drain the queue and harvest another system's credentials.
+ * They now require the privileged worker (the 'admin' crawler permission).
+ *
+ * SEC-NEW-3: the delta-token endpoints take a systemId and must be scoped to the
+ * systems the calling crawler may access (crawlerHasSystemAccess). The built-in
+ * worker (systemIds=null) keeps full access.
+ *
+ * These drive the real selfServiceCrawlersRouter via supertest with a stub
+ * middleware that sets req.crawler to the crawler-under-test. crawlerAuth's
+ * helpers (crawlerHasPermission / crawlerHasSystemAccess) run for real; only the
+ * DB and secret-vault dependencies are mocked.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+process.env.USE_SQL = 'true'; // crawlers.js captures this at module-load time
+
+const { mockDbQuery } = vi.hoisted(() => ({ mockDbQuery: vi.fn() }));
+
+// db.query (import * as db) — selfService handlers call db.query(...) directly.
+vi.mock('../db/connection.js', () => ({ query: (...a) => mockDbQuery(...a) }));
+// Secret vault + manifest + post-crawl pipeline are not under test here.
+vi.mock('../secrets/crawlerSecrets.js', () => ({
+  injectJobSecret: async (job) => ({ ...job.config, clientSecret: 'INJECTED' }),
+  deleteJobSecret: async () => {},
+}));
+vi.mock('../crawlerManifests.js', () => ({ getPushModeType: () => 'custom-connector' }));
+vi.mock('../postCrawlJobs.js', () => ({ runPostCrawlJobs: async () => {} }));
+// adminCrawlersRouter's gate is irrelevant here; keep it a passthrough.
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, n) => n() }));
+
+const { selfServiceCrawlersRouter } = await import('./crawlers.js');
+
+// Build an app that injects a chosen req.crawler, like crawlerAuthMiddleware would.
+function appAs(crawler) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', (req, _res, next) => { req.crawler = crawler; next(); }, selfServiceCrawlersRouter);
+  return app;
+}
+
+const worker = { id: 1, displayName: 'Built-in Worker', permissions: ['ingest', 'refreshViews', 'admin'], systemIds: null };
+const ingestOnly = { id: 2, displayName: 'External', permissions: ['ingest'], systemIds: [7] };
+
+beforeEach(() => mockDbQuery.mockReset());
+
+describe('SEC-NEW-2: job-orchestration endpoints require a worker (admin) crawler key', () => {
+  it('rejects an ingest-only key from claiming a job (403) — no secret handed out', async () => {
+    const res = await request(appAs(ingestOnly)).post('/api/crawlers/jobs/claim');
+    expect(res.status).toBe(403);
+    expect(mockDbQuery).not.toHaveBeenCalled(); // never reached the claim query
+  });
+
+  it('allows the worker to claim (reaches the handler; empty queue → job null)', async () => {
+    mockDbQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(appAs(worker)).post('/api/crawlers/jobs/claim');
+    expect(res.status).toBe(200);
+    expect(res.body.job).toBeNull();
+  });
+
+  it('rejects an ingest-only key from completing/failing/mark-delta-mode (403)', async () => {
+    for (const path of ['/api/crawlers/jobs/5/complete', '/api/crawlers/jobs/5/fail', '/api/crawlers/configs/5/mark-delta-mode']) {
+      const res = await request(appAs(ingestOnly)).post(path).send({});
+      expect(res.status, `${path} must 403 for an ingest-only key`).toBe(403);
+    }
+  });
+});
+
+describe('SEC-NEW-3: delta-token endpoints are scoped to the crawler\'s systems', () => {
+  it('rejects reading a token for a system the crawler cannot access (403)', async () => {
+    // ingestOnly is scoped to system 7; ask for system 9.
+    const res = await request(appAs(ingestOnly)).get('/api/crawlers/delta-tokens/users-delta?systemId=9');
+    expect(res.status).toBe(403);
+    expect(mockDbQuery).not.toHaveBeenCalled();
+  });
+
+  it('allows reading a token for an in-scope system', async () => {
+    mockDbQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(appAs(ingestOnly)).get('/api/crawlers/delta-tokens/users-delta?systemId=7');
+    expect(res.status).toBe(200);
+  });
+
+  it('the worker (systemIds=null) may read any system\'s token', async () => {
+    mockDbQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(appAs(worker)).get('/api/crawlers/delta-tokens/users-delta?systemId=999');
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an out-of-scope delta-token write (403)', async () => {
+    const res = await request(appAs(ingestOnly))
+      .put('/api/crawlers/delta-tokens/users-delta')
+      .send({ systemId: 9, token: 'abc' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/src/routes/perf.js
+++ b/app/api/src/routes/perf.js
@@ -4,8 +4,15 @@
 
 import { Router } from 'express';
 import { isEnabled, enable, disable, summarize, recent, slowest, clear } from '../perf/collector.js';
+import { requirePermission } from '../middleware/auth.js';
 
 const router = Router();
+
+// Security (SEC-NEW-4): perfRouter is mounted with authMiddleware only. Reads are
+// fine for any signed-in user (data.read is authentication-level / implicit), but
+// the state-changing /perf/clear and /perf/toggle had NO gate — any authenticated
+// user could wipe metrics or disable the collector. Those two are gated on
+// admin.feature-flags below (runtime-toggle territory). No-op when auth disabled.
 
 // ─── GET /api/perf ──────────────────────────────────────────────
 // Summary view: per-endpoint aggregations (p50, p95, p99, avg, min, max)
@@ -57,7 +64,7 @@ router.get('/perf/export', (req, res) => {
 
 // ─── POST /api/perf/clear ──────────────────────────────────────
 // Clear all collected metrics.
-router.post('/perf/clear', (req, res) => {
+router.post('/perf/clear', requirePermission('admin.feature-flags'), (req, res) => {
   clear();
   res.json({ ok: true, message: 'Metrics cleared' });
 });
@@ -65,7 +72,7 @@ router.post('/perf/clear', (req, res) => {
 // ─── POST /api/perf/toggle ─────────────────────────────────────
 // Enable or disable the metrics collector at runtime.
 // body: { enabled: boolean }
-router.post('/perf/toggle', (req, res) => {
+router.post('/perf/toggle', requirePermission('admin.feature-flags'), (req, res) => {
   const { enabled: target } = req.body || {};
   if (typeof target !== 'boolean') {
     return res.status(400).json({ error: 'enabled (boolean) is required' });

--- a/changes/security-authz-enforcement.md
+++ b/changes/security-authz-enforcement.md
@@ -1,0 +1,3 @@
+- Hardened crawler API-key authorization: a crawler key can no longer claim worker jobs, mark jobs complete/failed, or flip a config to delta mode unless it is the privileged built-in worker key. This closes a path where any valid crawler key could claim a queued job and receive another connected system's stored credentials.
+- Crawler delta-sync state (delta tokens) is now scoped to the systems a crawler is allowed to access — a system-scoped crawler can no longer read, overwrite, or delete another system's sync token.
+- The performance-metrics endpoints that clear collected metrics or enable/disable collection now require administrative permission instead of being open to any signed-in user.


### PR DESCRIPTION
## Summary
Closes three **authorization gaps** found in the maintenance-sprint security review. They were surfaced by an independent Codex cross-check of the Claude audit, then verified by reading the code directly.

All three only apply when `AUTH_ENABLED=true`; the changes are no-ops in open mode.

| ID | Sev | Endpoint(s) | Gap → Fix |
|----|-----|-------------|-----------|
| **SEC-NEW-2** | High | `POST /api/crawlers/jobs/claim` (+ `/complete`, `/fail`, `/phases`, `/configs/:id/mark-delta-mode`) | Gated only on "any valid crawler key". `/claim` returns the vaulted `clientSecret` via `injectJobSecret`, so any `fgc_` key could drain the queue and **harvest another system's Graph credentials**. → Now require the privileged worker (the `admin` crawler permission). The built-in worker holds `["ingest","refreshViews","admin"]`; external ingest-only keys (`["ingest"]`) are rejected. Push-only crawlers use `/api/ingest`, not this protocol. |
| **SEC-NEW-3** | Med | `GET/PUT/DELETE /api/crawlers/delta-tokens/:endpoint` | Took a `systemId` but never checked the caller's system scope — a system-scoped crawler could read/overwrite/delete another system's delta token. → Now enforced via the existing `crawlerHasSystemAccess()` helper. The built-in worker (`systemIds=null`) keeps full access. |
| **SEC-NEW-4** | Low | `POST /api/perf/clear`, `POST /api/perf/toggle` | No gate — any signed-in user could wipe metrics or disable the collector. → Now require `admin.feature-flags`. Perf **reads** stay open (see below). |

## Deliberately NOT included — SEC-NEW-1
The review (and Codex) initially flagged the read routers (matrix/details/resources/governance/…) as a broken-access-control bug because they carry no `requirePermission`. On inspection **this is intended design**: `permissionManifest.js` classifies `data.read` as an **IMPLICIT** permission — *"any signed-in user can read; no requirePermission gate"* — and it's covered by `auth/permissionMatrix.test.js`. Restricting reads to specific roles is a deliberate config choice via `AUTH_REQUIRED_ROLES`, not a code fix. Flagging here for the reviewer: **if you do want reads gated by role, that's a design decision — say so and I'll do it as a separate change.**

## Tests
Adds `app/api/src/routes/crawlers.selfservice.authz.test.js` covering: ingest-only key denied on claim/complete/fail/mark-delta-mode; worker allowed; delta-token reads/writes denied out-of-scope, allowed in-scope, worker unrestricted.

⚠️ **Not run locally** — this Windows checkout has a Linux-installed `node_modules` (rollup/lightningcss native bins are linux-x64), so vitest can't start here. Files pass `node --check`; the `unit-js` CI job will execute the suite. Please confirm green before merge.

## Review notes
- The `admin` crawler-permission gate for job orchestration assumes the v5 architecture where the built-in worker is the only job-runner (external crawlers push via `/ingest`). Confirm that holds for your deployments.
- Part of the maintenance-sprint security findings; the Bicep secret-output leak (H-1) and the rest of the backlog are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)