### PR TITLE
test(api): Phase 2 unit tests (slice 2) — systems/riskProfiles/governance/contextPlugins/llm/permissions

### DIFF
--- a/app/api/src/routes/contextPlugins.test.js
+++ b/app/api/src/routes/contextPlugins.test.js
@@ -1,0 +1,46 @@
+// Unit tests for routes/contextPlugins.js — id validation + plugin 404.
+// DB, plugin registry, and runner mocked (no plugin execution / DB).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../db/connection.js', () => ({ query: (...a) => query(...a), queryOne: (...a) => queryOne(...a) }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+const getPlugin = vi.fn();
+vi.mock('../contexts/plugins/registry.js', () => ({ REGISTERED_PLUGINS: [], getPlugin: (...a) => getPlugin(...a) }));
+vi.mock('../contexts/plugins/runner.js', () => ({
+  enqueueRun: vi.fn(), dryRun: vi.fn(), getRun: vi.fn(), listRuns: vi.fn(),
+}));
+vi.mock('../db/columnCache.js', () => ({ getPrincipalColumns: vi.fn(async () => []) }));
+
+const { default: router } = await import('./contextPlugins.js');
+const app = mountRouter(router);
+
+beforeEach(() => { query.mockReset(); queryOne.mockReset(); getPlugin.mockReset(); });
+
+describe('GET /context-plugins/runs/:id — validation', () => {
+  it('400 on a malformed run id', async () => {
+    const res = await request(app).get('/api/context-plugins/runs/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /context-plugins/:name/dry-run — branching', () => {
+  it('404 when the plugin name is unknown', async () => {
+    getPlugin.mockReturnValue(null);
+    const res = await request(app).post('/api/context-plugins/no-such-plugin/dry-run').send({});
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /context-plugins/trees — validation', () => {
+  it('400 when algorithmId is not a uuid', async () => {
+    const res = await request(app).delete('/api/context-plugins/trees').send({ algorithmId: 'nope' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/src/routes/governance.test.js
+++ b/app/api/src/routes/governance.test.js
@@ -1,0 +1,45 @@
+// Unit tests for routes/governance.js — summary mapping + branching. DB mocked.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const timedQuery = vi.fn();
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: (sql) => timedQuery(sql) }),
+  getQueryTimings: () => [],
+}));
+const query = vi.fn();
+vi.mock('../db/connection.js', () => ({ getPool: async () => ({}), query: (...a) => query(...a) }));
+
+const { default: router } = await import('./governance.js');
+const app = mountRouter(router);
+
+beforeEach(() => { timedQuery.mockReset(); query.mockReset(); });
+
+describe('GET /governance/summary', () => {
+  it('maps the aggregate row into the documented counts', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [{ totalAPs: 5, compliant: 3, overdue: 1, reviewedLate: 1, inProgress: 0 }] });
+    const res = await request(app).get('/api/governance/summary');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ totalAPs: 5, compliant: 3, overdue: 1, reviewedLate: 1, inProgress: 0 });
+  });
+
+  it('falls back to zeros when there is no aggregate row', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [] });
+    const res = await request(app).get('/api/governance/summary');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ totalAPs: 0, compliant: 0, overdue: 0 });
+  });
+});
+
+describe('GET /governance/categories', () => {
+  it('returns the category rows', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [{ id: 1, name: 'Finance' }] });
+    const res = await request(app).get('/api/governance/categories');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, name: 'Finance' }]);
+  });
+});

