### PR TITLE
test(api): route tests for recentChanges + riskScores (deepen coverage)

### DIFF
--- a/app/api/src/routes/recentChanges.routes.test.js
+++ b/app/api/src/routes/recentChanges.routes.test.js
@@ -1,0 +1,62 @@
+// Unit tests for routes/recentChanges.js handlers — id validation + empty-history
+// happy paths. DB mocked. (The diff/buildEntityTimeline pure functions are
+// covered by recentChanges.timeline.test.js; this exercises the route handlers.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../db/connection.js', () => ({ query: (...a) => query(...a), queryOne: (...a) => queryOne(...a) }));
+
+const { default: router } = await import('./recentChanges.js');
+const app = mountRouter(router);
+
+const VALID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  query.mockReset();
+  queryOne.mockReset();
+  query.mockResolvedValue({ rows: [] });   // no _history rows + empty batch label queries
+  queryOne.mockResolvedValue(null);
+});
+
+describe('recentChanges — id validation', () => {
+  const paths = [
+    '/api/user/nope/recent-changes',
+    '/api/resources/nope/recent-changes',
+    '/api/access-package/nope/recent-changes',
+    '/api/identities/nope/recent-changes',
+    '/api/user/nope/timeline',
+    '/api/resources/nope/timeline',
+    '/api/access-package/nope/timeline',
+    '/api/identities/nope/timeline',
+    '/api/contexts/nope/timeline',
+  ];
+  for (const path of paths) {
+    it(`400 on a malformed id: ${path}`, async () => {
+      expect((await request(app).get(path)).status).toBe(400);
+    });
+  }
+});
+
+describe('recentChanges — empty history (200)', () => {
+  for (const base of ['/api/user', '/api/resources', '/api/access-package', '/api/identities']) {
+    it(`GET ${base}/:id/recent-changes returns empty events`, async () => {
+      const res = await request(app).get(`${base}/${VALID}/recent-changes`);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ events: [], addedCount: 0, removedCount: 0 });
+    });
+  }
+
+  for (const base of ['/api/user', '/api/resources', '/api/access-package', '/api/identities', '/api/contexts']) {
+    it(`GET ${base}/:id/timeline returns empty events`, async () => {
+      const res = await request(app).get(`${base}/${VALID}/timeline`);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ events: [] });
+    });
+  }
+});

--- a/app/api/src/routes/riskScores.routes.test.js
+++ b/app/api/src/routes/riskScores.routes.test.js
@@ -1,0 +1,67 @@
+// Unit tests for routes/riskScores.js — paginated list happy paths + single/
+// override validation. DB + queryRiskScoresPage mocked. (riskScores.summary.test.js
+// covers the GET /risk-scores summary LIMIT clauses.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+// riskTableExists() runs one timed query and checks recordset[0].tbl != null.
+vi.mock('../perf/sqlTimer.js', () => ({
+  timedRequest: () => ({ input() { return this; }, query: async () => ({ recordset: [{ tbl: 'public.RiskScores' }] }) }),
+  getQueryTimings: () => [],
+}));
+vi.mock('../db/connection.js', () => ({ getPool: async () => ({}), query: vi.fn(), queryOne: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+
+const ROW = { id: 'x', riskScore: 80, riskTier: 'High', riskClassifierMatches: [], riskExplanation: {}, riskOverride: null };
+const queryRiskScoresPage = vi.fn(async () => ({ data: [ROW], total: 1 }));
+vi.mock('../db/queryHelpers.js', () => ({ queryRiskScoresPage: (...a) => queryRiskScoresPage(...a) }));
+
+const { default: router } = await import('./riskScores.js');
+const app = mountRouter(router);
+
+const VALID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => { queryRiskScoresPage.mockClear(); });
+
+describe('risk-scores — paginated lists (200)', () => {
+  for (const path of ['users', 'groups', 'business-roles', 'contexts', 'identities']) {
+    it(`GET /risk-scores/${path} returns { data, total, available }`, async () => {
+      const res = await request(app).get(`/api/risk-scores/${path}`);
+      expect(res.status).toBe(200);
+      expect(res.body.available).toBe(true);
+      expect(res.body.total).toBe(1);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0]).toMatchObject({ id: 'x', effectiveScore: 80 });
+    });
+  }
+});
+
+describe('GET /risk-scores/:type/:id — validation', () => {
+  it('400 on an invalid type', async () => {
+    expect((await request(app).get(`/api/risk-scores/bogus/${VALID}`)).status).toBe(400);
+  });
+  it('400 on a malformed id', async () => {
+    expect((await request(app).get('/api/risk-scores/users/not-a-uuid')).status).toBe(400);
+  });
+});
+
+describe('PUT /risk-scores/:type/:id/override — validation', () => {
+  it('400 when adjustment is out of range', async () => {
+    const res = await request(app).put(`/api/risk-scores/users/${VALID}/override`).send({ adjustment: 100, reason: 'valid reason' });
+    expect(res.status).toBe(400);
+  });
+  it('400 when reason is too short', async () => {
+    const res = await request(app).put(`/api/risk-scores/users/${VALID}/override`).send({ adjustment: 5, reason: 'a' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /risk-scores/:type/:id/override — validation', () => {
+  it('400 on an invalid type', async () => {
+    expect((await request(app).delete(`/api/risk-scores/bogus/${VALID}/override`)).status).toBe(400);
+  });
+});


### PR DESCRIPTION
Continues the API coverage push — deepens two large route files that were only partially tested (pure functions / summary LIMITs), with handler-level tests reusing `mountRouter`.

- **recentChanges.routes.test.js** — id `400` across all 9 routes; empty-history `200` for the recent-changes + timeline handlers (covers query-building + response shaping). The diff/`buildEntityTimeline` pure functions stay covered by `recentChanges.timeline.test.js`.
- **riskScores.routes.test.js** — paginated list `200`s (users/groups/business-roles/contexts/identities) via mocked `queryRiskScoresPage` + `riskTableExists`, plus single-entity and override (PUT/DELETE) validation `400`s.

28 tests, green locally.

Coverage (lines): `recentChanges.js` 26%→**52%**, `riskScores.js` 20%→**64%**.

Test-only PR — the heavy Integration/E2E/Load-Soak suites are correctly skipped (per #458).

🤖 Generated with [Claude Code](https://claude.com/claude-code)