### PR TITLE
fix(identities): show real group count + risk on identity detail (P1)

### DIFF
--- a/app/api/src/routes/identities.enrich.test.js
+++ b/app/api/src/routes/identities.enrich.test.js
@@ -1,0 +1,53 @@
+/**
+ * Unit test for enrichMembers() in identities.js.
+ *
+ * Regression: the identity-detail handler keyed its risk and group-count maps by
+ * `userId` — a column none of the source queries select (they select principalId)
+ * — so member group counts always rendered 0 and risk score/tier never attached.
+ * enrichMembers keys by principalId; these tests pin that and guard the old bug.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Keep the module import side-effect-free (no pool creation / timers).
+vi.mock('../db/connection.js', () => ({ getPool: vi.fn(), queryOne: vi.fn(), query: vi.fn() }));
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: async () => ({ recordset: [] }) }),
+  getQueryTimings: () => [],
+}));
+
+const { enrichMembers } = await import('./identities.js');
+
+const P1 = '11111111-1111-1111-1111-111111111111';
+const P2 = '22222222-2222-2222-2222-222222222222';
+
+describe('enrichMembers', () => {
+  it('attaches group counts + risk keyed by principalId', () => {
+    const members = [{ principalId: P1 }, { principalId: P2 }];
+    const riskRows = [{ principalId: P1, riskScore: 80, riskTier: 'High' }];
+    const groupRows = [{ principalId: P1, groupCount: 7 }, { principalId: P2, groupCount: 3 }];
+
+    enrichMembers(members, riskRows, groupRows);
+
+    expect(members[0].groupCount).toBe(7);
+    expect(members[0].riskScore).toBe(80);
+    expect(members[0].riskTier).toBe('High');
+    // P2 has a group count but no risk row → count attached, risk left unset.
+    expect(members[1].groupCount).toBe(3);
+    expect(members[1].riskScore).toBeUndefined();
+  });
+
+  it('defaults group count to 0 and leaves risk unset when nothing matches', () => {
+    const members = [{ principalId: P1 }];
+    enrichMembers(members, [], []);
+    expect(members[0].groupCount).toBe(0);
+    expect(members[0].riskScore).toBeUndefined();
+  });
+
+  it('does NOT enrich from a userId field (regression guard for the original bug)', () => {
+    const members = [{ principalId: P1, userId: P1 }];
+    // Rows in the OLD, wrong shape (only userId) must not match → no enrichment.
+    enrichMembers(members, [{ userId: P1, riskScore: 99, riskTier: 'High' }], [{ userId: P1, groupCount: 5 }]);
+    expect(members[0].groupCount).toBe(0);
+    expect(members[0].riskScore).toBeUndefined();
+  });
+});

--- a/app/api/src/routes/identities.js
+++ b/app/api/src/routes/identities.js
@@ -17,6 +17,27 @@ import { requirePermission } from '../middleware/auth.js';
 const router = Router();
 const useSql = process.env.USE_SQL === 'true';
 
+// Attach per-account group counts + risk to each linked-account member, keyed by
+// `principalId` — the column every source query selects. A prior version keyed
+// these maps by `userId` (which none of the queries return), so group counts
+// always rendered 0 and risk/tier never attached on the identity-detail page.
+// Pure + exported for unit testing (identities.enrich.test.js).
+export function enrichMembers(members, riskRows = [], groupCountRows = []) {
+  const riskMap = {};
+  for (const r of riskRows) riskMap[r.principalId] = { riskScore: r.riskScore, riskTier: r.riskTier };
+  const groupCountMap = {};
+  for (const gc of groupCountRows) groupCountMap[gc.principalId] = gc.groupCount;
+  for (const member of members) {
+    member.groupCount = groupCountMap[member.principalId] || 0;
+    const risk = riskMap[member.principalId];
+    if (risk) {
+      member.riskScore = risk.riskScore;
+      member.riskTier = risk.riskTier;
+    }
+  }
+  return members;
+}
+
 // Analyst decisions on a linked account are a write action — gate them like
 // risk-score overrides (riskScores.js uses data.write.risk). Reads stay open
 // to anyone who can sign in (data.read).
@@ -291,7 +312,7 @@ router.get('/identities/:id', async (req, res) => {
     }
 
     // Enrich members with risk scores (optional — try Principals then GraphUsers)
-    let memberRiskMap = {};
+    let riskRows = [];
     try {
       let riskResult;
       try {
@@ -313,40 +334,28 @@ router.get('/identities/:id', async (req, res) => {
             WHERE m."identityId" = @identityId
           `);
       }
-      for (const r of riskResult.recordset) {
-        memberRiskMap[r.userId] = { riskScore: r.riskScore, riskTier: r.riskTier };
-      }
+      riskRows = riskResult.recordset;
     } catch { /* risk columns may not exist yet */ }
 
     // Fetch group memberships per account for context
