### PR TITLE
ci: fix gates that could silently skip (F4/F7 + path-filter gaps)

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -42,6 +42,12 @@ on:
       - 'setup/IdentityAtlas.psd1'
       - '**.md'
 
+# Cancel superseded runs when a PR branch is pushed again — these Docker/load
+# suites are expensive, so don't let a stale run keep burning a runner (F4).
+concurrency:
+  group: pr-integration-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_NOLOGO: true
   POWERSHELL_TELEMETRY_OPTOUT: 1
@@ -121,6 +127,8 @@ jobs:
               - 'docker-compose*.yml'
             e2e:
               - 'app/ui/src/**'
+              - 'app/ui/e2e/**'
+              - 'app/ui/playwright*.config.js'
               - 'tools/crawlers/**/*.jsx'
               - 'app/api/src/**'
               - 'app/api/Dockerfile'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,12 @@ on:
       - dev
       - 'release/**'
 
+# Cancel superseded runs when a PR branch is pushed again, so a stale run can't
+# race the latest commit (or waste runners) (audit finding F4).
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_NOLOGO: true
   POWERSHELL_TELEMETRY_OPTOUT: 1
@@ -123,8 +129,15 @@ jobs:
               - 'test/unit/**'
             api:
               - 'app/api/src/**'
+              - 'app/api/package.json'
+              - 'app/api/vitest.config.js'
+              - 'app/api/eslint.config.js'
             ui:
               - 'app/ui/src/**'
+              - 'app/ui/package.json'
+              - 'app/ui/vite.config.js'
+              - 'app/ui/eslint.config.js'
+              - 'app/ui/eslint-rules/**'
               - 'tools/crawlers/**/*.jsx'
               - 'tools/crawlers/**/*.test.js'
               - 'tools/crawlers/**/*.test.jsx'
@@ -201,8 +214,13 @@ jobs:
   lint-js:
     name: 'Lint: ESLint'
     needs: [filter]
+    # This job lints BOTH app/ui and app/api — and the API config carries the
+    # eslint-plugin-security rules — so an API-only PR must still trigger it
+    # (audit finding F7: previously gated on `ui` alone, so API-only PRs skipped
+    # the security linter).
     if: |
       needs.filter.outputs.ui == 'true' ||
+      needs.filter.outputs.api == 'true' ||
       needs.filter.result == 'failure'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
Closes the CI-gate findings from the maintenance-sprint audit — cases where a required check could **silently not run** (a false green) or a stale run could race the latest commit. Motivated directly by #427, where a PR that changed `vite.config.js` + `eslint-rules/` only ran UI tests because the 8 touched `app/ui/src` files happened to trigger the `ui` scope — a config-only PR would have skipped them.

| ID | Fix |
|----|-----|
| **F4** | Add `concurrency: { cancel-in-progress: true }` to `pr.yml` and `pr-integration.yml` so a new push cancels the superseded run. |
| **F7** | The ESLint job lints **both** `app/ui` and `app/api` (the API carries the `eslint-plugin-security` rules) but was gated on the `ui` scope alone — an **API-only PR skipped the security linter**. Now also triggers on `api`. |
| path gaps | `api`/`ui` scopes matched only `src/**`, so a PR touching `package.json`, `vite/vitest.config.js`, `eslint.config.js`, or `eslint-rules/**` ran **neither lint nor unit tests**. Added those paths. |
| e2e gap | `pr-integration` `e2e` filter ignored `app/ui/e2e/**` and `playwright*.config.js` — a PR changing only e2e specs/config didn't run e2e. Added them. |

All scope changes are **fail-safe** (they cause *more* jobs to run, never fewer).

## Not included (own follow-ups)
- **F2** — fail loudly when required test secrets are missing on `main` PRs (vs the current silent skip).
- **F6** — wire `test/ci-scripts/*.sh` (the gate-logic self-tests) into a PR job.

Both add a job + `ci-passed` aggregator wiring and deserve separate review.

## Testing
Workflow-only change (no product code → hygiene needs no test/changelog). Both YAML files validated with a parser locally. ⚠️ `pr-integration.yml` won't run on this PR (it `paths-ignore`s `.github/workflows/**`); `pr.yml` will, and should pass with the scope jobs correctly skipping (no `src` changed) and hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)