### PR TITLE
test(ui): Phase 4 — component contract tests (Tier 1 + Tier 2)

### DIFF
--- a/app/ui/src/components/AccessPackageDetailPage.test.js
+++ b/app/ui/src/components/AccessPackageDetailPage.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'AccessPackageDetailPage.jsx'), 'utf8');
+
+describe('AccessPackageDetailPage', () => {
+  it('delegates the detail scaffold to EntityDetailPage', () => {
+    expect(src).toContain('EntityDetailPage');
+  });
+
+  it('fetches the access package and its (optional) risk score', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/access-package/');
+    expect(src).toContain('/api/risk-scores/business-roles/');
+  });
+
+  it('holds the risk data in state', () => {
+    expect(src).toContain('setRiskData');
+  });
+});

--- a/app/ui/src/components/AccessPackagesPage.test.js
+++ b/app/ui/src/components/AccessPackagesPage.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'AccessPackagesPage.jsx'), 'utf8');
+
+describe('AccessPackagesPage', () => {
+  it('has a loading state', () => {
+    expect(src).toContain('const [loading, setLoading] = useState(true);');
+    expect(src).toContain('Loading business roles...');
+  });
+
+  it('handles the empty / filtered-to-empty case', () => {
+    expect(src).toContain('packages.length === 0');
+    expect(src).toContain('No business roles match the current filters.');
+  });
+
+  it('fetches business roles through the auth-wrapped client', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/access-packages');
+  });
+
+  it('supports search and a type filter', () => {
+    expect(src).toContain('setSearch');
+    expect(src).toContain('setTypeFilter');
+  });
+});

--- a/app/ui/src/components/AdminPage.test.js
+++ b/app/ui/src/components/AdminPage.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'AdminPage.jsx'), 'utf8');
+
+describe('AdminPage', () => {
+  it('has loading + error state', () => {
+    expect(src).toContain('const [loading, setLoading] = useState(true);');
+    expect(src).toContain('const [error, setError] = useState(null);');
+  });
+
+  it('renders empty states for each section', () => {
+    expect(src).toContain('No risk profile saved yet.');
+    expect(src).toContain('No classifiers saved yet.');
+    expect(src).toContain('No tokens issued yet.');
+  });
+
+  it('fetches the admin sections through the auth-wrapped client', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/admin/risk-profile');
+    expect(src).toContain('/api/admin/classifiers');
+    expect(src).toContain('/api/admin/read-tokens');
+  });
+});

--- a/app/ui/src/components/ContextDetailPage.test.js
+++ b/app/ui/src/components/ContextDetailPage.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'ContextDetailPage.jsx'), 'utf8');
+
+describe('ContextDetailPage', () => {
+  it('has loading + error state', () => {
+    expect(src).toContain('const [loading, setLoading] = useState(true);');
+    expect(src).toContain('const [error, setError] = useState(null);');
+  });
+
+  it('renders a distinct error UI with a retry that re-runs the fetch', () => {
+    expect(src).toContain('Failed to load context');
+    expect(src).toContain('onClick={fetchDetail}');
+  });
+
+  it('handles the not-found / empty case', () => {
+    expect(src).toContain('Context not found.');
+  });
+
+  it('fetches the context detail through the auth-wrapped client', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/contexts/${contextId}');
+  });
+
+  it('gates member editing to manual/generated contexts', () => {
+    expect(src).toContain('canEditMembers');
+  });
+});

--- a/app/ui/src/components/CrawlersPage.test.js
+++ b/app/ui/src/components/CrawlersPage.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'CrawlersPage.jsx'), 'utf8');
+
+describe('CrawlersPage', () => {
+  it('has loading + error state', () => {
+    expect(src).toContain('const [loading, setLoading] = useState(true);');
+    expect(src).toContain('const [error, setError] = useState(null);');
+  });
+
+  it('renders the error and the getting-started empty state', () => {
+    expect(src).toContain('{error}');
+    expect(src).toContain('No identity data loaded yet. Add a crawler to get started.');
+  });
+
+  it('fetches configs, jobs, and status through the auth-wrapped client', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/admin/crawler-configs');
+    expect(src).toContain('/api/admin/crawler-jobs');
+    expect(src).toContain('/api/admin/status');
+  });
+});

