### PR TITLE
fix(ui): correct missing-hover dark colors + enforce dark-dup rule (M6)

### DIFF
--- a/app/ui/eslint-rules/no-duplicate-dark-color.js
+++ b/app/ui/eslint-rules/no-duplicate-dark-color.js
@@ -13,8 +13,8 @@
 // `dark:hover:text-...` is the CORRECT way to set a dark hover color, so a
 // `dark:text-X` + `dark:hover:text-Y` pair is fine and never flagged.
 //
-// Started as a warning (ratchet): it surfaces the remaining backlog without
-// failing CI; promote to 'error' once clean. See app/ui/CLAUDE.md § Dark Mode.
+// Enforced as an error (the C1/C2/M6 backlog is cleaned up). See app/ui/CLAUDE.md
+// § Dark Mode.
 
 const TAILWIND_COLORS = new Set([
   'gray', 'slate', 'zinc', 'neutral', 'stone',

--- a/app/ui/eslint-rules/no-duplicate-dark-color.test.js
+++ b/app/ui/eslint-rules/no-duplicate-dark-color.test.js
@@ -40,4 +40,15 @@ describe('findDuplicateProps', () => {
     // dark:text-sm is not a color; dark:p-2 is spacing — neither should count.
     expect(findDuplicateProps('dark:text-sm dark:text-gray-400')).toHaveLength(0);
   });
+
+  it('flags the M6 red-variant missing-hover pattern', () => {
+    // text-red-600 dark:text-red-400 hover:text-red-800 dark:text-red-300
+    expect(findDuplicateProps('text-red-600 dark:text-red-400 hover:text-red-800 dark:text-red-300')).toHaveLength(1);
+  });
+
+  it('does NOT flag the codemod output (base dark + dark:hover variant)', () => {
+    // This is the shape the M6 fix produces — must stay clean once the rule is an error.
+    expect(findDuplicateProps('text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300')).toHaveLength(0);
+    expect(findDuplicateProps('text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400')).toHaveLength(0);
+  });
 });

--- a/app/ui/eslint.config.js
+++ b/app/ui/eslint.config.js
@@ -51,10 +51,10 @@ export default [
     rules: {
       ...reactHooks.configs.recommended.rules,
       'local/no-low-contrast-text': 'error',
-      // Ratchet: warns on duplicate dark: color utilities (the audit's C1/C2/M6
-      // class). Promote to 'error' once the remaining `hover:text-X dark:text-Y`
-      // (missing-hover) backlog is cleaned up.
-      'local/no-duplicate-dark-color': 'warn',
+      // Flags two plain dark: utilities setting the same color property (the
+      // audit's C1/C2/M6 class — the later one silently wins). The missing-hover
+      // backlog (`hover:text-X dark:text-Y`) is now cleaned up, so this is an error.
+      'local/no-duplicate-dark-color': 'error',
       'local/no-native-dialogs': 'error',
       'local/no-legacy-jargon': 'error',
       'local/no-hardcoded-crawler-meta': 'error',

--- a/app/ui/src/components/ContextDetailPage.jsx
+++ b/app/ui/src/components/ContextDetailPage.jsx
@@ -133,7 +133,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
         <p className="text-red-600 dark:text-red-400 mt-2 text-sm">{error}</p>
         <div className="flex gap-3 mt-3">
           <button onClick={fetchDetail} className="text-sm text-red-700 dark:text-red-400 underline hover:text-red-900">Retry</button>
-          <button onClick={onClose} className="text-sm text-gray-500 dark:text-gray-400 underline hover:text-gray-700 dark:text-gray-300">Close</button>
+          <button onClick={onClose} className="text-sm text-gray-500 dark:text-gray-400 underline hover:text-gray-700 dark:hover:text-gray-300">Close</button>
         </div>
       </div>
     );
@@ -143,7 +143,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center text-gray-600 dark:text-gray-500 text-sm">
         Context not found.
-        <button onClick={onClose} className="ml-2 text-blue-500 dark:text-blue-400 underline hover:text-blue-700 dark:text-blue-300">Close</button>
+        <button onClick={onClose} className="ml-2 text-blue-500 dark:text-blue-400 underline hover:text-blue-700 dark:hover:text-blue-300">Close</button>
       </div>
     );
   }
@@ -247,7 +247,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
               >
                 <div className="flex items-center gap-2">
                   <span className="inline-flex items-center justify-center w-5 h-5 rounded bg-sky-100 text-sky-700 dark:text-sky-300 text-[9px] font-bold">CTX</span>
