### PR TITLE
fix(ui): collapse duplicated dark: classes breaking dark mode (C1/C2)

### DIFF
--- a/app/ui/eslint-rules/no-duplicate-dark-color.js
+++ b/app/ui/eslint-rules/no-duplicate-dark-color.js
@@ -1,0 +1,112 @@
+// ESLint rule: no-duplicate-dark-color
+//
+// Flags a className that sets the SAME dark-mode color property twice with two
+// plain `dark:` utilities (no state variant). Tailwind emits both rules and the
+// later one in its generated CSS wins, so the intended value is silently
+// overridden. This is the copy-paste artifact behind the dark-mode audit
+// findings, e.g.:
+//
+//   text-gray-500 dark:text-gray-400 dark:text-gray-500   // → renders gray-500, not 400
+//   dark:text-gray-400 ... hover:text-gray-700 dark:text-gray-300  // 2nd should be dark:hover:
+//
+// Only PLAIN `dark:` color utilities are considered. A stateful variant like
+// `dark:hover:text-...` is the CORRECT way to set a dark hover color, so a
+// `dark:text-X` + `dark:hover:text-Y` pair is fine and never flagged.
+//
+// Started as a warning (ratchet): it surfaces the remaining backlog without
+// failing CI; promote to 'error' once clean. See app/ui/CLAUDE.md § Dark Mode.
+
+const TAILWIND_COLORS = new Set([
+  'gray', 'slate', 'zinc', 'neutral', 'stone',
+  'red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald',
+  'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple',
+  'fuchsia', 'pink', 'rose', 'white', 'black',
+]);
+
+// Color-bearing utility namespaces (the part before the color name).
+const COLOR_PROPS = new Set([
+  'text', 'bg', 'border', 'ring', 'divide', 'placeholder',
+  'decoration', 'outline', 'accent', 'caret', 'fill', 'stroke',
+  'from', 'via', 'to', 'shadow',
+]);
+
+// Matches exactly `dark:<prop>-<color>[-<shade>][/<opacity>]` — NOT `dark:hover:…`.
+const DARK_COLOR = /^dark:([a-z]+)-([a-z]+)(?:-\d{1,3})?(?:\/\d{1,3})?$/;
+
+function findDuplicateProps(str) {
+  const seen = new Map(); // prop -> first token
+  const dupes = [];
+  for (const token of str.split(/\s+/)) {
+    if (!token.startsWith('dark:')) continue;
+    const m = DARK_COLOR.exec(token);
+    if (!m) continue;
+    const [, prop, color] = m;
+    if (!COLOR_PROPS.has(prop) || !TAILWIND_COLORS.has(color)) continue;
+    if (seen.has(prop)) dupes.push({ prop, first: seen.get(prop), second: token });
+    else seen.set(prop, token);
+  }
+  return dupes;
+}
+
+function checkStringValue(node, value, context) {
+  for (const d of findDuplicateProps(value)) {
+    context.report({ node, messageId: 'dupDark', data: { prop: d.prop, a: d.first, b: d.second } });
+  }
+}
+
+// Walks the expression forms that appear inside className={...} in this codebase.
+function walkExpr(node, context) {
+  if (!node) return;
+  switch (node.type) {
+    case 'Literal':
+      if (typeof node.value === 'string') checkStringValue(node, node.value, context);
+      break;
+    case 'TemplateLiteral':
+      for (const quasi of node.quasis) checkStringValue(quasi, quasi.value.cooked || '', context);
+      for (const expr of node.expressions) walkExpr(expr, context);
+      break;
+    case 'ConditionalExpression':
+      walkExpr(node.consequent, context);
+      walkExpr(node.alternate, context);
+      break;
+    case 'LogicalExpression':
+      walkExpr(node.left, context);
+      walkExpr(node.right, context);
+      break;
+    case 'BinaryExpression':
+      if (node.operator === '+') { walkExpr(node.left, context); walkExpr(node.right, context); }
+      break;
+    case 'CallExpression':
+      for (const arg of node.arguments) walkExpr(arg, context);
+      break;
+    default:
+      break;
+  }
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow two plain dark: utilities setting the same color property in one className (the later silently wins).',
+      url: 'app/ui/CLAUDE.md',
+    },
+    schema: [],
+    messages: {
+      dupDark:
+        'className sets dark: {{prop}} color twice ("{{a}}" and "{{b}}"); the later one silently wins. ' +
+        'Remove the redundant one, or make the hover/focus variant explicit (e.g. dark:hover:{{prop}}-...).',
+    },
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name?.name !== 'className') return;
+        const val = node.value;
+        if (!val) return;
+        if (val.type === 'Literal') checkStringValue(val, val.value ?? '', context);
+        else if (val.type === 'JSXExpressionContainer') walkExpr(val.expression, context);
+      },
+    };
+  },
+};

