### PR TITLE
feat(testing): fix E2E realism and make CI E2E blocking

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -134,7 +134,6 @@ jobs:
               - 'tools/crawlers/**/*.e2e.*'
               - 'app/api/src/**'
               - 'app/api/Dockerfile'
-              - '.github/workflows/pr-integration.yml'
             load_soak:
               - 'app/api/src/**'
               - 'tools/crawlers/shared/**'

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -679,11 +679,6 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'skip-e2e')
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Non-blocking for now: many E2E specs were written for local dev (mock
-    # backend, interactive browser) and need adaptation for the Docker CI
-    # environment (accessibility violations, visual regression baselines,
-    # optional tabs hidden by default). Filed as follow-up work.
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -128,10 +128,13 @@ jobs:
             e2e:
               - 'app/ui/src/**'
               - 'app/ui/e2e/**'
+              - 'app/ui/scripts/**'
               - 'app/ui/playwright*.config.js'
               - 'tools/crawlers/**/*.jsx'
+              - 'tools/crawlers/**/*.e2e.*'
               - 'app/api/src/**'
               - 'app/api/Dockerfile'
+              - '.github/workflows/pr-integration.yml'
             load_soak:
               - 'app/api/src/**'
               - 'tools/crawlers/shared/**'

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "npx playwright test",
+    "test:e2e:sql": "bash scripts/e2e-sql.sh",
     "test:e2e:headed": "npx playwright test --headed",
     "test:e2e:ui": "npx playwright test --ui"
   },

--- a/app/ui/playwright.ci.config.js
+++ b/app/ui/playwright.ci.config.js
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Playwright CI Configuration — runs against the Docker backend.
+ * Playwright CI Configuration — runs against the Docker backend (USE_SQL=true).
  *
  * Unlike the default config (playwright.config.js) which starts its own
  * backend in mock mode + Vite dev server, this config expects the full

--- a/app/ui/scripts/e2e-sql.sh
+++ b/app/ui/scripts/e2e-sql.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Run Playwright E2E tests against the real Docker stack (USE_SQL=true).
+#
+# Usage:
+#   npm run test:e2e:sql                 # run all E2E against real Docker DB
+#   npm run test:e2e:sql -- navigation   # filter by spec name
+#
+# If the stack is already running (e.g. in active dev), it is reused and NOT
+# torn down afterward. If the stack is not running, it is started here and
+# torn down when the tests finish.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+API_URL="http://localhost:3001/api/admin/status"
+
+# Check if the stack is already running
+STARTED_HERE=false
+if curl -sf "$API_URL" > /dev/null 2>&1; then
+  echo "Docker stack already running — reusing existing instance"
+elif command -v docker > /dev/null 2>&1; then
+  echo "Starting Docker stack..."
+  cd "$REPO_ROOT"
+  docker compose up -d --build
+  STARTED_HERE=true
+
+  echo "Waiting for API to be ready..."
+  for i in $(seq 1 60); do
+    if curl -sf "$API_URL" > /dev/null 2>&1; then
+      echo "API ready after $((i * 2))s"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: API did not become ready within 120s"
+      docker compose down
+      exit 1
+    fi
+    sleep 2
+  done
+
+  echo "Loading demo data..."
+  JOB=$(curl -sf -X POST http://localhost:3001/api/admin/crawler-jobs \
+    -H "Content-Type: application/json" -d '{"jobType": "demo"}')
+  JOB_ID=$(echo "$JOB" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+  if [ -n "$JOB_ID" ]; then
+    for i in $(seq 1 40); do
+      STATUS=$(curl -sf "http://localhost:3001/api/admin/crawler-jobs/$JOB_ID" | \
+        python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+      if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
+        echo "Demo data loaded (status: $STATUS)"
+        break
+      fi
+      sleep 3
+    done
+  fi
+else
+  echo "docker not found — assuming stack is already running externally (e.g. Docker Desktop on Windows)"
+  echo "If tests fail to connect, start the Docker stack manually first."
+fi
+
+# Run Playwright with the CI config (real-DB mode, port 3001)
+cd "$REPO_ROOT/app/ui"
+EXIT_CODE=0
+npx playwright test --config=playwright.ci.config.js "$@" || EXIT_CODE=$?
+
+# Only tear down if we started the stack
+if [ "$STARTED_HERE" = "true" ]; then
+  echo "Tearing down Docker stack..."
+  cd "$REPO_ROOT"
+  docker compose down
+fi
+
+exit $EXIT_CODE

--- a/changes/test-e2e-realism.md
+++ b/changes/test-e2e-realism.md
@@ -1,0 +1,2 @@
+- Added `npm run test:e2e:sql` command to run Playwright E2E tests against a real Docker stack locally, matching the CI environment exactly
+- E2E failures in CI now block PR merges (removed the `continue-on-error` bypass that was masking test failures)


### PR DESCRIPTION
## Summary

- Added `npm run test:e2e:sql` command to run Playwright E2E tests against a real Docker stack locally, matching the CI environment exactly
- E2E failures in CI now block PR merges (removed the `continue-on-error` bypass that was masking test failures)

## Changes

- `app/ui/scripts/e2e-sql.sh` — shell wrapper that starts all Docker services, loads demo data, runs `playwright.ci.config.js`, then tears down (reuses an already-running stack if detected)
- `app/ui/package.json` — added `test:e2e:sql` script
- `.github/workflows/pr-integration.yml` — removed `continue-on-error: true` from the E2E job

## Test plan

- [ ] `pr-integration.yml` E2E job passes (CI validates this)
- [ ] `npm run test:e2e:sql` works locally when Docker is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)