### PR TITLE
test(api): Phase 3 regression pins (matrix breakdown + context members)

### DIFF
--- a/app/api/contract-tests/contexts-routes.contract.test.js
+++ b/app/api/contract-tests/contexts-routes.contract.test.js
@@ -24,7 +24,8 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await pool.query(`UPDATE "Contexts" SET "parentContextId" = NULL WHERE "scopeSystemId" = $1`, [systemId]);
-  await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]); // cascades ContextMembers
+  await pool.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
   await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
   await pool.end();
   delete process.env.USE_SQL; // singleFork — env mutations leak across files
@@ -70,5 +71,38 @@ describe('GET /contexts/tree — nesting', () => {
     const root = res.body.find(n => n.id === a);
     expect(root).toBeTruthy();
     expect(root.children.some(ch => ch.id === b)).toBe(true);
+  });
+});
+
+describe('GET /contexts/:id/members — count pin (Phase 3)', () => {
+  // Regression pin: a context with 3 live Principal members must report exactly
+  // 3. loadMembers joins ContextMembers to the target table by memberId and
+  // filters on the context's targetType; a join/filter regression would silently
+  // under- or over-count membership. A failing pin without a feature PR is a bug.
+  it('reports the seeded member count and rows', async () => {
+    const ctxId = await insertContext({ name: 'Members Ctx' });
+
+    const memberIds = [];
+    for (const name of ['M1', 'M2', 'M3']) {
+      const r = await pool.query(
+        `INSERT INTO "Principals" ("systemId", "displayName", "principalType") VALUES ($1, $2, 'User') RETURNING "id"`,
+        [systemId, name],
+      );
+      memberIds.push(r.rows[0].id);
+    }
+    for (const memberId of memberIds) {
+      await pool.query(
+        `INSERT INTO "ContextMembers" ("contextId", "memberType", "memberId", "addedBy")
+         VALUES ($1, 'Principal', $2, 'sync')`,
+        [ctxId, memberId],
+      );
+    }
+
+    const res = await agent.get(`/api/contexts/${ctxId}/members`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data.map(m => m.id).sort()).toEqual([...memberIds].sort());
   });
 });

--- a/app/api/contract-tests/matrix-data.contract.test.js
+++ b/app/api/contract-tests/matrix-data.contract.test.js
@@ -42,19 +42,20 @@ beforeAll(async () => {
     resourceIds.push(r.rows[0].id);
   }
 
-  // 5 Direct assignments across the two principals.
+  // 5 assignments across the two principals: 4 Direct + 1 Indirect, so the
+  // matview's Direct/Indirect breakdown is exercised (Phase 3 regression pin).
   const pairs = [
-    [resourceIds[0], principalIds[0]],
-    [resourceIds[1], principalIds[0]],
-    [resourceIds[2], principalIds[0]],
-    [resourceIds[0], principalIds[1]],
-    [resourceIds[1], principalIds[1]],
+    [resourceIds[0], principalIds[0], 'Direct'],
+    [resourceIds[1], principalIds[0], 'Direct'],
+    [resourceIds[2], principalIds[0], 'Direct'],
+    [resourceIds[0], principalIds[1], 'Direct'],
+    [resourceIds[1], principalIds[1], 'Indirect'],
   ];
-  for (const [resourceId, principalId] of pairs) {
+  for (const [resourceId, principalId, assignmentType] of pairs) {
     await pool.query(
       `INSERT INTO "ResourceAssignments" ("resourceId", "principalId", "assignmentType", "systemId", "principalType")
-       VALUES ($1, $2, 'Direct', $3, 'User')`,
-      [resourceId, principalId, systemId],
+       VALUES ($1, $2, $3, $4, 'User')`,
+      [resourceId, principalId, assignmentType, systemId],
     );
   }
 
@@ -93,10 +94,24 @@ describe('POST /matrix/data — flat grid', () => {
     // Scope the row assertions to our own resources (unique uuids) so they're
     // deterministic regardless of any leftover rows from other test files.
     const ourRows = res.body.data.filter(r => resourceIds.includes(r.resourceId));
-    expect(ourRows.length).toBe(5); // the 5 seeded Direct assignments
+    expect(ourRows.length).toBe(5); // the 5 seeded assignments
     for (const row of ourRows) {
       expect(principalIds).toContain(row.memberId);
-      expect(row.membershipType).toBe('Direct');
+      expect(['Direct', 'Indirect']).toContain(row.membershipType);
     }
+  });
+
+  // Phase 3 regression pin: the matview must preserve the Direct/Indirect
+  // distinction (assignmentType → membershipType CASE, migration 043). A change
+  // that collapses them would silently merge access categories in the grid.
+  // A failing pin here without a feature PR is a bug — investigate, don't delete.
+  it('preserves the Direct vs Indirect membership breakdown', async () => {
+    const res = await agent
+      .post('/api/matrix/data')
+      .send({ filter: { subject: { include: [], exclude: [] }, resource: { include: [], exclude: [] } } });
+    expect(res.status).toBe(200);
+    const ourRows = res.body.data.filter(r => resourceIds.includes(r.resourceId));
+    const breakdown = ourRows.reduce((acc, r) => { acc[r.membershipType] = (acc[r.membershipType] || 0) + 1; return acc; }, {});
+    expect(breakdown).toEqual({ Direct: 4, Indirect: 1 });
   });
 });


### PR DESCRIPTION
Phase 3 of the test-layer reinforcement — regression pins added to the Phase 1 contract files (now in `main`).

- **matrix-data** — seed 4 Direct + 1 Indirect assignment, refresh the matview, assert the membershipType breakdown is exactly `{ Direct: 4, Indirect: 1 }`. Guards the `assignmentType → membershipType` CASE (migration 043) against a change that silently collapses access categories in the grid.
- **contexts-routes** — a context with 3 live Principal members must report `total: 3` via `GET /contexts/:id/members`. Guards `loadMembers`' join + targetType filter.

Per the plan, pins use the stable `membershipType` axis (the source assignmentTypes — AppRole/OAuth2Grant/etc. — were collapsed by migration 045, so `assignmentType` is now just Direct/Indirect/Eligible/Governed). The identity-enrichment pin (`members.length === 2`) already exists in `identities.contract.test.js`.

**Maintenance rule:** a failing pin without a feature PR is a bug — investigate, don't delete.

Seed inserts verified against the real schema; full run is on the Contract Tests CI job here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)