### PR TITLE
test(api): route tests for jobs + crawlers (deepen coverage)

### DIFF
--- a/app/api/src/routes/crawlers.routes.test.js
+++ b/app/api/src/routes/crawlers.routes.test.js
@@ -1,0 +1,86 @@
+// Unit tests for routes/crawlers.js — admin CRUD validation/list and self-service
+// auth + validation. DB + crawler helpers mocked. (crawlers.test.js covers the
+// create/delete pairing; crawlers.selfservice.authz.test.js covers 403 worker gates.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+let nextResult = { recordset: [], rowsAffected: [0] };
+const mockPool = { request() { const r = { input() { return r; }, query() { return Promise.resolve(nextResult); } }; return r; } };
+const query = vi.fn();
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool, query: (...a) => query(...a), queryOne: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+vi.mock('../secrets/crawlerSecrets.js', () => ({ injectJobSecret: vi.fn(async (j) => j.config), deleteJobSecret: vi.fn(async () => {}) }));
+vi.mock('../crawlerManifests.js', () => ({ getPushModeType: vi.fn(() => null) }));
+vi.mock('../postCrawlJobs.js', () => ({ runPostCrawlJobs: vi.fn(async () => {}) }));
+vi.mock('../middleware/crawlerAuth.js', () => ({ crawlerHasPermission: vi.fn(() => true), crawlerHasSystemAccess: vi.fn(() => true) }));
+
+const { adminCrawlersRouter, selfServiceCrawlersRouter } = await import('./crawlers.js');
+const adminApp = mountRouter(adminCrawlersRouter);
+
+// Self-service requests carry a crawler identity (set by the API-key middleware
+// in production). Inject one so we can reach the handler validation.
+function crawlerApp(crawler) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => { if (crawler) req.crawler = crawler; next(); });
+  app.use('/api', selfServiceCrawlersRouter);
+  return request(app);
+}
+const WORKER = { id: 1, systemIds: [1], permissions: ['admin'] };
+
+beforeEach(() => {
+  nextResult = { recordset: [], rowsAffected: [0] };
+  query.mockReset();
+  query.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+describe('admin crawlers', () => {
+  it('GET /admin/crawlers returns 200 list', async () => {
+    const res = await request(adminApp).get('/api/admin/crawlers');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+  it('POST 400 when displayName is missing', async () => {
+    expect((await request(adminApp).post('/api/admin/crawlers').send({})).status).toBe(400);
+  });
+  it('PATCH/:id 400 on a non-integer id', async () => {
+    expect((await request(adminApp).patch('/api/admin/crawlers/abc').send({})).status).toBe(400);
+  });
+  it('DELETE/:id 400 on a non-integer id', async () => {
+    expect((await request(adminApp).delete('/api/admin/crawlers/abc')).status).toBe(400);
+  });
+  it('GET/:id/audit 400 on a non-integer id', async () => {
+    expect((await request(adminApp).get('/api/admin/crawlers/abc/audit')).status).toBe(400);
+  });
+  it('POST/:id/reset 400 on a non-integer id', async () => {
+    expect((await request(adminApp).post('/api/admin/crawlers/abc/reset')).status).toBe(400);
+  });
+});
+
+describe('self-service crawlers — auth + validation', () => {
+  it('GET /crawlers/whoami 401 without a crawler key', async () => {
+    expect((await crawlerApp(null).get('/api/crawlers/whoami')).status).toBe(401);
+  });
+  it('POST /crawlers/jobs/claim 401 without a crawler key', async () => {
+    expect((await crawlerApp(null).post('/api/crawlers/jobs/claim')).status).toBe(401);
+  });
+  it('GET /crawlers/whoami 200 echoes the crawler', async () => {
+    const res = await crawlerApp(WORKER).get('/api/crawlers/whoami');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: 1 });
+  });
+  it('POST /crawlers/jobs/:id/phases 400 when phases is not an array', async () => {
+    expect((await crawlerApp(WORKER).post('/api/crawlers/jobs/1/phases').send({ phases: 'nope' })).status).toBe(400);
+  });
+  it('POST /crawlers/jobs/:id/complete 400 on a non-integer id', async () => {
+    expect((await crawlerApp(WORKER).post('/api/crawlers/jobs/abc/complete')).status).toBe(400);
+  });
+  it('POST /crawlers/configs/:id/mark-delta-mode 400 on a non-integer id', async () => {
+    expect((await crawlerApp(WORKER).post('/api/crawlers/configs/abc/mark-delta-mode')).status).toBe(400);
+  });
+});

--- a/app/api/src/routes/jobs.routes.test.js
+++ b/app/api/src/routes/jobs.routes.test.js
@@ -1,0 +1,79 @@
+// Unit tests for routes/jobs.js — crawler-config + crawler-job CRUD validation
+// and list happy paths. DB + crawler helpers mocked. (configValidation / discover
+// / fileUploads tests cover those specific endpoints.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { mountRouter } from '../../test-utils/routeTestKit.js';
+
+process.env.USE_SQL = 'true';
+
+let nextResult = { recordset: [], rowsAffected: [0] };
+const mockPool = { request() { const r = { input() { return r; }, query() { return Promise.resolve(nextResult); } }; return r; } };
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool, query: vi.fn(), queryOne: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({ requirePermission: () => (_q, _s, next) => next() }));
+vi.mock('./crawlerFiles.js', () => ({ getUploadFolderPath: vi.fn(() => '/tmp/x'), deleteConfigFolder: vi.fn(async () => {}) }));
+vi.mock('../secrets/crawlerSecrets.js', () => ({
+  storeConfigSecret: vi.fn(async () => {}), hasConfigSecret: vi.fn(async () => false),
+  deleteConfigSecret: vi.fn(async () => {}), getConfigSecret: vi.fn(async () => null),
+  storeJobSecret: vi.fn(async () => {}), storeJobCredentials: vi.fn(async () => {}), OTHER_SECRET_FIELDS: [],
+}));
+vi.mock('../crawlerManifests.js', () => ({
+  CRAWLER_MANIFESTS_DIR: '', _crawlerManifests: {}, VALID_JOB_TYPES: ['entra-id', 'csv', 'demo'],
+  validateCrawlerConfig: vi.fn(() => null), validateStoredCrawlerConfig: vi.fn(async () => null),
+  isSingletonJob: vi.fn(() => false), isPushModeType: vi.fn(() => false),
+}));
+
+const { default: router } = await import('./jobs.js');
+const app = mountRouter(router);
+
+beforeEach(() => { nextResult = { recordset: [], rowsAffected: [0] }; });
+
+describe('crawler-configs — validation', () => {
+  it('POST 400 when crawlerType/displayName are missing', async () => {
+    expect((await request(app).post('/api/admin/crawler-configs').send({})).status).toBe(400);
+  });
+  it('GET/:id 400 on a non-integer id', async () => {
+    expect((await request(app).get('/api/admin/crawler-configs/abc')).status).toBe(400);
+  });
+  it('PATCH/:id 400 on a non-integer id', async () => {
+    expect((await request(app).patch('/api/admin/crawler-configs/abc').send({})).status).toBe(400);
+  });
+  it('DELETE/:id 400 on a non-integer id', async () => {
+    expect((await request(app).delete('/api/admin/crawler-configs/abc')).status).toBe(400);
+  });
+  it('GET list returns 200 (empty)', async () => {
+    const res = await request(app).get('/api/admin/crawler-configs');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
+describe('crawler-jobs — validation', () => {
+  it('POST 400 on an unknown jobType', async () => {
+    expect((await request(app).post('/api/admin/crawler-jobs').send({ jobType: 'bogus' })).status).toBe(400);
+  });
+  it('POST 400 on an invalid syncMode', async () => {
+    expect((await request(app).post('/api/admin/crawler-jobs').send({ jobType: 'demo', syncMode: 'weird' })).status).toBe(400);
+  });
+  it('POST 400 on a non-positive configId', async () => {
+    expect((await request(app).post('/api/admin/crawler-jobs').send({ jobType: 'demo', configId: -1 })).status).toBe(400);
+  });
+  it('GET/:id 400 on a non-integer id', async () => {
+    expect((await request(app).get('/api/admin/crawler-jobs/abc')).status).toBe(400);
+  });
+  it('DELETE/:id 400 on a non-integer id', async () => {
+    expect((await request(app).delete('/api/admin/crawler-jobs/abc')).status).toBe(400);
+  });
+  it('force-stop 400 on a non-integer id', async () => {
+    expect((await request(app).post('/api/admin/crawler-jobs/abc/force-stop')).status).toBe(400);
+  });
+  it('log 400 on a non-integer id', async () => {
+    expect((await request(app).get('/api/admin/crawler-jobs/abc/log')).status).toBe(400);
+  });
+  it('GET list returns 200 (empty)', async () => {
+    const res = await request(app).get('/api/admin/crawler-jobs');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});


### PR DESCRIPTION
Continues the API coverage push — covers the uncovered CRUD/validation surface of two large route files (the existing tests cover discover/configValidation/fileUploads and the create-delete pairing + worker 403 gates).

- **jobs.routes.test.js** — crawler-config + crawler-job CRUD validation `400`s (bad id, missing fields, unknown jobType/syncMode) and list happy paths. Mocks `crawlerManifests` / `crawlerSecrets` / `crawlerFiles`.
- **crawlers.routes.test.js** — admin CRUD validation/list, plus self-service **auth** (`401` without a crawler key, `whoami` echo) and worker-endpoint validation `400`s (`phases` not-array, `complete`/`mark-delta-mode` bad id) using an injected crawler identity.

25 tests, green locally.

Coverage (lines): `jobs.js` 34%→**51%**, `crawlers.js` 33%→**44%**.

Test-only PR — heavy suites skip once #465 lands (they still run here until then, since #465 isn't merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)