### PR TITLE
feat(docs): publish test coverage to the documentation site

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,167 @@
+# ─── Publish test coverage to the docs ───────────────────────────────────────
+# On every push to main that touches source or tests, this workflow:
+#   1. Runs each test suite with coverage:
+#        - API  (app/api)  → Vitest v8 → lcov.info
+#        - UI   (app/ui)   → Vitest v8 → lcov.info
+#        - Pester (test/unit) → JaCoCo XML
+#   2. Converts each suite to a consistent browsable HTML report + a
+#      machine-readable Summary.json via ReportGenerator, under docs/coverage/.
+#   3. Renders the curated docs page (docs/reference/coverage.md) from those
+#      summaries (tools/generate-coverage-doc.py).
+#   4. Commits docs/reference/coverage.md + docs/coverage/** back to main.
+#
+# Why commit into docs/ rather than publish a one-off artifact: the docs site is
+# versioned with mike (edge = main, stable = release tag). Committing the page and
+# reports into the docs tree means mike builds them into BOTH versions naturally —
+# edge refreshes every merge, a release is frozen at its tag's numbers. The commit
+# touches only docs/** so it re-triggers docs.yml (redeploy) but NOT this workflow
+# (its paths filter is source/tests only) — no loop — and not docker-publish.yml
+# (gated on bump-version). Same protected-main push mechanics as sbom-update.yml:
+# the GitHub App token is required (GITHUB_TOKEN can't bypass branch protection),
+# and the push rebases-and-retries to absorb bump-version.yml's concurrent commit.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Publish coverage to docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/api/src/**'
+      - 'app/ui/src/**'
+      - 'tools/crawlers/**'
+      - 'tools/powershell-sdk/**'
+      - 'tools/riskscoring/**'
+      - 'test/unit/**'
+      - 'tools/generate-coverage-doc.py'
+      - '.github/workflows/coverage.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-docs-main
+  cancel-in-progress: false  # queue, don't drop — each merge's numbers matter
+
+permissions:
+  contents: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+
+      - name: Setup .NET (for ReportGenerator)
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: '8.0.x'
+
+      # ── API coverage (Vitest) ──────────────────────────────────────────────
+      - name: API tests with coverage
+        working-directory: app/api
+        continue-on-error: true  # publish coverage even if a suite has a failure
+        run: |
+          npm ci
+          npm run test:coverage
+
+      # ── UI coverage (Vitest) ───────────────────────────────────────────────
+      - name: UI tests with coverage
+        working-directory: app/ui
+        continue-on-error: true
+        run: |
+          npm ci
+          npm run test:coverage
+
+      # ── PowerShell coverage (Pester → JaCoCo) ──────────────────────────────
+      # Coverage scope mirrors pr.yml's pester job exactly.
+      - name: Pester tests with coverage
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          if (-not (Get-Module Pester -ListAvailable | Where-Object Version -ge '5.0.0')) {
+            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser
+          }
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = 'test/unit'
+          $cfg.Run.PassThru = $true
+          $cfg.CodeCoverage.Enabled = $true
+          $cfg.CodeCoverage.Path = @(
+            (Get-ChildItem 'tools/powershell-sdk' -Directory | Select-Object -ExpandProperty FullName)
+            (Get-ChildItem 'tools/crawlers' -Directory |
+              Where-Object { Test-Path (Join-Path $_.FullName 'crawler.json') } |
+              Select-Object -ExpandProperty FullName)
+            'tools/riskscoring'
+          )
+          $cfg.CodeCoverage.OutputPath = 'pester-coverage.xml'
+          $cfg.CodeCoverage.OutputFormat = 'JaCoCo'
+          Invoke-Pester -Configuration $cfg
+
+      # ── Convert each suite to HTML + Summary.json ──────────────────────────
+      - name: Install ReportGenerator
+        run: |
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Build coverage reports
+        run: |
+          gen() {
+            local slug="$1"; local src="$2"; local title="$3"
+            if [ -f "$src" ]; then
+              reportgenerator \
+                "-reports:$src" \
+                "-targetdir:docs/coverage/$slug" \
+                "-reporttypes:Html;JsonSummary" \
+                "-sourcedirs:." \
+                "-title:$title"
+            else
+              echo "::warning::No coverage input for $slug ($src) — skipping"
+            fi
+          }
+          gen api        app/api/coverage/lcov.info "API"
+          gen ui         app/ui/coverage/lcov.info  "UI"
+          gen powershell pester-coverage.xml        "PowerShell"
+
+      - name: Render coverage docs page
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: python3 tools/generate-coverage-doc.py
+              --coverage-dir docs/coverage
+              --out docs/reference/coverage.md
+              --commit "$GITHUB_SHA"
+
+      # ── Commit back to main ────────────────────────────────────────────────
+      - name: Commit coverage
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/reference/coverage.md docs/coverage
+          if git diff --cached --quiet; then
+            echo "Coverage unchanged — nothing to commit"
+            exit 0
+          fi
+          git commit -m "docs: update test coverage report"
+          # bump-version.yml may push to main on the same merge — rebase & retry.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed (attempt $attempt) — rebasing onto latest main"
+            git pull --rebase origin main
+          done
+          echo "::error::Could not push coverage update after 5 attempts"
+          exit 1

