### PR TITLE
ci(security): add Socket Firewall supply-chain gate to PR pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -429,6 +429,47 @@ jobs:
         working-directory: app/api
         run: npm audit --audit-level=high
 
+  # ── Stage 6b: Supply-chain firewall (Socket Firewall Free) ───────────────
+  # Installs both Node projects through Socket Firewall, which proxies the npm
+  # registry and BLOCKS known-malicious packages — typosquats, install-script
+  # malware, and hijacked/compromised maintainer releases — before they reach
+  # the build. This covers the supply-chain class that `npm audit` and
+  # Dependabot structurally miss: a freshly-published malicious version that
+  # has no CVE/advisory yet, including a malicious version bump proposed by
+  # Dependabot's own PRs. Complements (does not replace) the npm audit job.
+  #
+  # Note: setup-node's npm cache is intentionally NOT enabled here — the
+  # firewall must see the actual registry downloads, not a cache replay. A
+  # Dependabot bump changes the lockfile, so the relevant packages are fetched
+  # fresh and inspected regardless.
+  #
+  # Powered by Socket Firewall Free — https://github.com/SocketDev/sfw-free
+  supply-chain:
+    name: 'Audit: Supply-chain firewall (Socket)'
+    needs: [changes]
+    if: needs.changes.outputs.has_product_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+
+      - name: Enable Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - name: Install API dependencies through the firewall
+        working-directory: app/api
+        run: sfw npm ci
+
+      - name: Install UI dependencies through the firewall
+        working-directory: app/ui
+        run: sfw npm ci
+
   # ── Stage 7: PR hygiene (tests + changelog required for code changes) ────
   # Blocks merging a code change that ships without tests or a changelog
   # fragment — the gap that let an undocumented, untested feature reach main.
@@ -639,6 +680,7 @@ jobs:
       - node-launcher-ui-build
       - openapi
       - audit
+      - supply-chain
       - hygiene
       - crawler-manifest
       - docs-nav

--- a/changes/socket-firewall-supply-chain.md
+++ b/changes/socket-firewall-supply-chain.md
@@ -1,0 +1,2 @@
+- Added software supply-chain protection to the build pipeline: every pull request now installs Node dependencies through Socket Firewall, which blocks known-malicious packages (typosquats, install-script malware, hijacked maintainer releases) before they reach the build — including malicious version bumps that automated dependency updates might propose.
+- Credited Socket Firewall on the About and Security pages of the documentation.

--- a/docs/about.md
+++ b/docs/about.md
@@ -22,6 +22,12 @@ See the [History](history.md) page for the full story of how Identity Atlas got 
 - **Website:** [www.fortigi.nl](https://www.fortigi.nl)
 - **Issues and pull requests:** [GitHub repository](https://github.com/Fortigi/IdentityAtlas)
 
+## Acknowledgements
+
+Identity Atlas stands on the shoulders of the open-source community. We'd like to call out one tool in particular:
+
+- **[Socket Firewall](https://github.com/SocketDev/sfw-free)** by [Socket](https://socket.dev) — guards our build pipeline against software supply-chain attacks by blocking known-malicious npm packages before they can be installed. Thank you for making it freely available.
+
 ## License
 
 Copyright © Maatschap Fortigi. See the repository `LICENSE` file for licensing terms.

--- a/docs/contributing/ci-pipeline.md
+++ b/docs/contributing/ci-pipeline.md
@@ -37,7 +37,8 @@ These four jobs have **no path gate** — they always run when there are product
 
 | Job | Check name | Purpose |
 |---|---|---|
-| `audit` | Audit: npm audit | npm vulnerability scan |
+| `audit` | Audit: npm audit | npm vulnerability scan (known advisories) |
+| `supply-chain` | Audit: Supply-chain firewall (Socket) | Installs both Node projects through [Socket Firewall](https://github.com/SocketDev/sfw-free), blocking known-malicious packages with no CVE yet |
 | `hygiene` | PR Hygiene | Branch naming, PR description checks |
 | `crawler-manifest` | Lint: Crawler manifest completeness | Every crawler has a `crawler.json` |
 | `docs-nav` | Lint: Crawler docs registered in site nav | Every crawler has a docs entry in `mkdocs.yml` |

--- a/docs/security/assessment.md
+++ b/docs/security/assessment.md
@@ -100,7 +100,7 @@ The portable launcher was not in scope for the original assessment (it was added
 Beyond the per-finding fixes, the remediation programme added preventative guardrails:
 
 - **Permission model** — a documented, tested role/permission catalog with the granular-permission bug fixed and per-route gating, plus a CI gate that blocks merges lacking tests or documentation ([#194](https://github.com/Fortigi/IdentityAtlas/pull/194)).
-- **Supply chain** — all GitHub Actions pinned to commit SHAs with Dependabot keeping them current ([#214](https://github.com/Fortigi/IdentityAtlas/pull/214)).
+- **Supply chain** — all GitHub Actions pinned to commit SHAs with Dependabot keeping them current ([#214](https://github.com/Fortigi/IdentityAtlas/pull/214)). CI installs every Node dependency through [**Socket Firewall**](https://github.com/SocketDev/sfw-free), which blocks known-malicious packages (typosquats, install-script malware, hijacked maintainer releases) before they reach the build — covering the supply-chain class that advisory-based scanning misses until a CVE is published. A machine-readable [SBOM](../reference/sbom.md) is regenerated on every dependency change.
 
 ---
 


### PR DESCRIPTION
## What

Adds a software supply-chain protection gate to the PR pipeline using [**Socket Firewall Free**](https://github.com/SocketDev/sfw-free).

A new `supply-chain` job in [`pr.yml`](.github/workflows/pr.yml) installs both Node projects (`app/api` and `app/ui`) through Socket Firewall, which proxies the npm registry and **blocks known-malicious packages** — typosquats, install-script malware, hijacked/compromised maintainer releases — before they reach the build. The job is wired into the `CI Passed` gate, so a flagged package blocks the merge.

## Why

This closes a real gap. Our existing `npm audit` job and Dependabot are both **advisory-based** — they only catch a dependency once a CVE/GHSA exists for it. They do **not** catch a freshly-published *malicious* version that has no advisory yet, which is exactly the modern supply-chain attack (compromised maintainer pushes a poisoned patch release). Notably, **Dependabot will happily open a PR bumping to such a version** simply because it's newer; Socket Firewall now gates those PRs too.

The three tools are complementary:

| Layer | Catches |
|---|---|
| Dependabot / npm audit | Out-of-date deps + **known** advisories |
| CodeQL | Vulnerabilities in our own code |
| **Socket Firewall (new)** | **Malicious / compromised packages, no CVE needed** |

## Notes

- The action is SHA-pinned (`socketdev/action@ba6de6c # v1.3.2`), consistent with our policy of pinning every Action; the existing `github-actions` Dependabot config keeps it current automatically.
- The job deliberately does **not** use setup-node's npm cache, so the firewall inspects real registry downloads rather than a cache replay.
- Scope note: this hardens the **npm** dependency surface only — PowerShell Gallery modules and Docker base images are out of Socket Firewall Free's scope.

## Credit

Credits Socket on the [About](docs/about.md) and [Security Assessment](docs/security/assessment.md) docs pages, and documents the new job in [ci-pipeline.md](docs/contributing/ci-pipeline.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)