--- a/app/ui/src/components/MatrixView.test.js
+++ b/app/ui/src/components/MatrixView.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'MatrixView.jsx'), 'utf8');
+
+describe('MatrixView', () => {
+  it('tracks async loading state for nested groups and identity columns', () => {
+    expect(src).toContain('loadingNested');
+    expect(src).toContain('loadingIdentityCols');
+  });
+
+  it('shows an empty state before a slice is picked and when no data exists', () => {
+    expect(src).toContain('Pick a slice to inspect');
+    expect(src).toContain('No data available yet');
+  });
+
+  it('fetches expandable groups through the auth-wrapped client', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/groups-with-nested');
+  });
+});

--- a/app/ui/src/components/contexts/ContextTreeView.test.js
+++ b/app/ui/src/components/contexts/ContextTreeView.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'ContextTreeView.jsx'), 'utf8');
+
+// The prefix-stripping helpers are covered by ContextTreeView.prefix.test.js;
+// this pins the tree component's interaction surface.
+describe('ContextTreeView', () => {
+  it('tracks expand/collapse and member-visibility state', () => {
+    expect(src).toContain('expandedIds');
+    expect(src).toContain('showMembers');
+    expect(src).toContain('aria-expanded={expanded}');
+  });
+
+  it('shows a loading and an empty state for members', () => {
+    expect(src).toContain('members === null');
+    expect(src).toContain('Loading users');
+    expect(src).toContain('No directly-assigned users.');
+  });
+
+  it('supports rename, reparent (drag), and add-child interactions', () => {
+    expect(src).toContain('onDoubleClick');
+    expect(src).toContain('onDragStart');
+    expect(src).toContain('setAddingChild');
+  });
+});

--- a/app/ui/src/components/matrix/ContextFilterControl.test.js
+++ b/app/ui/src/components/matrix/ContextFilterControl.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, 'ContextFilterControl.jsx'), 'utf8');
+
+describe('ContextFilterControl', () => {
+  it('supports adding, removing, and toggling include-children on filter chips', () => {
+    expect(src).toContain('function add(node)');
+    expect(src).toContain('function remove(id)');
+    expect(src).toContain('function toggleChildren(id)');
+    expect(src).toContain('includeChildren');
+  });
+
+  it('resolves a context label through the auth-wrapped client', () => {
+    expect(src).toContain('useAuth()');
+    expect(src).toContain('/api/contexts/${v.id}');
+  });
+
+  it('opens a picker to add a new context filter', () => {
+    expect(src).toContain('setPickerOpen');
+  });
+});


### PR DESCRIPTION
Phase 4 of the test-layer plan — component tests for the Tier-1 (untested) and Tier-2 (expand) pages.

**Approach:** the plan described render-based tests, but the repo has **no `@testing-library`/jsdom**, and its existing page-component tests (`DashboardPage.test.js`, `EntityDetailPage.test.js` — the plan's own references) are **source-inspection** (read the `.jsx`, assert on key strings). Following that convention: each test pins the component's loading / error / empty / data-fetch / auth / interaction surface, so a regression that drops one of those fails CI. (Render tests for these dep-heavy pages would need new deps + mocking the whole hook graph.)

**Tier 1 (were untested):** `MatrixView`, `ContextDetailPage`, `AccessPackageDetailPage`, `CrawlersPage`, `AdminPage`
**Tier 2 (expanded):** `AccessPackagesPage`, `ContextFilterControl`, `ContextTreeView` (helpers already covered by `ContextTreeView.prefix.test.js`)

27 tests across 8 files, all green locally (Vitest UI). Test-only PR — heavy suites skip (per #465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)