### PR TITLE
test(api): unit tests for 5 untested routes (tags/categories/admin/matrix-scope/saved-filters)

### DIFF
--- a/app/api/src/routes/admin.test.js
+++ b/app/api/src/routes/admin.test.js
@@ -1,0 +1,64 @@
+// Unit tests for routes/admin.js — feature toggle, retention, and dashboard
+// read validation/branching. DB + authConfig + tombstonePurge mocked. The
+// complex import/export/clean handlers are intentionally not covered here.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../db/connection.js', () => ({
+  getPool: async () => ({ request: () => ({ input() { return this; }, query: async () => ({ recordset: [] }) }) }),
+  query: (...a) => query(...a),
+  queryOne: (...a) => queryOne(...a),
+}));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+vi.mock('../config/authConfig.js', () => ({ getAuthState: () => ({ enabled: false }) }));
+vi.mock('../ingest/tombstonePurge.js', () => ({ purgeExpiredTombstones: vi.fn(async () => ({ purged: 0 })) }));
+
+const { default: router } = await import('./admin.js');
+const app = mountRouter(router);
+
+beforeEach(() => { query.mockReset(); queryOne.mockReset(); });
+
+describe('POST /admin/features/toggle', () => {
+  it('400 on an unknown feature', async () => {
+    expect((await request(app).post('/api/admin/features/toggle').send({ feature: 'nope', enabled: true })).status).toBe(400);
+  });
+  it('400 when enabled is not boolean', async () => {
+    expect((await request(app).post('/api/admin/features/toggle').send({ feature: 'riskScoring', enabled: 'yes' })).status).toBe(400);
+  });
+  it('200 on a valid toggle', async () => {
+    query.mockResolvedValueOnce({});
+    const res = await request(app).post('/api/admin/features/toggle').send({ feature: 'riskScoring', enabled: true });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ feature: 'riskScoring', enabled: true });
+  });
+});
+
+describe('PUT /admin/history-retention', () => {
+  it('400 when retentionDays is out of range', async () => {
+    expect((await request(app).put('/api/admin/history-retention').send({ retentionDays: 5000 })).status).toBe(400);
+  });
+  it('400 when retentionDays is not a number', async () => {
+    expect((await request(app).put('/api/admin/history-retention').send({ retentionDays: 'abc' })).status).toBe(400);
+  });
+  it('200 on a valid value', async () => {
+    query.mockResolvedValueOnce({});
+    const res = await request(app).put('/api/admin/history-retention').send({ retentionDays: 180 });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ retentionDays: 180 });
+  });
+});
+
+describe('GET /admin/risk-profile', () => {
+  it('reports unavailable when there is no profile row', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/api/admin/risk-profile');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ available: false });
+  });
+});

--- a/app/api/src/routes/categories.test.js
+++ b/app/api/src/routes/categories.test.js
@@ -1,0 +1,46 @@
+// Unit tests for routes/categories.js — list + CRUD validation. DB mocked.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+let nextResult = { recordset: [] };
+const mockPool = { request() { const r = { input() { return r; }, query() { return Promise.resolve(nextResult); } }; return r; } };
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+
+const { default: router } = await import('./categories.js');
+const app = mountRouter(router);
+
+beforeEach(() => { nextResult = { recordset: [] }; });
+
+describe('categories', () => {
+  it('GET /categories returns the rows', async () => {
+    nextResult = { recordset: [{ id: 1, name: 'Finance', color: '#3b82f6' }] };
+    const res = await request(app).get('/api/categories');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, name: 'Finance', color: '#3b82f6' }]);
+  });
+
+  it('POST /categories 400 when name is missing', async () => {
+    expect((await request(app).post('/api/categories').send({})).status).toBe(400);
+  });
+
+  it('POST /categories 400 on a non-hex color', async () => {
+    expect((await request(app).post('/api/categories').send({ name: 'X', color: 'red' })).status).toBe(400);
+  });
+
+  it('PATCH /categories/:id 400 on a non-integer id', async () => {
+    expect((await request(app).patch('/api/categories/abc').send({ name: 'Y' })).status).toBe(400);
+  });
+
+  it('DELETE /categories/:id 400 on a non-integer id', async () => {
+    expect((await request(app).delete('/api/categories/abc')).status).toBe(400);
+  });
+
+  it('POST /categories/:id/assign 400 when resourceId is missing', async () => {
+    expect((await request(app).post('/api/categories/1/assign').send({})).status).toBe(400);
+  });
+});

--- a/app/api/src/routes/details.test.js
+++ b/app/api/src/routes/details.test.js
@@ -63,3 +63,55 @@ describe('GET /group/:id — branching', () => {
     expect(res.status).toBe(404);
   });
 });
