### PR TITLE
feat(entra-id): crawl Entra directory roles + permission actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ The data model supports importing authorization data from any system. Resources,
 | `resourceType` | Source | What it represents |
 |---|---|---|
 | `EntraGroup` | Entra crawler | Security / Microsoft 365 group |
+| `EntraRole` | `SyncDirectoryRoles` phase | One resource per Entra directory role (`id` = roleDefinitionId). `extendedAttributes` holds the role's granular `allowedResourceActions`, `isBuiltIn`, and `templateId`. Assigned to principals via `assignmentType='DirectoryRole'` (active) or `assignmentType='DirectoryRoleEligible'` (PIM-eligible) |
 | `BusinessRole` | Governance sync (Entra access packages, Omada business roles) | Wraps groups via `relationshipType='Contains'`; assigned to users via `assignmentType='Governed'` |
 | `Application` | OAuth2 / AppRoles phases | Enterprise application (service principal). Doesn't grant access by itself — it's the parent of AppRole / DelegatedPermission children |
 | `AppRole` | `SyncAppRoles` phase | One synthetic resource per (Application, appRoleId). Parent app linked via `relationshipType='HasAppRole'`. Assigned to users via `assignmentType='AppRole'` (direct) or `assignmentType='AppRoleViaGroup'` (expanded from a group's role) |
@@ -136,7 +137,7 @@ The data model supports importing authorization data from any system. Resources,
 
 **Assignment types in use:**
 
-`Direct`, `Indirect`, `Owner`, `Eligible` (the four "how does this user have it" types) plus the *source-attribute* types `Governed`, `OAuth2Grant`, `AppRole`, `AppRoleViaGroup`. The matrix view (`vw_ResourceUserPermissionAssignments`) collapses the source-attribute types in its `membershipType` output — see [`docs/architecture/matrix.md`](docs/architecture/matrix.md) for the badge-display rules.
+`Direct`, `Indirect`, `Owner`, `Eligible` (the four "how does this user have it" types) plus the *source-attribute* types `Governed`, `OAuth2Grant`, `AppRole`, `AppRoleViaGroup`, `DirectoryRole`, `DirectoryRoleEligible`. The matrix view (`vw_ResourceUserPermissionAssignments`) collapses the source-attribute types in its `membershipType` output (`DirectoryRole`→`Direct`, `DirectoryRoleEligible`→`Eligible`) — see [`docs/architecture/matrix.md`](docs/architecture/matrix.md) for the badge-display rules.
 
 **Relationship types in use:** `Contains` (BusinessRole → group), `HasAppRole` (Application → AppRole), `DelegatesScope` (Application → DelegatedPermission), `GrantsAccessTo` (reserved).
 

--- a/app/api/src/db/migrations/043_matrix_view_directory_roles.sql
+++ b/app/api/src/db/migrations/043_matrix_view_directory_roles.sql
@@ -1,0 +1,106 @@
+-- Identity Atlas — collapse the new directory-role assignment types in the matrix.
+--
+-- The Entra ID crawler's new SyncDirectoryRoles phase writes Entra directory
+-- roles as Resources(resourceType='EntraRole') with assignments carrying two
+-- new source-attribute assignment types:
+--   * 'DirectoryRole'          — an active role assignment (permanent or
+--                                PIM-activated). Renders as a 'Direct' badge.
+--   * 'DirectoryRoleEligible'  — a PIM-eligible (not yet active) assignment.
+--                                Renders as an 'Eligible' badge.
+--
+-- These get distinct raw assignment types (rather than reusing 'Direct' /
+-- 'Eligible') so the crawler's scoped full-sync delete keys on them without
+-- touching group memberships or PIM-group eligibilities — the same reason
+-- AppRole/AppRoleViaGroup are distinct. The matrix collapses them back to the
+-- standard Direct/Eligible badges here, mirroring how Governed/OAuth2Grant/
+-- AppRole already collapse (see migrations 025/026/041 and matrix.md).
+--
+-- This file mirrors migration 041 (its soft-delete filters are preserved
+-- verbatim) and recreates the matview plus all four of its indexes — including
+-- the partial Direct index added in 042, which a DROP MATERIALIZED VIEW removes.
+
+DROP VIEW IF EXISTS "vw_UserPermissionAssignments";
+DROP MATERIALIZED VIEW IF EXISTS "vw_ResourceUserPermissionAssignments";
+
+CREATE MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments" AS
+WITH governed_pairs AS (
+    SELECT DISTINCT "resourceId", "principalId"
+      FROM "ResourceAssignments"
+     WHERE "assignmentType" = 'Governed'
+       AND "principalId" IS NOT NULL
+       AND "deletedAt" IS NULL
+),
+collapsed AS (
+    -- Existing arm: principal-level assignments
+    SELECT
+        ra."resourceId",
+        ra."principalId",
+        ra."principalType",
+        CASE
+          WHEN ra."assignmentType" IN ('Governed', 'OAuth2Grant', 'AppRole', 'DirectoryRole') THEN 'Direct'
+          WHEN ra."assignmentType" = 'AppRoleViaGroup'                                        THEN 'Indirect'
+          WHEN ra."assignmentType" = 'DirectoryRoleEligible'                                  THEN 'Eligible'
+          ELSE ra."assignmentType"
+        END AS "membershipType",
+        (ra."assignmentType" = 'Governed' OR gp."resourceId" IS NOT NULL) AS "managedByAccessPackage"
+    FROM "ResourceAssignments" ra
+    LEFT JOIN governed_pairs gp
+           ON gp."resourceId"  = ra."resourceId"
+          AND gp."principalId" = ra."principalId"
+    WHERE ra."principalId" IS NOT NULL
+      AND ra."deletedAt" IS NULL
+      AND NOT EXISTS (SELECT 1 FROM "Resources"  r WHERE r.id = ra."resourceId"  AND r."deletedAt" IS NOT NULL)
+      AND NOT EXISTS (SELECT 1 FROM "Principals" p WHERE p.id = ra."principalId" AND p."deletedAt" IS NOT NULL)
+
+    UNION ALL
+
+    -- New arm: identity-level assignments expanded through IdentityMembers
+    SELECT
+        ra."resourceId",
+        im."principalId",
+        NULL AS "principalType",
+        CASE
+          WHEN ra."assignmentType" IN ('Governed', 'OAuth2Grant', 'AppRole', 'DirectoryRole') THEN 'Direct'
+          WHEN ra."assignmentType" = 'AppRoleViaGroup'                                        THEN 'Indirect'
+          WHEN ra."assignmentType" = 'DirectoryRoleEligible'                                  THEN 'Eligible'
+          ELSE ra."assignmentType"
+        END AS "membershipType",
+        (ra."assignmentType" = 'Governed') AS "managedByAccessPackage"
+    FROM "ResourceAssignments" ra
+    JOIN "IdentityMembers" im ON im."identityId" = ra."identityId"
+    WHERE ra."identityId" IS NOT NULL
+      AND ra."deletedAt" IS NULL
+      AND NOT EXISTS (SELECT 1 FROM "Resources"  r WHERE r.id = ra."resourceId"  AND r."deletedAt" IS NOT NULL)
+      AND NOT EXISTS (SELECT 1 FROM "Principals" p WHERE p.id = im."principalId" AND p."deletedAt" IS NOT NULL)
+)
+SELECT
+    "resourceId",
+    "principalId",
+    MAX("principalType") AS "principalType",
+    "membershipType",
+    bool_or("managedByAccessPackage") AS "managedByAccessPackage"
+FROM collapsed
+GROUP BY "resourceId", "principalId", "membershipType"
+WITH NO DATA;
+
+CREATE UNIQUE INDEX "ix_vw_ResUserPerm_pk"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId", "principalId", "membershipType");
+CREATE INDEX "ix_vw_ResUserPerm_principalId"
+    ON "vw_ResourceUserPermissionAssignments" ("principalId");
+CREATE INDEX "ix_vw_ResUserPerm_resourceId"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId");
+-- Partial Direct index — carried over from migration 042 (dropped with the matview).
+CREATE INDEX "ix_vw_ResUserPerm_direct"
+    ON "vw_ResourceUserPermissionAssignments" ("resourceId", "principalId")
+    WHERE "membershipType" = 'Direct';
+
+CREATE VIEW "vw_UserPermissionAssignments" AS
+SELECT
+    "resourceId"  AS "groupId",
+    "principalId" AS "memberId",
+    "principalType",
+    "membershipType",
+    "managedByAccessPackage"
+FROM "vw_ResourceUserPermissionAssignments";
+
+-- bootstrap.js refreshMatrixViews() repopulates the matview at startup.

--- a/app/api/src/ingest/validation.js
+++ b/app/api/src/ingest/validation.js
@@ -8,7 +8,7 @@
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const PRINCIPAL_TYPES = ['User', 'ServicePrincipal', 'ManagedIdentity', 'WorkloadIdentity', 'AIAgent', 'ExternalUser', 'SharedMailbox'];
-const ASSIGNMENT_TYPES = ['Direct', 'Indirect', 'Eligible', 'Owner', 'Governed', 'OAuth2Grant', 'AppRole', 'AppRoleViaGroup'];
+const ASSIGNMENT_TYPES = ['Direct', 'Indirect', 'Eligible', 'Owner', 'Governed', 'OAuth2Grant', 'AppRole', 'AppRoleViaGroup', 'DirectoryRole', 'DirectoryRoleEligible'];
 const RELATIONSHIP_TYPES = ['Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole'];
 
 // Schema definitions per entity type

--- a/app/api/src/ingest/validation.test.js
+++ b/app/api/src/ingest/validation.test.js
@@ -256,6 +256,7 @@ describe('validateRecords — resource-assignments', () => {
     const allTypes = [
       'Direct', 'Indirect', 'Eligible', 'Owner', 'Governed',
       'OAuth2Grant', 'AppRole', 'AppRoleViaGroup',
+      'DirectoryRole', 'DirectoryRoleEligible',
     ];
     for (const t of allTypes) {
       const result = validateRecords([{ ...validAssignment, assignmentType: t }], 'resource-assignments');

--- a/changes/entra-directory-roles.md
+++ b/changes/entra-directory-roles.md
@@ -1,0 +1,3 @@
+- The Entra ID crawler now imports directory roles (Global Administrator, Privileged Role Administrator, etc.). Enable the "Directory Roles" object type on the crawler to sync them.
+- Each directory role records its granular permission actions, whether it's a built-in role, and its template ID — the groundwork for scoring how critical a role is by what it can actually do.
+- Both active role holders and PIM-eligible role holders are imported, and show up in the access matrix as Direct and Eligible access respectively.

--- a/changes/entra-directory-roles.md
+++ b/changes/entra-directory-roles.md
@@ -1,3 +1,4 @@
 - The Entra ID crawler now imports directory roles (Global Administrator, Privileged Role Administrator, etc.). Enable the "Directory Roles" object type on the crawler to sync them.
 - Each directory role records its granular permission actions, whether it's a built-in role, and its template ID — the groundwork for scoring how critical a role is by what it can actually do.
 - Both active role holders and PIM-eligible role holders are imported, and show up in the access matrix as Direct and Eligible access respectively.
+- Fixed the Entra ID crawler edit wizard: the "Object Types to Sync" step now shows the full list of object types when editing an existing crawler (previously it could appear blank unless you re-entered the client secret), so you can enable Directory Roles on a crawler you've already set up.

--- a/tools/crawlers/entra-id/ConfigWizard.jsx
+++ b/tools/crawlers/entra-id/ConfigWizard.jsx
@@ -167,6 +167,28 @@ export function buildEntraConfigPayload({
   return { displayName, configPayload };
 }
 
+// Static fallback catalog of Entra object types, mirroring ENTRA_OBJECT_TYPES
+// in discover.js. The authoritative catalog comes from the live `validate`
+// response, but that response is wizard-runtime state and is never persisted
+// to the crawler config. In edit mode the user often opens step 2 without
+// re-entering the client secret (so no fresh validate runs), which left
+// `validation.objectTypes` empty and rendered a blank, non-functional step 2 —
+// you couldn't toggle a newly-added object type like Directory Roles. This
+// fallback keeps the full catalog available for selection in that case; the
+// per-object permission gate (canObjectBeSelected) already no-ops when the
+// live permission map is absent, so every type stays selectable.
+export const ENTRA_OBJECT_TYPES_FALLBACK = [
+  { key: 'identity', label: 'Identity', description: 'Personal user accounts that are synced from HR' },
+  { key: 'usersGroupsMembers', label: 'Users & Groups & Members', description: 'All users, security groups, and group memberships' },
+  { key: 'servicePrincipals', label: 'Service Principals', description: 'Non-human identities (enterprise app SPs, managed identities, AI agents)' },
+  { key: 'identityGovernance', label: 'Identity Governance', description: 'Access Packages, assignments, policies, reviews' },
+  { key: 'appsAppRoles', label: 'Apps & AppRoles', description: 'Application registrations and role assignments' },
+  { key: 'directoryRoles', label: 'Directory Roles', description: 'Entra ID directory role assignments' },
+  { key: 'pim', label: 'PIM', description: 'Privileged Identity Management eligible group memberships' },
+  { key: 'signInLogs', label: 'Sign-in Logs (per-app activity)', description: 'Aggregated sign-in events — last activity per (user, app) pair' },
+  { key: 'oauth2Grants', label: 'OAuth2 Delegated Grants', description: 'Per-user consent grants (user X allowed app Y to call API Z with scope W). Tenant-wide consents are skipped.' },
+];
+
 // ─── Wizard ───────────────────────────────────────────────────────────────────
 //
 // Steps:
@@ -427,6 +449,10 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
 
   // ── Render ────────────────────────────────────────────────────
 
+  // Authoritative catalog from a fresh validate, else the static fallback so
+  // edit mode (no re-validation) still shows every selectable object type.
+  const objectTypesCatalog = validation?.objectTypes?.length ? validation.objectTypes : ENTRA_OBJECT_TYPES_FALLBACK;
+
   const entraSteps = [
     { n: 1, label: 'Credentials' },
     { n: 2, label: 'Object Types' },
@@ -494,30 +520,36 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
       )}
 
       {/* ─── Step 2: Object Type Selection ──────────────────────── */}
-      {step === 2 && validation && (
+      {step === 2 && (validation || isEdit) && (
         <div>
           <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded dark:bg-green-900/20 dark:border-green-700">
             <span className="font-medium text-green-800 dark:text-green-300">
-              Connected to {validation.organization || 'tenant'}
+              Connected to {validation?.organization || 'tenant'}
             </span>
           </div>
 
-          <div className="mb-5">
-            <h4 className="text-sm font-semibold mb-2 dark:text-gray-200">Granted Permissions</h4>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
-              {Object.entries(validation.permissions || {}).sort(([a], [b]) => a.localeCompare(b)).map(([perm, granted]) => (
-                <div key={perm} className="flex items-center gap-2 text-sm py-1">
-                  <span className={granted ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>{granted ? '✓' : '✗'}</span>
-                  <span className={granted ? 'dark:text-gray-200' : 'text-gray-600 line-through dark:text-gray-500'}>{perm}</span>
-                </div>
-              ))}
+          {Object.keys(validation?.permissions || {}).length > 0 ? (
+            <div className="mb-5">
+              <h4 className="text-sm font-semibold mb-2 dark:text-gray-200">Granted Permissions</h4>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
+                {Object.entries(validation.permissions || {}).sort(([a], [b]) => a.localeCompare(b)).map(([perm, granted]) => (
+                  <div key={perm} className="flex items-center gap-2 text-sm py-1">
+                    <span className={granted ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>{granted ? '✓' : '✗'}</span>
+                    <span className={granted ? 'dark:text-gray-200' : 'text-gray-600 line-through dark:text-gray-500'}>{perm}</span>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="mb-5 text-xs text-gray-500 dark:text-gray-400">
+              Permissions weren't re-checked (no new client secret entered). Re-enter the secret on the previous step to verify Graph permissions — object types are still selectable here. Make sure the app has the permissions a type needs before enabling it.
+            </div>
+          )}
 
           <div className="mb-5">
             <h4 className="text-sm font-semibold mb-2 dark:text-gray-200">Object Types to Sync</h4>
             <div className="space-y-2">
-              {(validation.objectTypes || []).map(ot => {
+              {objectTypesCatalog.map(ot => {
                 const canSelect = canObjectBeSelected(ot.key);
                 return (
                   <label key={ot.key} className={`flex items-start gap-3 p-2 rounded ${canSelect ? '' : 'opacity-40'}`}>

--- a/tools/crawlers/entra-id/ConfigWizard.test.jsx
+++ b/tools/crawlers/entra-id/ConfigWizard.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement as h } from 'react';
-import ConfigWizard from './ConfigWizard.jsx';
+import ConfigWizard, { ENTRA_OBJECT_TYPES_FALLBACK } from './ConfigWizard.jsx';
 
 // renderToStaticMarkup executes the render synchronously, so a missing import
 // (e.g. the back-references to app/ui/src/components/ScheduleEditor or
@@ -28,5 +28,22 @@ describe('Entra ID crawler ConfigWizard', () => {
     const html = render({ isEdit: true, initialConfig: { id: 1, displayName: 'Existing', tenantId: 't', clientId: 'c' } });
     expect(html).toContain('Edit Microsoft Graph Crawler');
     expect(html).toContain('leave blank to keep');
+  });
+
+  // The fallback catalog is what makes step 2 usable in edit mode (where the
+  // live validate response — the authoritative catalog — isn't available). It
+  // must stay in sync with ENTRA_OBJECT_TYPES in discover.js, and must include
+  // directoryRoles so an existing crawler can be edited to add directory roles.
+  it('fallback object-type catalog includes directoryRoles and the full key set', () => {
+    const keys = ENTRA_OBJECT_TYPES_FALLBACK.map(o => o.key);
+    expect(keys).toContain('directoryRoles');
+    expect(keys).toEqual([
+      'identity', 'usersGroupsMembers', 'servicePrincipals', 'identityGovernance',
+      'appsAppRoles', 'directoryRoles', 'pim', 'signInLogs', 'oauth2Grants',
+    ]);
+    // Every entry needs key + label + description for the step-2 checkbox row.
+    for (const o of ENTRA_OBJECT_TYPES_FALLBACK) {
+      expect(o.key && o.label && o.description, `entry ${o.key} missing a field`).toBeTruthy();
+    }
   });
 });

--- a/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1
+++ b/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1
@@ -49,6 +49,15 @@
     assignments are skipped (those would need SP-as-principal which the
     data model doesn't yet support). Default: false.
 
+.PARAMETER SyncDirectoryRoles
+    Sync Entra ID directory roles — the role catalog (roleDefinitions,
+    including each role's granular allowedResourceActions), active role
+    assignments, and PIM-eligible role assignments. Roles are stored as
+    Resources(resourceType='EntraRole'); assignments use 'DirectoryRole'
+    (active) and 'DirectoryRoleEligible' (eligible). Group-typed assignments
+    are recorded against the group principal but not yet expanded to members.
+    Default: false.
+
 .PARAMETER RefreshViews
     Refresh materialized SQL views after sync (default: true)
 
@@ -93,6 +102,7 @@ $SyncPim               = $false
 $SyncSignInLogs        = $false
 $SyncOAuth2Grants      = $false
 $SyncAppRoles          = $false
+$SyncDirectoryRoles    = $false
 $RefreshViews          = $true
 $SignInLogsDays        = 7
 $CustomUserAttributes  = @()
@@ -116,6 +126,7 @@ if ($objects) {
     if ($objects.ContainsKey('signInLogs'))         { $SyncSignInLogs        = [bool]$objects['signInLogs'] }
     if ($objects.ContainsKey('oauth2Grants'))       { $SyncOAuth2Grants      = [bool]$objects['oauth2Grants'] }
     if ($objects.ContainsKey('appsAppRoles'))       { $SyncAppRoles          = [bool]$objects['appsAppRoles'] }
+    if ($objects.ContainsKey('directoryRoles'))     { $SyncDirectoryRoles    = [bool]$objects['directoryRoles'] }
 }
 # Direct config toggles (backward compat with older job configs)
 if ($RawConfig.ContainsKey('syncPrincipals'))        { $SyncPrincipals        = [bool]$RawConfig['syncPrincipals'] }
@@ -127,6 +138,7 @@ if ($RawConfig.ContainsKey('syncSignInLogs'))         { $SyncSignInLogs        =
 if ($RawConfig.ContainsKey('signInLogsDays'))         { $SignInLogsDays        = [int]$RawConfig['signInLogsDays'] }
 if ($RawConfig.ContainsKey('syncOAuth2Grants'))       { $SyncOAuth2Grants      = [bool]$RawConfig['syncOAuth2Grants'] }
 if ($RawConfig.ContainsKey('syncAppRoles'))           { $SyncAppRoles          = [bool]$RawConfig['syncAppRoles'] }
+if ($RawConfig.ContainsKey('syncDirectoryRoles'))     { $SyncDirectoryRoles    = [bool]$RawConfig['syncDirectoryRoles'] }
 if ($RawConfig['customUserAttributes'])  { $CustomUserAttributes  = @($RawConfig['customUserAttributes']) }
 if ($RawConfig['identityAttributes'])    { $CustomUserAttributes  += @($RawConfig['identityAttributes']); $CustomUserAttributes = $CustomUserAttributes | Select-Object -Unique }
 if ($RawConfig['customGroupAttributes']) { $CustomGroupAttributes = @($RawConfig['customGroupAttributes']) }
@@ -2344,6 +2356,167 @@ if ($SyncAppRoles) {
     $__appRoleErr = $script:phaseErrors | Where-Object { $_.StartsWith('AppRoles:') } | Select-Object -Last 1
     $__appRoleErrMsg = if ($__appRoleErr) { $__appRoleErr.Substring('AppRoles:'.Length).Trim() } else { $null }
     Write-Phase -Name 'AppRoles' -Duration $__phaseSW.Elapsed -ErrorMsg $__appRoleErrMsg
+}
+
+# ─── Sync Directory Roles ────────────────────────────────────────
+# Entra ID directory roles (Global Administrator, Privileged Role
+# Administrator, etc.). Three Graph reads, modelled as:
+#
+#     Resources(EntraRole)            <-- one per roleDefinition (id = roleDefinitionId)
+#       └─ ResourceAssignments(DirectoryRole)          <-- active (permanent or PIM-activated)
+#       └─ ResourceAssignments(DirectoryRoleEligible)  <-- PIM eligible (not yet active)
+#
+# Each role Resource stores its granular permission actions
+# (rolePermissions[].allowedResourceActions, flattened + de-duped) in
+# extendedAttributes so a later risk-scoring pass can tier a role by what
+# it can actually do (EAM Control/Management plane), not just its name.
+#
+# Distinct assignment types ('DirectoryRole' / 'DirectoryRoleEligible')
+# rather than reusing 'Direct' / 'Eligible' so the scoped full-sync delete
+# keys on them without wiping group memberships or PIM-group eligibilities —
+# the same reason AppRole uses a distinct type. The matrix view collapses
+# them to Direct/Eligible badges (migration 043).
+#
+# Group-typed assignments (a role-assignable group granted a role) are
+# recorded against the group principal but NOT yet expanded to per-member
+# rows — that's a follow-up, mirroring how the matrix shows group-typed
+# AppRole rows only in the nested-group expand.
+if ($SyncDirectoryRoles) {
+    $__phaseSW = [Diagnostics.Stopwatch]::StartNew()
+    Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Syncing directory roles..." -ForegroundColor Cyan
+    Update-CrawlerProgress -Step 'Syncing directory roles' -Pct 75 -Detail 'Fetching role definitions from Microsoft Graph...'
+
+    # Map a Graph directory-object @odata.type to our principalType vocabulary.
+    function Resolve-DirectoryRolePrincipalType {
+        param($Principal)
+        switch -Wildcard ($Principal.'@odata.type') {
+            '*servicePrincipal' { 'ServicePrincipal'; break }
+            '*group'            { 'Group'; break }
+            '*user'             { 'User'; break }
+            default             { 'User' }
+        }
+    }
+
+    try {
+        # 1. Role catalog. /roleDefinitions returns the full set of built-in
+        #    roles plus any custom roles. id == templateId for built-ins.
+        $roleDefs = @(Invoke-FGGetRequest -URI "https://graph.microsoft.com/beta/roleManagement/directory/roleDefinitions")
+        Write-Host "  Fetched $($roleDefs.Count) role definitions" -ForegroundColor Gray
+
+        $roleRecords = foreach ($rd in $roleDefs) {
+            $actions = [System.Collections.Generic.List[string]]::new()
+            foreach ($rp in @($rd.rolePermissions)) {
+                foreach ($a in @($rp.allowedResourceActions)) {
+                    if ($a) { $actions.Add([string]$a) }
+                }
+            }
+            $uniqueActions = @($actions | Select-Object -Unique)
+            @{
+                id           = $rd.id
+                displayName  = $rd.displayName
+                description  = $rd.description
+                resourceType = 'EntraRole'
+                enabled      = [bool]$rd.isEnabled
+                extendedAttributes = @{
+                    templateId             = $rd.templateId
+                    isBuiltIn              = [bool]$rd.isBuiltIn
+                    isEnabled              = [bool]$rd.isEnabled
+                    roleVersion            = $rd.version
+                    allowedResourceActions = $uniqueActions
+                    permissionCount        = $uniqueActions.Count
+                }
+            }
+        }
+        $roleRecords = @($roleRecords)
+
+        # 2. Active assignments (permanent + currently-activated PIM). $expand=principal
+        #    gives us the principal's @odata.type so we can set principalType
+        #    without a second lookup per assignment.
+        $activeList = [System.Collections.Generic.List[object]]::new()
+        try {
+            $roleAssignments = @(Invoke-FGGetRequest -URI "https://graph.microsoft.com/beta/roleManagement/directory/roleAssignments?`$expand=principal")
+            foreach ($ra in $roleAssignments) {
+                if (-not $ra.principalId -or -not $ra.roleDefinitionId) { continue }
+                $activeList.Add(@{
+                    resourceId     = $ra.roleDefinitionId
+                    principalId    = $ra.principalId
+                    principalType  = (Resolve-DirectoryRolePrincipalType -Principal $ra.principal)
+                    assignmentType = 'DirectoryRole'
+                    extendedAttributes = @{
+                        roleAssignmentId = $ra.id
+                        directoryScopeId = $ra.directoryScopeId
+                    }
+                })
+            }
+        } catch {
+            Write-Host "    /roleAssignments failed: $($_.Exception.Message)" -ForegroundColor DarkYellow
+        }
+
+        # 3. PIM-eligible assignments (eligible but not active). Tenants without
+        #    PIM (no Entra ID P2) return 400/403 here — non-fatal.
+        $eligibleList = [System.Collections.Generic.List[object]]::new()
+        try {
+            $eligibility = @(Invoke-FGGetRequest -URI "https://graph.microsoft.com/beta/roleManagement/directory/roleEligibilityScheduleInstances?`$expand=principal")
+            foreach ($e in $eligibility) {
+                if (-not $e.principalId -or -not $e.roleDefinitionId) { continue }
+                $eligibleList.Add(@{
+                    resourceId         = $e.roleDefinitionId
+                    principalId        = $e.principalId
+                    principalType      = (Resolve-DirectoryRolePrincipalType -Principal $e.principal)
+                    assignmentType     = 'DirectoryRoleEligible'
+                    expirationDateTime = $e.endDateTime
+                    extendedAttributes = @{
+                        memberType       = $e.memberType
+                        directoryScopeId = $e.directoryScopeId
+                    }
+                })
+            }
+        } catch {
+            Write-Host "    /roleEligibilityScheduleInstances failed (PIM may be unavailable): $($_.Exception.Message)" -ForegroundColor DarkYellow
+        }
+
+        # Dedupe on the assignment PK (resourceId, principalId, assignmentType).
+        # The same principal can hold one role at multiple directory scopes; the
+        # PK has no scope component, so collapse to the first (tenant-wide is the
+        # dominant case — per-scope modelling is a follow-up).
+        $seenActive = @{}
+        $activeRecords = @($activeList | Where-Object {
+            $k = "$($_.resourceId)|$($_.principalId)"
+            if ($seenActive.ContainsKey($k)) { $false } else { $seenActive[$k] = $true; $true }
+        })
+        $seenEligible = @{}
+        $eligibleRecords = @($eligibleList | Where-Object {
+            $k = "$($_.resourceId)|$($_.principalId)"
+            if ($seenEligible.ContainsKey($k)) { $false } else { $seenEligible[$k] = $true; $true }
+        })
+
+        Write-Host "  Roles: $($roleRecords.Count) · Active: $($activeRecords.Count) · Eligible: $($eligibleRecords.Count)" -ForegroundColor Gray
+
+        if ($roleRecords.Count -gt 0) {
+            Update-CrawlerProgress -Detail "Uploading $($roleRecords.Count) directory roles..."
+            Send-IngestBatch -Endpoint 'ingest/resources' -SystemId $systemId -SyncMode 'full' `
+                -Scope @{ resourceType = 'EntraRole' } -Records $roleRecords
+        }
+        if ($activeRecords.Count -gt 0) {
+            Update-CrawlerProgress -Detail "Uploading $($activeRecords.Count) active role assignments..."
+            Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $systemId -SyncMode 'full' `
+                -Scope @{ assignmentType = 'DirectoryRole' } -Records $activeRecords
+        }
+        if ($eligibleRecords.Count -gt 0) {
+            Update-CrawlerProgress -Detail "Uploading $($eligibleRecords.Count) eligible role assignments..."
+            Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $systemId -SyncMode 'full' `
+                -Scope @{ assignmentType = 'DirectoryRoleEligible' } -Records $eligibleRecords
+        }
+    }
+    catch {
+        Write-Host "  Directory role sync failed: $($_.Exception.Message)" -ForegroundColor Red
+        $script:phaseErrors.Add("DirectoryRoles: $($_.Exception.Message)")
+        Write-Host "  (Requires RoleManagement.Read.Directory or Directory.Read.All; eligible assignments also need RoleEligibilitySchedule.Read.Directory.)" -ForegroundColor Yellow
+    }
+    $__phaseSW.Stop(); $phaseTimings['DirectoryRoles'] = $__phaseSW.Elapsed
+    $__dirRoleErr = $script:phaseErrors | Where-Object { $_.StartsWith('DirectoryRoles:') } | Select-Object -Last 1
+    $__dirRoleErrMsg = if ($__dirRoleErr) { $__dirRoleErr.Substring('DirectoryRoles:'.Length).Trim() } else { $null }
+    Write-Phase -Name 'DirectoryRoles' -Duration $__phaseSW.Elapsed -ErrorMsg $__dirRoleErrMsg
 }
 
 # ─── Refresh Views ───────────────────────────────────────────────

--- a/tools/crawlers/entra-id/Test-EntraIdCrawler.ps1
+++ b/tools/crawlers/entra-id/Test-EntraIdCrawler.ps1
@@ -695,10 +695,14 @@ foreach ($scenario in $Scenarios) {
                     # invariant below ensures their badge collapses cleanly.
                     Assert-ApiCount  -Name 'EntraID/Full-Sync/AppRoles'         -Path '/resources?resourceType=AppRole&limit=1'              -MinExpected 0
 
-                    # NOTE: `directoryRoles` is still a stub in
-                    # Start-EntraIDCrawler.ps1 — the wizard surfaces the
-                    # checkbox but no phase emits rows. Remove this note when
-                    # the directoryRoles phase ships.
+                    # Directory roles — the crawler imports the role catalog
+                    # (resourceType='EntraRole', with each role's granular
+                    # allowedResourceActions in extendedAttributes) plus active
+                    # and PIM-eligible assignments. A demo tenant always has the
+                    # built-in role catalog, so this endpoint should respond;
+                    # MinExpected=0 keeps it green if the selected object types
+                    # for this run didn't include directoryRoles.
+                    Assert-ApiCount  -Name 'EntraID/Full-Sync/DirectoryRoles'    -Path '/resources?resourceType=EntraRole&limit=1'            -MinExpected 0
 
                     # Dashboard timeseries endpoint — backs the Trends tab on
                     # the dashboard. The scheduler writes a snapshot row once


### PR DESCRIPTION
## What

Adds Entra ID **directory roles** to the crawler — the gap behind the EntraOps risk-scoring evaluation (Phase 1 of that work).

### Changelog
- The Entra ID crawler now imports directory roles (Global Administrator, Privileged Role Administrator, etc.). Enable the "Directory Roles" object type on the crawler to sync them.
- Each directory role records its granular permission actions, whether it's a built-in role, and its template ID — the groundwork for scoring how critical a role is by what it can actually do.
- Both active role holders and PIM-eligible role holders are imported, and show up in the access matrix as Direct and Eligible access respectively.
- Fixed the Entra ID crawler edit wizard: the "Object Types to Sync" step now shows the full list of object types when editing an existing crawler (previously it could appear blank unless you re-entered the client secret), so you can enable Directory Roles on a crawler you've already set up.

## How
- New `SyncDirectoryRoles` phase reads `roleDefinitions` (incl. `rolePermissions[].allowedResourceActions`), `roleAssignments` (active), and `roleEligibilityScheduleInstances` (PIM-eligible).
- Roles stored as `Resources(resourceType='EntraRole')`; the flattened, de-duped permission actions + `isBuiltIn` + `templateId` live in `extendedAttributes`.
- Assignments use distinct types `DirectoryRole` / `DirectoryRoleEligible` so the scoped full-sync delete keys on them without touching group memberships or PIM-group eligibilities (same rationale as `AppRole`). Migration `043` collapses them to Direct/Eligible badges in the matrix matview (mirrors 041, recreates 042's index).
- `ASSIGNMENT_TYPES` ingest enum extended with the two new types.
- Wizard: static fallback object-type catalog so edit mode renders step 2 without a fresh validate call.

## Verification
Run against a real tenant on a sidekick (full sync):
- 144 `EntraRole` resources, 20 active assignments, 24 PIM-eligible.
- Permission actions captured: Global Administrator = 254 actions, Security Administrator = 82, User Administrator = 56, Privileged Role Administrator = 28.
- Matrix surfaces them with correct badges (e.g. Global Administrator: 7 Eligible + 4 Direct).

## Permissions
The SP needs `RoleManagement.Read.Directory` (catalog + active assignments) and `RoleEligibilitySchedule.Read.Directory` (PIM-eligible). The eligible endpoint requires Entra ID P2.

## Not in scope (follow-ups)
- Group-assigned roles are recorded against the group principal but not yet expanded to members.
- Per-scope (scoped/AU) assignments collapse to the first scope.
- Phase 2 (EAM/EntraOps tiering from the captured actions) — separate PR.