-                  <span className="text-sm text-gray-900 dark:text-white group-hover:text-sky-700 dark:text-sky-300">{sc.displayName}</span>
+                  <span className="text-sm text-gray-900 dark:text-white group-hover:text-sky-700 dark:hover:text-sky-300">{sc.displayName}</span>
                 </div>
                 {sc.memberCount != null && (
                   <span className="text-xs text-gray-600 dark:text-gray-500">{sc.memberCount} members</span>
@@ -377,7 +377,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                 <button
                   onClick={() => setMemberPage(p => Math.max(0, p - 1))}
                   disabled={memberPage === 0}
-                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
                 >
                   Previous
                 </button>
@@ -387,7 +387,7 @@ export default function ContextDetailPage({ contextId, cachedData, onCacheData, 
                 <button
                   onClick={() => setMemberPage(p => Math.min(totalPages - 1, p + 1))}
                   disabled={memberPage >= totalPages - 1}
-                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-700 rounded px-2 py-1"
                 >
                   Next
                 </button>
@@ -454,7 +454,7 @@ function ContextHeader({ attrs, onClose }) {
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Parent: {attrs.parentDisplayName}</p>
           )}
         </div>
-        <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 p-1" title="Close">
+        <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 p-1" title="Close">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -475,7 +475,7 @@ function RemoveMemberButton({ memberRow, onRemove, isGenerated }) {
     return (
       <button
         onClick={e => { e.stopPropagation(); onRemove(memberRow.id); }}
-        className="text-[11px] text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:text-amber-300"
+        className="text-[11px] text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300"
         title="Algorithm-produced member — removing now; the next plugin run will re-add it unless you tune plugin parameters."
       >Remove (will return)</button>
     );
@@ -483,7 +483,7 @@ function RemoveMemberButton({ memberRow, onRemove, isGenerated }) {
   return (
     <button
       onClick={e => { e.stopPropagation(); onRemove(memberRow.id); }}
-      className="text-[11px] text-red-600 dark:text-red-400 hover:text-red-800 dark:text-red-300"
+      className="text-[11px] text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
       title="Remove from context"
     >Remove</button>
   );
@@ -552,7 +552,7 @@ function GeneratedContextActions({ contextId, attrs, authFetch, onDeleted }) {
       ) : (
         <button
           onClick={() => setConfirming(true)}
-          className="text-[11px] text-red-600 dark:text-red-400 hover:text-red-700 dark:text-red-400"
+          className="text-[11px] text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-400"
         >Delete context…</button>
       )}
     </div>

--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -285,7 +285,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
               <div className="text-2xl font-bold text-gray-800 dark:text-gray-200">{c.aggregateRiskScore}</div>
               <TierBadge tier={c.riskTier} />
             </div>
-            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 p-1">
+            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 p-1">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
             </button>
           </div>
@@ -345,7 +345,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
                 <button
                   onClick={handleRemoveOwner}
                   disabled={saving}
-                  className="text-xs text-red-600 dark:text-red-400 hover:text-red-800 dark:text-red-300 border border-red-200 dark:border-red-700 rounded px-2 py-0.5 hover:bg-red-50 dark:bg-red-900/30 disabled:opacity-40"
+                  className="text-xs text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 border border-red-200 dark:border-red-700 rounded px-2 py-0.5 hover:bg-red-50 dark:bg-red-900/30 disabled:opacity-40"
                 >
                   Remove
                 </button>
@@ -386,7 +386,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
                     )}
                     <button
                       onClick={() => { setShowOwnerSearch(false); setOwnerSearch(''); }}
-                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300"
+                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
                     >
                       Cancel
                     </button>

--- a/app/ui/src/components/RunDetailPage.jsx
+++ b/app/ui/src/components/RunDetailPage.jsx
@@ -56,7 +56,7 @@ export default function RunDetailPage({ runId, onClose }) {
       <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg p-6 max-w-md mx-auto mt-12">
         <h2 className="text-red-800 dark:text-red-300 font-semibold text-lg">Failed to load run</h2>
         <p className="text-red-600 dark:text-red-400 mt-2 text-sm">{error}</p>
-        <button onClick={onClose} className="mt-3 text-sm text-gray-500 dark:text-gray-400 underline hover:text-gray-700 dark:text-gray-300">Close</button>
+        <button onClick={onClose} className="mt-3 text-sm text-gray-500 dark:text-gray-400 underline hover:text-gray-700 dark:hover:text-gray-300">Close</button>
       </div>
     );
   }
