### PR TITLE
fix(api): surface real errors from optional-data reads (audit Q2 part 2)

### DIFF
--- a/app/api/src/routes/identities.js
+++ b/app/api/src/routes/identities.js
@@ -13,6 +13,7 @@
 import { Router } from 'express';
 import { timedRequest } from '../perf/sqlTimer.js';
 import { requirePermission } from '../middleware/auth.js';
+import { isMissingSchema } from '../db/schemaErrors.js';
 
 const router = Router();
 const useSql = process.env.USE_SQL === 'true';
@@ -299,7 +300,8 @@ router.get('/identities/:id', async (req, res) => {
           WHERE m."identityId" = @identityId
           ORDER BY m."isPrimary" DESC NULLS LAST, m."accountType" ASC
         `);
-    } catch {
+    } catch (e) {
+      if (!isMissingSchema(e)) throw e;
       membersResult = await timedRequest(p, 'identity-members-legacy', res)
         .input('identityId', identityId)
         .query(`
@@ -324,7 +326,8 @@ router.get('/identities/:id', async (req, res) => {
             LEFT JOIN "Principals" u ON m."principalId" = u.id
             WHERE m."identityId" = @identityId
           `);
-      } catch {
+      } catch (e) {
+        if (!isMissingSchema(e)) throw e;
         riskResult = await timedRequest(p, 'identity-member-risks-legacy', res)
           .input('identityId', identityId)
           .query(`
@@ -335,7 +338,7 @@ router.get('/identities/:id', async (req, res) => {
           `);
       }
       riskRows = riskResult.recordset;
-    } catch { /* risk columns may not exist yet */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* risk columns may not exist yet */ }
 
     // Fetch group memberships per account for context
     let groupCountRows = [];
@@ -350,8 +353,8 @@ router.get('/identities/:id', async (req, res) => {
           GROUP BY m."principalId"
         `);
       groupCountRows = groupCountResult.recordset;
-    } catch {
-      // ResourceAssignments may not exist
+    } catch (e) {
+      if (!isMissingSchema(e)) throw e;  // ResourceAssignments may not exist
     }
 
     // Attach per-account group counts + risk (keyed by principalId — see enrichMembers).
@@ -377,7 +380,7 @@ router.get('/identities/:id', async (req, res) => {
       for (const row of aggResult.recordset) {
         if (row.assignmentType in aggregate) aggregate[row.assignmentType] = row.cnt;
       }
-    } catch { /* ResourceAssignments may not exist */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* ResourceAssignments may not exist */ }
 
     // Context-membership count across the identity's linked principal IDs.
     let contextCount = 0;
@@ -389,7 +392,7 @@ router.get('/identities/:id', async (req, res) => {
                  WHERE cm."memberId"::text = @identityId
                    AND cm."memberType" = 'Identity'`);
       contextCount = r.recordset[0]?.cnt || 0;
-    } catch { /* ContextMembers may not exist */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* ContextMembers may not exist */ }
 
     res.json({
       identity,
@@ -681,7 +684,7 @@ router.get('/identity-columns', async (req, res) => {
             `SELECT DISTINCT "${col}" AS v FROM "Identities" WHERE "${col}" IS NOT NULL AND "${col}" <> '' ORDER BY "${col}" LIMIT 500`
           );
           grouped[col] = r.recordset.map(x => x.v);
-        } catch { grouped[col] = []; }
+        } catch (e) { if (!isMissingSchema(e)) throw e; grouped[col] = []; }
       }
     }
 
@@ -695,7 +698,7 @@ router.get('/identity-columns', async (req, res) => {
          ORDER BY t.name
       `);
       grouped['__identityTag'] = schemaOnly ? [] : r.recordset.map(x => x.name);
-    } catch { /* GraphTags may not exist yet */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* GraphTags may not exist yet */ }
 
     return res.json(Object.entries(grouped).map(([column, values]) => ({ column, values })));
   } catch (err) {

--- a/app/api/src/routes/permissions.js
+++ b/app/api/src/routes/permissions.js
@@ -6,6 +6,7 @@ import { getGroupColumns, getResourceColumns, getPrincipalOrUserColumns, getPrin
 import { timedRequest } from '../perf/sqlTimer.js';
 import { buildContextFilterSql, parseAndResolveContextFilters } from '../contexts/contextFilters.js';
 import { expandCapabilityDown, effectiveAccessForNodes } from '../effectiveAccess/engine.js';
+import { isMissingSchema } from '../db/schemaErrors.js';
 
 const router = Router();
 const useSql = process.env.USE_SQL === 'true';
@@ -81,7 +82,7 @@ router.get('/user-columns', async (req, res) => {
       `);
       const userTags = tagResult.recordset.map(r => r.name);
       grouped['__userTag'] = userTags; // always include values — tag query is fast
-    } catch { /* tag tables may not exist yet — skip silently */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* tag tables may not exist yet — skip silently */ }
 
     return res.json(
       Object.entries(grouped).map(([column, values]) => ({ column, values }))
@@ -130,7 +131,8 @@ router.get('/permissions', async (req, res) => {
       let allGroupCols;
       try {
         allGroupCols = await getResourceColumns(p);
-      } catch {
+      } catch (e) {
+        if (!isMissingSchema(e)) throw e;
         allGroupCols = await getGroupColumns(p);
       }
       const groupColNames = new Set(allGroupCols.map(c => GROUP_COL_ALIASES[c.name] || c.name));
@@ -242,7 +244,8 @@ router.get('/permissions', async (req, res) => {
       if (userTagFilter || groupTagFilter) {
         try {
           await ensureTagTables(p);
-        } catch {
+        } catch (e) {
+          if (!isMissingSchema(e)) throw e;
           userTagFilter = null;
           groupTagFilter = null;
         }
@@ -434,7 +437,7 @@ router.get('/permissions', async (req, res) => {
             GROUP BY ap."userId", ap."resourceId"
           `);
           apMapping = apRes.recordset;
-        } catch { /* AP view may not exist */ }
+        } catch (e) { if (!isMissingSchema(e)) throw e; /* AP view may not exist */ }
 
         const managedByPackages = apMapping
           .filter(r => r.memberId)
@@ -514,7 +517,7 @@ router.get('/permissions', async (req, res) => {
           GROUP BY ap."userId", ap."resourceId"
         `);
         apMapping = apResult.recordset;
-      } catch { /* AP view may not exist */ }
+      } catch (e) { if (!isMissingSchema(e)) throw e; /* AP view may not exist */ }
 
       const managedByPackages = apMapping
         .filter(r => r.memberId)
@@ -568,7 +571,7 @@ async function accessPackageResourcesHandler(req, res) {
   try {
     if (useSql) {
       const p = await db.getPool();
-      try { await ensureCategoryTables(p); } catch { /* category tables optional */ }
+      try { await ensureCategoryTables(p); } catch (e) { if (!isMissingSchema(e)) throw e; /* category tables optional */ }
       // Performance notes:
       //  - Previous version returned one row per (AP, resource) pair and
       //    let Node de-normalize it. On the load-test dataset that was

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { timedRequest } from '../perf/sqlTimer.js';
 import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
 import { ensureTagTables, buildFilterWhere } from './tags.js';
+import { isMissingSchema } from '../db/schemaErrors.js';
 
 const router = Router();
 const useSql = process.env.USE_SQL === 'true';
@@ -203,7 +204,7 @@ router.get('/resources/:id', async (req, res) => {
         [resourceId]
       );
       if (rs.rows.length > 0) Object.assign(attributes, cleanRow(rs.rows[0]));
-    } catch { /* RiskScores may not exist on older deployments */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* RiskScores may not exist on older deployments */ }
 
     // 2. Tags (support both 'resource' and 'group' entity types for backward compat)
     let tags = [];
@@ -217,7 +218,7 @@ router.get('/resources/:id', async (req, res) => {
           WHERE ta."entityId" = @id AND t."entityType" IN ('resource', 'group')
         `);
       tags = r.recordset;
-    } catch { /* table may not exist */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* table may not exist */ }
 
     // 3. Member count — broken down by assignmentType so the entity graph
     //    can show a node per type (Direct / Governed / Owner / Eligible).
@@ -237,7 +238,8 @@ router.get('/resources/:id', async (req, res) => {
         if (row.assignmentType in assignmentByType) assignmentByType[row.assignmentType] = row.cnt;
       }
       memberCount = Object.values(assignmentByType).reduce((a, b) => a + b, 0);
-    } catch {
+    } catch (e) {
+      if (!isMissingSchema(e)) throw e;
       // Fall back to permission view (no type breakdown there — leave counts 0)
       try {
         const table = await getPermissionTable(pool);
@@ -245,7 +247,7 @@ router.get('/resources/:id', async (req, res) => {
           .input('id', resourceId)
           .query(`SELECT COUNT(DISTINCT "memberId") AS cnt FROM ${table} WHERE "resourceId" = @id`);
         memberCount = r.recordset[0].cnt;
-      } catch { /* view may not exist */ }
+      } catch (e) { if (!isMissingSchema(e)) throw e; /* view may not exist */ }
     }
 
     // 4. Access package count (business roles that contain this resource)
@@ -262,7 +264,7 @@ router.get('/resources/:id', async (req, res) => {
             AND rrs."parentResourceId" IS NOT NULL
         `);
       accessPackageCount = r.recordset[0].cnt;
-    } catch { /* table may not exist */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* table may not exist */ }
 
     // 4b. Parent resource count (all parent resources via any relationship type)
     let parentResourceCount = 0;
@@ -275,7 +277,7 @@ router.get('/resources/:id', async (req, res) => {
           WHERE rrs."childResourceId" = @id
         `);
       parentResourceCount = r.recordset[0].cnt;
-    } catch { /* table may not exist */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* table may not exist */ }
 
     // 5. History count (v5: queries the _history audit table)
     let historyCount = 0;
@@ -285,7 +287,7 @@ router.get('/resources/:id', async (req, res) => {
         [resourceId]
       );
       historyCount = r?.cnt ?? 0;
-    } catch { /* _history may not exist on older deployments */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* _history may not exist on older deployments */ }
 
     // 6. Context-membership count (v6 — Resources.contextId column was
     // dropped in favor of the many-to-many ContextMembers join).
@@ -296,7 +298,7 @@ router.get('/resources/:id', async (req, res) => {
         [resourceId]
       );
       contextCount = r?.cnt ?? 0;
-    } catch { /* ContextMembers may not exist on older deployments */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* ContextMembers may not exist on older deployments */ }
 
     res.json({ attributes, tags, memberCount, assignmentByType, accessPackageCount, parentResourceCount, historyCount, hasHistory: historyCount > 0, contextCount });
   } catch (err) {
@@ -491,7 +493,7 @@ router.get('/resource-columns', async (req, res) => {
       `);
       const resourceTags = tagResult.recordset.map(r => r.name);
       grouped['__resourceTag'] = schemaOnly ? [] : resourceTags;
-    } catch { /* tag tables may not exist yet */ }
+    } catch (e) { if (!isMissingSchema(e)) throw e; /* tag tables may not exist yet */ }
 
     return res.json(Object.entries(grouped).map(([column, values]) => ({ column, values })));
   } catch (err) {

--- a/app/api/src/routes/resources.test.js
+++ b/app/api/src/routes/resources.test.js
@@ -23,7 +23,15 @@ const mockPool = {
   },
 };
 
-vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+// db.query / db.queryOne back the optional-data reads in GET /resources/:id
+// (RiskScores, history, context counts) — exposed so the de-masking tests below
+// can make a single optional read fail on demand.
+const mockDb = { query: vi.fn(), queryOne: vi.fn() };
+vi.mock('../db/connection.js', () => ({
+  getPool: async () => mockPool,
+  query: (...a) => mockDb.query(...a),
+  queryOne: (...a) => mockDb.queryOne(...a),
+}));
 
 // timedRequest is used only by GET /resources/:id.
 const timedQuery = vi.fn();
@@ -89,5 +97,34 @@ describe('GET /resources/:id — detail', () => {
     timedQuery.mockResolvedValueOnce({ recordset: [] });
     const res = await request(app).get(`/api/resources/${VALID_ID}`);
     expect(res.status).toBe(404);
+  });
+});
+
+// Audit finding Q2: optional-data reads (RiskScores, tags, counts, history) are
+// each wrapped in try/catch. They must swallow ONLY a missing table/column/view
+// and let every other error surface — otherwise a real failure silently returns
+// a 200 with empty/zero data, masking the outage.
+describe('GET /resources/:id — optional-data error handling (Q2 de-masking)', () => {
+  // A resource row (passes the 404 gate) + cnt:0 for every count query.
+  const okRow = { recordset: [{ id: VALID_ID, displayName: 'Eng', cnt: 0, assignmentType: 'Direct' }] };
+  beforeEach(() => {
+    timedQuery.mockReset();
+    timedQuery.mockResolvedValue(okRow);
+    mockDb.query.mockReset();
+    mockDb.query.mockResolvedValue({ rows: [] });   // RiskScores
+    mockDb.queryOne.mockReset();
+    mockDb.queryOne.mockResolvedValue({ cnt: 0 });   // history + context counts
+  });
+
+  it('degrades to 200 when an optional table/view is absent (missing-schema code)', async () => {
+    mockDb.query.mockRejectedValueOnce({ code: '42P01' }); // RiskScores table missing
+    const res = await request(app).get(`/api/resources/${VALID_ID}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('surfaces a 500 when an optional read fails for a non-schema reason', async () => {
+    mockDb.query.mockRejectedValueOnce(new Error('connection reset')); // real failure
+    const res = await request(app).get(`/api/resources/${VALID_ID}`);
+    expect(res.status).toBe(500);
   });
 });

--- a/changes/q2-demask-list-routes.md
+++ b/changes/q2-demask-list-routes.md
@@ -1,0 +1,1 @@
+- Identity, resource, and permission pages now report a clear error when an underlying data lookup genuinely fails, instead of silently showing empty or zero values — only a legitimately absent optional table/column is treated as "no data".


### PR DESCRIPTION
## What

Part 2 of audit finding **Q2** (part 1 covered `details.js`). The list/detail endpoints in `identities.js`, `resources.js` and `permissions.js` wrapped their optional-schema reads — RiskScores, tags, business-role / access-package counts, history, context membership, and legacy-table fallbacks — in bare `catch {}` blocks that swallowed **every** error and returned empty/zero. A genuine failure (a typo'd column, a dropped connection, a logic bug) was indistinguishable from "no data" and silently surfaced as a normal, empty 200.

## Change

Apply the existing `details.js` idiom everywhere:

```js
} catch (e) { if (!isMissingSchema(e)) throw e; /* table may not exist */ }
```

`isMissingSchema` (already shared in `db/schemaErrors.js`) tolerates only a genuinely-absent optional object (SQLSTATE `42P01` / `42703` / `42704`) on older deployments; any other error now propagates to the route handler and returns a 500, so real outages are visible instead of masked.

~24 catch sites converted across the three files. Legitimate `JSON.parse` bad-input catches were left untouched.

## Tests

Adds two `resources.js` detail-path tests covering both branches:
- missing-schema code → still **200** (graceful degradation preserved)
- non-schema error → **500** (real failure now surfaced)

Full API unit suite green locally (the one unrelated failure is a Linux-only path-traversal test that can't pass on a Windows checkout).

Independent of #462 — different files, both branched off `main`.