--- a/changes/coverage-docs.md
+++ b/changes/coverage-docs.md
@@ -1,0 +1,1 @@
+- Added a Test Coverage page to the documentation (Reference → Test Coverage) showing line/branch/method coverage for the API, UI, and PowerShell suites, with links to full browsable per-file reports. It refreshes automatically on every merge and is versioned alongside the docs (edge tracks the latest, a release is frozen at its version).

--- a/docs/contributing/ci-pipeline.md
+++ b/docs/contributing/ci-pipeline.md
@@ -1,6 +1,6 @@
 # CI Pipeline
 
-Two GitHub Actions workflows run on every PR targeting `main`. Both use the same two-step pattern: a **commit-range skip** job that detects housekeeping-only pushes, then **path-filter gates** that run only what actually changed.
+Two GitHub Actions workflows run on every PR targeting `main`. Both use the same two-step pattern: a **commit-range skip** job that detects housekeeping-only pushes, then **path-filter gates** that run only what actually changed. A handful of **post-merge** workflows then run on the push to `main` itself (version bump, docs deploy, SBOM and coverage refresh) — see [Post-merge workflows](#post-merge-workflows-push-to-main) below.
 
 Branch protection requires two checks to pass before a PR can merge:
 
@@ -105,6 +105,28 @@ Example: only `omada` changed → `testSet = [omada]`, `runSet = [odata, omada]`
 | `load-soak` | Forces load soak regardless of which paths changed |
 | `skip-load-soak` | Skips load soak even when paths would trigger it |
 | `skip-e2e` | Skips Playwright E2E |
+
+---
+
+## Post-merge workflows (push to main)
+
+These run **after** a PR merges, on the push to `main` — not as PR gates. They push their results back to `main` with the GitHub App token (branch protection blocks `GITHUB_TOKEN`), each rebasing-and-retrying to absorb the concurrent `bump-version.yml` commit on the same merge.
+
+| Workflow | Triggers on | What it does |
+|---|---|---|
+| `bump-version.yml` | Every PR merge | Increments `Minor` + timestamp in `setup/IdentityAtlas.psd1`, merges `changes/*.md` fragments into `CHANGES.md`, pushes `:edge` Docker tag |
+| `docs.yml` | `docs/**`, `mkdocs.yml` changes; releases | Builds the MkDocs site and deploys with `mike` (edge from `main`, stable from a release tag) |
+| `sbom-update.yml` | Dependency-manifest changes | Regenerates the SPDX SBOM and refreshes `docs/reference/sbom.md` |
+| `coverage.yml` | `app/api/src/**`, `app/ui/src/**`, `tools/crawlers/**`, `tools/powershell-sdk/**`, `tools/riskscoring/**`, `test/unit/**` | Runs API/UI (Vitest) + Pester with coverage, converts each suite to a browsable HTML report via ReportGenerator, renders `docs/reference/coverage.md`, and commits the page + `docs/coverage/**` |
+
+### coverage.yml — test coverage to docs
+
+The coverage workflow publishes line/branch/method coverage for all three suites to the **Reference → Test Coverage** docs page, each suite linking to a full per-file HTML report.
+
+- **Build:** `npm run test:coverage` for API and UI (Vitest v8 → `lcov.info`); Pester over `tools/powershell-sdk`, the crawler dirs, and `tools/riskscoring` (→ JaCoCo XML). [ReportGenerator](https://github.com/danielpalme/ReportGenerator) converts each to a consistent HTML report + `Summary.json`, which `tools/generate-coverage-doc.py` turns into the curated page.
+- **Versioning:** because the page and reports are committed into `docs/`, `mike` builds them into **both** doc versions — edge refreshes every merge, a release is frozen at its tag's numbers.
+- **No loop:** the commit only touches `docs/**`, so it re-triggers `docs.yml` (redeploy) but not `coverage.yml` (its paths filter is source/tests only) and not `docker-publish.yml` (gated on `bump-version`).
+- A suite that fails or produces no coverage degrades gracefully — the page still renders, marking that suite as having no report.
 
 ---
 

--- a/docs/reference/coverage.md
+++ b/docs/reference/coverage.md
@@ -1,0 +1,12 @@
+# Test Coverage
+
+<!-- GENERATED FILE — do not edit by hand. Produced by tools/generate-coverage-doc.py via .github/workflows/coverage.yml. -->
+
+Line coverage across the project's automated test suites (API, UI, PowerShell),
+regenerated on every merge to `main`.
+
+!!! info "Pending first generation"
+    This page is populated by the **Publish coverage to docs** workflow on the
+    next merge to `main`. Until then it shows no figures. The numbers reflect the
+    version of the docs you are viewing — **edge** tracks `main`, a released
+    version is frozen at its release tag.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,12 @@ plugins:
   - mike:
       canonical_version: stable
 
+# The per-suite HTML coverage reports under docs/coverage/ are generated and
+# committed by .github/workflows/coverage.yml. They're linked from the curated
+# Test Coverage page rather than the nav, so silence the "not in nav" warnings.
+not_in_nav: |
+  /coverage/
+
 extra_css:
   - assets/extra.css
 
@@ -128,6 +134,7 @@ nav:
       - Permissions & Roles: reference/permissions.md
       - Database Views: reference/sql-views.md
       - Software Bill of Materials: reference/sbom.md
+      - Test Coverage: reference/coverage.md
 
   - Project:
       - About Identity Atlas: about.md

--- a/tools/generate-coverage-doc.py
+++ b/tools/generate-coverage-doc.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Render the curated test-coverage docs page from ReportGenerator summaries.
+
+The coverage CI workflow (.github/workflows/coverage.yml) runs each test suite
+with coverage, converts every suite to a consistent browsable HTML report plus a
+machine-readable ``Summary.json`` via ReportGenerator, then calls this script to
+turn those summaries into ``docs/reference/coverage.md``. The page and the HTML
+reports under ``docs/coverage/`` are committed so mike versions them into the
+edge (main) and release (tag) documentation sites — see the workflow header.
+
+This mirrors the SBOM docs pattern (tools/update-sbom-doc.py): CI regenerates a
+curated Markdown page from a generated artifact and commits it back to main.
+
+Usage:
+    python3 tools/generate-coverage-doc.py \
+        --coverage-dir docs/coverage \
+        --out docs/reference/coverage.md \
+        --commit "$GITHUB_SHA"
+
+Each suite is expected at ``<coverage-dir>/<slug>/Summary.json`` (the JsonSummary
+ReportGenerator emits). Missing suites are skipped with a note rather than failing
+the build, so the page still renders if one suite produced no coverage.
+"""
+import argparse
+import datetime
+import json
+import os
+import sys
+
+# Display label + browsable-report subfolder for each suite slug. Order here is
+# the order rows appear in the table.
+SUITES = [
+    ("api", "API (Node / Vitest)"),
+    ("ui", "UI (React / Vitest)"),
+    ("powershell", "PowerShell (Pester)"),
+]
+
+
+def load_summary(coverage_dir, slug):
+    """Return the ReportGenerator 'summary' dict for a suite, or None if absent."""
+    path = os.path.join(coverage_dir, slug, "Summary.json")
+    if not os.path.isfile(path):
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    # ReportGenerator JsonSummary nests everything under "summary".
+    return data.get("summary", data)
+
+
+def pct(value):
+    """ReportGenerator emits coverage as a float percent or null (no branches)."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def fmt_pct(value):
+    return "—" if value is None else f"{value:.1f}%"
+
+
+def badge_color(value):
+    if value is None:
+        return "lightgrey"
+    if value >= 80:
+        return "brightgreen"
+    if value >= 60:
+        return "yellow"
+    if value >= 40:
+        return "orange"
+    return "red"
+
+
+def shield(label, value):
+    """A static shields.io badge URL. Renders alt text if the image can't load."""
+    color = badge_color(value)
+    shown = "n%2Fa" if value is None else f"{value:.1f}%25"
+    # Spaces → underscores per shields.io static-badge escaping.
+    safe_label = label.replace("-", "--").replace(" ", "_")
+    return f"https://img.shields.io/badge/{safe_label}-{shown}-{color}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--coverage-dir", default="docs/coverage")
+    ap.add_argument("--out", default="docs/reference/coverage.md")
+    ap.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
+    ap.add_argument("--report-base", default="../coverage",
+                    help="Relative path from the page to the coverage report root.")
+    args = ap.parse_args()
+
+    rows = []
+    overall_covered = 0
+    overall_coverable = 0
+    for slug, label in SUITES:
+        summary = load_summary(args.coverage_dir, slug)
+        if summary is None:
+            rows.append((slug, label, None))
+            continue
+        line_cov = pct(summary.get("linecoverage"))
+        branch_cov = pct(summary.get("branchcoverage"))
+        method_cov = pct(summary.get("methodcoverage"))
+        covered = int(summary.get("coveredlines", 0) or 0)
+        coverable = int(summary.get("coverablelines", 0) or 0)
+        overall_covered += covered
+        overall_coverable += coverable
+        rows.append((slug, label, {
+            "line": line_cov,
+            "branch": branch_cov,
+            "method": method_cov,
+            "covered": covered,
+            "coverable": coverable,
+        }))
+
+    overall = (100.0 * overall_covered / overall_coverable) if overall_coverable else None
+
+    generated = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    commit = args.commit.strip()
+    commit_short = commit[:8] if commit else ""
+
+    lines = []
+    lines.append("# Test Coverage")
+    lines.append("")
+    lines.append(
+        "<!-- GENERATED FILE — do not edit by hand. "
+        "Produced by tools/generate-coverage-doc.py via .github/workflows/coverage.yml. -->"
+    )
+    lines.append("")
+    lines.append(
+        "Line coverage across the project's automated test suites, regenerated on "
+        "every merge to `main`. The figures on this page reflect the version of the "
+        "docs you are viewing — **edge** tracks `main`, a released version is frozen "
+        "at its release tag."
+    )
+    lines.append("")
+    lines.append(f"![Overall coverage]({shield('coverage', overall)})")
+    lines.append("")
+    lines.append("| Suite | Line | Branch | Method | Lines covered |")
+    lines.append("|-------|------|--------|--------|---------------|")
+    for slug, label, data in rows:
+        if data is None:
+            lines.append(f"| {label} | — | — | — | _no report_ |")
+            continue
+        report_link = f"[{label}]({args.report_base}/{slug}/index.html)"
+        covered_cell = f"{data['covered']:,} / {data['coverable']:,}"
+        lines.append(
+            f"| {report_link} | {fmt_pct(data['line'])} | {fmt_pct(data['branch'])} "
+            f"| {fmt_pct(data['method'])} | {covered_cell} |"
+        )
+    lines.append(f"| **Overall** | **{fmt_pct(overall)}** | | | "
+                 f"**{overall_covered:,} / {overall_coverable:,}** |")
+    lines.append("")
+    lines.append("## Browsable reports")
+    lines.append("")
+    lines.append("Each suite links to a full per-file, line-by-line HTML report:")
+    lines.append("")
+    for slug, label, data in rows:
+        if data is None:
+            lines.append(f"- {label} — _no report for this version_")
+        else:
+            lines.append(f"- [{label}]({args.report_base}/{slug}/index.html)")
+    lines.append("")
+    footer = f"_Generated {generated}"
+    if commit_short:
+        footer += f" from commit `{commit_short}`"
+    footer += "._"
+    lines.append(footer)
+    lines.append("")
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write("\n".join(lines))
+
+    print(f"Wrote {args.out} ({overall_coverable:,} coverable lines across "
+          f"{sum(1 for _, _, d in rows if d)} suite(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a **Reference → Test Coverage** page to the docs showing line/branch/method coverage for all three test suites, each linking to a full browsable per-file HTML report:

- **API** (Node / Vitest)
- **UI** (React / Vitest)
- **PowerShell** (Pester)

## How it works

A new `coverage.yml` workflow runs on every push to `main` that touches source or tests:

1. Runs each suite with coverage (`npm run test:coverage` for API/UI; Pester → JaCoCo).
2. Converts each to a consistent browsable HTML report + a machine-readable `Summary.json` via **ReportGenerator**, under `docs/coverage/`.
3. Renders the curated page (`docs/reference/coverage.md`) from those summaries with `tools/generate-coverage-doc.py`.
4. Commits the page + `docs/coverage/**` back to `main`.

## Versioning (edge + release)

Because the page and reports live in the docs tree, **mike** versions them into both sites naturally: **edge** (built from `main`) refreshes on every merge; a **release/stable** version is frozen at its release tag''s numbers. No separate gh-pages handling.

The commit touches only `docs/**`, so it re-triggers `docs.yml` (redeploy) but **not** this workflow (paths filter is source/tests only — no loop) and not `docker-publish.yml`. Same protected-`main` push mechanics as `sbom-update.yml` (GitHub App token + rebase-and-retry to absorb `bump-version.yml`''s concurrent commit).

## Testing

- `tools/generate-coverage-doc.py` verified locally against ReportGenerator-shaped fixtures: line-weighted overall %, null-branch handling (`—`), and the degraded path where a suite produced no report.
- `coverage.yml` and `mkdocs.yml` validated as well-formed YAML.
- The committed `docs/reference/coverage.md` is a placeholder; the first merge to `main` populates real figures and the HTML reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)