### PR TITLE
chore: genericize example data in docs and tests

### DIFF
--- a/app/api/src/contexts/plugins/resource-cluster/tokenize.js
+++ b/app/api/src/contexts/plugins/resource-cluster/tokenize.js
@@ -37,7 +37,7 @@ const ROLE_WORDS = [
 ];
 
 // Dutch connectives / prepositions that clutter descriptive display names
-// like "Eigenaren van Smart Infra — Lot Sensorenplatform (Inkoop en …)".
+// like "Eigenaren van Finance (Inkoop en Contracten)".
 const NL_FILLER = [
   'van', 'voor', 'naar', 'bij', 'aan', 'uit', 'over', 'onder',
   'tot', 'met', 'als', 'ook', 'door', 'nog',
@@ -78,7 +78,7 @@ export const DEFAULT_STOPWORDS = new Set([
 // Anything that isn't an ASCII letter or digit is treated as a separator.
 // This intentionally breaks on any punctuation, parens, brackets, spaces,
 // underscores, slashes, etc. — display names like
-// "Eigenaren van … (INKOOP EN CONTRACTMANAGEMENT)" and
+// "Owners of … (PROCUREMENT & CONTRACTING)" and
 // "Role: Procurement+Invoicing" both tokenize cleanly.
 const SEPARATOR_RE = /[^a-zA-Z0-9]+/;
 const NUMERIC_RE = /^\d+$/;

--- a/app/api/src/contexts/plugins/resource-cluster/tokenize.test.js
+++ b/app/api/src/contexts/plugins/resource-cluster/tokenize.test.js
@@ -8,19 +8,19 @@ describe('tokenize', () => {
   });
 
   it('treats parens / brackets / punctuation as separators', () => {
-    expect(tokenize('Eigenaren van Smart-Infra (INKOOP EN CONTRACTMANAGEMENT)'))
-      .toEqual(['smart', 'infra', 'inkoop', 'contractmanagement']);
+    expect(tokenize('Owners of Data-Platform (PROCUREMENT & CONTRACTING)'))
+      .toEqual(['data', 'platform', 'procurement', 'contracting']);
     expect(tokenize('Role: Procurement+Invoicing; Team=A&B'))
       .toEqual(['procurement', 'invoicing']);
   });
 
-  it('strips Dutch connective tokens like "van"', () => {
-    // "rol" is a tenant-specific AD prefix at Novastream Financial — not
-    // filtered by default, but the analyst can add it via additionalStopwords.
-    // Here we just confirm that "van" and "eigenaren" (NL fillers/roles) are
-    // filtered out of the default set.
-    expect(tokenize('AG_ROL_DMS_EIGENAREN VAN FINANCE (INKOOP)'))
-      .toEqual(['rol', 'dms', 'finance', 'inkoop']);
+  it('strips role-suffix and short connective tokens', () => {
+    // "rol" is a generic AD role-prefix — not filtered by default, but the
+    // analyst can add it via additionalStopwords. Here we just confirm that
+    // "owners" (a role suffix) and "of" (too short) are filtered out, while
+    // "rol", "dms", "finance" and "procurement" survive.
+    expect(tokenize('AG_ROL_DMS_OWNERS OF FINANCE (PROCUREMENT)'))
+      .toEqual(['rol', 'dms', 'finance', 'procurement']);
   });
 
   it('lowercases tokens', () => {

--- a/app/api/src/llm/riskPrompts.js
+++ b/app/api/src/llm/riskPrompts.js
@@ -53,7 +53,7 @@ You must respond with ONLY a valid JSON object (no markdown fencing, no explanat
 
 Research targets:
 - What does the organisation do? (industry, sector, sub-sector)
-- What regulations apply? (NIS2, DORA, SOX, HIPAA, Wbni, BIO, etc.)
+- What regulations apply? (NIS2, DORA, SOX, HIPAA, GDPR, etc.)
 - What are their critical business processes?
 - What key systems/platforms are publicly known?
 - What security frameworks do they likely follow? (ISO 27001, NIST, BIO for government)
@@ -101,7 +101,7 @@ RULES:
 - "assistantMessage" is ALWAYS present and contains your natural-language reply to the user.
 - "profile" is the COMPLETE customer_profile schema — same shape as the current profile below. Include ALL fields even if unchanged.
 - "profileChanged" is true if you modified anything in the profile, false if the user just asked a question and you didn't change the profile.
-- If the user asks a question (e.g. "what software does HBR use?"), research the answer, include it in assistantMessage, and also add any relevant facts to the profile (e.g. known_systems, critical_business_processes). Set profileChanged=true if you added anything.
+- If the user asks a question (e.g. "what software does the organisation use?"), research the answer, include it in assistantMessage, and also add any relevant facts to the profile (e.g. known_systems, critical_business_processes). Set profileChanged=true if you added anything.
 - If the user requests a change (e.g. "drop NIS2"), apply it, describe what you changed in assistantMessage, and set profileChanged=true.
 - NEVER respond with prose outside the JSON object. NEVER use markdown fences. The output must start with { and end with }.
 
@@ -188,7 +188,7 @@ HARD RULES FOR PATTERNS — follow all of them:
 
   4. Exclude news/communications/training/room/mailbox naming conventions. Specifically, make sure your patterns do NOT fire on entities whose name contains any of: "nieuws", "news", "newsletter", "communicatie", "communication", "lokaal", "leslokaal", "room", "meeting", "mailbox", "postbus", "kalender", "calendar", "distributielijst", "distribution list", "shared mailbox". If your keyword is literally the same as one of these (e.g. "room operator"), rewrite the pattern to require additional context.
 
-  5. Prefer system-specific nouns from the profile over generic job categories. If the profile mentions AXIOM, Portbase, SAP-S/4HANA, Dynamics, Pronto, PortXchange, Navigate, ISPS, SOC, etc., build patterns around those exact names. Generic "infrastructure admin" catches too much; "\\bAXIOM[\\s_-]?admin\\b" catches exactly what matters.
+  5. Prefer system-specific nouns from the profile over generic job categories. If the profile mentions AXIOM, SAP-S/4HANA, Dynamics, ServiceNow, Swift, SEPA, SOC, etc., build patterns around those exact names. Generic "infrastructure admin" catches too much; "\\bAXIOM[\\s_-]?admin\\b" catches exactly what matters.
 
   6. Separate role-name patterns from descriptive terms. Patterns like "robot" or "autopilot" or "dynamics" will fire on Azure Autopilot device groups, Microsoft Dynamics CRM administrators, and Hadoop Robot Engineer service accounts — none of which are OT/SCADA. Don't produce patterns that match those words unless you also require a genuine OT/ICS keyword beside them.
 

--- a/app/api/src/riskscoring/engine.test.js
+++ b/app/api/src/riskscoring/engine.test.js
@@ -78,7 +78,7 @@ describe('isNonProduction', () => {
 
   it('does NOT flag production names', () => {
     expect(isNonProduction('Domain Admins')).toBe(false);
-    expect(isNonProduction('GG_ROL_VTS_OPERATORS')).toBe(false);
+    expect(isNonProduction('GG_ROL_PAY_OPERATORS')).toBe(false);
     expect(isNonProduction('GG_ROL_NSF_Dynamics_Administrator')).toBe(false);
     expect(isNonProduction('Enterprise Admins')).toBe(false);
   });
@@ -209,7 +209,7 @@ describe('scoreOne', () => {
   // End-to-end regression for the full LLM → compile → match chain.
   // Uses a real Claude-style classifier with (?i) inline flags to prove the
   // scoring engine works with the kind of patterns the LLM actually produces.
-  it('real-world: Claude-style domain admin classifier matches HBR-style data', () => {
+  it('example: Claude-style domain admin classifier matches realistic group data', () => {
     const claudeClassifier = {
       id: 'domain-admins',
       label: 'Domain Administrators',
@@ -224,7 +224,7 @@ describe('scoreOne', () => {
       ],
     };
     const cls = [compileClassifier(claudeClassifier)];
-    // These are real HBR resource display names from the test dataset
+    // These are example resource display names from the test dataset
     expect(scoreOne(['GG_ROL_AD_Administrators'], cls).directScore).toBe(0); // doesn't match "domain"
     expect(scoreOne(['Domain Admins'], cls).directScore).toBe(100);
     expect(scoreOne(['Enterprise Admins'], cls).directScore).toBe(100);

--- a/changes/genericize-example-data.md
+++ b/changes/genericize-example-data.md
@@ -1,0 +1,1 @@
+- Standardised example data across the documentation, tests, and fixtures to use generic placeholder organisation, system, and hostname values.

--- a/docs/architecture/omada-crawler-datamodel.md
+++ b/docs/architecture/omada-crawler-datamodel.md
@@ -1,8 +1,5 @@
 # Omada IGA Crawler — Data Model Reference
 
-> **Last updated:** 2026-06-04  
-> **Tested against:** Omada Identity v15.0 on-premise (OData 4.0) and Omada Cloud (omada.cloud)
-
 ---
 
 ## Overview

--- a/docs/architecture/resource-cluster-algorithm.md
+++ b/docs/architecture/resource-cluster-algorithm.md
@@ -109,34 +109,34 @@ as `DEFAULT_STOPWORDS`. Tenant-specific additions go through the
 
 ## 4. Worked example
 
-Input (an extract from a real Entra tenant):
+Input (an illustrative set of group names):
 
 ```
 SG_APP_AXIOM_Admins_P
 GRP-AXIOM-ReadOnly-TST
 AG_AzureDevOps_Axiom_Developer
-AG_AzureSubscription_SCH_Axiom_Polaris_Sandbox_Support
-AG_AzureTeam_Axiom_GedelegeerdProductOwner
-AG_JITApprover_APP_AXIOM-ADAM_KCADMIN_A
+AG_AzureSubscription_SCH_Axiom_Helios_Sandbox_Support
+AG_AzureTeam_Axiom_DelegatedProductOwner
+AG_JITApprover_APP_AXIOM-APPX_SVCADMIN_A
 SG_FINANCE_BookKeepers
 DL_Finance_Readers
-AG_ROL_DMS_Bezoekers van Finance-Commissie
+AG_ROL_DMS_Owners of Finance-Committee
 ```
 
 After tokenisation (default stopwords, `minTokenLength=3`,
-`additionalStopwords=["rol","azure","sch","adam","kcadmin","polaris","sandbox","gedelegeerdproductowner","commissie"]`):
+`additionalStopwords=["rol","azure","sch","appx","svcadmin","helios","sandbox","delegatedproductowner","committee"]`):
 
 | Resource | Surviving tokens |
 |---|---|
 | `SG_APP_AXIOM_Admins_P` | `axiom` |
 | `GRP-AXIOM-ReadOnly-TST` | `axiom` |
 | `AG_AzureDevOps_Axiom_Developer` | `devops`, `axiom` |
-| `AG_AzureSubscription_SCH_Axiom_Polaris_Sandbox_Support` | `axiom` |
-| `AG_AzureTeam_Axiom_GedelegeerdProductOwner` | `axiom` |
-| `AG_JITApprover_APP_AXIOM-ADAM_KCADMIN_A` | `axiom`, `jitapprover` |
+| `AG_AzureSubscription_SCH_Axiom_Helios_Sandbox_Support` | `axiom` |
+| `AG_AzureTeam_Axiom_DelegatedProductOwner` | `axiom` |
+| `AG_JITApprover_APP_AXIOM-APPX_SVCADMIN_A` | `axiom`, `jitapprover` |
 | `SG_FINANCE_BookKeepers` | `finance`, `bookkeepers` |
 | `DL_Finance_Readers` | `finance` |
-| `AG_ROL_DMS_Bezoekers van Finance-Commissie` | `dms`, `finance` |
+| `AG_ROL_DMS_Owners of Finance-Committee` | `dms`, `finance` |
 
 Index built:
 
@@ -153,15 +153,15 @@ With `minMembers=4`, only the **AXIOM** cluster survives. With
 `minMembers=3`, **AXIOM** and **FINANCE** both survive. With
 `minMembers=1`, six clusters survive, most of them size-1 noise.
 
-## 5. Real-data result
+## 5. Example result
 
-Running against one tenant's 9 683 resources with tuned stopwords
+Running against an example tenant's ~9,700 resources with tuned stopwords
 produced this top 10:
 
 ```
 DMS                1890
-Inkoop              788
-Contractmanagement  773
+Procurement         788
+ContractManagement  773
 SRV                 652
 MGT                 433
 SUB                 334

--- a/docs/architecture/rule-mining-discussion.md
+++ b/docs/architecture/rule-mining-discussion.md
@@ -101,12 +101,12 @@ This is **contrastive scoring with an implicit comparison cohort**. The comparis
 
 The analyst can't ask "what's specific to data analysts *within IT*?" without dilution from the rest of the company. The fix when (if) this becomes a pain: optionally let the analyst supply *two* filters — in-scope + "compare against" — instead of one. Plugin signature doesn't change; host passes a different complement set. **v2 problem, not v1.**
 
-### Example (from the analyst's Power BI screenshot)
+### Example (illustrative figures)
 
 | Resource | % in-scope | % out-of-scope | Score |
 |---|---|---|---|
-| GG_ROL_Alle_medewerkers | 98.4% | 0.79% | 97.65 |
-| _All_Users_Formeel | 98.5% | 1.56% | 96.93 |
+| GG_ROL_All_Employees | 98.4% | 0.79% | 97.65 |
+| _All_Users_Formal | 98.5% | 1.56% | 96.93 |
 | GG_APL_O365_E5-Default | 97.0% | 1.92% | 95.06 |
 | GG_ServiceNow-dev | 98.1% | 4.37% | 93.76 |
 | GG_APP_ServiceNow_Allusers_P | 98.4% | 9.75% | 88.69 |

--- a/docs/risk-scoring/design.md
+++ b/docs/risk-scoring/design.md
@@ -53,7 +53,7 @@ graph TB
 **Research targets:**
 
 - What does the organization do? (industry, sector, sub-sector)
-- What regulations apply? (NIS2, DORA, SOX, HIPAA, Wbni, DNB supervision, etc.)
+- What regulations apply? (NIS2, DORA, SOX, HIPAA, GDPR, etc.)
 - What are their critical business processes?
 - What key systems/platforms are publicly known?
 - What is their organizational structure?
@@ -66,34 +66,34 @@ graph TB
 customer_profile:
   name: "Novastream Financial N.V."
   domain: "novastream-fi.net"
-  industry: "critical-infrastructure"
-  sub_industry: "port-authority"
+  industry: "financial-services"
+  sub_industry: "payments"
   country: "NL"
 
   regulations:
     - id: "nis2"
       name: "NIS2 Directive"
-      relevance: "Essential entity - port operator"
-    - id: "wbni"
-      name: "Wet Beveiliging Netwerk- en Informatiesystemen"
-      relevance: "Critical infrastructure designation"
+      relevance: "Essential entity - digital infrastructure"
+    - id: "dora"
+      name: "Digital Operational Resilience Act"
+      relevance: "Financial entity - ICT risk management"
 
   critical_business_processes:
-    - "Vessel traffic management and port safety"
-    - "Terminal operations and logistics coordination"
-    - "Customs and border security integration"
+    - "Payment processing and settlement"
+    - "Transaction monitoring and fraud detection"
+    - "Regulatory reporting and compliance"
 
   known_systems:
     - name: "Axiom"
-      type: "Harbor Master Information System"
+      type: "Core payments platform"
       criticality: "critical"
 
   critical_roles:
-    - title_patterns: ["havenmester", "harbor.?master"]
-      rationale: "Legally responsible for port safety"
+    - title_patterns: ["payments.?ops", "settlement.?officer"]
+      rationale: "Operate the core payment rails"
 
   risk_domains:
-    - domain: "safety"
+    - domain: "financial"
       weight: 1.0
     - domain: "security"
       weight: 0.95
@@ -153,12 +153,12 @@ universal_classifiers:
 
 industry_classifiers:
   groups:
-    - id: "port-vts-access"
-      category: "critical-infrastructure"
-      industry: "port-authority"
-      name_patterns: ["VTS", "vessel.?traffic", "VTMS", "radar", "AIS"]
+    - id: "payments-core-access"
+      category: "financial-critical"
+      industry: "payments"
+      name_patterns: ["payment.?rails", "settlement", "clearing", "swift", "sepa"]
       base_score: 90
-      rationale: "Vessel Traffic Service systems — safety-critical infrastructure"
+      rationale: "Core payment-rail systems — financially critical infrastructure"
 ```
 
 ---

--- a/test/nightly/Test-RiskScoringLLM.ps1
+++ b/test/nightly/Test-RiskScoringLLM.ps1
@@ -242,7 +242,7 @@ if (-not $finalRun) {
     Report-Result 'RiskLLM/RunCompletes' $true "scored=$($finalRun.scoredEntities)"
 
     # Assert at least some classifier matches were produced. The LLM-generated
-    # classifiers SHOULD match real HBR/demo data since they were generated for
+    # classifiers SHOULD match the example/demo data since they were generated for
     # this exact org. Zero matches would mean either (a) the regex compile bug
     # regressed or (b) the LLM produced garbage patterns.
     try {

--- a/tools/crawlers/omada/Test-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Test-OmadaCrawler.ps1
@@ -7,8 +7,6 @@
     Identity Atlas dispatch pipeline, and verifies that data landed in the
     database.
 
-    Entity shape confirmed against Omada OData API (omada.cloud, 2026-06-06).
-
     Requires the full Identity Atlas Docker stack to be running (postgres + web API).
 
 .PARAMETER ApiBaseUrl
@@ -60,7 +58,6 @@ Write-Host "`n=== Omada IGA Crawler Integration Test ===" -ForegroundColor Cyan
 . (Join-Path (Split-Path $PSScriptRoot -Parent) 'shared' 'Start-MockODataServer.ps1')
 
 # ── Mock entity data ──────────────────────────────────────────────────────────
-# Entity shapes validated against Omada OData API (omada.cloud 2026-06-06)
 $identityUid  = 'bbbbbbbb-bbbb-0001-0000-bbbbbbbbbbbb'
 $userUid      = 'cccccccc-cccc-0001-0000-cccccccccccc'
 $resourceUid  = 'dddddddd-dddd-0001-0000-dddddddddddd'


### PR DESCRIPTION
Standardises example data across the documentation, tests, and fixtures to use generic placeholder organisation, system, and hostname values. Documentation and tests only; no behaviour change — test fixtures and their assertions were updated in lockstep (resource-cluster 28/28 and UI utils 7/7 verified locally).