### PR TITLE
test(api): Phase 7 — HTTP integration tests (real app + DB + auth)

### DIFF
--- a/app/api/contract-tests/auth.integration.test.js
+++ b/app/api/contract-tests/auth.integration.test.js
@@ -1,0 +1,94 @@
+// HTTP integration test — boots the real Express app against the testcontainers
+// DB with auth ENABLED, exercising the full auth middleware chain end-to-end
+// (something the DB-mocked unit tests can't reach).
+//
+// Only authConfig + jsonwebtoken are mocked — db/connection.js is NOT, so the
+// requests hit the real PG16 container (per Phase 7 of the test plan).
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+// Enable auth by overriding only what the middleware reads; keep every other
+// export real (importActual) so nothing is accidentally undefined.
+// role-admin -> '*' (all permissions); role-reader -> data.read only.
+vi.mock('../src/config/authConfig.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isAuthEnabled: () => true,
+  getTenantId: () => 'test-tenant',
+  getClientId: () => 'test-client',
+  getJwksClient: () => ({}),
+  getRequiredRoles: () => null,
+  getRolePermissions: () => ({ 'role-admin': ['*'], 'role-reader': ['data.read'] }),
+}));
+// The bearer token string carries the roles: 'roles:role-admin' -> ['role-admin'].
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: (token, _key, _opts, cb) => {
+      const roles = token.startsWith('roles:') ? token.slice(6).split(',').filter(Boolean) : [];
+      cb(null, { roles, tid: 'test-tenant' });
+    },
+  },
+}));
+
+let agent;
+let pool;
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+});
+
+afterAll(async () => {
+  await pool.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+const adminToken = 'Bearer roles:role-admin';
+const readerToken = 'Bearer roles:role-reader';
+
+describe('auth gating — GET /api/contexts (any authenticated user)', () => {
+  it('401 without an Authorization header', async () => {
+    expect((await agent.get('/api/contexts')).status).toBe(401);
+  });
+  it('401 on a non-Bearer header', async () => {
+    expect((await agent.get('/api/contexts').set('Authorization', 'Basic abc')).status).toBe(401);
+  });
+  it('200 + { data: [...] } with a valid bearer token', async () => {
+    const res = await agent.get('/api/contexts').set('Authorization', adminToken);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});
+
+describe('auth gating — GET /api/admin/crawler-configs (requires admin.crawlers)', () => {
+  it('401 without a token', async () => {
+    expect((await agent.get('/api/admin/crawler-configs')).status).toBe(401);
+  });
+  it('403 for a token lacking the permission (role-reader)', async () => {
+    expect((await agent.get('/api/admin/crawler-configs').set('Authorization', readerToken)).status).toBe(403);
+  });
+  it('200 (array) for an admin token', async () => {
+    const res = await agent.get('/api/admin/crawler-configs').set('Authorization', adminToken);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});
+
+describe('matrix data through the real auth chain — POST /api/matrix/data', () => {
+  const body = { filter: { subject: { include: [], exclude: [] }, resource: { include: [], exclude: [] } } };
+  it('401 without a token', async () => {
+    expect((await agent.post('/api/matrix/data').send(body)).status).toBe(401);
+  });
+  it('200 + documented shape with an admin token', async () => {
+    const res = await agent.post('/api/matrix/data').set('Authorization', adminToken).send(body);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(typeof res.body.subjectTotal).toBe('number');
+  });
+});
+
+describe('crawler-auth gating — POST /api/ingest/* rejects a non-crawler caller', () => {
+  it('rejects an unauthenticated ingest call (no crawler key)', async () => {
+    const res = await agent.post('/api/ingest/contexts').send({ records: [], syncMode: 'full', systemId: 1 });
+    expect([401, 403]).toContain(res.status);
+  });
+});

--- a/app/api/vitest.contract.config.js
+++ b/app/api/vitest.contract.config.js
@@ -13,7 +13,9 @@ export default defineConfig({
     alias: { '@api': path.resolve(__dirname, 'src') },
   },
   test: {
-    include: ['contract-tests/**/*.contract.test.js'],
+    // *.contract.test.js — SQL-shape tests; *.integration.test.js — full HTTP
+    // tests booting the real app against the testcontainers DB with auth enabled.
+    include: ['contract-tests/**/*.contract.test.js', 'contract-tests/**/*.integration.test.js'],
     globalSetup: ['./test-utils/contractGlobalSetup.js'],
     // Single worker: contract tests share one DB container; parallelism would
     // require per-test isolation that adds complexity. Keep it simple.


### PR DESCRIPTION
Phase 7 of the test-layer plan — full HTTP integration tests that boot the real Express app against the testcontainers PG16 with **auth enabled**, exercising the auth middleware chain end-to-end (which the DB-mocked unit tests can't reach).

## Pre-work
`vitest.contract.config.js` now also includes `contract-tests/**/*.integration.test.js` — without this the files exist but never execute.

## auth.integration.test.js
Mocks **only** `authConfig` + `jsonwebtoken` (db/connection.js is real, so requests hit the real DB):
- **GET /api/contexts** — 401 (missing / non-Bearer header), 200 + `{ data: [] }` with a bearer token
- **GET /api/admin/crawler-configs** — 401 (no token), **403** (role lacking the permission), 200 (admin role → `*`)
- **POST /api/matrix/data** — 401, 200 + documented shape through the full chain
- **POST /api/ingest/\*** — rejects an unauthenticated (non-crawler) caller

`role-admin → ['*']`, `role-reader → ['data.read']`; the bearer string carries the roles (`roles:role-admin`) that the mocked `jwt.verify` decodes. `vi.importActual` keeps every other `authConfig` export real, so nothing is accidentally undefined.

Verified locally: syntax + config valid, all override names are real `authConfig` exports. The full run is on the Contract Tests CI job here (testcontainers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)