@@ -83,7 +83,7 @@ export default function RunDetailPage({ runId, onClose }) {
               {isDone && durationMs != null && <> · took {formatDurationMs(durationMs)}</>}
             </p>
           </div>
-          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400" aria-label="Close">
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400" aria-label="Close">
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/app/ui/src/components/contexts/ContextTreeView.jsx
+++ b/app/ui/src/components/contexts/ContextTreeView.jsx
@@ -339,7 +339,7 @@ function TreeNode({ node, displayLabel, depth, isLast, onOpenDetail, onRename, o
           <button
             aria-expanded={expanded}
             onClick={() => toggleExpanded(node.id)}
-            className="w-5 h-5 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded shrink-0"
+            className="w-5 h-5 flex items-center justify-center text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded shrink-0"
             title={expanded ? 'Collapse' : 'Expand'}
           >
             {expanded ? '▾' : '▸'}

--- a/app/ui/src/components/contexts/ManualContextEditor.jsx
+++ b/app/ui/src/components/contexts/ManualContextEditor.jsx
@@ -239,7 +239,7 @@ export default function ManualContextEditor({ contextId, attrs, onUpdated, onDel
           ) : (
             <button
               onClick={() => setConfirmingDelete(true)}
-              className="text-[11px] text-red-600 dark:text-red-400 hover:text-red-700 dark:text-red-400"
+              className="text-[11px] text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-400"
             >Delete context…</button>
           )}
         </div>

--- a/app/ui/src/components/contexts/ModalPrimitives.jsx
+++ b/app/ui/src/components/contexts/ModalPrimitives.jsx
@@ -22,7 +22,7 @@ export function Modal({ title, subtitle, onClose, children, width = 480, dismiss
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">{title}</h3>
             {subtitle && <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">{subtitle}</p>}
           </div>
-          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:text-gray-400 ml-4" aria-label="Close">✕</button>
+          <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 ml-4" aria-label="Close">✕</button>
         </div>
         {children}
       </div>

--- a/changes/fix-darkmode-missing-hover.md
+++ b/changes/fix-darkmode-missing-hover.md
@@ -1,0 +1,2 @@
+- Fixed dark-mode hover states on buttons and links across the context detail/tree, risk-scoring, run-detail, and modal screens. A hover text color was being applied permanently in dark mode (instead of only on hover) because its `hover:` modifier was missing, so the affected controls didn't visibly respond to hover in dark mode.
+- The lint check for duplicate dark-mode colors is now enforced as an error, preventing the issue from returning.


### PR DESCRIPTION
## Summary
Finishes the dark-mode cleanup (audit finding **M6**) and promotes the guard rule to an error.

Several buttons/links had `hover:text-X dark:text-Y` where the `dark:` token was **missing its `hover:` modifier** — so the "dark hover" color became a second *base* dark color. Since the later same-property utility wins in Tailwind's CSS, the control showed that color permanently and didn't visibly respond to hover in dark mode.

**Fix:** converts the 2nd plain `dark:` color in each affected className to its hover variant (`dark:hover:…`). **17 classNames across 6 files** (ContextDetailPage, RiskScoringPage, RunDetailPage, ContextTreeView, ManualContextEditor, ModalPrimitives).

Example:
```
- text-red-600 dark:text-red-400 hover:text-red-800 dark:text-red-300
+ text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300
```

## Rule promoted to `error`
`local/no-duplicate-dark-color` goes from `warn` → `error` now that the backlog is clean, so this class of bug can't return. Added rule tests for the M6 pattern and the codemod's output shape.

## How I verified completeness (couldn't run eslint locally)
The node_modules here is a Linux install, so I replicated the rule's per-string evaluation in a checker: it splits each line into individual quoted strings / template quasis / ternary branches (the units the rule walks) and runs the dup logic on each. After the codemod it reports **0 genuine single-string duplicates** — the ~31 remaining two-`dark:text` lines are all ternary branches (`{cond ? '…' : '…'}`), which the rule correctly evaluates separately. CI's ESLint job (now at error) is the authoritative final check.

Out of scope (noted, not fixed): a few close buttons still have a no-op *light* hover (`text-gray-600 hover:text-gray-600`) — cosmetic, not flagged by the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)