--- a/app/ui/eslint-rules/no-duplicate-dark-color.js
+++ b/app/ui/eslint-rules/no-duplicate-dark-color.js
@@ -33,7 +33,7 @@ const COLOR_PROPS = new Set([
 // Matches exactly `dark:<prop>-<color>[-<shade>][/<opacity>]` — NOT `dark:hover:…`.
 const DARK_COLOR = /^dark:([a-z]+)-([a-z]+)(?:-\d{1,3})?(?:\/\d{1,3})?$/;
 
-function findDuplicateProps(str) {
+export function findDuplicateProps(str) {
   const seen = new Map(); // prop -> first token
   const dupes = [];
   for (const token of str.split(/\s+/)) {

--- a/app/ui/eslint-rules/no-duplicate-dark-color.test.js
+++ b/app/ui/eslint-rules/no-duplicate-dark-color.test.js
@@ -1,0 +1,43 @@
+// Unit tests for the no-duplicate-dark-color rule's matching logic.
+//
+// Exercises findDuplicateProps directly (no RuleTester) so the test is robust
+// and fast: it pins that two plain dark: color utilities for the same property
+// are flagged, while the correct `dark:` + `dark:hover:` pairing is not.
+import { describe, it, expect } from 'vitest';
+import { findDuplicateProps } from './no-duplicate-dark-color.js';
+
+describe('findDuplicateProps', () => {
+  it('flags the doubled dark:text (C1) pattern', () => {
+    const dupes = findDuplicateProps('text-gray-500 dark:text-gray-400 dark:text-gray-500');
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0].prop).toBe('text');
+  });
+
+  it('flags a missing-hover dark:text pair (M6: hover:text-X dark:text-Y)', () => {
+    expect(findDuplicateProps('dark:text-gray-400 hover:text-gray-700 dark:text-gray-300')).toHaveLength(1);
+  });
+
+  it('does NOT flag the correct dark + dark:hover pairing', () => {
+    expect(findDuplicateProps('dark:text-gray-400 dark:hover:text-gray-300')).toHaveLength(0);
+  });
+
+  it('does NOT flag the post-codemod class string', () => {
+    expect(findDuplicateProps('text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700')).toHaveLength(0);
+  });
+
+  it('does NOT flag distinct dark color properties (text vs bg vs border)', () => {
+    expect(findDuplicateProps('bg-white dark:bg-gray-800 dark:border-gray-700 dark:text-white')).toHaveLength(0);
+  });
+
+  it('flags a doubled dark:bg color and reports the offending tokens', () => {
+    const dupes = findDuplicateProps('dark:bg-gray-700 dark:bg-gray-800');
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0].prop).toBe('bg');
+    expect(dupes[0].second).toBe('dark:bg-gray-800');
+  });
+
+  it('ignores non-color dark utilities (e.g. sizing/spacing)', () => {
+    // dark:text-sm is not a color; dark:p-2 is spacing — neither should count.
+    expect(findDuplicateProps('dark:text-sm dark:text-gray-400')).toHaveLength(0);
+  });
+});

--- a/app/ui/eslint.config.js
+++ b/app/ui/eslint.config.js
@@ -6,6 +6,7 @@ import noNativeDialogs from './eslint-rules/no-native-dialogs.js';
 import noLegacyJargon from './eslint-rules/no-legacy-jargon.js';
 import noHardcodedCrawlerMeta from './eslint-rules/no-hardcoded-crawler-meta.js';
 import noRelativePackageImports from './eslint-rules/no-relative-package-imports.js';
+import noDuplicateDarkColor from './eslint-rules/no-duplicate-dark-color.js';
 
 // Files that still use native confirm()/alert()/prompt() (the pre-existing
 // backlog). They're downgraded to a warning so CI stays green while new code
@@ -43,12 +44,17 @@ export default [
           'no-legacy-jargon': noLegacyJargon,
           'no-hardcoded-crawler-meta': noHardcodedCrawlerMeta,
           'no-relative-package-imports': noRelativePackageImports,
+          'no-duplicate-dark-color': noDuplicateDarkColor,
         },
       },
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       'local/no-low-contrast-text': 'error',
+      // Ratchet: warns on duplicate dark: color utilities (the audit's C1/C2/M6
+      // class). Promote to 'error' once the remaining `hover:text-X dark:text-Y`
+      // (missing-hover) backlog is cleaned up.
+      'local/no-duplicate-dark-color': 'warn',
       'local/no-native-dialogs': 'error',
       'local/no-legacy-jargon': 'error',
       'local/no-hardcoded-crawler-meta': 'error',

