### PR TITLE
test(api): Phase 1 contract tests (matrix/identities/resources/contexts)

### DIFF
--- a/app/api/contract-tests/contexts-routes.contract.test.js
+++ b/app/api/contract-tests/contexts-routes.contract.test.js
@@ -1,0 +1,74 @@
+// Contract test — GET /api/contexts and GET /api/contexts/tree against a real
+// PostgreSQL schema.
+//
+// Verifies the list (roots only) and tree (nested children) route handlers run
+// their USE_SQL-gated SQL against the real schema and return the documented
+// shapes. Self-contained: seeds its own system and contexts. The cyclic-CTE
+// regression lives in contexts.contract.test.js.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { randomUUID } from 'crypto';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+let agent;
+let pool;
+let systemId;
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'contract-contexts-routes') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+});
+
+afterAll(async () => {
+  await pool.query(`UPDATE "Contexts" SET "parentContextId" = NULL WHERE "scopeSystemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+beforeEach(async () => {
+  await pool.query(`UPDATE "Contexts" SET "parentContextId" = NULL WHERE "scopeSystemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);
+});
+
+async function insertContext({ id = randomUUID(), parent = null, name }) {
+  await pool.query(
+    `INSERT INTO "Contexts" ("id", "variant", "targetType", "contextType", "displayName", "parentContextId", "scopeSystemId")
+     VALUES ($1, 'synced', 'Principal', 'Department', $2, $3, $4)`,
+    [id, name, parent, systemId],
+  );
+  return id;
+}
+
+describe('GET /contexts — roots', () => {
+  it('returns root contexts as { data: [...] } and omits children', async () => {
+    const a = await insertContext({ name: 'HTTP Root' });
+    await insertContext({ parent: a, name: 'HTTP Child' });
+
+    const res = await agent.get('/api/contexts');
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data.some(c => c.id === a)).toBe(true);
+    expect(res.body.data.some(c => c.displayName === 'HTTP Child')).toBe(false);
+  });
+});
+
+describe('GET /contexts/tree — nesting', () => {
+  it('nests children under the requested root', async () => {
+    const a = await insertContext({ name: 'Tree Root' });
+    const b = await insertContext({ parent: a, name: 'Tree Child' });
+
+    const res = await agent.get(`/api/contexts/tree?root=${a}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    const root = res.body.find(n => n.id === a);
+    expect(root).toBeTruthy();
+    expect(root.children.some(ch => ch.id === b)).toBe(true);
+  });
+});

--- a/app/api/contract-tests/engine.contract.test.js
+++ b/app/api/contract-tests/engine.contract.test.js
@@ -123,3 +123,66 @@ describe('scopedDelete — soft-delete path (Principals)', () => {
     }
   });
 });
+
+describe('scopedDelete — hard-delete path (ResourceRelationships)', () => {
+  // ResourceRelationships is NOT in SOFT_DELETE_TABLES, so scopedDelete takes
+  // the DELETE branch: rows absent from the temp table are physically removed,
+  // not stamped. parent/childResourceId are plain uuids (no FK to Resources),
+  // so the fixture needs no seeded resources.
+  const KEY = ['parentResourceId', 'childResourceId', 'relationshipType'];
+  const parentId = randomUUID();
+  const keepChild = randomUUID();
+  const dropChild = randomUUID();
+
+  beforeEach(async () => {
+    await pool.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [systemId]);
+    for (const child of [keepChild, dropChild]) {
+      await pool.query(
+        `INSERT INTO "ResourceRelationships" ("parentResourceId", "childResourceId", "relationshipType", "systemId")
+         VALUES ($1, $2, 'Contains', $3)`,
+        [parentId, child, systemId],
+      );
+    }
+  });
+
+  it('physically deletes rows absent from the temp table, keeps present rows', async () => {
+    expect(SOFT_DELETE_TABLES.has('ResourceRelationships')).toBe(false);
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const tempName = 'tmp_relationships_spike';
+      // Temp table holds only the row to KEEP (parent→keepChild).
+      await client.query(
+        `CREATE TEMP TABLE "${tempName}" ("parentResourceId" uuid, "childResourceId" uuid, "relationshipType" text) ON COMMIT DROP`,
+      );
+      await client.query(
+        `INSERT INTO "${tempName}" VALUES ($1, $2, 'Contains')`,
+        [parentId, keepChild],
+      );
+
+      const tableColumnNames = new Set(['parentResourceId', 'childResourceId', 'relationshipType', 'systemId']);
+      const deleted = await scopedDelete(
+        client, 'ResourceRelationships', KEY, tempName,
+        systemId, {}, 'systemId', tableColumnNames,
+      );
+      await client.query('COMMIT');
+
+      expect(deleted).toBe(1); // only parent→dropChild was absent
+
+      const remaining = await pool.query(
+        `SELECT "childResourceId" FROM "ResourceRelationships" WHERE "systemId" = $1`,
+        [systemId],
+      );
+      const childIds = remaining.rows.map(r => r.childResourceId);
+      expect(childIds).toContain(keepChild);
+      expect(childIds).not.toContain(dropChild); // hard-deleted (gone), not stamped
+    } finally {
+      client.release();
+    }
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [systemId]);
+  });
+});

--- a/app/api/contract-tests/engine.contract.test.js
+++ b/app/api/contract-tests/engine.contract.test.js
@@ -8,6 +8,7 @@
 // the hard-delete path. If both pass reliably in CI we expand to matrix.js.
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { randomUUID } from 'crypto';
 import pg from 'pg';
 import { scopedDelete, SOFT_DELETE_TABLES } from '../src/ingest/engine.js';
 

--- a/app/api/contract-tests/identities.contract.test.js
+++ b/app/api/contract-tests/identities.contract.test.js
@@ -1,0 +1,78 @@
+// Contract test — GET /api/identities/:id against a real PostgreSQL schema.
+//
+// Verifies the identity-detail endpoint's SQL (Identities → IdentityMembers →
+// Principals joins) runs against the real schema and returns the documented
+// shape, including all linked accounts under `members`.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'crypto';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+let agent;
+let pool;
+let systemId;
+let identityId;
+const principalIds = [];
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'contract-identities') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+
+  // Two principals (linked accounts) for one identity.
+  for (const name of ['Jane (Entra)', 'Jane (AD)']) {
+    const r = await pool.query(
+      `INSERT INTO "Principals" ("systemId", "displayName", "email", "principalType")
+       VALUES ($1, $2, $3, 'User') RETURNING "id"`,
+      [systemId, name, 'jane@example.com'],
+    );
+    principalIds.push(r.rows[0].id);
+  }
+
+  // One identity aggregating both principals.
+  identityId = randomUUID();
+  await pool.query(
+    `INSERT INTO "Identities" ("id", "displayName", "email") VALUES ($1, 'Jane Doe', 'jane@example.com')`,
+    [identityId],
+  );
+  await pool.query(
+    `INSERT INTO "IdentityMembers" ("identityId", "principalId", "isPrimary") VALUES ($1, $2, true)`,
+    [identityId, principalIds[0]],
+  );
+  await pool.query(
+    `INSERT INTO "IdentityMembers" ("identityId", "principalId", "isPrimary") VALUES ($1, $2, false)`,
+    [identityId, principalIds[1]],
+  );
+});
+
+afterAll(async () => {
+  await pool.query(`DELETE FROM "IdentityMembers" WHERE "identityId" = $1`, [identityId]);
+  await pool.query(`DELETE FROM "Identities" WHERE "id" = $1`, [identityId]);
+  await pool.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+describe('GET /identities/:id', () => {
+  it('returns the identity with both linked accounts under members', async () => {
+    const res = await agent.get(`/api/identities/${identityId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.identity).toBeTruthy();
+    expect(res.body.identity.id).toBe(identityId);
+    expect(Array.isArray(res.body.members)).toBe(true);
+    // Regression pin: both linked principals are returned.
+    expect(res.body.members.length).toBe(2);
+    const returnedPrincipalIds = res.body.members.map(m => m.principalId).sort();
+    expect(returnedPrincipalIds).toEqual([...principalIds].sort());
+  });
+
+  it('returns 400 for a malformed id', async () => {
+    const res = await agent.get('/api/identities/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/contract-tests/matrix-data.contract.test.js
+++ b/app/api/contract-tests/matrix-data.contract.test.js
@@ -1,0 +1,98 @@
+// Contract test — POST /api/matrix/data against a real PostgreSQL schema.
+//
+// Verifies the matrix data endpoint's SQL runs against the real schema and the
+// materialized view, and returns the documented shape. The matrix grid is the
+// product's core surface; a wrong column name or view name here is a 500 in
+// production that unit tests (which mock the DB) cannot catch.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+let agent;
+let pool;
+let systemId;
+const resourceIds = [];
+const principalIds = [];
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'contract-matrix-data') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+
+  // 2 principals (subjects).
+  for (const name of ['Alice', 'Bob']) {
+    const r = await pool.query(
+      `INSERT INTO "Principals" ("systemId", "displayName", "email", "principalType")
+       VALUES ($1, $2, $3, 'User') RETURNING "id"`,
+      [systemId, name, `${name.toLowerCase()}@example.com`],
+    );
+    principalIds.push(r.rows[0].id);
+  }
+
+  // 3 resources.
+  for (const name of ['Engineering', 'Finance', 'Sales']) {
+    const r = await pool.query(
+      `INSERT INTO "Resources" ("systemId", "displayName", "resourceType")
+       VALUES ($1, $2, 'EntraGroup') RETURNING "id"`,
+      [systemId, name],
+    );
+    resourceIds.push(r.rows[0].id);
+  }
+
+  // 5 Direct assignments across the two principals.
+  const pairs = [
+    [resourceIds[0], principalIds[0]],
+    [resourceIds[1], principalIds[0]],
+    [resourceIds[2], principalIds[0]],
+    [resourceIds[0], principalIds[1]],
+    [resourceIds[1], principalIds[1]],
+  ];
+  for (const [resourceId, principalId] of pairs) {
+    await pool.query(
+      `INSERT INTO "ResourceAssignments" ("resourceId", "principalId", "assignmentType", "systemId", "principalType")
+       VALUES ($1, $2, 'Direct', $3, 'User')`,
+      [resourceId, principalId, systemId],
+    );
+  }
+
+  // The grid reads a materialized view that migrations create unpopulated.
+  await pool.query(`REFRESH MATERIALIZED VIEW "vw_ResourceUserPermissionAssignments"`);
+  await pool.query(`REFRESH MATERIALIZED VIEW "vw_UserPermissionAssignmentViaBusinessRole"`);
+});
+
+afterAll(async () => {
+  await pool.query(`DELETE FROM "ResourceAssignments" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+describe('POST /matrix/data — flat grid', () => {
+  it('returns 200 with the documented shape and the seeded assignments', async () => {
+    const res = await agent
+      .post('/api/matrix/data')
+      .send({ filter: { subject: { include: [], exclude: [] }, resource: { include: [], exclude: [] } } });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(typeof res.body.subjectTotal).toBe('number');
+    expect(typeof res.body.resourceTotal).toBe('number');
+
+    // Regression pins on the fresh contract DB: 2 principals, 3 resources.
+    expect(res.body.subjectTotal).toBe(2);
+    expect(res.body.resourceTotal).toBe(3);
+
+    // The seeded Direct assignments surface through the materialized view.
+    expect(res.body.data.length).toBe(5);
+    const row = res.body.data[0];
+    expect(row).toHaveProperty('resourceId');
+    expect(row).toHaveProperty('memberId');
+    expect(row).toHaveProperty('membershipType');
+    expect(resourceIds).toContain(res.body.data[0].resourceId);
+  });
+});

--- a/app/api/contract-tests/matrix-data.contract.test.js
+++ b/app/api/contract-tests/matrix-data.contract.test.js
@@ -83,16 +83,20 @@ describe('POST /matrix/data — flat grid', () => {
     expect(typeof res.body.subjectTotal).toBe('number');
     expect(typeof res.body.resourceTotal).toBe('number');
 
-    // Regression pins on the fresh contract DB: 2 principals, 3 resources.
-    expect(res.body.subjectTotal).toBe(2);
-    expect(res.body.resourceTotal).toBe(3);
+    // subjectTotal / resourceTotal are GLOBAL counts (every Principal / Resource
+    // in the DB), and the contract suite shares one singleFork database where
+    // other files leave rows behind — so assert our seed is *included*, not the
+    // exact totals.
+    expect(res.body.subjectTotal).toBeGreaterThanOrEqual(2);
+    expect(res.body.resourceTotal).toBeGreaterThanOrEqual(3);
 
-    // The seeded Direct assignments surface through the materialized view.
-    expect(res.body.data.length).toBe(5);
-    const row = res.body.data[0];
-    expect(row).toHaveProperty('resourceId');
-    expect(row).toHaveProperty('memberId');
-    expect(row).toHaveProperty('membershipType');
-    expect(resourceIds).toContain(res.body.data[0].resourceId);
+    // Scope the row assertions to our own resources (unique uuids) so they're
+    // deterministic regardless of any leftover rows from other test files.
+    const ourRows = res.body.data.filter(r => resourceIds.includes(r.resourceId));
+    expect(ourRows.length).toBe(5); // the 5 seeded Direct assignments
+    for (const row of ourRows) {
+      expect(principalIds).toContain(row.memberId);
+      expect(row.membershipType).toBe('Direct');
+    }
   });
 });

--- a/app/api/contract-tests/resources.contract.test.js
+++ b/app/api/contract-tests/resources.contract.test.js
@@ -1,0 +1,65 @@
+// Contract test — GET /api/resources against a real PostgreSQL schema.
+//
+// Verifies the resource list/filter endpoint's SQL runs against the real schema
+// and that the resourceType filter selects only matching rows. Response is an
+// object { data, total }, not a bare array.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+let agent;
+let pool;
+let systemId;
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'contract-resources') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+
+  const seed = [
+    ['Engineering', 'EntraGroup'],
+    ['Finance', 'EntraGroup'],
+    ['Global Admin', 'DirectoryRole'],
+    ['Sales App', 'Application'],
+    ['Joiner Package', 'BusinessRole'],
+  ];
+  for (const [name, type] of seed) {
+    await pool.query(
+      `INSERT INTO "Resources" ("systemId", "displayName", "resourceType", "enabled")
+       VALUES ($1, $2, $3, true)`,
+      [systemId, name, type],
+    );
+  }
+});
+
+afterAll(async () => {
+  await pool.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+describe('GET /resources', () => {
+  it('filters to exactly the requested resourceType', async () => {
+    const res = await agent.get(`/api/resources?resourceType=EntraGroup&systemId=${systemId}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.data.every(r => r.resourceType === 'EntraGroup')).toBe(true);
+    expect(typeof res.body.total).toBe('number');
+    expect(res.body.total).toBe(2);
+  });
+
+  it('excludes BusinessRole resources when no resourceType filter is given', async () => {
+    const res = await agent.get(`/api/resources?systemId=${systemId}`);
+
+    expect(res.status).toBe(200);
+    // Engineering, Finance, Global Admin, Sales App — but NOT Joiner Package.
+    expect(res.body.data.every(r => r.resourceType !== 'BusinessRole')).toBe(true);
+    expect(res.body.data.some(r => r.displayName === 'Joiner Package')).toBe(false);
+  });
+});

--- a/app/api/contract-tests/runner.contract.test.js
+++ b/app/api/contract-tests/runner.contract.test.js
@@ -1,0 +1,83 @@
+// Contract test — context-plugin runner (enqueueRun) against a real PostgreSQL
+// schema.
+//
+// Verifies the run-enqueue path's SQL runs against the real schema: the
+// ContextAlgorithms lookup, the ContextAlgorithmRuns INSERT, and the two guard
+// errors (unknown plugin / unregistered algorithm). enqueueRun uses the shared
+// db/connection.js pool, so DATABASE_URL is pointed at the contract DB before
+// the module is imported.
+//
+// Full reconciliation (diff/merge of ContextMembers) is intentionally left to a
+// higher-layer test — it runs a real registered plugin against live data and is
+// entangled with the in-flight assignment/context-model migrations (045-047).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { randomUUID } from 'crypto';
+import pg from 'pg';
+
+const PLUGIN_NAME = 'principal-type-tree'; // a real registered plugin (registry.js)
+
+let enqueueRun;
+let pool;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.CONTRACT_DB_URL;
+  ({ enqueueRun } = await import('../src/contexts/plugins/runner.js'));
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+});
+
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+beforeEach(cleanup);
+
+async function cleanup() {
+  // Contexts reference the algorithm; remove them before the algorithm row.
+  // Deleting the ContextAlgorithms row cascades its ContextAlgorithmRuns.
+  await pool.query(`DELETE FROM "Contexts" WHERE "sourceAlgorithmId" IN (SELECT id FROM "ContextAlgorithms" WHERE name = $1)`, [PLUGIN_NAME]);
+  await pool.query(`DELETE FROM "ContextAlgorithms" WHERE name = $1`, [PLUGIN_NAME]);
+}
+
+async function seedAlgorithm() {
+  const r = await pool.query(
+    `INSERT INTO "ContextAlgorithms" ("id", "name", "displayName", "targetType")
+     VALUES ($1, $2, 'Principal Type Tree', 'Principal') RETURNING "id"`,
+    [randomUUID(), PLUGIN_NAME],
+  );
+  return r.rows[0].id;
+}
+
+describe('enqueueRun — guards', () => {
+  it('throws for an unknown plugin name', async () => {
+    await expect(enqueueRun('no-such-plugin', {}, 'test')).rejects.toThrow(/Unknown plugin/);
+  });
+
+  it('throws when the plugin has no ContextAlgorithms row', async () => {
+    // Registered in the registry, but not seeded into ContextAlgorithms.
+    await expect(enqueueRun(PLUGIN_NAME, {}, 'test')).rejects.toThrow(/not registered/);
+  });
+});
+
+describe('enqueueRun — inserts a run row', () => {
+  it('inserts a ContextAlgorithmRuns row linked to the algorithm', async () => {
+    const algorithmId = await seedAlgorithm();
+
+    // awaitCompletion runs executeRun inline so the row reaches a terminal state
+    // before we assert (no dangling background work). We assert on the row's
+    // identity/linkage, not the plugin's output (which depends on seeded data).
+    const runId = await enqueueRun(PLUGIN_NAME, { values: ['ManagedIdentity'] }, 'contract-test', { awaitCompletion: true });
+
+    expect(typeof runId).toBe('string');
+    const run = await pool.query(
+      `SELECT "algorithmId", "triggeredBy", status, parameters FROM "ContextAlgorithmRuns" WHERE id = $1`,
+      [runId],
+    );
+    expect(run.rows).toHaveLength(1);
+    expect(run.rows[0].algorithmId).toBe(algorithmId);
+    expect(run.rows[0].triggeredBy).toBe('contract-test');
+    expect(['queued', 'running', 'succeeded', 'failed', 'cancelled']).toContain(run.rows[0].status);
+    expect(run.rows[0].parameters).toMatchObject({ values: ['ManagedIdentity'] });
+  });
+});

