### PR TITLE
test(crawlers): Phase 6 — expand CapabilityId + CrawlerIngest Pester tests

### DIFF
--- a/app/api/src/lib/capabilityId.test.js
+++ b/app/api/src/lib/capabilityId.test.js
@@ -16,6 +16,10 @@ const GOLDENS = [
   { target: 'C:\\Finance', capability: 'Write', expected: 'ded9f1e4-b426-7bf9-a4e9-68cb2e9758bd' },
   { target: 'a', capability: 'b', expected: '0eab8a0a-3380-abf4-c7d1-fb0b43b66aaf' },
   { target: 'café', capability: 'rôle', expected: '50c1f141-9d52-c66f-1ca8-04ebef754098' }, // UTF-8 multibyte
+  { target: 'Привет', capability: 'роль', expected: '5979aa3b-4757-56cd-eff2-98f32bf23c7a' }, // Cyrillic
+  { target: '財務部', capability: '書き込み', expected: '12cea6f4-05e5-f34f-9c58-8ea9fa5ccf82' }, // CJK
+  { target: 'مرحبا', capability: 'مدير', expected: 'e66813b8-93da-557d-cf32-d9cb0bc0c69e' }, // Arabic (RTL)
+  { target: '🔐lock', capability: '✏️edit', expected: 'cf0f8181-eb90-75bb-4655-071b608d1f1e' }, // emoji / surrogate pairs
 ];
 
 describe('capabilityResourceId', () => {

--- a/test/unit/CapabilityId.Tests.ps1
+++ b/test/unit/CapabilityId.Tests.ps1
@@ -25,6 +25,10 @@ $goldens = @(
     @{ t = 'C:\Finance'; c = 'Write'; expected = 'ded9f1e4-b426-7bf9-a4e9-68cb2e9758bd' }
     @{ t = 'a'; c = 'b'; expected = '0eab8a0a-3380-abf4-c7d1-fb0b43b66aaf' }
     @{ t = 'café'; c = 'rôle'; expected = '50c1f141-9d52-c66f-1ca8-04ebef754098' }  # UTF-8 multibyte
+    @{ t = 'Привет'; c = 'роль';     expected = '5979aa3b-4757-56cd-eff2-98f32bf23c7a' }  # Cyrillic
+    @{ t = '財務部';  c = '書き込み'; expected = '12cea6f4-05e5-f34f-9c58-8ea9fa5ccf82' }  # CJK
+    @{ t = 'مرحبا';   c = 'مدير';     expected = 'e66813b8-93da-557d-cf32-d9cb0bc0c69e' }  # Arabic (RTL)
+    @{ t = '🔐lock';  c = '✏️edit';   expected = 'cf0f8181-eb90-75bb-4655-071b608d1f1e' }  # emoji / surrogate pairs
 )
 
 BeforeAll {

--- a/test/unit/CrawlerIngest.Tests.ps1
+++ b/test/unit/CrawlerIngest.Tests.ps1
@@ -122,3 +122,45 @@ Describe 'Update-CrawlerProgress — HTTP 409 abort' {
         { Update-CrawlerProgress -Step 'test' -Pct 50 } | Should -Not -Throw
     }
 }
+
+Describe 'Invoke-IngestAPI — error handling and payload serialisation' {
+
+    It 'throws (does not swallow) on HTTP 400, without retrying — 400 is non-transient' {
+        Mock Invoke-RestMethod -MockWith {
+            $sc   = [PSCustomObject]@{ value__ = 400 }
+            $resp = [PSCustomObject]@{ StatusCode = $sc }
+            $ex   = [System.Exception]::new('Bad Request')
+            $ex | Add-Member -NotePropertyName 'Response' -NotePropertyValue $resp -Force
+            throw $ex
+        }
+        { Invoke-IngestAPI -Endpoint 'ingest/test' -Body @{ records = @() } } | Should -Throw
+        Should -Invoke Invoke-RestMethod -Times 1
+    }
+
+    It 'retries a transient 503, then re-throws after exhausting all attempts' {
+        # statusCode >= 500 is transient → retried up to maxAttempts (5).
+        Mock Start-Sleep { }   # skip the real exponential backoff
+        Mock Invoke-RestMethod -MockWith {
+            $sc   = [PSCustomObject]@{ value__ = 503 }
+            $resp = [PSCustomObject]@{ StatusCode = $sc }
+            $ex   = [System.Exception]::new('Service Unavailable')
+            $ex | Add-Member -NotePropertyName 'Response' -NotePropertyValue $resp -Force
+            throw $ex
+        }
+        { Invoke-IngestAPI -Endpoint 'ingest/test' -Body @{ records = @() } } | Should -Throw
+        Should -Invoke Invoke-RestMethod -Times 5
+    }
+
+    It 'serialises records with null fields cleanly (null preserved, valid JSON)' {
+        $items  = @(@{ id = 1; name = $null; email = $null })
+        $result = ConvertTo-JsonArray -Items $items
+        $json   = @{ records = $result } | ConvertTo-Json -Depth 5 -Compress
+        $json | Should -Match '"name":null'
+    }
+
+    It 'preserves duplicate-id records (no client-side dedup; the server upserts)' {
+        $items  = @(@{ id = 'dup' }, @{ id = 'dup' }, @{ id = 'other' })
+        $result = ConvertTo-JsonArray -Items $items
+        $result.Count | Should -Be 3
+    }
+}


### PR DESCRIPTION
Phase 6 of the test-layer plan — expands two existing Pester suites (no new files), plus the matching JS golden table.

## CapabilityId — non-Latin Unicode goldens (cross-language)
Adds 4 golden vectors to **both** `test/unit/CapabilityId.Tests.ps1` and `app/api/src/lib/capabilityId.test.js`: Cyrillic, CJK (Japanese), Arabic (RTL), and emoji + surrogate pairs. Each expected id was computed with **both** runtimes (`Get-CapabilityId` and `capabilityResourceId`) and verified **byte-identical** — the two tables stay in lockstep, since a divergence between crawler-written and engine-synthesized ids is a release blocker.

## CrawlerIngest — Invoke-IngestAPI
Adds error-handling + serialization coverage:
- HTTP **400** throws without retrying (non-transient, not silently swallowed) — `Should -Invoke ... -Times 1`
- transient **503** retries to the cap then re-throws — `-Times 5` (backoff mocked)
- records with **null fields** serialise cleanly (`"name":null` preserved)
- **duplicate-id** records are preserved (no client-side dedup — the server upserts)

## Verified locally
Pester **29/29** (pwsh 7.6 / Pester 5.7), JS capabilityId **15/15**. This PR triggers both the Pester and Vitest-API jobs; heavy suites skip (test-only, per #465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)