--- a/app/ui/src/components/ContextDetailPage.jsx
+++ b/app/ui/src/components/ContextDetailPage.jsx
@@ -121,7 +121,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-gray-500 dark:text-gray-400 dark:text-gray-500">Loading context details...</div>
+        <div className="text-gray-500 dark:text-gray-400">Loading context details...</div>
       </div>
     );
   }
@@ -133,7 +133,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
         <p className="text-red-600 dark:text-red-400 mt-2 text-sm">{error}</p>
         <div className="flex gap-3 mt-3">
           <button onClick={fetchDetail} className="text-sm text-red-700 dark:text-red-400 underline hover:text-red-900">Retry</button>
-          <button onClick={onClose} className="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500 underline hover:text-gray-700 dark:text-gray-300">Close</button>
+          <button onClick={onClose} className="text-sm text-gray-500 dark:text-gray-400 underline hover:text-gray-700 dark:text-gray-300">Close</button>
         </div>
       </div>
     );
@@ -264,13 +264,13 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
           <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
             Members ({memberTotal})
             {detail.attributes.totalMemberCount > (detail.attributes.directMemberCount || 0) && !includeDescendants && (
-              <span className="ml-2 text-[11px] font-normal text-gray-500 dark:text-gray-400 dark:text-gray-500">
+              <span className="ml-2 text-[11px] font-normal text-gray-500 dark:text-gray-400">
                 direct only — {detail.attributes.directMemberCount || 0} of {detail.attributes.totalMemberCount} total
               </span>
             )}
           </h3>
           <div className="flex items-center gap-3">
-            <label className="flex items-center gap-1.5 text-[11px] text-gray-600 dark:text-gray-400 dark:text-gray-500 cursor-pointer">
+            <label className="flex items-center gap-1.5 text-[11px] text-gray-600 dark:text-gray-400 cursor-pointer">
               <input
                 type="checkbox"
                 checked={includeDescendants}