--- a/app/api/test-utils/contractApp.js
+++ b/app/api/test-utils/contractApp.js
@@ -1,0 +1,28 @@
+// Boots the real Express app against the contract-test PostgreSQL container so
+// contract tests can exercise route handlers (and the inline SQL they emit)
+// end-to-end via supertest — not just standalone SQL strings.
+//
+// Two env vars must be set BEFORE app.js is imported, which is why this helper
+// uses a dynamic import:
+//   - DATABASE_URL → CONTRACT_DB_URL, so db/connection.js's pool targets the
+//     testcontainers database (buildConfig() honours DATABASE_URL first).
+//   - USE_SQL=true, read at module load by USE_SQL-gated routes (contexts,
+//     resources, identities, matrix/data); without it they return empty mocks.
+//
+// Auth is left disabled (no auth config loaded → authMiddleware /
+// requirePermission are no-ops), so routes are reachable without a token.
+//
+// singleFork note: USE_SQL leaks across files in the shared process. Each test
+// that calls this MUST `delete process.env.USE_SQL` in afterAll.
+
+import request from 'supertest';
+import pg from 'pg';
+
+export async function bootContractApp() {
+  process.env.DATABASE_URL = process.env.CONTRACT_DB_URL;
+  process.env.USE_SQL = 'true';
+  const { createApp } = await import('../src/app.js');
+  const app = createApp();
+  const pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+  return { agent: request(app), pool };
+}

