### PR TITLE
test(api): Phase 2 unit tests + JS coverage CI wiring

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -329,9 +329,17 @@ jobs:
         working-directory: app/api
         run: npm ci
 
-      - name: Run Vitest
+      - name: Run Vitest (with coverage)
         working-directory: app/api
-        run: npm test
+        run: npm run test:coverage
+
+      - name: Upload coverage (lcov + text)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: api-coverage
+          path: app/api/coverage/
+          retention-days: 14
 
   # ── Stage 4b: Contract tests (Vitest + testcontainers) ──────────────────
   # Runs *.contract.test.js files against a real PostgreSQL container spun up

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/demo-dataset/demo-company.json
 test/demo-dataset/verify-results.json
 node_modules/
 .last-run.json
+coverage/
 tools/csv-templates/demodata/
 tools/csv-templates/demodataTransformed/
 .claude/settings.local.json

--- a/app/api/src/routes/contexts.test.js
+++ b/app/api/src/routes/contexts.test.js
@@ -5,8 +5,8 @@
 // tests; here we pin the handler logic.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import express from 'express';
 import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
 
 process.env.USE_SQL = 'true';
 
@@ -23,14 +23,7 @@ vi.mock('../middleware/auth.js', () => ({
 }));
 
 const { default: router } = await import('./contexts.js');
-
-function makeApp() {
-  const app = express();
-  app.use(express.json());
-  app.use('/api', router);
-  return app;
-}
-const app = makeApp();
+const app = mountRouter(router);
 
 const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 

