### PR TITLE
feat: assignment-model phase 4 — group ownership becomes its own resource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@
 
 > **Reuse before creating.** Search before writing any function, constant, helper, hook, or component. Only create something new when nothing suitable exists. Applies across all languages (PowerShell, JavaScript, SQL). See each subdirectory CLAUDE.md for known utilities specific to that layer.
 
+> **Fix at the source, not the surface.** When a value is missing, wrongly shaped, or derived, fix it where the data is produced — the crawler, the ingest layer, the schema, or the matview — so every consumer benefits. **Before writing any client-side workaround** (computing, deriving, reshaping, or faking in the UI what the data should already provide), stop and ask: *should this live in the data model instead?* Client-side patches that paper over a data-model gap silently accrue as duplication and drift — e.g. the matrix once simulated "owner as its own row" in React while the data still stamped `assignmentType='Owner'` on the group; two mechanisms for one concept, kept in sync by hand. Prefer the deeper fix. If a surface-level fix is genuinely the right call, say why in the PR.
+
 ## Project Overview
 
 Identity Atlas is a Docker-deployed application that pulls authorization data from Microsoft Graph (and other systems via CSV) into a **PostgreSQL** database, then surfaces it through a React role-mining UI. The worker container ships PowerShell crawler scripts; all persistence flows through the Node.js API.

--- a/app/api/src/db/migrations/046_owner_as_resource.sql
+++ b/app/api/src/db/migrations/046_owner_as_resource.sql
@@ -55,3 +55,10 @@ UPDATE "ResourceAssignments" ra
   FROM owned o
  WHERE ra."resourceId" = o.group_id
    AND ra."assignmentType" = 'Owner';
+
+-- This is a VISIBLE change (Owner badges become GroupOwnership resource rows).
+-- Migrations run before the web port binds, so refresh the matrix matview here
+-- (plain REFRESH — allowed in a migration transaction, unlike CONCURRENTLY) so
+-- the matrix is correct the instant the app serves, rather than briefly showing
+-- phantom Owner cells until the boot/end-of-sync refresh catches up.
+REFRESH MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments";

--- a/app/api/src/db/migrations/046_owner_as_resource.sql
+++ b/app/api/src/db/migrations/046_owner_as_resource.sql
@@ -1,0 +1,57 @@
+-- Assignment-model redesign — Phase 4: group ownership becomes its own resource.
+-- See docs/architecture/assignment-model-redesign.md.
+--
+-- 'Owner' was a membership "how" stamped on the group's OWN resource, which kept
+-- the matrix from being uniform (Direct/Indirect/Eligible only) and made
+-- ownership a second-class concept. Ownership now becomes a Direct assignment to
+-- a synthetic "Owner @ <group>" resource (resourceType='GroupOwnership'), linked
+-- to the group by a HasOwnership relationship — mirroring how an AppRole hangs
+-- off its Application. The matrix then shows ownership as its own column.
+--
+-- The ownership resource id is deterministic over the group id, matching the
+-- crawler's New-OwnershipResourceId (md5('entraid-ownership:'||groupId) formatted
+-- as a uuid), so a re-sync upserts the same rows rather than duplicating them.
+--
+-- Collision-free: the rewritten owner rows live on the new GroupOwnership
+-- resource (a fresh resourceId), so (resourceId, principalId, 'Direct') can't
+-- clash with the group's own Direct members.
+
+WITH owned AS MATERIALIZED (
+    SELECT DISTINCT
+        g."id"          AS group_id,
+        g."systemId"    AS system_id,
+        g."displayName" AS group_name,
+        (substring(md5('entraid-ownership:' || g."id"::text),  1, 8) || '-' ||
+         substring(md5('entraid-ownership:' || g."id"::text),  9, 4) || '-' ||
+         substring(md5('entraid-ownership:' || g."id"::text), 13, 4) || '-' ||
+         substring(md5('entraid-ownership:' || g."id"::text), 17, 4) || '-' ||
+         substring(md5('entraid-ownership:' || g."id"::text), 21,12))::uuid AS ownership_id
+    FROM "Resources" g
+    WHERE EXISTS (
+        SELECT 1 FROM "ResourceAssignments" ra
+         WHERE ra."resourceId" = g."id" AND ra."assignmentType" = 'Owner'
+    )
+),
+new_resources AS (
+    INSERT INTO "Resources" ("id", "systemId", "displayName", "resourceType", "externalId", "extendedAttributes")
+    SELECT ownership_id, system_id, 'Owner @ ' || COALESCE(group_name, '(group)'),
+           'GroupOwnership', 'entraid-ownership:' || group_id::text,
+           jsonb_build_object('ownedResourceId', group_id::text)
+      FROM owned
+    ON CONFLICT ("id") DO NOTHING
+    RETURNING 1
+),
+new_rels AS (
+    INSERT INTO "ResourceRelationships" ("parentResourceId", "childResourceId", "relationshipType", "systemId")
+    SELECT group_id, ownership_id, 'HasOwnership', system_id
+      FROM owned
+    ON CONFLICT ("parentResourceId", "childResourceId", "relationshipType") DO NOTHING
+    RETURNING 1
+)
+UPDATE "ResourceAssignments" ra
+   SET "resourceId"     = o.ownership_id,
+       "assignmentType" = 'Direct',
+       "resourceType"   = 'GroupOwnership'
+  FROM owned o
+ WHERE ra."resourceId" = o.group_id
+   AND ra."assignmentType" = 'Owner';