--- a/app/api/test-utils/withRealDb.js
+++ b/app/api/test-utils/withRealDb.js
@@ -55,6 +55,15 @@ export async function startDb() {
 
   await runMigrations(pool);
 
+  // Cap every connection to this database at a 10s statement timeout so a
+  // runaway query (e.g. a recursive CTE over cyclic data) can't wedge the
+  // singleFork contract suite. ALTER DATABASE ... SET applies to all sessions
+  // that connect after this point — including the per-file pools each contract
+  // test opens in its beforeAll. The container DB name isn't always "postgres"
+  // (testcontainers defaults to "test"), so resolve it at runtime.
+  const { rows } = await pool.query('SELECT current_database() AS db');
+  await pool.query(`ALTER DATABASE "${rows[0].db}" SET statement_timeout = '10s'`);
+
   return {
     connectionString,
     async stop() {


### PR DESCRIPTION
Independent of #448 — targets `main` directly. (The contexts cycle-guard regression test lives on #448; this PR's contexts coverage is the standalone `contexts-routes.contract.test.js` happy-path list/tree, which needs no cycle fix.)

## What — Phase 1 of the test-layer reinforcement
HTTP/SQL-level contract tests that run against the testcontainers PG16, exercising real route SQL and ingest internals (not mocks).

- **test-utils/contractApp.js** — `bootContractApp()` points `DATABASE_URL` at the contract DB, enables `USE_SQL`, leaves auth disabled; returns a supertest agent + seeding pool.
- **matrix-data** — `POST /matrix/data` returns the documented shape; seeded Direct assignments surface through the refreshed matview. (Endpoint has **no** `principals` array — pins are on `subjectTotal`/`resourceTotal`/`data`.)
- **identities** — `GET /identities/:id` returns both linked accounts under **`members`**; malformed id → 400.
- **resources** — `GET /resources` filters to exactly the requested `resourceType`, excludes `BusinessRole` by default.
- **contexts-routes** — `GET /contexts` (roots) + `GET /contexts/tree` (nesting).
- **engine** (P1-5) — adds the hard-delete branch: `scopedDelete` on `ResourceRelationships` physically removes absent rows, keeps present ones.
- **runner** (P1-6) — `enqueueRun` throws for unknown plugin / unregistered algorithm (validates the lookup SQL), and inserts a `ContextAlgorithmRuns` row linked to the seeded algorithm.

## Pre-work
`withRealDb.js` sets `statement_timeout='10s'` at the database level (resolved via `current_database()`, since testcontainers' default DB is `test`, not `postgres`).

## Plan corrections made during the work
- `POST /matrix/data` has no `principals` array; `GET /identities/:id` uses `members` not `principals`.
- Migration **044 is inert** (one-time backfill, no trigger) — the planned "ingest populates `ResourceAssignments.resourceType`" assertion is false, so it was dropped in favour of real hard-delete coverage.
- Repo schema is at migration **047**; migrations 045-047 move the assignment model past the plan's 044 baseline — relevant for later phases.

## CI
Contract Tests, API Unit Tests, ESLint, PR Hygiene all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)