### PR TITLE
fix(ingest): resolve cross-entity refs for hyphenated system types

### DIFF
--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -38,11 +38,14 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * @param {object} options
  * @param {string} options.idGeneration - 'native' (default) or 'deterministic'
  * @param {string} options.idPrefix - Namespace for deterministic GUIDs
+ * @param {string} options.systemPrefix - System-only prefix (no entity suffix) for
+ *   cross-entity reference resolution. When omitted, falls back to idPrefix.split('-')[0],
+ *   which is wrong whenever the system prefix itself contains a hyphen.
  * @param {number} options.systemId - System ID to set on each record
  * @returns {object[]} Normalized records
  */
 export function normalizeRecords(records, coreColumns, options = {}) {
-  const { idGeneration = 'native', idPrefix = '', systemId } = options;
+  const { idGeneration = 'native', idPrefix = '', systemId, systemPrefix } = options;
   const coreSet = new Set(coreColumns);
 
   return records.map(rec => {
@@ -77,17 +80,19 @@ export function normalizeRecords(records, coreColumns, options = {}) {
     if (idGeneration === 'deterministic') {
       // Cross-entity ID resolution: derive the prefix used to generate the
       // target entity's deterministic GUID. The convention is that the ingest
-      // caller sets idPrefix = "<systemType>-<endpointSuffix>", e.g.:
-      //   resources:              "CSV-resources"
-      //   principals:             "CSV-principals"
-      //   resource-assignments:   "CSV-resource-assignments"
-      //   resource-relationships: "CSV-resource-relationships"
-      //   certifications:         "CSV-certifications"
+      // caller sets idPrefix = "<systemPrefix>-<endpointSuffix>", e.g.
+      // "<sys>-resources", "<sys>-principals", "<sys>-resource-assignments".
       //
-      // To resolve a resourceExternalId we need "CSV-resources" — i.e. keep
-      // the system prefix (everything before the first hyphen) and swap the
-      // entity suffix. Same for principals.
-      const sysPrefix = idPrefix.split('-')[0]; // e.g. "CSV", "Omada"
+      // To resolve a resourceExternalId we need "<sys>-resources" — i.e. keep
+      // the system prefix and swap the entity suffix. Same for principals.
+      //
+      // Prefer the explicit systemPrefix the route recovers by stripping the
+      // known entity suffix off idPrefix — that survives a system prefix that
+      // itself contains hyphens. Splitting on the first hyphen only works when
+      // the system prefix is hyphen-free, and otherwise resolves references to
+      // the wrong namespace, causing FK violations (e.g.
+      // ContextMembers_contextId_fkey on the context-members upsert).
+      const sysPrefix = systemPrefix || idPrefix.split('-')[0];
 
       if (rec.parentExternalId && !normalized.parentResourceId) {
         normalized.parentResourceId = deterministicGuid(`${sysPrefix}-resources`, String(rec.parentExternalId));

--- a/app/api/src/ingest/normalization.test.js
+++ b/app/api/src/ingest/normalization.test.js
@@ -157,4 +157,35 @@ describe('normalizeRecords — context-member externalId resolution', () => {
     );
     expect(r[0].contextId).toBe(explicit);
   });
+
+  it('honours an explicit systemPrefix when the prefix contains a hyphen (regression)', () => {
+    // A hyphenated systemType used to break here: the old idPrefix.split('-')[0]
+    // recovered only the first segment, so members resolved their contextId
+    // under "<first>-contexts" while the Contexts endpoint created rows under
+    // the full "<first>-<rest>-contexts" — every contextId mismatched and the
+    // upsert failed with ContextMembers_contextId_fkey. The route now strips the
+    // known entity suffix and passes the full systemPrefix.
+    const sys = 'Two-Part';
+    const ctx = normalizeRecords(
+      [{ externalId: 'OU123', displayName: 'OU', variant: 'synced', targetType: 'Identity', contextType: 'OrgUnit' }],
+      ['id', 'externalId', 'displayName', 'variant', 'targetType', 'contextType', 'systemId'],
+      { idGeneration: 'deterministic', idPrefix: `${sys}-contexts`, systemId: 1 }
+    );
+    const memberCols2 = ['contextId', 'memberId', 'memberType'];
+    const withPrefix = normalizeRecords(
+      [{ contextExternalId: 'OU123', memberExternalId: 'alice', memberType: 'Identity' }],
+      memberCols2,
+      { idGeneration: 'deterministic', idPrefix: `${sys}-context-members`, systemPrefix: sys, systemId: 1 }
+    );
+    // With the recovered systemPrefix the member resolves to the exact context id.
+    expect(withPrefix[0].contextId).toBe(ctx[0].id);
+
+    // And the old fallback (no systemPrefix → split on first hyphen) would NOT.
+    const oldBehaviour = normalizeRecords(
+      [{ contextExternalId: 'OU123', memberExternalId: 'alice', memberType: 'Identity' }],
+      memberCols2,
+      { idGeneration: 'deterministic', idPrefix: `${sys}-context-members`, systemId: 1 }
+    );
+    expect(oldBehaviour[0].contextId).not.toBe(ctx[0].id);
+  });
 });

--- a/app/api/src/routes/ingest.js
+++ b/app/api/src/routes/ingest.js
@@ -89,9 +89,24 @@ function createIngestHandler(entityType) {
         r.column_name.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
       );
 
+      // Recover the system-only prefix used to namespace deterministic GUIDs.
+      // Callers build idPrefix as "<systemPrefix>-<entitySuffix>" where the
+      // suffix is this endpoint's slug (e.g. "context-members"). Stripping that
+      // known suffix recovers <systemPrefix> intact even when it contains
+      // hyphens, so cross-entity externalId references resolve to the SAME GUID
+      // the referenced entity was created under. Without this, a hyphenated
+      // systemType broke contextId resolution and blew up the context-members
+      // upsert with ContextMembers_contextId_fkey.
+      const entitySuffix = '-' + entityType.split('/').pop();
+      const idPrefix = body.idPrefix || '';
+      const systemPrefix = idPrefix.endsWith(entitySuffix)
+        ? idPrefix.slice(0, -entitySuffix.length)
+        : idPrefix.split('-')[0];
+
       const normalized = normalizeRecords(body.records, coreColumns, {
         idGeneration: body.idGeneration || 'native',
-        idPrefix: body.idPrefix || '',
+        idPrefix,
+        systemPrefix,
         systemId: body.systemId,
       });
 

--- a/changes/omada-import-fixes.md
+++ b/changes/omada-import-fixes.md
@@ -1,0 +1,2 @@
+- Fixed CSV/Omada imports failing with a `ContextMembers_contextId_fkey` foreign-key error when the configured system type contained a hyphen (e.g. a two-word system name). Context members now resolve to the same contexts that were imported, regardless of hyphens in the system type.
+- Omada transform: identities are now keyed by `_ID` first (then `_UID`, then `_IdentityID`), and identity-to-account links use the same key derivation so a person and their accounts always connect.

--- a/tools/csv-templates/transforms/omada-to-identityatlas.ps1
+++ b/tools/csv-templates/transforms/omada-to-identityatlas.ps1
@@ -269,7 +269,7 @@ if ($ident) {
         (-not $t) -or ($t -in @('Primary','Person','Employee'))
     } | ForEach-Object {
         [PSCustomObject]@{
-            ExternalId = if ($_._UID) { $_._UID } elseif ($_.IDENTITYID) { $_.IDENTITYID } else { $_._ID }
+            ExternalId = if ($_._ID) { $_._ID } elseif ($_._UID) { $_._UID } else { $_._IdentityID }
             DisplayName = if ($_._DISPLAYNAME) { $_._DISPLAYNAME } else { $_.DisplayName }
             Email       = $_.EMAIL
             EmployeeId  = if ($_.EMPLOYEEID) { $_.EMPLOYEEID } else { $_.EmployeeID }
@@ -297,7 +297,10 @@ if ($ident -and $users) {
         $joinKey = $_.IDENTITYID
         $joinKey -and $userIds.ContainsKey($joinKey)
     } | ForEach-Object {
-        $identId = if ($_._UID) { $_._UID } else { $_._ID }
+        # Key identities the SAME way the Identities section does (_ID → _UID →
+        # _IdentityID), otherwise a person and their membership row resolve to
+        # different deterministic GUIDs and the account→identity link breaks.
+        $identId = if ($_._ID) { $_._ID } elseif ($_._UID) { $_._UID } else { $_._IdentityID }
         [PSCustomObject]@{
             IdentityExternalId = $identId
             UserExternalId     = $_.IDENTITYID


### PR DESCRIPTION
## Problem

Importing via the Omada → Identity Atlas CSV flow failed at the context-members step with:

```
insert or update on table "ContextMembers" violates foreign key constraint "ContextMembers_contextId_fkey"
```

followed by a cascade of `Invalid or expired syncId` (the crawler retrying an already-rolled-back sync session).

## Root cause

Contexts are created under the **full** deterministic-GUID namespace `"<systemType>-contexts"`. But cross-entity references (a context-member''s `contextExternalId`) were resolved by reconstructing the namespace as `idPrefix.split("-")[0] + "-contexts"` — which only recovers `<systemType>` when it contains **no hyphen**. A hyphenated system type (e.g. a two-word system name) collapsed to its first segment, so every `contextId` resolved to a namespace that doesn''t exist → FK violation. Because multi-batch sync sessions stage rows in a temp table and only upsert on `end`, the failure surfaced on the final batch (earlier batches reported `0 ins, 0 upd`).

## Fix

- `routes/ingest.js` recovers the full system prefix by stripping the **known endpoint suffix** off `idPrefix` (robust to hyphens) and passes it to `normalizeRecords` as `systemPrefix`.
- `ingest/normalization.js` uses that explicit `systemPrefix`, falling back to the old split only when not provided.
- One fix in the API benefits every crawler (CSV, Omada, midPoint, custom-connector) with no crawler redeploy.

## Also included

- Omada transform: `Identities` and `IdentityMembers` now derive the identity key the same way (`_ID` → `_UID` → `_IdentityID`), so a person and their accounts always resolve to the same GUID.

## Testing

- Added a regression unit test for hyphenated prefixes in `normalization.test.js`.
- Verified end-to-end against the live Docker stack: a `Two-Part` system type imports a context + context-member with no FK error, and the member''s `contextId` matches the imported context (`matches = t`). Test rows cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)