@@ -293,7 +293,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
         {canEditMembers && (
           <div className="mb-4">
             {isGenerated && (
-              <p className="text-[11px] text-gray-500 dark:text-gray-400 dark:text-gray-500 mb-1">
+              <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-1">
                 Manually-added members (<code>addedBy=analyst</code>) survive future plugin runs.
                 Algorithm-produced members are replaced on every run.
               </p>
@@ -315,7 +315,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
           <>
             <table className="w-full text-sm">
               <thead>
-                <tr className="text-left text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-gray-700">
+                <tr className="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
                   <th className="pb-2 font-medium">Name</th>
                   <th className="pb-2 font-medium">Email</th>
                   <th className="pb-2 font-medium">Job Title</th>
@@ -328,7 +328,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                 {members.map(m => (
                   <tr
                     key={m.id}
-                    className="border-b border-gray-50 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 cursor-pointer"
+                    className="border-b border-gray-50 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
                     onClick={() => {
                       const tt = detail.attributes.targetType;
                       const kind = tt === 'Identity' ? 'identity'
@@ -339,11 +339,11 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                     }}
                   >
                     <td className="py-1.5 text-blue-600 dark:text-blue-400 hover:underline">{m.displayName}</td>
-                    <td className="py-1.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">{m.email || '-'}</td>
-                    <td className="py-1.5 text-gray-600 dark:text-gray-400 dark:text-gray-500">{m.jobTitle || '-'}</td>
+                    <td className="py-1.5 text-gray-600 dark:text-gray-400">{m.email || '-'}</td>
+                    <td className="py-1.5 text-gray-600 dark:text-gray-400">{m.jobTitle || '-'}</td>
                     <td className="py-1.5">
                       {m.principalType && (
-                        <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 dark:text-gray-500 rounded px-1.5 py-0.5">{m.principalType}</span>
+                        <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded px-1.5 py-0.5">{m.principalType}</span>
                       )}
                     </td>
                     <td className="py-1.5">
@@ -377,7 +377,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                 <button
                   onClick={() => setMemberPage(p => Math.max(0, p - 1))}
                   disabled={memberPage === 0}
-                  className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
                 >
                   Previous
                 </button>
@@ -387,7 +387,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                 <button
                   onClick={() => setMemberPage(p => Math.min(totalPages - 1, p + 1))}
                   disabled={memberPage >= totalPages - 1}
-                  className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
                 >
                   Next
                 </button>
@@ -430,7 +430,7 @@ function ContextHeader({ attrs, onClose }) {
             <span className={`w-1.5 h-8 ${v.dotClass} rounded`} aria-hidden="true" />
             <h2 className="text-xl font-semibold text-gray-900 dark:text-white truncate">{attrs.displayName || attrs.id}</h2>
             {attrs.contextType && (
-              <span className="text-[10px] uppercase tracking-wide text-gray-600 dark:text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-700 rounded px-1.5 py-0.5">
+              <span className="text-[10px] uppercase tracking-wide text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-700 rounded px-1.5 py-0.5">
                 {attrs.contextType}
               </span>
             )}
@@ -449,12 +449,12 @@ function ContextHeader({ attrs, onClose }) {
               </span>
             )}
           </div>
-          {provenance && <p className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-2">{provenance}</p>}
+          {provenance && <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">{provenance}</p>}
           {attrs.parentDisplayName && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-1">Parent: {attrs.parentDisplayName}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Parent: {attrs.parentDisplayName}</p>
           )}
         </div>
-        <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 p-1" title="Close">
+        <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 p-1" title="Close">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -525,7 +525,7 @@ function GeneratedContextActions({ contextId, attrs, authFetch, onDeleted }) {
           Generated by {algo}
         </span>
       </div>
-      <p className="text-[11px] text-gray-600 dark:text-gray-400 dark:text-gray-500 mb-3">
+      <p className="text-[11px] text-gray-600 dark:text-gray-400 mb-3">
         Delete this context if it's noise. Re-running <code className="px-1 bg-gray-100 dark:bg-gray-700 rounded">{attrs.sourceAlgorithmName || 'the plugin'}</code>{' '}
         with the same parameters will recreate it — to keep it gone, also tune the plugin
         parameters (e.g., add noise tokens to <code className="px-1 bg-gray-100 dark:bg-gray-700 rounded">additionalStopwords</code>)
@@ -546,7 +546,7 @@ function GeneratedContextActions({ contextId, attrs, authFetch, onDeleted }) {
           </button>
           <button
             onClick={() => setConfirming(false)}
-            className="px-3 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300"
+            className="px-3 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-700 dark:text-gray-300"
           >Cancel</button>
         </div>
       ) : (

--- a/app/ui/src/components/ContextsPage.jsx
+++ b/app/ui/src/components/ContextsPage.jsx
@@ -185,7 +185,7 @@ export default function ContextsPage({ onOpenDetail, onNavigate }) {
           )}
 
           {!selectedRoot && !rootsLoading && (
-            <div className="flex-1 flex items-center justify-center p-8 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
+            <div className="flex-1 flex items-center justify-center p-8 text-sm text-gray-500 dark:text-gray-400">
               Select a tree on the left, or click <span className="font-semibold">+ New</span> to create one.
             </div>
           )}
@@ -212,7 +212,7 @@ export default function ContextsPage({ onOpenDetail, onNavigate }) {
                   doesn't unmount-and-remount — that would reset every node's
                   expand/collapse state and collapse the tree on each drag-drop. */}
               {subtreeLoading && nodes.length === 0 ? (
-                <div className="p-4 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Loading subtree…</div>
+                <div className="p-4 text-sm text-gray-500 dark:text-gray-400">Loading subtree…</div>
               ) : viewMode === 'tree' ? (
                 <ContextTreeView
                   nodes={nodes}
@@ -290,7 +290,7 @@ function SelectedRootHeader({ root, viewMode, onChangeViewMode, onDeleteTree, de
               </span>
             )}
           </div>
-          {root.description && <p className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-1 truncate">{root.description}</p>}
+          {root.description && <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate">{root.description}</p>}
         </div>
 
         <div className="flex items-center gap-3">

--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -20,7 +20,7 @@ function ScoreBar({ score, maxScore = 100 }) {
       <div className="w-24 h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
         <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
       </div>
-      <span className="text-xs font-mono text-gray-600 dark:text-gray-400 dark:text-gray-500 w-6 text-right">{score}</span>
+      <span className="text-xs font-mono text-gray-600 dark:text-gray-400 w-6 text-right">{score}</span>
     </div>
   );
 }
@@ -45,7 +45,7 @@ function DistributionChart({ label, byTier, total }) {
               <div className="flex-1 h-5 bg-gray-50 dark:bg-gray-700/50 rounded overflow-hidden">
                 <div className={`h-full ${s.dot} rounded`} style={{ width: `${pct}%` }} />
               </div>
-              <span className="w-8 text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 text-right">{count}</span>
+              <span className="w-8 text-xs text-gray-500 dark:text-gray-400 text-right">{count}</span>
             </div>
           );
         })}
@@ -104,14 +104,14 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
       <table className="min-w-full text-sm">
         <thead>
           <tr className="border-b border-gray-200 dark:border-gray-700">
-            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500 uppercase">Name</th>
+            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Name</th>
             {cols.map(c => (
-              <th key={c.key} className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500 uppercase">{c.label}</th>
+              <th key={c.key} className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{c.label}</th>
             ))}
-            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500 uppercase w-20">Score</th>
-            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500 uppercase w-24">Tier</th>
-            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500 uppercase">Why</th>
-            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 dark:text-gray-500 uppercase w-20">Override</th>
+            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase w-20">Score</th>
+            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase w-24">Tier</th>
+            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Why</th>
+            <th className="text-left py-2 px-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase w-20">Override</th>
           </tr>
         </thead>
         <tbody>
@@ -124,7 +124,7 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
             return (
               <tr
                 key={entity.id}
-                className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 cursor-pointer"
+                className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
                 onClick={() => openDetail(entity)}
                 title="Open detail page"
               >
@@ -135,7 +135,7 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
                   )}
                 </td>
                 {cols.map(c => (
-                  <td key={c.key} className="py-2 px-3 text-gray-600 dark:text-gray-400 dark:text-gray-500">{c.render(entity)}</td>
+                  <td key={c.key} className="py-2 px-3 text-gray-600 dark:text-gray-400">{c.render(entity)}</td>
                 ))}
                 <td className="py-2 px-3">
                   <ScoreBar score={entity.effectiveScore ?? entity.riskScore} />
@@ -272,7 +272,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{c.displayName}</h3>
             <div className="flex items-center gap-2 mt-0.5">
               <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                c.clusterType === 'classifier' ? 'bg-blue-50 text-blue-700 dark:text-blue-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 dark:text-gray-500'
+                c.clusterType === 'classifier' ? 'bg-blue-50 text-blue-700 dark:text-blue-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
               }`}>{c.clusterType}</span>
               {c.sourceClassifierCategory && (
                 <span className="text-xs text-gray-600 dark:text-gray-500">{c.sourceClassifierCategory}</span>
@@ -285,7 +285,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
               <div className="text-2xl font-bold text-gray-800 dark:text-gray-200">{c.aggregateRiskScore}</div>
               <TierBadge tier={c.riskTier} />
             </div>
-            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 p-1">
+            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 p-1">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
             </button>
           </div>
@@ -296,15 +296,15 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
           <div className="grid grid-cols-3 gap-3">
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
               <div className="text-lg font-bold text-gray-800 dark:text-gray-200">{c.aggregateRiskScore}</div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400 dark:text-gray-500">Aggregate</div>
+              <div className="text-[10px] text-gray-500 dark:text-gray-400">Aggregate</div>
             </div>
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
               <div className="text-lg font-bold text-gray-800 dark:text-gray-200">{c.maxMemberRiskScore}</div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400 dark:text-gray-500">Max</div>
+              <div className="text-[10px] text-gray-500 dark:text-gray-400">Max</div>
             </div>
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
               <div className="text-lg font-bold text-gray-800 dark:text-gray-200">{c.avgMemberRiskScore}</div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400 dark:text-gray-500">Avg</div>
+              <div className="text-[10px] text-gray-500 dark:text-gray-400">Avg</div>
             </div>
           </div>
 
@@ -386,7 +386,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
                     )}
                     <button
                       onClick={() => { setShowOwnerSearch(false); setOwnerSearch(''); }}
-                      className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300"
+                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300"
                     >
                       Cancel
                     </button>
@@ -402,7 +402,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
               <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Match Patterns</h4>
               <div className="flex gap-1.5 flex-wrap">
                 {c.matchPatterns.map((p, i) => (
-                  <span key={i} className="text-[10px] font-mono bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 dark:text-gray-500 px-1.5 py-0.5 rounded">
+                  <span key={i} className="text-[10px] font-mono bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-1.5 py-0.5 rounded">
                     {p}
                   </span>
                 ))}
@@ -420,7 +420,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
             ) : (
               <div className="space-y-1 max-h-[300px] overflow-y-auto">
                 {members.map(m => (
-                  <div key={`${m.resourceType}-${m.resourceId}`} className="flex items-center justify-between py-1.5 px-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50">
+                  <div key={`${m.resourceType}-${m.resourceId}`} className="flex items-center justify-between py-1.5 px-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50">
                     <div className="flex items-center gap-2 min-w-0">
                       <button
                         onClick={() => onOpenDetail?.('group', m.resourceId, m.resourceName)}
@@ -572,7 +572,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
   if (loading && !summary) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-gray-500 dark:text-gray-400 dark:text-gray-500">Loading risk scores...</div>
+        <div className="text-gray-500 dark:text-gray-400">Loading risk scores...</div>
       </div>
     );
   }
@@ -630,7 +630,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Identity Risk Scores</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-0.5">
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
             Persisted risk scores computed by <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">Invoke-FGRiskScoring</code>
             {totalOverrides > 0 && (
               <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">
@@ -678,7 +678,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
                         <div className="flex-1 h-5 bg-gray-50 dark:bg-gray-700/50 rounded overflow-hidden">
                           <div className={`h-full ${st.dot} rounded`} style={{ width: `${pct}%` }} />
                         </div>
-                        <span className="w-8 text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 text-right">{count}</span>
+                        <span className="w-8 text-xs text-gray-500 dark:text-gray-400 text-right">{count}</span>
                       </div>
                     );
                   })}
@@ -754,7 +754,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
               <button
                 onClick={() => setView('groups')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
-                  view === 'groups' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700'
+                  view === 'groups' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
               >
                 Resources
@@ -764,7 +764,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
               <button
                 onClick={() => setView('users')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
-                  view === 'users' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700'
+                  view === 'users' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
               >
                 Users
@@ -774,7 +774,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
               <button
                 onClick={() => setView('business-roles')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
-                  view === 'business-roles' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700'
+                  view === 'business-roles' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
               >
                 Business Roles
@@ -784,7 +784,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
               <button
                 onClick={() => setView('contexts')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
-                  view === 'contexts' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700'
+                  view === 'contexts' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
               >
                 Contexts
@@ -794,7 +794,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
               <button
                 onClick={() => setView('identities')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
-                  view === 'identities' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700'
+                  view === 'identities' ? 'bg-gray-900 text-white' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
               >
                 Identities
@@ -804,7 +804,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
 
           <div className="flex items-center gap-3">
             {view !== 'clusters' && (
-              <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 cursor-pointer">
+              <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={overridesOnly}
@@ -847,14 +847,14 @@ export default function RiskScoringPage({ onOpenDetail }) {
         {/* Pagination */}
         {totalPages > 1 && (
           <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 dark:border-gray-700">
-            <span className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">
+            <span className="text-xs text-gray-500 dark:text-gray-400">
               {page * PAGE_SIZE + 1}&ndash;{Math.min((page + 1) * PAGE_SIZE, activeTotal)} of {activeTotal}
             </span>
             <div className="flex gap-1">
               <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0}
-                className="px-2 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 disabled:opacity-30 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50">Prev</button>
+                className="px-2 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 disabled:opacity-30 hover:bg-gray-50 dark:hover:bg-gray-700/50">Prev</button>
               <button onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))} disabled={page >= totalPages - 1}
-                className="px-2 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 disabled:opacity-30 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50">Next</button>
+                className="px-2 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 disabled:opacity-30 hover:bg-gray-50 dark:hover:bg-gray-700/50">Next</button>
             </div>
           </div>
         )}

--- a/app/ui/src/components/RunDetailPage.jsx
+++ b/app/ui/src/components/RunDetailPage.jsx
@@ -49,14 +49,14 @@ export default function RunDetailPage({ runId, onClose }) {
   }, [fetchRun]);
 
   if (loading && !run) {
-    return <div className="p-8 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">Loading run…</div>;
+    return <div className="p-8 text-sm text-gray-500 dark:text-gray-400">Loading run…</div>;
   }
   if (error && !run) {
     return (
       <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg p-6 max-w-md mx-auto mt-12">
         <h2 className="text-red-800 dark:text-red-300 font-semibold text-lg">Failed to load run</h2>
         <p className="text-red-600 dark:text-red-400 mt-2 text-sm">{error}</p>
-        <button onClick={onClose} className="mt-3 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500 underline hover:text-gray-700 dark:text-gray-300">Close</button>
+        <button onClick={onClose} className="mt-3 text-sm text-gray-500 dark:text-gray-400 underline hover:text-gray-700 dark:text-gray-300">Close</button>
       </div>
     );
   }
@@ -78,12 +78,12 @@ export default function RunDetailPage({ runId, onClose }) {
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white">{run.algorithmDisplayName || run.algorithmName}</h2>
               <span className={`text-[11px] px-2 py-0.5 rounded border ${statusMeta.className}`}>{statusMeta.label}</span>
             </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-2">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
               Triggered by {run.triggeredBy || 'unknown'} · started {fmt(run.startedAt)}
               {isDone && durationMs != null && <> · took {formatDurationMs(durationMs)}</>}
             </p>
           </div>
-          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500" aria-label="Close">
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400" aria-label="Close">
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -131,13 +131,13 @@ export default function RunDetailPage({ runId, onClose }) {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2">
             {Object.entries(run.parameters).map(([k, v]) => (
               <div key={k} className="flex items-baseline gap-2 py-1">
-                <span className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500 font-medium min-w-[140px]">{k}</span>
+                <span className="text-xs text-gray-500 dark:text-gray-400 font-medium min-w-[140px]">{k}</span>
                 <span className="text-sm text-gray-900 dark:text-white break-all">{typeof v === 'object' ? JSON.stringify(v) : String(v)}</span>
               </div>
             ))}
           </div>
         ) : (
-          <p className="text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">No parameters were supplied.</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">No parameters were supplied.</p>
         )}
       </div>
 
@@ -166,7 +166,7 @@ const STATUS_META = {
 function Stat({ label, value }) {
   return (
     <div>
-      <div className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 dark:text-gray-500">{label}</div>
+      <div className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">{label}</div>
       <div className="text-lg font-semibold text-gray-900 dark:text-white">{value ?? 0}</div>
     </div>
   );

--- a/app/ui/src/components/contexts/ContextMemberPicker.jsx
+++ b/app/ui/src/components/contexts/ContextMemberPicker.jsx
@@ -93,7 +93,7 @@ export default function ContextMemberPicker({ contextId, targetType, onAdded, ex
   }, [authFetch, contextId, onAdded]);
 
   if (!SEARCH_ENDPOINT[targetType]) {
-    return <p className="text-[11px] text-gray-500 dark:text-gray-400 dark:text-gray-500">No search endpoint for target type "{targetType}".</p>;
+    return <p className="text-[11px] text-gray-500 dark:text-gray-400">No search endpoint for target type "{targetType}".</p>;
   }
 
   return (
@@ -108,7 +108,7 @@ export default function ContextMemberPicker({ contextId, targetType, onAdded, ex
 
       {open && (results.length > 0 || loading) && (
         <div className="absolute left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg z-20 max-h-64 overflow-auto">
-          {loading && <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 dark:text-gray-500">Searching…</div>}
+          {loading && <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">Searching…</div>}
           {!loading && results.map(r => {
             const alreadyIn = existing.has(r.id);
             return (
@@ -116,7 +116,7 @@ export default function ContextMemberPicker({ contextId, targetType, onAdded, ex
                 key={r.id}
                 disabled={alreadyIn || adding === r.id}
                 onClick={() => add(r)}
-                className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 ${alreadyIn ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 ${alreadyIn ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 <span className="truncate">{r.displayName || r.id}</span>
                 <span className="text-[11px] text-gray-600 dark:text-gray-500 ml-2">

--- a/app/ui/src/components/contexts/ContextTreeView.jsx
+++ b/app/ui/src/components/contexts/ContextTreeView.jsx
@@ -339,7 +339,7 @@ function TreeNode({ node, displayLabel, depth, isLast, onOpenDetail, onRename, o
           <button
             aria-expanded={expanded}
             onClick={() => toggleExpanded(node.id)}
-            className="w-5 h-5 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:bg-gray-700 rounded shrink-0"
+            className="w-5 h-5 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded shrink-0"
             title={expanded ? 'Collapse' : 'Expand'}
           >
             {expanded ? '▾' : '▸'}
@@ -585,7 +585,7 @@ function MemberCount({ direct, total }) {
   if (t > d) {
     return (
       <span className="text-[11px] text-gray-600 dark:text-gray-500 whitespace-nowrap shrink-0">
-        {d} · <span className="text-gray-600 dark:text-gray-400 dark:text-gray-500">{t}</span>
+        {d} · <span className="text-gray-600 dark:text-gray-400">{t}</span>
       </span>
     );
   }

--- a/app/ui/src/components/contexts/ManualContextEditor.jsx
+++ b/app/ui/src/components/contexts/ManualContextEditor.jsx
@@ -233,7 +233,7 @@ export default function ManualContextEditor({ contextId, attrs, onUpdated, onDel
               </button>
               <button
                 onClick={() => setConfirmingDelete(false)}
-                className="px-3 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300"
+                className="px-3 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-700 dark:text-gray-300"
               >Cancel</button>
             </div>
           ) : (
@@ -276,7 +276,7 @@ function Field({ label, help, full, children }) {
     <div className={full ? 'sm:col-span-2' : ''}>
       <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</label>
       {children}
-      {help && <p className="text-[11px] text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-0.5">{help}</p>}
+      {help && <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">{help}</p>}
     </div>
   );
 }

--- a/app/ui/src/components/contexts/ModalPrimitives.jsx
+++ b/app/ui/src/components/contexts/ModalPrimitives.jsx
@@ -20,9 +20,9 @@ export function Modal({ title, subtitle, onClose, children, width = 480, dismiss
         <div className="flex items-start justify-between mb-3">
           <div className="min-w-0">
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">{title}</h3>
-            {subtitle && <p className="text-[11px] text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-0.5">{subtitle}</p>}
+            {subtitle && <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">{subtitle}</p>}
           </div>
-          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:text-gray-500 ml-4" aria-label="Close">✕</button>
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 ml-4" aria-label="Close">✕</button>
         </div>
         {children}
       </div>
@@ -35,7 +35,7 @@ export function Field({ label, help, children }) {
     <div>
       <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">{label}</label>
       {children}
-      {help && <p className="text-[11px] text-gray-500 dark:text-gray-400 dark:text-gray-500 mt-0.5">{help}</p>}
+      {help && <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">{help}</p>}
     </div>
   );
 }
@@ -66,7 +66,7 @@ export function SecondaryButton({ onClick, disabled, children }) {
     <button
       onClick={onClick}
       disabled={disabled}
-      className="px-3 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 disabled:opacity-50"
+      className="px-3 py-1 text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-700 dark:text-gray-300 disabled:opacity-50"
     >
       {children}
     </button>

--- a/app/ui/vite.config.js
+++ b/app/ui/vite.config.js
@@ -15,9 +15,10 @@ export default defineConfig({
     },
   },
   test: {
-    // Also pick up tests co-located with crawler wizard plugins, which live
-    // outside src/ (tools/crawlers/<type>/*.test.{js,jsx}).
-    include: ['src/**/*.test.{js,jsx}', '../../tools/crawlers/**/*.test.{js,jsx}'],
+    // Also pick up tests co-located with crawler wizard plugins (outside src/,
+    // tools/crawlers/<type>/*.test.{js,jsx}) and the custom ESLint rule tests
+    // (eslint-rules/*.test.js).
+    include: ['src/**/*.test.{js,jsx}', '../../tools/crawlers/**/*.test.{js,jsx}', 'eslint-rules/**/*.test.{js,jsx}'],
     // configValidation.test.js imports app/api/src/crawlerManifests.js, which
     // transitively requires the 'pg' package — only installed under
     // app/api/node_modules. Those tests run under app/api's vitest instead

--- a/changes/fix-darkmode-duplicate-classes.md
+++ b/changes/fix-darkmode-duplicate-classes.md
@@ -1,0 +1,2 @@
+- Fixed dark-mode styling on the context detail/tree, risk-scoring, run detail, and modal screens where duplicated Tailwind classes silently overrode the intended values: secondary text now renders at the correct (higher-contrast) shade, and table rows, list items, and sub-tabs no longer appear permanently highlighted in dark mode.
+- Added a lint check that flags a className setting the same dark-mode color twice, to stop the issue from creeping back in.


### PR DESCRIPTION
## Summary
Fixes findings **C1/C2** from the maintenance-sprint audit. A bad global find/replace had doubled several Tailwind `dark:` utilities; since the later utility wins in Tailwind's generated CSS, the intended value was silently overridden — and because it only affects dark mode, it shipped unnoticed.

**74 replacements across 8 files** (ContextDetailPage, ContextsPage, RiskScoringPage, RunDetailPage, ContextMemberPicker, ContextTreeView, ManualContextEditor, ModalPrimitives):

| Pattern | Effect | Fix |
|---|---|---|
| `dark:text-gray-400 dark:text-gray-500` | secondary text downgraded to lower-contrast gray-500 in dark mode | keep `dark:text-gray-400` |
| `dark:hover:bg-gray-700/50 dark:bg-gray-700/50` | permanent dark bg defeated the hover → rows looked always-highlighted | keep the hover form |
| `dark:hover:bg-gray-700 dark:bg-gray-700` | same, on risk-scoring sub-tabs + tree expanders | keep the hover form |

## Guard rail
Adds `local/no-duplicate-dark-color` (eslint-rules/) — flags a className that sets the same `dark:` color property twice. Set to **`warn`** as a ratchet: it also surfaces a separate, still-open backlog (`hover:text-X dark:text-Y` where the `dark:` token is missing its `hover:` — audit finding **M6**) without failing CI. Promote to `error` once M6 is cleaned up (good next dark-mode PR).

Rule logic validated against 5 representative classNames (C1 pre-fix flagged; post-codemod clean; M6 flagged; different-property pairs clean; correct `dark:hover:` form clean).

## Testing
Codemod verified by grep: all three patterns now return 0 occurrences. ⚠️ ESLint/vitest not run locally (this Windows checkout's `node_modules` is a Linux install); `node --check` passes on the rule + config and CI will run lint.

Findings C1/C2 from the maintenance-sprint audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)