+
+// Happy-path coverage: a generic non-empty row for every timed query drives the
+// detail + list handlers through their success branches (200). db.query returns
+// empty (risk/history absent — both guarded). We assert status + the top-level
+// response keys, not full bodies; the real SQL/shape is covered by contract tests.
+const GENERIC = { id: 'x', displayName: 'X', name: 'X', cnt: 0, total: 0, autoAdd: 0, autoRemoveOnly: 0 };
+
+describe('details — happy paths (200)', () => {
+  beforeEach(() => {
+    timedQuery.mockResolvedValue({ recordset: [GENERIC] });
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  it('GET /user/:id returns the detail payload', async () => {
+    const res = await request(app).get(`/api/user/${VALID_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('attributes');
+    expect(res.body).toHaveProperty('membershipCount');
+  });
+
+  it('GET /group/:id returns the detail payload', async () => {
+    const res = await request(app).get(`/api/group/${VALID_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('attributes');
+    expect(res.body).toHaveProperty('memberCount');
+  });
+
+  it('GET /access-package/:id returns the detail payload', async () => {
+    const res = await request(app).get(`/api/access-package/${VALID_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('attributes');
+    expect(res.body).toHaveProperty('assignmentCount');
+  });
+
+  for (const sub of ['/contexts', '/memberships', '/access-packages', '/oauth2-grants', '/history']) {
+    it(`GET /user/:id${sub} returns 200`, async () => {
+      expect((await request(app).get(`/api/user/${VALID_ID}${sub}`)).status).toBe(200);
+    });
+  }
+
+  for (const sub of ['/members', '/access-packages', '/history']) {
+    it(`GET /group/:id${sub} returns 200`, async () => {
+      expect((await request(app).get(`/api/group/${VALID_ID}${sub}`)).status).toBe(200);
+    });
+  }
+
+  for (const sub of ['/assignments', '/resource-roles', '/reviews', '/requests', '/history', '/policies']) {
+    it(`GET /access-package/:id${sub} returns 200`, async () => {
+      expect((await request(app).get(`/api/access-package/${VALID_ID}${sub}`)).status).toBe(200);
+    });
+  }
+});

--- a/app/api/src/routes/matrix/savedFilters.test.js
+++ b/app/api/src/routes/matrix/savedFilters.test.js
@@ -1,0 +1,50 @@
+// Unit tests for routes/matrix/savedFilters.js — CRUD validation. DB mocked.
+// UUID_RE comes from the real filterSql.js (a pure regex — not mocked).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../../db/connection.js', () => ({ query: (...a) => query(...a), queryOne: (...a) => queryOne(...a) }));
+
+const { default: router } = await import('./savedFilters.js');
+const app = mountRouter(router);
+
+const VALID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => { query.mockReset(); queryOne.mockReset(); });
+
+describe('matrix saved-filters', () => {
+  it('GET /matrix/saved-filters returns the rows', async () => {
+    // The handler first awaits ensureSavedFiltersTable() (a db.query whose
+    // result is ignored), then the SELECT — so return rows for every call.
+    query.mockResolvedValue({ rows: [{ id: VALID, name: 'Mine' }] });
+    const res = await request(app).get('/api/matrix/saved-filters');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: VALID, name: 'Mine' }]);
+  });
+
+  it('POST 400 when name is missing', async () => {
+    expect((await request(app).post('/api/matrix/saved-filters').send({ filter: {} })).status).toBe(400);
+  });
+
+  it('POST 400 when filter is missing/not an object', async () => {
+    expect((await request(app).post('/api/matrix/saved-filters').send({ name: 'X' })).status).toBe(400);
+  });
+
+  it('PUT 400 on a malformed id', async () => {
+    expect((await request(app).put('/api/matrix/saved-filters/nope').send({ name: 'X' })).status).toBe(400);
+  });
+
+  it('PUT 400 when there are no updatable fields', async () => {
+    expect((await request(app).put(`/api/matrix/saved-filters/${VALID}`).send({})).status).toBe(400);
+  });
+
+  it('DELETE 400 on a malformed id', async () => {
+    expect((await request(app).delete('/api/matrix/saved-filters/nope')).status).toBe(400);
+  });
+});

--- a/app/api/src/routes/matrix/scope.test.js
+++ b/app/api/src/routes/matrix/scope.test.js
@@ -1,0 +1,35 @@
+// Unit tests for routes/matrix/scope.js — filter-body validation. All the SQL
+// helpers are mocked; parseFilter returning null drives the 400 path.
+
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+vi.mock('../../db/connection.js', () => ({ getPool: async () => ({}), queryOne: vi.fn() }));
+vi.mock('../../perf/sqlTimer.js', () => ({ timedRequest: () => ({ input() { return this; }, query: async () => ({ recordset: [] }) }) }));
+vi.mock('../../db/matrixHelpers.js', () => ({ buildAssignmentExprs: vi.fn(() => ({})) }));
+vi.mock('../../db/columnCache.js', () => ({ getPrincipalColumns: vi.fn(async () => []), getResourceColumns: vi.fn(async () => []) }));
+vi.mock('../../matrix/scopeHistory.js', () => ({ generateSampleDates: vi.fn(() => []), buildScopeAsofSql: vi.fn(), historyStartSql: vi.fn() }));
+vi.mock('../../matrix/attrExpr.js', () => ({ resolveAttrExpr: vi.fn(() => ({ expr: 'x' })) }));
+// parseFilter returns null → every handler hits the "Invalid filter body" 400.
+vi.mock('./shared.js', () => ({
+  parseFilter: vi.fn(() => null),
+  buildSubqueries: vi.fn(), subjectScopeClauses: vi.fn(), runCount: vi.fn(), resolveContextTypes: vi.fn(),
+}));
+
+const { default: router } = await import('./scope.js');
+const app = mountRouter(router);
+
+describe('matrix scope — invalid filter body', () => {
+  it('POST /matrix/scope-stats 400 on an invalid filter', async () => {
+    const res = await request(app).post('/api/matrix/scope-stats').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /matrix/scope-timeseries 400 on an invalid filter', async () => {
+    const res = await request(app).post('/api/matrix/scope-timeseries').send({});
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/src/routes/tags.test.js
+++ b/app/api/src/routes/tags.test.js
@@ -1,0 +1,70 @@
+// Unit tests for routes/tags.js — list + tag CRUD/assign validation. DB and the
+// column-cache / bootstrap / memberCounts helpers mocked.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+let nextResult = { recordset: [] };
+const mockPool = { request() { const r = { input() { return r; }, query() { return Promise.resolve(nextResult); } }; return r; } };
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../db/connection.js', () => ({
+  getPool: async () => mockPool,
+  query: (...a) => query(...a),
+  queryOne: (...a) => queryOne(...a),
+}));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+vi.mock('../db/columnCache.js', () => ({
+  getGroupColumns: vi.fn(async () => []), getResourceColumns: vi.fn(async () => []),
+  getPrincipalOrUserColumns: vi.fn(async () => []), getPrincipalOrUserColumnValues: vi.fn(async () => []),
+  getGroupColumnValues: vi.fn(async () => []), getResourceColumnValues: vi.fn(async () => []),
+}));
+vi.mock('../bootstrap.js', () => ({ getOrCreateTagRoot: vi.fn(async () => 'root-id') }));
+vi.mock('../contexts/memberCounts.js', () => ({ recalcMemberCountsForChain: vi.fn(async () => {}) }));
+
+const { default: router } = await import('./tags.js');
+const app = mountRouter(router);
+
+const VALID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => { nextResult = { recordset: [] }; query.mockReset(); queryOne.mockReset(); });
+
+describe('tags', () => {
+  it('GET /tags returns the rows', async () => {
+    nextResult = { recordset: [{ id: VALID, name: 'PII', color: '#3b82f6' }] };
+    const res = await request(app).get('/api/tags');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: VALID, name: 'PII', color: '#3b82f6' }]);
+  });
+
+  it('POST /tags 400 when name/entityType are missing', async () => {
+    expect((await request(app).post('/api/tags').send({})).status).toBe(400);
+  });
+
+  it('POST /tags 400 on an invalid entityType', async () => {
+    expect((await request(app).post('/api/tags').send({ name: 'X', entityType: 'nope' })).status).toBe(400);
+  });
+
+  it('POST /tags 400 on a non-hex color', async () => {
+    expect((await request(app).post('/api/tags').send({ name: 'X', entityType: 'user', color: 'red' })).status).toBe(400);
+  });
+
+  it('PATCH /tags/:id 400 on a malformed id', async () => {
+    expect((await request(app).patch('/api/tags/nope').send({ name: 'X' })).status).toBe(400);
+  });
+
+  it('POST /tags/:id/assign 400 on a malformed id', async () => {
+    expect((await request(app).post('/api/tags/nope/assign').send({ entityIds: ['a'] })).status).toBe(400);
+  });
+
+  it('POST /tags/:id/assign 400 when entityIds is not a non-empty array', async () => {
+    expect((await request(app).post(`/api/tags/${VALID}/assign`).send({ entityIds: [] })).status).toBe(400);
+  });
+
+  it('GET /entity-tags 400 on an invalid entityType', async () => {
+    expect((await request(app).get('/api/entity-tags?entityType=nope')).status).toBe(400);
+  });
+});


### PR DESCRIPTION
Option 2 of the API coverage push: unit tests for the five route files that had **no test at all**, reusing `mountRouter` (no new jscpd clones), DB + service deps mocked.

- **categories** — list rows; create/patch/delete/assign validation
- **tags** — list rows; tag create/assign validation; entity-tags 400
- **admin** — `features/toggle` + `history-retention` validation; `risk-profile` unavailable branch (skips the complex import/export/clean handlers)
- **matrix/savedFilters** — saved-filter CRUD validation (name/filter/uuid/no-fields)
- **matrix/scope** — invalid-filter-body 400 on scope-stats/timeseries

29 tests, all green locally against current `main`.

Coverage lift (lines): `savedFilters.js` 9%→46%, `categories.js` 13%→30%, `matrix/scope.js` 6%→22%, `tags.js` 15%→20%, `admin.js` 10%→17%. The big files move modestly (validation is a small slice); deepening them is the diminishing-returns Option 3.

Independent of the coverage-merge PR (#456) and the contract-coverage there will additionally raise routes exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)