--- a/app/api/src/routes/llm.test.js
+++ b/app/api/src/routes/llm.test.js
@@ -1,0 +1,36 @@
+// Unit tests for routes/llm.js — provider/config validation. Service + vault mocked.
+
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+vi.mock('../llm/service.js', () => ({
+  SUPPORTED_PROVIDERS: ['openai', 'azure-openai', 'anthropic'],
+  DEFAULT_MODELS: {},
+  getLLMConfig: vi.fn(), saveLLMConfig: vi.fn(), clearLLMConfig: vi.fn(),
+  testLLMConfig: vi.fn(), isLLMConfigured: vi.fn(), listModelsForConfig: vi.fn(),
+}));
+vi.mock('../secrets/vault.js', () => ({ hasSecret: vi.fn() }));
+
+const { default: router } = await import('./llm.js');
+const app = mountRouter(router);
+
+describe('PUT /admin/llm/config — validation', () => {
+  it('400 on an unsupported provider', async () => {
+    const res = await request(app).put('/api/admin/llm/config').send({ provider: 'nope' });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when azure-openai is missing its endpoint', async () => {
+    const res = await request(app).put('/api/admin/llm/config').send({ provider: 'azure-openai' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /admin/llm/test — validation', () => {
+  it('400 on an unknown provider', async () => {
+    const res = await request(app).post('/api/admin/llm/test').send({ provider: 'nope' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/src/routes/permissions.test.js
+++ b/app/api/src/routes/permissions.test.js
@@ -1,0 +1,56 @@
+// Unit tests for routes/permissions.js — the access-package → resource flatten.
+// permissions.js has no 400 paths and pulls in many helpers; all are mocked so
+// the import is inert and we exercise the grouped→flat transform in Node.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const timedQuery = vi.fn();
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: (sql) => timedQuery(sql) }),
+  getQueryTimings: () => [],
+}));
+vi.mock('../db/connection.js', () => ({ getPool: async () => ({}), query: vi.fn() }));
+vi.mock('./tags.js', () => ({ ensureTagTables: async () => {}, buildFilterWhere: () => '' }));
+vi.mock('./categories.js', () => ({ ensureCategoryTables: async () => {} }));
+vi.mock('../mock/data.js', () => ({ permissionAssignments: [] }));
+vi.mock('../db/columnCache.js', () => ({
+  getGroupColumns: vi.fn(async () => []), getResourceColumns: vi.fn(async () => []),
+  getPrincipalOrUserColumns: vi.fn(async () => []), getPrincipalOrUserColumnValues: vi.fn(async () => []),
+}));
+vi.mock('../contexts/contextFilters.js', () => ({ buildContextFilterSql: vi.fn(), parseAndResolveContextFilters: vi.fn() }));
+vi.mock('../effectiveAccess/engine.js', () => ({ expandCapabilityDown: vi.fn(), effectiveAccessForNodes: vi.fn() }));
+
+const { default: router } = await import('./permissions.js');
+const app = mountRouter(router);
+
+beforeEach(() => timedQuery.mockReset());
+
+const apRow = (over) => ({
+  accessPackageId: 'ap1', businessRoleId: 'ap1', accessPackageName: 'AP One',
+  systemId: 1, catalogName: 'Cat', totalAssignments: 0,
+  categoryId: null, categoryName: null, categoryColor: null, resources: [], ...over,
+});
+
+describe('GET /access-package-groups', () => {
+  it('flattens grouped resources into (ap, resource) rows', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [apRow({
+      resources: [{ resourceId: 'r1', groupId: 'r1', resourceName: 'Eng', groupName: 'Eng', resourceType: 'EntraGroup', systemId: 1, roleName: null }],
+    })] });
+    const res = await request(app).get('/api/access-package-groups');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ accessPackageId: 'ap1', resourceId: 'r1', resourceName: 'Eng' });
+  });
+
+  it('emits a single null-resource row for an AP with no resources', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [apRow({ accessPackageId: 'ap2', resources: [] })] });
+    const res = await request(app).get('/api/access-package-groups');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ accessPackageId: 'ap2', resourceId: null, resourceName: null });
+  });
+});

