### PR TITLE
fix(sbom): record docs toolchain (MkDocs, Material, Mike)

### DIFF
--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Deploy versioned docs
         run: |
-          pip install --quiet mike mkdocs-material
+          pip install --quiet -r docs/requirements.txt
           mike deploy --push --title "$VERSION" stable
 
       - name: Post run summary

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Deploy versioned docs
         run: |
-          pip install --quiet mike mkdocs-material
+          pip install --quiet -r docs/requirements.txt
           mike deploy --push --title "$VERSION" stable
 
       - name: Post run summary

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install dependencies
-        run: pip install mkdocs-material mike
+        run: pip install -r docs/requirements.txt
 
       - name: Configure git for mike
         run: |

--- a/.github/workflows/sbom-update.yml
+++ b/.github/workflows/sbom-update.yml
@@ -29,6 +29,7 @@ on:
       - app/api/package-lock.json
       - app/ui/package.json
       - app/ui/package-lock.json
+      - docs/requirements.txt
       - app/api/Dockerfile
       - app/ui/Dockerfile
       - setup/docker/Dockerfile.powershell

--- a/changes/sbom-missing-docs-toolchain.md
+++ b/changes/sbom-missing-docs-toolchain.md
@@ -1,0 +1,1 @@
+- Added the documentation build toolchain (MkDocs, Material for MkDocs, Mike) to the Software Bill of Materials, so it now appears in both the generated SBOM and the SBOM reference page. These were previously installed ad-hoc during CI and went unrecorded.

--- a/docs/reference/sbom.md
+++ b/docs/reference/sbom.md
@@ -120,6 +120,18 @@ This document lists all major software components, dependencies, and infrastruct
 
 ---
 
+## Documentation Toolchain (Python)
+
+The documentation site is built and versioned from [`docs/requirements.txt`](https://github.com/Fortigi/IdentityAtlas/blob/main/docs/requirements.txt). These packages run only in CI (docs deploy and release packaging) and are never installed into the shipped containers.
+
+| Package | Version | Purpose | License |
+|---------|---------|---------|---------|
+| mkdocs | 1.6.1 | Static documentation site generator | BSD-2-Clause |
+| mkdocs-material | 9.7.6 | Material for MkDocs — docs site theme and UI | MIT |
+| mike | 2.2.0 | Versioned docs deployment (edge / stable) | BSD-3-Clause |
+
+---
+
 ## PowerShell Module
 
 ### Module Information
@@ -205,7 +217,8 @@ All direct dependencies use permissive open-source licenses:
 - **MIT License**: 95%+ of dependencies
 - **Apache 2.0**: swagger-ui-express, @playwright/test, eslint-plugin-security
 - **MPL 2.0**: @axe-core/playwright
-- **BSD-3-Clause**: re2
+- **BSD-3-Clause**: re2, mike
+- **BSD-2-Clause**: mkdocs
 - **PostgreSQL License**: PostgreSQL server
 
 Identity Atlas itself is licensed under the **MIT License**. See the repository `LICENSE` file for full terms.
@@ -218,6 +231,7 @@ The module version is automatically bumped on every PR merge to `main`. For the 
 
 - API backend: [`app/api/package.json`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/api/package.json)
 - Frontend: [`app/ui/package.json`](https://github.com/Fortigi/IdentityAtlas/blob/main/app/ui/package.json)
+- Documentation toolchain: [`docs/requirements.txt`](https://github.com/Fortigi/IdentityAtlas/blob/main/docs/requirements.txt)
 - PowerShell module: [`setup/IdentityAtlas.psd1`](https://github.com/Fortigi/IdentityAtlas/blob/main/setup/IdentityAtlas.psd1)
 
 ---

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,10 @@
+# Documentation site build toolchain — MkDocs + Material theme + Mike versioning.
+#
+# Pinned so the published docs are reproducible AND the dependency set is captured
+# by the SBOM (Syft scans requirements*.txt). These run only in CI (docs deploy
+# and release packaging); they are never installed into the shipped containers.
+#
+# Install:  pip install -r docs/requirements.txt
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+mike==2.2.0

--- a/tools/update-sbom-doc.py
+++ b/tools/update-sbom-doc.py
@@ -10,6 +10,8 @@ untouched.
 Sources of truth, by section:
   * "API Backend (Node.js)" / "Frontend (React)" — Version column from the npm
     manifests (app/api/package.json, app/ui/package.json).
+  * "Documentation Toolchain (Python)" — Version column from the pinned pip
+    manifest (docs/requirements.txt).
   * "Infrastructure Components" — Version column from the Docker base images and
     compose file (Postgres, PowerShell, Node).
   * "Docker Images" — Base column from the Dockerfiles.
@@ -27,6 +29,7 @@ REPO = Path(__file__).resolve().parent.parent
 DOC = REPO / "docs" / "reference" / "sbom.md"
 API_PKG = REPO / "app" / "api" / "package.json"
 UI_PKG = REPO / "app" / "ui" / "package.json"
+DOCS_REQ = REPO / "docs" / "requirements.txt"
 API_DOCKERFILE = REPO / "app" / "api" / "Dockerfile"
 PWSH_DOCKERFILE = REPO / "setup" / "docker" / "Dockerfile.powershell"
 COMPOSE = REPO / "docker-compose.yml"
@@ -38,6 +41,20 @@ def load_versions(pkg_path):
     versions = {}
     versions.update(data.get("dependencies", {}))
     versions.update(data.get("devDependencies", {}))
+    return versions
+
+
+def load_pip_versions(req_path):
+    """name -> pinned version from a pip requirements file (``name==version``)."""
+    versions = {}
+    if not req_path.exists():
+        return versions
+    for raw in req_path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if "==" not in line:
+            continue
+        name, _, ver = line.partition("==")
+        versions[name.strip()] = ver.strip()
     return versions
 
 
@@ -113,6 +130,7 @@ def update_docker_image(cells, images):
 def main():
     api = load_versions(API_PKG)
     ui = load_versions(UI_PKG)
+    docs = load_pip_versions(DOCS_REQ)
     components, images = build_infra()
 
     lines = DOC.read_text().splitlines()
@@ -143,6 +161,8 @@ def main():
             new_value = update_npm_row(cells, api, missing)
         elif section and "Frontend" in section:
             new_value = update_npm_row(cells, ui, missing)
+        elif section and "Documentation Toolchain" in section:
+            new_value = update_npm_row(cells, docs, missing)
         elif section == "Infrastructure Components":
             new_value = update_infra_component(cells, components)
         elif section == "Docker Images":


### PR DESCRIPTION
- Added the documentation build toolchain (MkDocs, Material for MkDocs, Mike) to the Software Bill of Materials, so it now appears in both the generated SBOM and the SBOM reference page. These were previously installed ad-hoc during CI and went unrecorded.

## How
- New `docs/requirements.txt` pins `mkdocs`, `mkdocs-material`, `mike` — Syft scans `requirements*.txt`, so they're now catalogued.
- `docs.yml`, `cut-release.yml`, `cut-hotfix.yml` install from the manifest (what's installed = what's recorded).
- `sbom-update.yml` triggers on `docs/requirements.txt`, so `sbom-edge.spdx.json` regenerates on merge with the three packages named.
- Curated "Documentation Toolchain (Python)" section added to `docs/reference/sbom.md`; `update-sbom-doc.py` keeps its versions in sync from the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)