### PR TITLE
ci: skip integration/e2e/load-soak for test-only PRs

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -125,6 +125,11 @@ jobs:
               - 'app/api/Dockerfile'
               - 'setup/docker/Dockerfile.powershell'
               - 'docker-compose*.yml'
+              # Test files are co-located under src/ but aren't app source — a
+              # test-only change leaves the running app unchanged, so don't spin
+              # up the ~50-min integration/e2e/load-soak suites for it.
+              - '!**/*.test.js'
+              - '!**/*.test.jsx'
             e2e:
               - 'app/ui/src/**'
               - 'app/ui/e2e/**'
@@ -134,6 +139,8 @@ jobs:
               - 'tools/crawlers/**/*.e2e.*'
               - 'app/api/src/**'
               - 'app/api/Dockerfile'
+              - '!**/*.test.js'
+              - '!**/*.test.jsx'
             load_soak:
               - 'app/api/src/**'
               - 'tools/crawlers/shared/**'
@@ -142,6 +149,8 @@ jobs:
               - 'setup/docker/Invoke-CrawlerJob.ps1'
               - 'setup/docker/Dockerfile.powershell'
               - 'docker-compose*.yml'
+              - '!**/*.test.js'
+              - '!**/*.test.jsx'
 
       # Dynamically detect which crawler types changed from the git diff.
       # No hardcoded type list — new crawlers are picked up automatically.

--- a/changes/ci-skip-heavy-jobs-on-test-only.md
+++ b/changes/ci-skip-heavy-jobs-on-test-only.md
@@ -1,0 +1,1 @@
+- CI no longer spins up the ~50-minute Integration, Playwright E2E, and Load & Soak suites for pull requests that only change test files — the application under test is unchanged, so those suites are skipped (unit and contract tests still run).


### PR DESCRIPTION
## Why
The `integration`, `e2e`, and `load_soak` path filters in `pr-integration.yml` match `app/api/src/**` / `app/ui/src/**`, which also match the **co-located `*.test.js` unit tests**. So a PR that only changes unit tests triggered the ~50-minute Integration / Playwright E2E / Load & Soak suites — even though the running app is unchanged. (And when a follow-up push supersedes the run, the cancelled run's "Integration CI Passed" gate shows a spurious ❌.)

This is the same reason contract tests live *outside* `src/` (per the CLAUDE.md note) — but unit tests are co-located by vitest convention, so they slipped through.

## Fix
Add `!**/*.test.js` / `!**/*.test.jsx` exclusions to the three heavy filters (dorny/paths-filter negation). Test-only changes now skip them.

- **Unit + contract tests still run** — the `api`/`ui` filters in `pr.yml` are untouched.
- **E2E specs unaffected** — they're `*.spec.js` (verified: 20 specs, zero `*.test.js` in `app/ui/e2e/`).
- A PR that touches both a source file and a test still runs everything (the source file matches the positive glob).

YAML validated; this PR itself only changes a workflow file, so the heavy jobs correctly skip on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)