### PR TITLE
fix(coverage): stop .gitignore from excluding the published coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ node_modules/
 .last-run.json
 coverage/
 coverage-contract/
+# The published, versioned coverage report lives under docs/ and IS committed
+# (coverage.yml renders it into the docs site). Keep it out of the broad
+# `coverage/` ignore above, which otherwise matches a `coverage` dir at any depth.
+!docs/coverage/
+!docs/coverage/**
 tools/csv-templates/demodata/
 tools/csv-templates/demodataTransformed/
 .claude/settings.local.json

--- a/changes/coverage-docs-gitignore.md
+++ b/changes/coverage-docs-gitignore.md
@@ -1,0 +1,1 @@
+- Fixed the published test-coverage page (and its browsable HTML reports) so they update on every merge again. The coverage workflow had been failing silently because the report directory under `docs/` was being excluded by an over-broad version-control ignore rule, so the page stayed frozen at its initial version.


### PR DESCRIPTION
- Fixed the published test-coverage page (and its browsable HTML reports) so they update on every merge again. The coverage workflow had been failing silently because the report directory under `docs/` was being excluded by an over-broad version-control ignore rule, so the page stayed frozen at its initial version.

## Root cause
`.gitignore` line `coverage/` has no leading slash, so it matches a `coverage` dir at **any depth** — including `docs/coverage/`, which `coverage.yml` renders and commits into the versioned docs site. The "Commit coverage" step runs `git add docs/reference/coverage.md docs/coverage`; git **exits 1** when an explicitly-named path is fully ignored, and the step's `bash -e` turns that into a job failure. Every run since #455 has failed there (confirmed in run logs: *"The following paths are ignored by one of your .gitignore files: docs/coverage … exit code 1"*).

## Fix
Carve `docs/coverage/` out of the broad ignore with a negation. Verified with `git check-ignore`:
- `docs/coverage/**` → now tracked
- `app/api/coverage`, `coverage-contract`, `app/ui/coverage`, any `coverage/` → still ignored
- the exact failing `git add …` now exits 0 and stages the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)