--- a/app/api/src/routes/riskProfiles.test.js
+++ b/app/api/src/routes/riskProfiles.test.js
@@ -1,0 +1,55 @@
+// Unit tests for routes/riskProfiles.js — body validation + 404. DB + LLM/vault
+// service modules mocked (no network, no scraping, no vault).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../db/connection.js', () => ({ query: (...a) => query(...a), queryOne: (...a) => queryOne(...a) }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+vi.mock('../llm/service.js', () => ({ chatWithSavedConfig: vi.fn(), isLLMConfigured: vi.fn(), getLLMConfig: vi.fn() }));
+vi.mock('../llm/scraper.js', () => ({ scrapeAll: vi.fn(), buildLLMContextFromScrapes: vi.fn() }));
+vi.mock('../llm/riskPrompts.js', () => ({
+  profileGenerationPrompt: vi.fn(), profileRefinementPrompt: vi.fn(),
+  classifierGenerationPrompt: vi.fn(), extractJson: vi.fn(),
+}));
+vi.mock('../secrets/vault.js', () => ({ putSecret: vi.fn(), getSecret: vi.fn(), deleteSecret: vi.fn() }));
+
+const { default: router } = await import('./riskProfiles.js');
+const app = mountRouter(router);
+
+beforeEach(() => { query.mockReset(); queryOne.mockReset(); });
+
+describe('POST /risk-profiles/scrape — validation', () => {
+  it('400 when urls is missing or empty', async () => {
+    expect((await request(app).post('/api/risk-profiles/scrape').send({})).status).toBe(400);
+    expect((await request(app).post('/api/risk-profiles/scrape').send({ urls: [] })).status).toBe(400);
+  });
+  it('400 when more than 20 urls are supplied', async () => {
+    const urls = Array.from({ length: 21 }, (_, i) => `https://example.com/${i}`);
+    expect((await request(app).post('/api/risk-profiles/scrape').send({ urls })).status).toBe(400);
+  });
+});
+
+describe('POST /risk-profiles — validation', () => {
+  it('400 when displayName is missing', async () => {
+    const res = await request(app).post('/api/risk-profiles').send({ profile: {} });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /risk-profiles/:id — branching', () => {
+  it('400 when the id is not an integer', async () => {
+    const res = await request(app).get('/api/risk-profiles/abc');
+    expect(res.status).toBe(400);
+  });
+  it('404 when the profile does not exist', async () => {
+    queryOne.mockResolvedValueOnce(null);
+    const res = await request(app).get('/api/risk-profiles/5');
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/src/routes/systems.test.js
+++ b/app/api/src/routes/systems.test.js
@@ -1,0 +1,44 @@
+// Unit tests for routes/systems.js — id validation, 404, write-guards. DB mocked.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const timedQuery = vi.fn();
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: (sql) => timedQuery(sql) }),
+  getQueryTimings: () => [],
+}));
+vi.mock('../db/connection.js', () => ({ getPool: async () => ({}) }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+
+const { default: router } = await import('./systems.js');
+const app = mountRouter(router);
+const VALID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => timedQuery.mockReset());
+
+describe('systems', () => {
+  it('400 on a malformed system id', async () => {
+    const res = await request(app).get('/api/systems/bad');
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when the system is not found', async () => {
+    timedQuery.mockResolvedValueOnce({ recordset: [] });
+    const res = await request(app).get(`/api/systems/${VALID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT 400 when no updatable fields are supplied', async () => {
+    const res = await request(app).put(`/api/systems/${VALID}`).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('POST owners 400 when userId is missing/invalid', async () => {
+    const res = await request(app).post(`/api/systems/${VALID}/owners`).send({ userId: 'nope' });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Follow-up to #450. The six remaining Phase 2 route unit tests — these were on the `feature/unit-test-fill` branch but landed *after* #450 was squash-merged (at slice 1), so they never reached `main`. (#450 is merged and can't be reopened; this is the same branch, rebased so the diff is only these six files.)

Reuses `mountRouter()` from #450's `test-utils/routeTestKit.js` — no new jscpd clones. DB + service deps mocked.

- **systems** — id 400, 404, PUT no-fields 400, owners userId 400
- **riskProfiles** — scrape url validation, create validation, /:id 400/404
- **governance** — summary count mapping + zero fallback, categories rows
- **contextPlugins** — run-id 400, unknown-plugin 404, trees algorithmId 400
- **llm** — provider/azure config validation (400s)
- **permissions** — access-package → resource flatten (happy + empty)

20 tests, verified green against current `main`. Coverage lift (lines): systems 15.5%→45%, governance 12%→42%, llm 19%→38%, riskProfiles 7%→15%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)