--- a/app/api/src/ingest/validation.js
+++ b/app/api/src/ingest/validation.js
@@ -9,7 +9,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 const PRINCIPAL_TYPES = ['User', 'ServicePrincipal', 'ManagedIdentity', 'WorkloadIdentity', 'AIAgent', 'ExternalUser', 'SharedMailbox'];
 const ASSIGNMENT_TYPES = ['Direct', 'Indirect', 'Eligible', 'Owner', 'Governed', 'OAuth2Grant', 'AppRole', 'AppRoleViaGroup', 'DirectoryRole', 'DirectoryRoleEligible'];
-const RELATIONSHIP_TYPES = ['Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole'];
+const RELATIONSHIP_TYPES = ['Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole', 'HasOwnership'];
 
 // Schema definitions per entity type
 const SCHEMAS = {

--- a/app/api/src/ingest/validation.test.js
+++ b/app/api/src/ingest/validation.test.js
@@ -289,7 +289,7 @@ describe('validateRecords — resource-relationships', () => {
 
   it('accepts all valid relationshipType values', () => {
     // Keep this in sync with RELATIONSHIP_TYPES in validation.js.
-    const allTypes = ['Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole'];
+    const allTypes = ['Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole', 'HasOwnership'];
     for (const t of allTypes) {
       const result = validateRecords([{ ...validRel, relationshipType: t }], 'resource-relationships');
       expect(result.valid, `Expected valid for relationshipType=${t}`).toBe(true);

--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -350,37 +350,18 @@ export default function MatrixView({
         });
       }
 
-      // Owner memberships go to a separate synthetic group row
-      const isOwner = d.membershipType === 'Owner';
-      if (isOwner && gid) {
-        const ownerGroupId = `${gid}__owner`;
-        if (!groupMap.has(ownerGroupId)) {
-          const name = d.resourceDisplayName || d.groupDisplayName || gid;
-          const tags = groupTagMap?.get(gid.toUpperCase()) || [];
-          groupMap.set(ownerGroupId, {
-            id: ownerGroupId,
-            realGroupId: gid,
-            displayName: `${name} (Owner)`,
-            tags,
-            description: d.resourceDescription || d.groupDescription || '',
-            groupType: d.resourceType || d.groupTypeCalculated || '',
-            systemName: d.systemName || '',
-          });
-        }
-      }
-
-      // Memberships: Owner -> synthetic owner group, others -> real group
-      const effectiveGroupId = isOwner ? `${gid}__owner` : gid;
-      const key = `${effectiveGroupId}|${d.memberId}`;
+      // Group ownership is its own resource now (resourceType='GroupOwnership',
+      // shown as a normal row), so every membership lands on its real resource
+      // row — no client-side owner-row simulation. (See "Fix at the source" in
+      // the root CLAUDE.md.)
+      const key = `${gid}|${d.memberId}`;
       if (!membershipMap.has(key)) {
         membershipMap.set(key, new Set());
       }
       membershipMap.get(key).add(d.membershipType);
 
       // Track managedByAccessPackage per cell (boolean from view, used for filtering)
-      // Owner rows are NOT managed by APs — the managedByAccessPackage flag from the
-      // SQL view checks AP→Direct membership, which doesn't apply to Owner relationships.
-      if (d.managedByAccessPackage && !isOwner) {
+      if (d.managedByAccessPackage) {
         managed.set(key, true);
       }
     });
@@ -393,27 +374,23 @@ export default function MatrixView({
     // Per-type counts enable priority sorting: Direct > Eligible > Owner > Indirect
     const userList = [...userMap.values()];
     for (const group of groupMap.values()) {
-      let memberCount = 0, directCount = 0, eligibleCount = 0, ownerCount = 0, nonIndirectCount = 0;
+      let memberCount = 0, directCount = 0, eligibleCount = 0, nonIndirectCount = 0;
       for (const u of userList) {
         const types = membershipMap.get(`${group.id}|${u.id}`);
         if (!types || types.size === 0) continue;
         memberCount++;
         if (types.has('Direct'))   directCount++;
         if (types.has('Eligible')) eligibleCount++;
-        if (types.has('Owner'))    ownerCount++;
         for (const t of types) { if (t !== 'Indirect') { nonIndirectCount++; break; } }
       }
       group.memberCount = memberCount;
       group.directCount = directCount;
       group.eligibleCount = eligibleCount;
-      group.ownerCount = ownerCount;
       group.nonIndirectCount = nonIndirectCount;
     }
 
-    // Sort groups by member count descending; filter out groups with 0 members
-    // (e.g., a base group with only Owner memberships will have 0 members since
-    // those went to the __owner synthetic row)
-    // Priority: Direct > Eligible > Owner > Indirect-only
+    // Sort groups by member count descending; filter out groups with 0 members.
+    // Priority: Direct > Eligible > Indirect-only
     const groups = [...groupMap.values()]
       .filter(g => g.memberCount > 0)
       .sort((a, b) => {
@@ -423,9 +400,6 @@ export default function MatrixView({
         // Then eligible
         const eligibleCmp = (b.eligibleCount || 0) - (a.eligibleCount || 0);
         if (eligibleCmp !== 0) return eligibleCmp;
-        // Then owner
-        const ownerCmp = (b.ownerCount || 0) - (a.ownerCount || 0);
-        if (ownerCmp !== 0) return ownerCmp;
         // Then total member count (indirect as tiebreaker)
         return b.memberCount - a.memberCount;
       });
@@ -566,13 +540,11 @@ export default function MatrixView({
       const aBucket = groupApBucket.get(a.id);
       const bBucket = groupApBucket.get(b.id);
       if (aBucket !== bBucket) return aBucket - bBucket;
-      // Same bucket: sort by type priority (Direct > Eligible > Owner > Indirect)
+      // Same bucket: sort by type priority (Direct > Eligible > Indirect)
       const directCmp = (b.directCount || 0) - (a.directCount || 0);
       if (directCmp !== 0) return directCmp;
       const eligibleCmp = (b.eligibleCount || 0) - (a.eligibleCount || 0);
       if (eligibleCmp !== 0) return eligibleCmp;
-      const ownerCmp = (b.ownerCount || 0) - (a.ownerCount || 0);
-      if (ownerCmp !== 0) return ownerCmp;
       return b.memberCount - a.memberCount;
     });
   }, [groups, accessPackages, apGroupMap, managedFilter]);

--- a/app/ui/src/hooks/useMatrixRowOrder.js
+++ b/app/ui/src/hooks/useMatrixRowOrder.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 
 // Bump this when the default sort logic changes (e.g., staircase sort introduced).
 // Stored orders from an older version are discarded so the new default takes effect.
-const ROW_ORDER_VERSION = 5;
+const ROW_ORDER_VERSION = 6;
 
 function getStorageKey(department) {
   return `fgraph-roworder-${department || 'all'}`;

--- a/changes/assignment-owner-resource.md
+++ b/changes/assignment-owner-resource.md
@@ -1,0 +1,2 @@
+- Group ownership is now modelled as its own "Owner @ \<group\>" resource (a Direct assignment) instead of a separate "Owner" membership kind — so the matrix uses one consistent set of assignment types (Direct / Indirect / Eligible) and ownership can be listed, related, and certified like any other access.
+- The matrix shows ownership as a real resource row rather than a client-side-simulated "(Owner)" sub-row.

--- a/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1
+++ b/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1
@@ -1361,9 +1361,27 @@ if ($SyncAssignments) {
     Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $systemId -SyncMode 'full' `
         -Scope @{ assignmentType = 'Direct'; resourceType = 'EntraGroup' } -Records $allMembers
 
-    # Group Owners
+    # Group Owners — modelled as a Direct assignment to a synthetic
+    # "Owner @ <group>" resource (resourceType='GroupOwnership'), linked to the
+    # group by a HasOwnership relationship — mirroring how an AppRole hangs off
+    # its Application. The ownership resource id is deterministic over the group
+    # id (same scheme as New-AppRoleResourceId and migration 046), so re-syncs
+    # upsert the same rows.
     Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Syncing assignments (group owners)..." -ForegroundColor Cyan
     Update-CrawlerProgress -Step 'Syncing group owners' -Pct 51 -Detail "0 of $totalGroups groups"
+
+    function New-OwnershipResourceId {
+        param([string]$GroupId)
+        $seed = "entraid-ownership:${GroupId}"
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($seed)
+            $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
+        } finally {
+            $md5.Dispose()
+        }
+        return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
+    }
 
     $ownerResult = Get-FGGroupChildrenParallel `
         -Groups $groups -ChildPath 'owners' -ThrottleLimit 16 `
@@ -1371,19 +1389,62 @@ if ($SyncAssignments) {
         -RecordBuilder {
             param($o)
             @{
-                resourceId     = $o.resourceId
-                principalId    = $o.principalId
-                assignmentType = 'Owner'
+                groupId     = $o.resourceId
+                principalId = $o.principalId
             }
         }
-    $allOwners = $ownerResult.records
+    $rawOwners = $ownerResult.records
     if ($ownerResult.errorCount -gt 0) {
         Write-Host "  WARNING: $($ownerResult.errorCount) groups failed during owner fetch (skipped)" -ForegroundColor Yellow
     }
 
-    Update-CrawlerProgress -Detail "Uploading $($allOwners.Count) owner assignments..."
+    # Build ownership resources (one per owned group), HasOwnership relationships,
+    # and the owner assignments (Direct to the ownership resource).
+    $groupNameById = @{}
+    foreach ($g in $groups) { $groupNameById[$g.id] = $g.displayName }
+
+    $ownershipResMap = @{}   # ownershipId -> resource record
+    $ownershipRelMap = @{}   # "groupId|ownershipId" -> relationship record
+    $ownerAssns = [System.Collections.Generic.List[object]]::new()
+    foreach ($ow in $rawOwners) {
+        $ownId = New-OwnershipResourceId -GroupId $ow.groupId
+        if (-not $ownershipResMap.ContainsKey($ownId)) {
+            $gname = $groupNameById[$ow.groupId]
+            if (-not $gname) { $gname = '(group)' }
+            $ownershipResMap[$ownId] = @{
+                id                 = $ownId
+                displayName        = "Owner @ $gname"
+                resourceType       = 'GroupOwnership'
+                externalId         = "entraid-ownership:$($ow.groupId)"
+                extendedAttributes = @{ ownedResourceId = $ow.groupId }
+            }
+            $ownershipRelMap["$($ow.groupId)|$ownId"] = @{
+                parentResourceId = $ow.groupId
+                childResourceId  = $ownId
+                relationshipType = 'HasOwnership'
+            }
+        }
+        $ownerAssns.Add(@{
+            resourceId     = $ownId
+            principalId    = $ow.principalId
+            assignmentType = 'Direct'
+            resourceType   = 'GroupOwnership'
+        })
+    }
+    $ownershipResources = @($ownershipResMap.Values)
+    $ownershipRels      = @($ownershipRelMap.Values)
+    $ownerRecords       = @($ownerAssns)
+
+    # Send unconditionally (even when empty) so a full-sync reconcile clears
+    # ownership resources/relationships/assignments for groups that lost owners.
+    Update-CrawlerProgress -Detail "Uploading $($ownershipResources.Count) ownership resources..."
+    Send-IngestBatch -Endpoint 'ingest/resources' -SystemId $systemId -SyncMode 'full' `
+        -Scope @{ resourceType = 'GroupOwnership' } -Records $ownershipResources
+    Send-IngestBatch -Endpoint 'ingest/resource-relationships' -SystemId $systemId -SyncMode 'full' `
+        -Scope @{ relationshipType = 'HasOwnership' } -Records $ownershipRels
+    Update-CrawlerProgress -Detail "Uploading $($ownerRecords.Count) owner assignments..."
     Send-IngestBatch -Endpoint 'ingest/resource-assignments' -SystemId $systemId -SyncMode 'full' `
-        -Scope @{ assignmentType = 'Owner' } -Records $allOwners
+        -Scope @{ assignmentType = 'Direct'; resourceType = 'GroupOwnership' } -Records $ownerRecords
     } catch {
         $script:phaseErrors.Add("Assignments: $($_.Exception.Message)")
         Write-Host "  Assignments phase failed: $($_.Exception.Message)" -ForegroundColor Red


### PR DESCRIPTION
Phase 4 of the assignment-model redesign (after #444 resourceType + #445 source-type collapse). See [`docs/architecture/assignment-model-redesign.md`](docs/architecture/assignment-model-redesign.md).

## What
`Owner` was a membership "how" stamped on the group's own resource **and** simulated as a separate row client-side in the matrix (synthetic `groupId__owner` rows). Both are removed. Ownership is now a **`Direct` assignment to a synthetic `GroupOwnership` resource** ("Owner @ \<group\>"), linked to the group by a `HasOwnership` relationship — mirroring how an AppRole hangs off its Application. The matrix shows ownership as a real resource row; the membership "how" set collapses toward the universal Direct/Indirect/Eligible.

- **migration 046:** create a `GroupOwnership` resource per owned group (deterministic id = `md5('entraid-ownership:'||groupId)`, matching the crawler) + a `HasOwnership` relationship, and rewrite existing `Owner` assignments to `Direct` on it. Collision-free (the ownership resource is a fresh resourceId). Refreshes the matview at the end (migrations run pre-port-bind, so the matrix is correct the instant the app serves).
- **Entra crawler:** owner phase emits the ownership resources/relationships + `Direct` assignments (`resourceType='GroupOwnership'`), unconditionally so reconcile clears stale ones.
- **validation.js:** accept the `HasOwnership` relationship type.
- **UI:** removed the client-side owner-membership simulation (synthetic `__owner` rows, `ownerCount`, owner-priority sorts); bumped `ROW_ORDER_VERSION`.
- **CLAUDE.md:** new coding principle **"Fix at the source, not the surface"** — the rule that came out of finding ownership faked in the view layer.

## Validation (SK1 + SK3)
- **SK3 (real data):** migration applied → `Owner` assignmentType **0**, **2,865 `GroupOwnership` resources** created, **8,238 owner assignments preserved** as `Direct` on them, 2,865 `HasOwnership` relationships. Matview after refresh: `Owner` gone, `Direct` 306,542 (= prior 298,304 + 8,238), total unchanged → **zero data loss**.
- **SK3 UI (via browse):** Resources page lists the "Owner @ \<group\>" resources with `resourceType=GroupOwnership`; the **matrix renders cleanly (302 rows, no console errors, no leftover `(Owner)` rows)**. Screenshot confirms the grid + legend intact.

## Scope note (per the new rule)
A few **inert** owner branches (`isOwnerRow`/`BADGE_OWNER`/the legend's `O` entry) remain inside the client-side AP-SOLL / provisioning-gap display, which **phase 3 (governed)** reworks to data-driven. They're removed there in one coherent pass rather than blind-edited now; `realGroupId` is kept because nested-group rows reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)