--- a/app/api/src/routes/contexts.test.js
+++ b/app/api/src/routes/contexts.test.js
@@ -1,0 +1,94 @@
+// Unit tests for routes/contexts.js — create validation + branching, DB mocked.
+//
+// Covers the POST /contexts validation gauntlet and the parent-lookup branches
+// without a database. The recursive-CTE SQL itself is covered by the contract
+// tests; here we pin the handler logic.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+process.env.USE_SQL = 'true';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../db/connection.js', () => ({
+  getPool: async () => ({}),
+  query: (...a) => query(...a),
+  queryOne: (...a) => queryOne(...a),
+}));
+// Auth gate is asserted elsewhere; here it's a passthrough so we reach the logic.
+vi.mock('../middleware/auth.js', () => ({
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
+const { default: router } = await import('./contexts.js');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}
+const app = makeApp();
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+beforeEach(() => {
+  query.mockReset();
+  queryOne.mockReset();
+});
+
+describe('GET /contexts/:id — validation', () => {
+  it('400 on a malformed id', async () => {
+    const res = await request(app).get('/api/contexts/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /contexts — body validation', () => {
+  const base = { targetType: 'Principal', contextType: 'Department', displayName: 'Eng' };
+
+  it('400 when targetType is missing/invalid', async () => {
+    const res = await request(app).post('/api/contexts').send({ ...base, targetType: 'Nope' });
+    expect(res.status).toBe(400);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('400 when contextType is missing', async () => {
+    const { contextType, ...noType } = base;
+    const res = await request(app).post('/api/contexts').send(noType);
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when displayName is missing', async () => {
+    const { displayName, ...noName } = base;
+    const res = await request(app).post('/api/contexts').send(noName);
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when parentContextId is not a uuid', async () => {
+    const res = await request(app).post('/api/contexts').send({ ...base, parentContextId: 'nope' });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when the parent context does not exist', async () => {
+    queryOne.mockResolvedValueOnce(null); // parent lookup → not found
+    const res = await request(app).post('/api/contexts').send({ ...base, parentContextId: VALID_ID });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when the parent has a different targetType', async () => {
+    queryOne.mockResolvedValueOnce({ targetType: 'Resource' }); // parent of a different type
+    const res = await request(app).post('/api/contexts').send({ ...base, parentContextId: VALID_ID });
+    expect(res.status).toBe(400);
+  });
+
+  it('201 and returns the created row on a valid body', async () => {
+    query.mockResolvedValueOnce({}); // INSERT
+    queryOne.mockResolvedValueOnce({ id: 'new-id', displayName: 'Eng' }); // SELECT back
+    const res = await request(app).post('/api/contexts').send(base);
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ id: 'new-id', displayName: 'Eng' });
+  });
+});

--- a/app/api/src/routes/details.test.js
+++ b/app/api/src/routes/details.test.js
@@ -6,8 +6,8 @@
 // no container is needed (contract tests cover the real SQL).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import express from 'express';
 import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
 
 // useSql is captured at module load — enable it before importing the router.
 process.env.USE_SQL = 'true';
@@ -28,14 +28,7 @@ vi.mock('../db/connection.js', () => ({
 }));
 
 const { default: router } = await import('./details.js');
-
-function makeApp() {
-  const app = express();
-  app.use(express.json());
-  app.use('/api', router);
-  return app;
-}
-const app = makeApp();
+const app = mountRouter(router);
 
 const VALID_ID = '11111111-1111-1111-1111-111111111111';
 

--- a/app/api/src/routes/details.test.js
+++ b/app/api/src/routes/details.test.js
@@ -1,0 +1,72 @@
+// Unit tests for routes/details.js — input validation + branching, DB mocked.
+//
+// details.js has the lowest route coverage in the API. These pin the cheap,
+// high-value contracts: malformed ids are rejected before any query, and the
+// entity-detail handlers 404 when the row is absent. The DB layer is mocked so
+// no container is needed (contract tests cover the real SQL).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// useSql is captured at module load — enable it before importing the router.
+process.env.USE_SQL = 'true';
+
+// timedRequest(...).input(...).query(sql) → { recordset }. Route it through a
+// controllable mock so each test can stage the rows the handler sees.
+const timedQuery = vi.fn();
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: (sql) => timedQuery(sql) }),
+  getQueryTimings: () => [],
+}));
+
+const dbQuery = vi.fn();
+vi.mock('../db/connection.js', () => ({
+  getPool: async () => ({}),
+  query: (...a) => dbQuery(...a),
+  queryOne: vi.fn(),
+}));
+
+const { default: router } = await import('./details.js');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}
+const app = makeApp();
+
+const VALID_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  timedQuery.mockReset();
+  dbQuery.mockReset();
+});
+
+describe('details — id validation (400 before any query)', () => {
+  for (const path of ['/api/user/not-a-uuid', '/api/group/xyz', '/api/access-package/short']) {
+    it(`rejects ${path}`, async () => {
+      const res = await request(app).get(path);
+      expect(res.status).toBe(400);
+      expect(timedQuery).not.toHaveBeenCalled();
+      expect(dbQuery).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe('GET /user/:id — branching', () => {
+  it('404 when the principal does not exist', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [] }); // user-attributes query → no row
+    const res = await request(app).get(`/api/user/${VALID_ID}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /group/:id — branching', () => {
+  it('404 when the group does not exist', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [] }); // group-attributes query → no row
+    const res = await request(app).get(`/api/group/${VALID_ID}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/src/routes/resources.test.js
+++ b/app/api/src/routes/resources.test.js
@@ -1,0 +1,100 @@
+// Unit tests for routes/resources.js — list filter-building + detail branching,
+// DB mocked. The real SQL is covered by resources.contract.test.js; here we pin
+// the handler logic (response shape, the resourceType filter branch, 400/404).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+process.env.USE_SQL = 'true';
+
+// pool.request() recorder — captures the SQL + bound inputs of the list query
+// and returns a controllable result.
+let captured = { sql: '', inputs: {} };
+let nextListResult = { recordsets: [[], [{ total: 0 }]] };
+const mockPool = {
+  request() {
+    captured = { sql: '', inputs: {} };
+    const r = {
+      input(n, v) { captured.inputs[n] = v; return r; },
+      query(sql) { captured.sql = sql; return Promise.resolve(nextListResult); },
+    };
+    return r;
+  },
+};
+
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+
+// timedRequest is used only by GET /resources/:id.
+const timedQuery = vi.fn();
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: (sql) => timedQuery(sql) }),
+  getQueryTimings: () => [],
+}));
+
+vi.mock('../db/columnCache.js', () => ({
+  getResourceColumns: async () => [{ name: 'displayName' }, { name: 'resourceType' }],
+  getResourceColumnValues: vi.fn(),
+}));
+vi.mock('./tags.js', () => ({
+  ensureTagTables: async () => {},
+  buildFilterWhere: () => '',
+}));
+
+const { default: router } = await import('./resources.js');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}
+const app = makeApp();
+
+const VALID_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  timedQuery.mockReset();
+  nextListResult = { recordsets: [[], [{ total: 0 }]] };
+});
+
+describe('GET /resources — list', () => {
+  it('returns { data, total } with parsed tags and backward-compat aliases', async () => {
+    nextListResult = {
+      recordsets: [
+        [{ id: 'r1', displayName: 'Eng', description: 'd', resourceType: 'EntraGroup', extendedAttributes: null, tagString: null }],
+        [{ total: 1 }],
+      ],
+    };
+    const res = await request(app).get('/api/resources');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({ id: 'r1', groupId: 'r1', groupTypeCalculated: 'EntraGroup', tags: [] });
+  });
+
+  it('filters by resourceType when supplied', async () => {
+    await request(app).get('/api/resources?resourceType=EntraGroup');
+    expect(captured.sql).toContain('r."resourceType" = @resourceType');
+    expect(captured.inputs.resourceType).toBe('EntraGroup');
+  });
+
+  it('excludes BusinessRole resources when no resourceType filter is given', async () => {
+    await request(app).get('/api/resources');
+    expect(captured.sql).toContain(`r."resourceType" <> 'BusinessRole'`);
+  });
+});
+
+describe('GET /resources/:id — detail', () => {
+  it('400 on a malformed id', async () => {
+    const res = await request(app).get('/api/resources/not-a-uuid');
+    expect(res.status).toBe(400);
+    expect(timedQuery).not.toHaveBeenCalled();
+  });
+
+  it('404 when the resource does not exist', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [] });
+    const res = await request(app).get(`/api/resources/${VALID_ID}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/src/routes/resources.test.js
+++ b/app/api/src/routes/resources.test.js
@@ -3,8 +3,8 @@
 // the handler logic (response shape, the resourceType filter branch, 400/404).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import express from 'express';
 import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
 
 process.env.USE_SQL = 'true';
 
@@ -42,14 +42,7 @@ vi.mock('./tags.js', () => ({
 }));
 
 const { default: router } = await import('./resources.js');
-
-function makeApp() {
-  const app = express();
-  app.use(express.json());
-  app.use('/api', router);
-  return app;
-}
-const app = makeApp();
+const app = mountRouter(router);
 
 const VALID_ID = '11111111-1111-1111-1111-111111111111';
 

--- a/app/api/test-utils/routeTestKit.js
+++ b/app/api/test-utils/routeTestKit.js
@@ -1,0 +1,17 @@
+// Shared helpers for route unit tests.
+//
+// The per-file `makeApp()` (express + json + mount router under /api) was being
+// cloned across every route test (jscpd). This centralises it. Note: the
+// `vi.mock(...)` calls themselves must stay in each test file — vitest hoists
+// them above imports, so they can't be injected from here.
+
+import express from 'express';
+
+// Mount a single router under /api with JSON body parsing; returns the app for
+// `request(app)`.
+export function mountRouter(router) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}


### PR DESCRIPTION
Independent, targets `main`. Phase 2 (unit-test fill) of the test-layer reinforcement — first slice, plus the coverage tooling it motivated.

## Unit tests (DB mocked, no container)
Three lowest-coverage route files, following the repo's router-mount + `vi.mock('../db/connection.js')` convention:

- **details.test.js** — id validation (400 before any query) + 404 branching (user/group detail).
- **contexts.test.js** — `POST /contexts` validation gauntlet (targetType / contextType / displayName / parent-lookup) + the 201 create path.
- **resources.test.js** — list shape (`{ data, total }` + tag parsing + back-compat aliases), the `resourceType` filter branch + default `BusinessRole` exclusion, `/:id` 400/404.

18 tests, all green.

## Coverage → CI (new)
- The **"Unit Tests: Vitest (API)"** job now runs `npm run test:coverage` (v8 provider was already in `package.json`; the job just ran plain `npm test`) and uploads `coverage/` (lcov.info + HTML) as the **`api-coverage`** artifact. Per-PR JS coverage was previously absent.
- `coverage/` is gitignored.

Coverage after this slice: **resources.js 33%, contexts.js 14%, details.js 12.5%** (lines) — up from the plan's ~5-7% baseline.

## Dedup (jscpd)
- Extracted the cloned `makeApp` boilerplate into **`test-utils/routeTestKit.js`** (`mountRouter`). The three test files no longer register as jscpd clones (`src/routes` duplication 2.14% → 1.98%); the remaining Phase 2 files reuse the helper.

## Deviations from the plan (rationale)
- **No `makeMockApp.js`** — `vi.mock` is hoisted per-file and can't be injected by a shared factory; 20+ existing route tests use a local mount. Followed convention.
- **Stale plan coverage data** — `riskscoring/engine.js`, `matrix.js`, `identities.js` already have tests; excluded to avoid duplication.
- Plan's "resources cap at 500" is actually 10000 in code.

## Remaining Phase 2 candidates (genuinely untested)
`riskProfiles.js`, `governance.js`, `contextPlugins.js`, `systems.js`, `permissions.js`, `llm.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)