### PR TITLE
feat(coverage): include contract tests in the API coverage docs number

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,7 @@
 # ─── Publish test coverage to the docs ───────────────────────────────────────
 # On every push to main that touches source or tests, this workflow:
 #   1. Runs each test suite with coverage:
-#        - API  (app/api)  → Vitest v8 → lcov.info
+#        - API  (app/api)  → Vitest v8, unit + contract → two lcov.info (merged)
 #        - UI   (app/ui)   → Vitest v8 → lcov.info
 #        - Pester (test/unit) → JaCoCo XML
 #   2. Converts each suite to a consistent browsable HTML report + a
@@ -71,12 +71,23 @@ jobs:
           dotnet-version: '8.0.x'
 
       # ── API coverage (Vitest) ──────────────────────────────────────────────
-      - name: API tests with coverage
+      # The API number reflects BOTH suites: unit tests (mocked DB) and contract
+      # tests (real PostgreSQL via testcontainers). They run under separate vitest
+      # configs into separate lcov dirs; ReportGenerator merges them below. Without
+      # the contract run, route files exercised only end-to-end (matrix/data,
+      # contexts, identities, resources, ingest engine, plugin runner) would read
+      # as near-zero here even though they're well covered.
+      - name: API unit tests with coverage
         working-directory: app/api
         continue-on-error: true  # publish coverage even if a suite has a failure
         run: |
           npm ci
           npm run test:coverage
+
+      - name: API contract tests with coverage
+        working-directory: app/api
+        continue-on-error: true  # testcontainers spins up postgres:16 on the runner
+        run: npm run test:contract -- --coverage
 
       # ── UI coverage (Vitest) ───────────────────────────────────────────────
       - name: UI tests with coverage
@@ -118,22 +129,29 @@ jobs:
 
       - name: Build coverage reports
         run: |
+          # gen <slug> <title> <src...> — ReportGenerator merges every input
+          # report that exists (union of line hits), so a suite can be fed more
+          # than one lcov (the API suite = unit + contract).
           gen() {
-            local slug="$1"; local src="$2"; local title="$3"
-            if [ -f "$src" ]; then
+            local slug="$1"; local title="$2"; shift 2
+            local reports=""
+            for src in "$@"; do
+              [ -f "$src" ] && reports="${reports:+$reports;}$src"
+            done
+            if [ -n "$reports" ]; then
               reportgenerator \
-                "-reports:$src" \
+                "-reports:$reports" \
                 "-targetdir:docs/coverage/$slug" \
                 "-reporttypes:Html;JsonSummary" \
                 "-sourcedirs:." \
                 "-title:$title"
             else
-              echo "::warning::No coverage input for $slug ($src) — skipping"
+              echo "::warning::No coverage input for $slug — skipping"
             fi
           }
-          gen api        app/api/coverage/lcov.info "API"
-          gen ui         app/ui/coverage/lcov.info  "UI"
-          gen powershell pester-coverage.xml        "PowerShell"
+          gen api        "API"        app/api/coverage/lcov.info app/api/coverage-contract/lcov.info
+          gen ui         "UI"         app/ui/coverage/lcov.info
+          gen powershell "PowerShell" pester-coverage.xml
 
       - name: Render coverage docs page
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/demo-dataset/verify-results.json
 node_modules/
 .last-run.json
 coverage/
+coverage-contract/
 tools/csv-templates/demodata/
 tools/csv-templates/demodataTransformed/
 .claude/settings.local.json

--- a/app/api/vitest.contract.config.js
+++ b/app/api/vitest.contract.config.js
@@ -22,5 +22,17 @@ export default defineConfig({
     // Container startup + migrations take ~30-60s; allow enough headroom.
     testTimeout: 30000,
     hookTimeout: 120000,
+    // Coverage is opt-in via `--coverage` (kept off for normal local runs).
+    // Output goes to its own dir so the docs pipeline (coverage.yml) can feed
+    // BOTH this lcov and the unit lcov to ReportGenerator, which merges them
+    // into one API coverage report. Same include/exclude as the unit config so
+    // the two measure the same file set.
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov'],
+      reportsDirectory: './coverage-contract',
+      include: ['src/**/*.js'],
+      exclude: ['src/**/*.test.js', 'src/index.js'],
+    },
   },
 });

