### PR TITLE
perf(matrix): add partial Direct index on the matrix matview (P3)

### DIFF
--- a/app/api/src/db/migrations/042_matrix_direct_index.sql
+++ b/app/api/src/db/migrations/042_matrix_direct_index.sql
@@ -1,0 +1,20 @@
+-- Identity Atlas — partial index on the matrix matview for Direct memberships
+--
+-- The roll-up and scope endpoints scan the matrix matview filtered to
+-- membershipType='Direct' and group with count(DISTINCT "principalId") per
+-- resource. The existing single-column "resourceId" index gives resourceId
+-- order only, so the planner adds an Incremental Sort to reach
+-- (resourceId, principalId) order for the distinct count. A composite,
+-- Direct-only index provides that order directly, letting the GroupAggregate
+-- stream without the sort.
+--
+-- Measured on a real 367k-row matview (298k Direct): the broad/unscoped roll-up
+-- drops from ~126 ms to ~51 ms (~2.5x) with identical results. Scoped queries
+-- are unaffected (already index-only via the primary key). Index size ~14 MB.
+--
+-- Partial (WHERE membershipType='Direct') so it only covers the rows the matrix
+-- reads, keeping the index small and the REFRESH MATERIALIZED VIEW cost low.
+
+CREATE INDEX IF NOT EXISTS "ix_vw_ResUserPerm_direct"
+  ON "vw_ResourceUserPermissionAssignments" ("resourceId", "principalId")
+  WHERE "membershipType" = 'Direct';

--- a/changes/matrix-direct-index.md
+++ b/changes/matrix-direct-index.md
@@ -1,0 +1,1 @@
+- Improved matrix performance on large tenants: the roll-up and scope views now use a dedicated index for direct memberships, roughly halving the query time for broad matrix loads (measured ~2.5x faster on a real ~370k-row dataset). No change to results.


### PR DESCRIPTION
## Summary
Audit finding **P3**. The roll-up and scope endpoints scan `vw_ResourceUserPermissionAssignments` filtered to `membershipType='Direct'`, grouping `count(DISTINCT "principalId")` per resource. The existing single-column `resourceId` index only yields resourceId order, so the planner adds an **Incremental Sort** to reach `(resourceId, principalId)` for the distinct count.

Migration 042 adds a composite, Direct-only **partial index** that provides that order directly, so the GroupAggregate streams without the sort:
```sql
CREATE INDEX IF NOT EXISTS "ix_vw_ResUserPerm_direct"
  ON "vw_ResourceUserPermissionAssignments" ("resourceId", "principalId")
  WHERE "membershipType" = 'Direct';
```

## Measured on SK3 (real 367k-row matview, 298k Direct) — measure-first
The original report assumed a ~1.5M-row matview with seq-scans; the real numbers are smaller, so I measured `EXPLAIN ANALYZE` before deciding, then again after applying the migration:

| | Plan | Time |
|---|---|---|
| **Before** | `Index Scan (resourceId)` → **Incremental Sort** → GroupAggregate | **126 ms** |
| **After** | `Index Scan (ix_vw_ResUserPerm_direct)` → GroupAggregate (no sort) | **53 ms** (~2.5×) |

- The win is **sort elimination**, not selectivity (Direct is 81% of rows — I initially expected the index *not* to help; the measurement proved otherwise).
- **Scoped/interactive queries are unaffected** — already index-only at ~0.3 ms via the PK.
- Index size ~14 MB; partial `WHERE` keeps it small and limits the `REFRESH MATERIALIZED VIEW` cost.

## Validation
Deployed the branch to SK3 → `migrate.js` applied 042 on startup → index created → re-ran the plan (53 ms, index used, sort gone) → **`/matrix/data` roll-up byte-identical** to baseline (`f7810930…`: same result, just faster). No JS changed, so nothing else is affected; CI integration tests exercise the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)