-    let memberGroupCounts = [];
+    let groupCountRows = [];
     try {
       const groupCountResult = await timedRequest(p, 'identity-member-groups', res)
         .input('identityId', identityId)
         .query(`
-          SELECT m."principalId", COUNT(DISTINCT gm."resourceId") AS "groupCount"
+          SELECT m."principalId", COUNT(DISTINCT gm."resourceId")::int AS "groupCount"
           FROM "IdentityMembers" m
           LEFT JOIN "ResourceAssignments" gm ON m."principalId" = gm."principalId" AND gm."assignmentType" = 'Direct'
           WHERE m."identityId" = @identityId
           GROUP BY m."principalId"
         `);
-      memberGroupCounts = groupCountResult.recordset;
+      groupCountRows = groupCountResult.recordset;
     } catch {
       // ResourceAssignments may not exist
     }
 
-    // Enrich members with group counts and risk scores
-    const groupCountMap = {};
-    for (const gc of memberGroupCounts) {
-      groupCountMap[gc.userId] = gc.groupCount;
-    }
-    for (const member of membersResult.recordset) {
-      member.groupCount = groupCountMap[member.userId] || 0;
-      if (memberRiskMap[member.userId]) {
-        member.riskScore = memberRiskMap[member.userId].riskScore;
-        member.riskTier = memberRiskMap[member.userId].riskTier;
-      }
-    }
+    // Attach per-account group counts + risk (keyed by principalId — see enrichMembers).
+    enrichMembers(membersResult.recordset, riskRows, groupCountRows);
 
     // Aggregate relationship counts across every linked account — the entity
     // graph shows these as nodes ("32 groups across 3 accounts", "4 access

--- a/changes/fix-identity-detail-counts.md
+++ b/changes/fix-identity-detail-counts.md
@@ -1,0 +1,1 @@
+- Fixed the identity detail page so each linked account again shows its real group count and risk score/tier. Previously the per-account group count always displayed 0 and the risk score/tier never appeared, regardless of the account's actual access.


### PR DESCRIPTION
## Summary
Fixes finding **P1** from the maintenance-sprint audit: on the identity-detail page, every linked account showed **group count = 0** and **no risk score/tier**, regardless of its actual access.

## Root cause
The handler built its risk and group-count lookup maps keyed by `userId` and read them back with `member.userId` / `gc.userId` / `r.userId` — but all three source queries `SELECT m."principalId"` and never `userId`. So every key was `undefined`: the maps never matched, counts defaulted to 0, and risk never attached. The two extra DB round-trips ran and their results were silently discarded.

## Fix
- Extract the enrichment into a pure, exported `enrichMembers(members, riskRows, groupCountRows)` keyed by `principalId`, and route the handler through it.
- Cast the group `COUNT(...)` to `::int` so it returns a number, not a bigint string.
- Add `identities.enrich.test.js` — pure unit tests, including a regression guard that old `userId`-shaped rows do **not** enrich.

## Testing
Pure-function unit tests (no DB/supertest), so they're robust. ⚠️ Not run locally — this Windows checkout's `node_modules` is a Linux install, so vitest can't start here; `node --check` passes and CI `unit-js` will execute them.

Part of the maintenance-sprint backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)