--- a/changes/coverage-merge-contract.md
+++ b/changes/coverage-merge-contract.md
@@ -1,0 +1,1 @@
+- The API row on the Test Coverage docs page now reflects both unit *and* contract tests, so route code exercised only end-to-end (the matrix grid, contexts, identities, resources, ingest, plugin runner) no longer reads as untested.

--- a/docs/contributing/ci-pipeline.md
+++ b/docs/contributing/ci-pipeline.md
@@ -123,7 +123,7 @@ These run **after** a PR merges, on the push to `main` — not as PR gates. They
 
 The coverage workflow publishes line/branch/method coverage for all three suites to the **Reference → Test Coverage** docs page, each suite linking to a full per-file HTML report.
 
-- **Build:** `npm run test:coverage` for API and UI (Vitest v8 → `lcov.info`); Pester over `tools/powershell-sdk`, the crawler dirs, and `tools/riskscoring` (→ JaCoCo XML). [ReportGenerator](https://github.com/danielpalme/ReportGenerator) converts each to a consistent HTML report + `Summary.json`, which `tools/generate-coverage-doc.py` turns into the curated page.
+- **Build:** `npm run test:coverage` for API and UI (Vitest v8 → `lcov.info`); Pester over `tools/powershell-sdk`, the crawler dirs, and `tools/riskscoring` (→ JaCoCo XML). The API suite also runs the contract tests with coverage (`npm run test:contract -- --coverage` → a second `lcov.info`); [ReportGenerator](https://github.com/danielpalme/ReportGenerator) merges the unit + contract lcov for the API row, so route code exercised only end-to-end still counts. It converts each suite to a consistent HTML report + `Summary.json`, which `tools/generate-coverage-doc.py` turns into the curated page.
 - **Versioning:** because the page and reports are committed into `docs/`, `mike` builds them into **both** doc versions — edge refreshes every merge, a release is frozen at its tag's numbers.
 - **No loop:** the commit only touches `docs/**`, so it re-triggers `docs.yml` (redeploy) but not `coverage.yml` (its paths filter is source/tests only) and not `docker-publish.yml` (gated on `bump-version`).
 - A suite that fails or produces no coverage degrades gracefully — the page still renders, marking that suite as having no report.

--- a/tools/generate-coverage-doc.py
+++ b/tools/generate-coverage-doc.py
@@ -30,7 +30,7 @@ import sys
 # Display label + browsable-report subfolder for each suite slug. Order here is
 # the order rows appear in the table.
 SUITES = [
-    ("api", "API (Node / Vitest)"),
+    ("api", "API (Node / Vitest — unit + contract)"),
     ("ui", "UI (React / Vitest)"),
     ("powershell", "PowerShell (Pester)"),
 ]


### PR DESCRIPTION
Follow-up to #455 (now merged). The coverage docs pipeline measured API coverage from the **unit suite only**, so route code exercised end-to-end by **contract tests** (matrix grid, contexts, identities, resources, ingest engine, plugin runner) read as near-zero on the Test Coverage page despite being well covered. This makes the published API number reflect *all* the tests.

(Same `feature/coverage-docs` branch, reset onto current `main` since #455 was squash-merged and can't reopen.)

## Changes
- **vitest.contract.config.js** — opt-in coverage block (v8 → `./coverage-contract`, same include/exclude as the unit config), emitted only with `--coverage`.
- **coverage.yml** — runs the contract suite with coverage alongside the unit suite, then feeds **both** lcov files to ReportGenerator for the `api` slug. ReportGenerator merges them (union of line hits) into one report, so the docs page reflects unit + contract.
- `gen()` now accepts N source reports and includes each that exists (skips missing).
- **Docs** — `ci-pipeline.md` and the generated page's API label note the unit+contract merge.
- `coverage-contract/` gitignored.

## Why it matters
On the latest unit-only artifact, `routes/matrix/data.js` showed 7%, `contexts.js` 14%, `identities.js` 24% — all heavily exercised by contract tests that simply weren't being measured. After this, those count toward the published number.

Validated locally: YAML parses, the `gen()` merge logic builds the right multi-`-reports` string, configs/generator compile. The real merged number lands when `coverage.yml` runs on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)