### PR TITLE
test(e2e): Phase 8 — audit + track the two deferred E2E suites

### DIFF
--- a/app/ui/e2e/accessibility.spec.js
+++ b/app/ui/e2e/accessibility.spec.js
@@ -15,7 +15,7 @@ const pages = [
 // Skipped: the lime-on-white theme has color-contrast issues and search
 // inputs are missing <label> elements. These are real a11y issues that will
 // be addressed when we add theme selection (high-contrast theme option).
-// Re-enable after the theme work lands.
+// Re-enable after the theme work lands. Tracked in #471.
 for (const p of pages) {
   test.skip(`${p.name} page has no critical accessibility violations`, async ({ page }) => {
     await page.goto(`${BASE}/${p.hash}`);

--- a/app/ui/e2e/visual-regression.spec.js
+++ b/app/ui/e2e/visual-regression.spec.js
@@ -12,7 +12,7 @@ const pages = [
 
 // Skipped: baselines are platform-specific (chromium-linux in CI vs
 // chromium-win32 locally) and don't exist yet. Re-enable after committing
-// baselines or adding a baseline-generation CI step.
+// baselines or adding a baseline-generation CI step. Tracked in #472.
 for (const p of pages) {
   test.skip(`visual regression: ${p.name}`, async ({ page }) => {
     await page.goto(`${BASE}/${p.hash}`);


### PR DESCRIPTION
Phase 8 of the test-layer plan — E2E stabilization. **Finding: the suite is already stable**, so this is an audit + tracking pass rather than a fix.

## Audit (20 specs)
- **No red specs** — E2E is CI-blocking and green on `main`.
- **Data-conditional skips** (`detail-pages`, `identities`, `tags`: `if (rows===0) skip()`) **don't fire in CI** — the E2E job loads demo data first (`POST /api/admin/crawler-jobs {jobType:demo}`). They're safety nets for empty/local envs, and the same behaviours are already covered at the lower layer by Phases 1-2 (identities/details/tags contract + unit tests). The plan's "convert data-conditional skips to seeded lower-layer tests" is **effectively already done**.
- **Optional-tab skips** (org-chart/performance/risk-scoring/identities) — intentional gating on tabs not enabled in preferences.
- **Two permanently-`test.skip`'d suites**, documented but untracked — now have issues.

## Change
Reference tracking issues in the two deferred suites' skip comments:
- `accessibility.spec.js` -> #471 (real a11y bugs: lime-on-white contrast + missing `<label>`s; pending theme work)
- `visual-regression.spec.js` -> #472 (no committed chromium-linux baselines)

No test behaviour changes. This PR re-runs the full E2E suite (spec files changed), which doubles as a stability check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)