### PR TITLE
refactor(midpoint): extract crawler functions into a loadable library

### DIFF
--- a/changes/refactor-midpoint-crawler.md
+++ b/changes/refactor-midpoint-crawler.md
@@ -1,0 +1,2 @@
+- Refactored the midpoint crawler so its internal functions live in a loadable `MidpointCrawler.Functions.ps1` library (dot-sourced by the entry-point script) instead of being trapped in the script's top-level execution body — no change to runtime behavior.
+- Added unit tests for the midpoint crawler's helper functions (batched and streaming ingest, per-endpoint performance stats, phase-error tracking, shadow-account labelling).

--- a/test/unit/MidpointCrawlerFunctions.Tests.ps1
+++ b/test/unit/MidpointCrawlerFunctions.Tests.ps1
@@ -1,0 +1,346 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Pester unit tests for the extracted midPoint crawler functions
+    (MidpointCrawler.Functions.ps1).
+
+.DESCRIPTION
+    These cover the ingest batching/streaming, performance-stat, phase-error, and
+    shadow-labelling functions that were moved verbatim out of Start-MidpointCrawler.ps1.
+    The Start script's Main body is NOT run — only the function file is dot-sourced.
+
+    Functions that build records or compute modes are tested directly; functions that
+    call the Ingest API (Send-IngestBatch and the streaming helpers) are tested by
+    mocking Invoke-IngestAPI so no network is hit. The midPoint REST helpers used by
+    Get-MidpointShadowLabel come from Invoke-MidpointApi.ps1, also dot-sourced here.
+
+    No case here duplicates test/unit/Midpoint.Tests.ps1 (which tests the pure helpers
+    in Invoke-MidpointApi.ps1 — not the Start-script functions extracted here).
+
+.USAGE
+    Invoke-Pester -Path test/unit/MidpointCrawlerFunctions.Tests.ps1 -Output Detailed
+#>
+
+BeforeAll {
+    $script:repoRoot    = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:midpointDir = Join-Path $script:repoRoot 'tools' 'crawlers' 'midpoint'
+
+    # The midPoint REST helpers (Get-MidpointAttrValue, Get-MidpointString,
+    # Format-AccountLabel, …) are used by Get-MidpointShadowLabel.
+    . (Join-Path $script:midpointDir 'Invoke-MidpointApi.ps1')
+
+    # ConvertTo-JsonArray / Invoke-IngestAPI live in the shared helpers; the streaming
+    # and batch functions call them. (Invoke-IngestAPI is mocked per-test.)
+    . (Join-Path $script:repoRoot 'tools' 'crawlers' 'shared' 'Invoke-CrawlerIngest.ps1')
+
+    # The unit under test.
+    . (Join-Path $script:midpointDir 'MidpointCrawler.Functions.ps1')
+
+    # ── Script-scope state the functions read at call time ──────────────────────
+    # (Normally set up by Start-MidpointCrawler.ps1's Configuration region / Main.)
+    $script:CrossSystemEntities = @('systems', 'identities', 'identity-members', 'context-members', 'governance/certifications')
+    $script:SyncMode            = 'full'
+    $script:ingestStats         = [ordered]@{}
+    $script:fetchStats          = [ordered]@{}
+    $script:phaseErrors         = [System.Collections.Generic.List[string]]::new()
+
+    # Lookup maps consumed by Get-MidpointShadowLabel.
+    $script:ShadowOidToUserOid = @{}
+    $script:UserOidToName      = @{}
+    $script:ResourceOidToName  = @{}
+}
+
+# ─── Get-EntitySyncMode ───────────────────────────────────────────────────────
+Describe 'Get-EntitySyncMode' {
+    It 'forces cross-system entities to delta regardless of the configured mode' {
+        $script:SyncMode = 'full'
+        Get-EntitySyncMode -Entity 'systems'               | Should -Be 'delta'
+        Get-EntitySyncMode -Entity 'identities'            | Should -Be 'delta'
+        Get-EntitySyncMode -Entity 'identity-members'      | Should -Be 'delta'
+        Get-EntitySyncMode -Entity 'context-members'       | Should -Be 'delta'
+        Get-EntitySyncMode -Entity 'governance/certifications' | Should -Be 'delta'
+    }
+    It 'returns the configured sync mode for a per-system-scoped entity' {
+        $script:SyncMode = 'full'
+        Get-EntitySyncMode -Entity 'resources' | Should -Be 'full'
+        $script:SyncMode = 'delta'
+        Get-EntitySyncMode -Entity 'resources' | Should -Be 'delta'
+        $script:SyncMode = 'full'   # restore
+    }
+}
+
+# ─── Send-IngestBatch ─────────────────────────────────────────────────────────
+Describe 'Send-IngestBatch' {
+    BeforeEach {
+        $script:ingestStats = [ordered]@{}
+        $script:SyncMode    = 'full'
+    }
+
+    It 'skips the API call and returns zeros when there are no records' {
+        Mock Invoke-IngestAPI { throw 'should not be called' }
+        $r = Send-IngestBatch -Endpoint 'ingest/resources' -SystemId 7 -Records @()
+        $r.inserted | Should -Be 0
+        $r.updated  | Should -Be 0
+        $r.deleted  | Should -Be 0
+        Should -Invoke Invoke-IngestAPI -Times 0
+    }
+
+    It 'sends a single batch (records ≤ BatchSize) with the resolved sync mode and scope' {
+        $captured = $null
+        Mock Invoke-IngestAPI { $script:captured = $Body; return @{ inserted = 2; updated = 1; deleted = 0 } }
+        $recs = @([pscustomobject]@{ id = 'a' }, [pscustomobject]@{ id = 'b' })
+        $r = Send-IngestBatch -Endpoint 'ingest/resources' -SystemId 7 -Scope @{ resourceType = 'Service' } -Records $recs
+        Should -Invoke Invoke-IngestAPI -Times 1
+        $r.inserted | Should -Be 2
+        $r.updated  | Should -Be 1
+        $script:captured.systemId          | Should -Be 7
+        $script:captured.syncMode          | Should -Be 'full'
+        $script:captured.scope.resourceType | Should -Be 'Service'
+        # Records are always wrapped as a List so they serialise as a JSON array.
+        @($script:captured.records).Count  | Should -Be 2
+    }
+
+    It 'forces delta mode for a cross-system endpoint even when SyncMode is full' {
+        $captured = $null
+        Mock Invoke-IngestAPI { $script:captured = $Body; return @{ inserted = 1; updated = 0; deleted = 0 } }
+        Send-IngestBatch -Endpoint 'ingest/identities' -SystemId 3 -Records @([pscustomobject]@{ id = 'u1' }) | Out-Null
+        $script:captured.syncMode | Should -Be 'delta'
+    }
+
+    It 'honours an explicit SyncModeOverride' {
+        $captured = $null
+        Mock Invoke-IngestAPI { $script:captured = $Body; return @{ inserted = 0; updated = 0; deleted = 0 } }
+        Send-IngestBatch -Endpoint 'ingest/resources' -SyncModeOverride 'delta' -Records @([pscustomobject]@{ id = 'x' }) | Out-Null
+        $script:captured.syncMode | Should -Be 'delta'
+    }
+
+    It 'chunks a large batch into a start→continue→end session and aggregates totals' {
+        $script:bodies = [System.Collections.Generic.List[object]]::new()
+        Mock Invoke-IngestAPI {
+            $script:bodies.Add($Body)
+            # Only the first (start) call returns a syncId; each call inserts its chunk count.
+            $isStart = ($Body.syncSession -eq 'start')
+            return @{ inserted = $Body.records.Count; updated = 0; deleted = 0; syncId = $(if ($isStart) { 'SESSION-1' } else { $null }) }
+        }
+        # 12 records, BatchSize 5 → chunks of 5, 5, 2 → start, continue, end.
+        $recs = 1..12 | ForEach-Object { [pscustomobject]@{ id = "r$_" } }
+        $r = Send-IngestBatch -Endpoint 'ingest/resources' -SystemId 9 -Records @($recs) -BatchSize 5
+        Should -Invoke Invoke-IngestAPI -Times 3
+        @($script:bodies).Count | Should -Be 3
+        $script:bodies[0].syncSession | Should -Be 'start'
+        $script:bodies[1].syncSession | Should -Be 'continue'
+        $script:bodies[2].syncSession | Should -Be 'end'
+        # The syncId from the start call is threaded into the later calls.
+        $script:bodies[1].syncId | Should -Be 'SESSION-1'
+        $script:bodies[2].syncId | Should -Be 'SESSION-1'
+        # Totals summed across chunks (5 + 5 + 2).
+        $r.inserted | Should -Be 12
+    }
+
+    It 'records a per-endpoint ingest stat for the call' {
+        Mock Invoke-IngestAPI { return @{ inserted = 1; updated = 0; deleted = 0 } }
+        Send-IngestBatch -Endpoint 'ingest/principals' -SystemId 1 -Records @([pscustomobject]@{ id = 'p' }) | Out-Null
+        $script:ingestStats.Contains('principals') | Should -BeTrue
+        $script:ingestStats['principals'].calls    | Should -Be 1
+        $script:ingestStats['principals'].records  | Should -Be 1
+    }
+}
+
+# ─── New-IngestStream ─────────────────────────────────────────────────────────
+Describe 'New-IngestStream' {
+    It 'initialises an empty stream with the supplied endpoint/system/scope/batch size' {
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 4 -Scope @{ assignmentType = 'Direct' } -BatchSize 100
+        $s.Endpoint        | Should -Be 'ingest/resource-assignments'
+        $s.SystemId        | Should -Be 4
+        $s.Scope.assignmentType | Should -Be 'Direct'
+        $s.BatchSize       | Should -Be 100
+        $s.Buffer.Count    | Should -Be 0
+        $s.Started         | Should -BeFalse
+        $s.Records         | Should -Be 0
+        $s.Inserted        | Should -Be 0
+    }
+}
+
+# ─── Add-IngestStreamRecord / Send-IngestStreamChunk / Complete-IngestStream ──
+Describe 'Streaming ingest (Add-IngestStreamRecord + Complete-IngestStream)' {
+    BeforeEach {
+        $script:ingestStats = [ordered]@{}
+        $script:SyncMode    = 'full'
+    }
+
+    It 'buffers records without flushing until MORE than a full batch is held' {
+        Mock Invoke-IngestAPI { throw 'should not flush yet' }
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 1 -BatchSize 3
+        1..3 | ForEach-Object { Add-IngestStreamRecord -Stream $s -Record ([pscustomobject]@{ id = "a$_" }) }
+        # Exactly BatchSize records → no flush yet (a non-empty remainder must remain for 'end').
+        Should -Invoke Invoke-IngestAPI -Times 0
+        $s.Buffer.Count | Should -Be 3
+        $s.Started      | Should -BeFalse
+        $s.Records      | Should -Be 3
+    }
+
+    It 'flushes a start chunk once the buffer exceeds the batch size, leaving a remainder' {
+        $script:bodies = [System.Collections.Generic.List[object]]::new()
+        Mock Invoke-IngestAPI { $script:bodies.Add($Body); return @{ inserted = 0; updated = 0; deleted = 0; syncId = 'SS' } }
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 1 -BatchSize 3
+        1..4 | ForEach-Object { Add-IngestStreamRecord -Stream $s -Record ([pscustomobject]@{ id = "a$_" }) }
+        # 4 > 3 → flush a 'start' chunk of 3, keep 1 in the buffer.
+        Should -Invoke Invoke-IngestAPI -Times 1
+        $script:bodies[0].syncSession | Should -Be 'start'
+        $s.Started      | Should -BeTrue
+        $s.SyncId       | Should -Be 'SS'
+        $s.Buffer.Count | Should -Be 1
+    }
+
+    It 'emits a single (no-session) call when everything fits in one batch on Complete' {
+        $script:bodies = [System.Collections.Generic.List[object]]::new()
+        Mock Invoke-IngestAPI { $script:bodies.Add($Body); return @{ inserted = 2; updated = 0; deleted = 0 } }
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 1 -BatchSize 10
+        1..2 | ForEach-Object { Add-IngestStreamRecord -Stream $s -Record ([pscustomobject]@{ id = "a$_" }) }
+        Complete-IngestStream -Stream $s
+        Should -Invoke Invoke-IngestAPI -Times 1
+        # 'single' → no syncSession key on the body.
+        $script:bodies[0].ContainsKey('syncSession') | Should -BeFalse
+        $s.Inserted | Should -Be 2
+    }
+
+    It 'closes a started session with an end chunk on Complete' {
+        $script:bodies = [System.Collections.Generic.List[object]]::new()
+        Mock Invoke-IngestAPI { $script:bodies.Add($Body); return @{ inserted = 0; updated = 0; deleted = 0; syncId = 'SS' } }
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 1 -BatchSize 3
+        1..4 | ForEach-Object { Add-IngestStreamRecord -Stream $s -Record ([pscustomobject]@{ id = "a$_" }) }  # 1 start flush
+        Complete-IngestStream -Stream $s                                                                        # end flush
+        Should -Invoke Invoke-IngestAPI -Times 2
+        $script:bodies[0].syncSession | Should -Be 'start'
+        $script:bodies[1].syncSession | Should -Be 'end'
+        $script:bodies[1].syncId      | Should -Be 'SS'   # threaded from the start response
+    }
+
+    It 'does nothing on Complete when no records were ever added (no scoped delete)' {
+        Mock Invoke-IngestAPI { throw 'should not be called for an empty stream' }
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 1 -BatchSize 5
+        Complete-IngestStream -Stream $s
+        Should -Invoke Invoke-IngestAPI -Times 0
+    }
+
+    It 'streams the full record set across chunk boundaries (totals add up)' {
+        Mock Invoke-IngestAPI {
+            return @{ inserted = $Body.records.Count; updated = 0; deleted = 0; syncId = 'SS' }
+        }
+        $s = New-IngestStream -Endpoint 'ingest/resource-assignments' -SystemId 1 -BatchSize 4
+        1..10 | ForEach-Object { Add-IngestStreamRecord -Stream $s -Record ([pscustomobject]@{ id = "a$_" }) }
+        Complete-IngestStream -Stream $s
+        $s.Records  | Should -Be 10
+        $s.Inserted | Should -Be 10   # every record reported inserted exactly once
+    }
+}
+
+# ─── Add-IngestStat ───────────────────────────────────────────────────────────
+Describe 'Add-IngestStat' {
+    BeforeEach { $script:ingestStats = [ordered]@{} }
+
+    It 'creates a new endpoint bucket on first call' {
+        Add-IngestStat -Endpoint 'resources' -Seconds 1.5 -Records 10
+        $script:ingestStats['resources'].seconds | Should -Be 1.5
+        $script:ingestStats['resources'].calls   | Should -Be 1
+        $script:ingestStats['resources'].records | Should -Be 10
+    }
+    It 'accumulates seconds, calls and records across multiple calls to the same endpoint' {
+        Add-IngestStat -Endpoint 'resources' -Seconds 1.0 -Records 5
+        Add-IngestStat -Endpoint 'resources' -Seconds 2.0 -Records 7
+        $script:ingestStats['resources'].seconds | Should -Be 3.0
+        $script:ingestStats['resources'].calls   | Should -Be 2
+        $script:ingestStats['resources'].records | Should -Be 12
+    }
+}
+
+# ─── Measure-MidpointFetch ────────────────────────────────────────────────────
+Describe 'Measure-MidpointFetch' {
+    BeforeEach { $script:fetchStats = [ordered]@{} }
+
+    It 'returns the scriptblock result unchanged' {
+        $r = Measure-MidpointFetch -Label 'users' -Script { @('u1', 'u2', 'u3') }
+        @($r) | Should -Be @('u1', 'u2', 'u3')
+    }
+    It 'records the object count for the labelled read' {
+        Measure-MidpointFetch -Label 'roles' -Script { @('r1', 'r2') } | Out-Null
+        $script:fetchStats.Contains('roles') | Should -BeTrue
+        $script:fetchStats['roles'].count    | Should -Be 2
+    }
+    It 'counts a single (scalar) result as one object' {
+        Measure-MidpointFetch -Label 'one' -Script { 'solo' } | Out-Null
+        $script:fetchStats['one'].count | Should -Be 1
+    }
+}
+
+# ─── Add-PhaseError ───────────────────────────────────────────────────────────
+Describe 'Add-PhaseError' {
+    BeforeEach { $script:phaseErrors = [System.Collections.Generic.List[string]]::new() }
+
+    It 'appends a "Phase: message" entry to the shared phase-error list' {
+        Add-PhaseError -Phase 'Roles' -Msg 'boom'
+        $script:phaseErrors.Count | Should -Be 1
+        $script:phaseErrors[0]    | Should -Be 'Roles: boom'
+    }
+    It 'accumulates multiple phase errors in order' {
+        Add-PhaseError -Phase 'Orgs'  -Msg 'a'
+        Add-PhaseError -Phase 'Users' -Msg 'b'
+        $script:phaseErrors.Count | Should -Be 2
+        $script:phaseErrors[1]    | Should -Be 'Users: b'
+    }
+}
+
+# ─── Write-Step ───────────────────────────────────────────────────────────────
+Describe 'Write-Step' {
+    It 'runs without throwing (progress logging only)' {
+        { Write-Step -Msg 'doing the thing' } | Should -Not -Throw
+    }
+}
+
+# ─── Get-MidpointShadowLabel ──────────────────────────────────────────────────
+Describe 'Get-MidpointShadowLabel' {
+    BeforeEach {
+        $script:ShadowOidToUserOid = @{}
+        $script:UserOidToName      = @{}
+        $script:ResourceOidToName  = @{}
+    }
+
+    It 'prefers a readable attribute (fullName) over the raw shadow name' {
+        $shadow = [pscustomobject]@{
+            name       = '12345'
+            attributes = [pscustomobject]@{ 'ri:fullName' = [pscustomobject]@{ '@value' = 'Andrea Hill' } }
+        }
+        Get-MidpointShadowLabel -Shadow $shadow -ShadowOid 'sh-1' -ResourceOid 'res-1' | Should -Be 'Andrea Hill'
+    }
+
+    It 'falls back to the formatted shadow name when no readable attribute exists' {
+        $shadow = [pscustomobject]@{ name = 'CN=Jane Roe [JROE@x.com],OU=Users,DC=x'; attributes = [pscustomobject]@{} }
+        Get-MidpointShadowLabel -Shadow $shadow -ShadowOid 'sh-2' -ResourceOid 'res-1' | Should -Be 'Jane Roe'
+    }
+
+    It 'uses "owner name (resource)" when the shadow name is purely numeric and the owner is known' {
+        $script:ShadowOidToUserOid = @{ 'sh-3' = 'user-9' }
+        $script:UserOidToName      = @{ 'user-9' = 'Bob Smith' }
+        $script:ResourceOidToName  = @{ 'res-2'  = 'Active Directory' }
+        $shadow = [pscustomobject]@{ name = '99001'; attributes = [pscustomobject]@{} }
+        Get-MidpointShadowLabel -Shadow $shadow -ShadowOid 'sh-3' -ResourceOid 'res-2' | Should -Be 'Bob Smith (Active Directory)'
+    }
+
+    It 'uses "owner name (account)" when the resource name is unknown' {
+        $script:ShadowOidToUserOid = @{ 'sh-4' = 'user-1' }
+        $script:UserOidToName      = @{ 'user-1' = 'Carol King' }
+        $shadow = [pscustomobject]@{ name = '4242'; attributes = [pscustomobject]@{} }
+        Get-MidpointShadowLabel -Shadow $shadow -ShadowOid 'sh-4' -ResourceOid 'res-unknown' | Should -Be 'Carol King (account)'
+    }
+
+    It 'falls back to the raw shadow name when numeric and no owner is known' {
+        $shadow = [pscustomobject]@{ name = '7777'; attributes = [pscustomobject]@{} }
+        Get-MidpointShadowLabel -Shadow $shadow -ShadowOid 'sh-orphan' -ResourceOid 'res-x' | Should -Be '7777'
+    }
+
+    It 'falls back to the shadow OID when the shadow has no name and no owner' {
+        # A truly absent (null) name makes Get-MidpointString fall through to the OID fallback.
+        $shadow = [pscustomobject]@{ name = $null; attributes = [pscustomobject]@{} }
+        Get-MidpointShadowLabel -Shadow $shadow -ShadowOid 'sh-id-5' -ResourceOid 'res-x' | Should -Be 'sh-id-5'
+    }
+}

--- a/tools/crawlers/midpoint/MidpointCrawler.Functions.ps1
+++ b/tools/crawlers/midpoint/MidpointCrawler.Functions.ps1
@@ -1,0 +1,173 @@
+# MidpointCrawler.Functions.ps1
+#
+# Extracted top-level functions from Start-MidpointCrawler.ps1 so they can be
+# dot-sourced and unit-tested in isolation (the Start script's Main body would
+# otherwise run on import). Bodies are moved verbatim — behaviour is unchanged;
+# the Start script dot-sources this file before its Main body runs, which is
+# identical to defining the functions inline. The only addition is a leading
+# [CmdletBinding()] in each body (required by the Pester quality gate).
+#
+# These functions read script-scoped state ($SyncMode, $CrossSystemEntities,
+# $Script:ingestStats, $Script:fetchStats, $Script:phaseErrors, and the shadow
+# label lookup maps) from the caller's scope at call time, exactly as before.
+
+# Cross-system tables have no per-system delete scope → never reconcile-delete them
+# (would remove other sources' data). Always upsert-only (delta) for these.
+function Get-EntitySyncMode {
+    [CmdletBinding()]
+    param([string]$Entity)
+    if ($CrossSystemEntities -contains $Entity) { return 'delta' }
+    return $SyncMode
+}
+
+function Send-IngestBatch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [int]$SystemId      = 0,
+        [string]$SyncModeOverride = $null,
+        [hashtable]$Scope   = @{},
+        [array]$Records     = @(),
+        [int]$BatchSize     = 5000
+    )
+    $entity = ($Endpoint -replace '^ingest/', '')
+    $mode   = if ($SyncModeOverride) { $SyncModeOverride } else { Get-EntitySyncMode -Entity $entity }
+
+    if (-not $Records -or $Records.Count -eq 0) {
+        # The ingest API rejects an empty records array (no scoped-delete-only mode),
+        # so skip the call entirely when a phase produced no records.
+        Write-Host "  (no records for $Endpoint — skipping)" -ForegroundColor DarkGray
+        return @{ inserted = 0; updated = 0; deleted = 0 }
+    }
+    $swIngest = [System.Diagnostics.Stopwatch]::StartNew()
+    if ($Records.Count -le $BatchSize) {
+        $Body   = @{ systemId = $SystemId; syncMode = $mode; scope = $Scope; records = ConvertTo-JsonArray $Records }
+        $Result = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
+    }
+    else {
+        # Chunked session for large batches
+        $SyncId = $null; $TotIns = 0; $TotUpd = 0; $TotDel = 0
+        for ($i = 0; $i -lt $Records.Count; $i += $BatchSize) {
+            $Chunk   = $Records[$i..([Math]::Min($i + $BatchSize - 1, $Records.Count - 1))]
+            $IsFirst = ($i -eq 0)
+            $IsLast  = ($i + $BatchSize -ge $Records.Count)
+            $Body    = @{ systemId = $SystemId; syncMode = $mode; scope = $Scope; records = ConvertTo-JsonArray $Chunk
+                          syncSession = if ($IsFirst) { 'start' } elseif ($IsLast) { 'end' } else { 'continue' } }
+            if ($SyncId) { $Body.syncId = $SyncId }
+            $R = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
+            if ($IsFirst -and $R.syncId) { $SyncId = $R.syncId }
+            $TotIns += ($R.inserted ?? 0); $TotUpd += ($R.updated ?? 0); $TotDel += ($R.deleted ?? 0)
+        }
+        $Result = @{ inserted = $TotIns; updated = $TotUpd; deleted = $TotDel }
+    }
+    $swIngest.Stop()
+    Add-IngestStat -Endpoint $entity -Seconds $swIngest.Elapsed.TotalSeconds -Records $Records.Count
+    return $Result
+}
+
+# ── Streaming ingest ──────────────────────────────────────────────────────────
+# Flush records in BatchSize chunks within ONE sync session so a full-sync's scoped
+# delete still sees the complete set — without ever holding all records in memory.
+# Mirrors Send-IngestBatch's chunked-session protocol (start → continue → end), or a
+# single full-sync call when everything fits in one batch.
+function New-IngestStream {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Endpoint, [int]$SystemId = 0, [hashtable]$Scope = @{}, [int]$BatchSize = 5000)
+    [pscustomobject]@{
+        Endpoint = $Endpoint; SystemId = $SystemId; Scope = $Scope; BatchSize = $BatchSize
+        Buffer = [System.Collections.Generic.List[object]]::new(); SyncId = $null; Started = $false
+        Records = 0; Inserted = 0; Updated = 0; Deleted = 0
+    }
+}
+function Send-IngestStreamChunk {
+    [CmdletBinding()]
+    param($Stream, [string]$Session)   # 'start' | 'continue' | 'end' | 'single'
+    $entity = ($Stream.Endpoint -replace '^ingest/', '')
+    $mode   = Get-EntitySyncMode -Entity $entity
+    $count  = $Stream.Buffer.Count
+    $body   = @{ systemId = $Stream.SystemId; syncMode = $mode; scope = $Stream.Scope; records = ConvertTo-JsonArray @($Stream.Buffer) }
+    if ($Session -ne 'single') {
+        $body['syncSession'] = $Session
+        if ($Stream.SyncId) { $body['syncId'] = $Stream.SyncId }
+    }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $R  = Invoke-IngestAPI -Endpoint $Stream.Endpoint -Body $body
+    $sw.Stop()
+    if ($Session -in @('start', 'single') -and $R.syncId) { $Stream.SyncId = $R.syncId }
+    $Stream.Inserted += ($R.inserted ?? 0); $Stream.Updated += ($R.updated ?? 0); $Stream.Deleted += ($R.deleted ?? 0)
+    Add-IngestStat -Endpoint $entity -Seconds $sw.Elapsed.TotalSeconds -Records $count
+    $Stream.Buffer.Clear()
+}
+function Add-IngestStreamRecord {
+    [CmdletBinding()]
+    param($Stream, $Record)
+    $Stream.Buffer.Add($Record); $Stream.Records++
+    # Flush only once we hold MORE than a full batch, so a non-empty remainder is always
+    # left for the closing 'end' (the ingest API rejects an empty records array, and the
+    # scoped delete fires on 'end').
+    if ($Stream.Buffer.Count -gt $Stream.BatchSize) {
+        $remainder = [System.Collections.Generic.List[object]]::new()
+        for ($i = $Stream.BatchSize; $i -lt $Stream.Buffer.Count; $i++) { $remainder.Add($Stream.Buffer[$i]) }
+        while ($Stream.Buffer.Count -gt $Stream.BatchSize) { $Stream.Buffer.RemoveAt($Stream.Buffer.Count - 1) }
+        Send-IngestStreamChunk -Stream $Stream -Session ($(if ($Stream.Started) { 'continue' } else { 'start' }))
+        $Stream.Started = $true
+        $Stream.Buffer = $remainder
+    }
+}
+function Complete-IngestStream {
+    [CmdletBinding()]
+    param($Stream)
+    if ($Stream.Records -eq 0) { return }   # nothing → no scoped delete (matches Send-IngestBatch empty-skip)
+    Send-IngestStreamChunk -Stream $Stream -Session ($(if ($Stream.Started) { 'end' } else { 'single' }))
+}
+
+function Write-Step {
+    [CmdletBinding()]
+    param([string]$Msg) Write-Host "  → $Msg" -ForegroundColor DarkGray
+}
+
+function Add-PhaseError {
+    [CmdletBinding()]
+    param([string]$Phase, [string]$Msg)
+    Write-Host "  $Phase failed: $Msg" -ForegroundColor Red
+    $Script:phaseErrors.Add("${Phase}: $Msg")
+}
+
+function Add-IngestStat {
+    [CmdletBinding()]
+    param([string]$Endpoint, [double]$Seconds, [int]$Records)
+    if (-not $Script:ingestStats.Contains($Endpoint)) { $Script:ingestStats[$Endpoint] = @{ seconds = 0.0; calls = 0; records = 0 } }
+    $Script:ingestStats[$Endpoint].seconds += $Seconds
+    $Script:ingestStats[$Endpoint].calls++
+    $Script:ingestStats[$Endpoint].records += $Records
+}
+function Measure-MidpointFetch {
+    [CmdletBinding()]
+    param([string]$Label, [scriptblock]$Script)
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $result = & $Script
+    $sw.Stop()
+    $n = @($result).Count
+    $Script:fetchStats[$Label] = @{ seconds = $sw.Elapsed.TotalSeconds; count = $n }
+    return $result
+}
+
+# Build a human-readable label for a shadow account. Some connectors (e.g. DatabaseTable)
+# name shadows by a numeric key; prefer a readable attribute, then the owner's name +
+# resource, and only fall back to the raw (possibly numeric) shadow name as a last resort.
+function Get-MidpointShadowLabel {
+    [CmdletBinding()]
+    param($Shadow, [string]$ShadowOid, [string]$ResourceOid)
+    $readable = Get-MidpointAttrValue -Shadow $Shadow -Keys @('fullName', 'cn', 'displayName', 'sAMAccountName', 'login', 'name')
+    if (-not $readable) { $readable = Format-AccountLabel (Get-MidpointString $Shadow.name '') }
+    else { $readable = Format-AccountLabel $readable }
+    if ($readable -and $readable -match '[A-Za-z]') { return $readable }
+    if ($ShadowOidToUserOid.ContainsKey($ShadowOid)) {
+        $ownerOid = $ShadowOidToUserOid[$ShadowOid]
+        if ($UserOidToName.ContainsKey($ownerOid)) {
+            $rn = if ($ResourceOidToName.ContainsKey($ResourceOid)) { $ResourceOidToName[$ResourceOid] } else { 'account' }
+            return ($UserOidToName[$ownerOid] + ' (' + $rn + ')')
+        }
+    }
+    return (Get-MidpointString $Shadow.name $ShadowOid)
+}

--- a/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
@@ -72,6 +72,11 @@ if ($objects) {
 # Dot-source shared ingest helpers (Invoke-IngestAPI, Update-CrawlerProgress, ConvertTo-JsonArray)
 . (Join-Path $PSScriptRoot '..' 'shared' 'Invoke-CrawlerIngest.ps1')
 
+# Dot-source the crawler's own extracted functions (ingest batching/streaming, stats,
+# phase-error tracking, shadow labelling). Moved out of this script verbatim so they can
+# be unit-tested; dot-sourcing here is equivalent to defining them inline below.
+. (Join-Path $PSScriptRoot 'MidpointCrawler.Functions.ps1')
+
 # The dispatcher dot-sources Invoke-MidpointApi.ps1 (sibling library) before this
 # entry point runs. For standalone invocation, load it here if absent.
 if (-not (Get-Command Connect-MidpointAPI -ErrorAction SilentlyContinue)) {
@@ -83,115 +88,8 @@ if (-not (Get-Command Connect-MidpointAPI -ErrorAction SilentlyContinue)) {
 # Cross-system tables have no per-system delete scope → never reconcile-delete them
 # (would remove other sources' data). Always upsert-only (delta) for these.
 $CrossSystemEntities = @('systems', 'identities', 'identity-members', 'context-members', 'governance/certifications')
-function Get-EntitySyncMode {
-    param([string]$Entity)
-    if ($CrossSystemEntities -contains $Entity) { return 'delta' }
-    return $SyncMode
-}
-
-function Send-IngestBatch {
-    param(
-        [Parameter(Mandatory)] [string]$Endpoint,
-        [int]$SystemId      = 0,
-        [string]$SyncModeOverride = $null,
-        [hashtable]$Scope   = @{},
-        [array]$Records     = @(),
-        [int]$BatchSize     = 5000
-    )
-    $entity = ($Endpoint -replace '^ingest/', '')
-    $mode   = if ($SyncModeOverride) { $SyncModeOverride } else { Get-EntitySyncMode -Entity $entity }
-
-    if (-not $Records -or $Records.Count -eq 0) {
-        # The ingest API rejects an empty records array (no scoped-delete-only mode),
-        # so skip the call entirely when a phase produced no records.
-        Write-Host "  (no records for $Endpoint — skipping)" -ForegroundColor DarkGray
-        return @{ inserted = 0; updated = 0; deleted = 0 }
-    }
-    $swIngest = [System.Diagnostics.Stopwatch]::StartNew()
-    if ($Records.Count -le $BatchSize) {
-        $Body   = @{ systemId = $SystemId; syncMode = $mode; scope = $Scope; records = ConvertTo-JsonArray $Records }
-        $Result = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-    }
-    else {
-        # Chunked session for large batches
-        $SyncId = $null; $TotIns = 0; $TotUpd = 0; $TotDel = 0
-        for ($i = 0; $i -lt $Records.Count; $i += $BatchSize) {
-            $Chunk   = $Records[$i..([Math]::Min($i + $BatchSize - 1, $Records.Count - 1))]
-            $IsFirst = ($i -eq 0)
-            $IsLast  = ($i + $BatchSize -ge $Records.Count)
-            $Body    = @{ systemId = $SystemId; syncMode = $mode; scope = $Scope; records = ConvertTo-JsonArray $Chunk
-                          syncSession = if ($IsFirst) { 'start' } elseif ($IsLast) { 'end' } else { 'continue' } }
-            if ($SyncId) { $Body.syncId = $SyncId }
-            $R = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-            if ($IsFirst -and $R.syncId) { $SyncId = $R.syncId }
-            $TotIns += ($R.inserted ?? 0); $TotUpd += ($R.updated ?? 0); $TotDel += ($R.deleted ?? 0)
-        }
-        $Result = @{ inserted = $TotIns; updated = $TotUpd; deleted = $TotDel }
-    }
-    $swIngest.Stop()
-    Add-IngestStat -Endpoint $entity -Seconds $swIngest.Elapsed.TotalSeconds -Records $Records.Count
-    return $Result
-}
-
-# ── Streaming ingest ──────────────────────────────────────────────────────────
-# Flush records in BatchSize chunks within ONE sync session so a full-sync's scoped
-# delete still sees the complete set — without ever holding all records in memory.
-# Mirrors Send-IngestBatch's chunked-session protocol (start → continue → end), or a
-# single full-sync call when everything fits in one batch.
-function New-IngestStream {
-    param([Parameter(Mandatory)][string]$Endpoint, [int]$SystemId = 0, [hashtable]$Scope = @{}, [int]$BatchSize = 5000)
-    [pscustomobject]@{
-        Endpoint = $Endpoint; SystemId = $SystemId; Scope = $Scope; BatchSize = $BatchSize
-        Buffer = [System.Collections.Generic.List[object]]::new(); SyncId = $null; Started = $false
-        Records = 0; Inserted = 0; Updated = 0; Deleted = 0
-    }
-}
-function Send-IngestStreamChunk {
-    param($Stream, [string]$Session)   # 'start' | 'continue' | 'end' | 'single'
-    $entity = ($Stream.Endpoint -replace '^ingest/', '')
-    $mode   = Get-EntitySyncMode -Entity $entity
-    $count  = $Stream.Buffer.Count
-    $body   = @{ systemId = $Stream.SystemId; syncMode = $mode; scope = $Stream.Scope; records = ConvertTo-JsonArray @($Stream.Buffer) }
-    if ($Session -ne 'single') {
-        $body['syncSession'] = $Session
-        if ($Stream.SyncId) { $body['syncId'] = $Stream.SyncId }
-    }
-    $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    $R  = Invoke-IngestAPI -Endpoint $Stream.Endpoint -Body $body
-    $sw.Stop()
-    if ($Session -in @('start', 'single') -and $R.syncId) { $Stream.SyncId = $R.syncId }
-    $Stream.Inserted += ($R.inserted ?? 0); $Stream.Updated += ($R.updated ?? 0); $Stream.Deleted += ($R.deleted ?? 0)
-    Add-IngestStat -Endpoint $entity -Seconds $sw.Elapsed.TotalSeconds -Records $count
-    $Stream.Buffer.Clear()
-}
-function Add-IngestStreamRecord {
-    param($Stream, $Record)
-    $Stream.Buffer.Add($Record); $Stream.Records++
-    # Flush only once we hold MORE than a full batch, so a non-empty remainder is always
-    # left for the closing 'end' (the ingest API rejects an empty records array, and the
-    # scoped delete fires on 'end').
-    if ($Stream.Buffer.Count -gt $Stream.BatchSize) {
-        $remainder = [System.Collections.Generic.List[object]]::new()
-        for ($i = $Stream.BatchSize; $i -lt $Stream.Buffer.Count; $i++) { $remainder.Add($Stream.Buffer[$i]) }
-        while ($Stream.Buffer.Count -gt $Stream.BatchSize) { $Stream.Buffer.RemoveAt($Stream.Buffer.Count - 1) }
-        Send-IngestStreamChunk -Stream $Stream -Session ($(if ($Stream.Started) { 'continue' } else { 'start' }))
-        $Stream.Started = $true
-        $Stream.Buffer = $remainder
-    }
-}
-function Complete-IngestStream {
-    param($Stream)
-    if ($Stream.Records -eq 0) { return }   # nothing → no scoped delete (matches Send-IngestBatch empty-skip)
-    Send-IngestStreamChunk -Stream $Stream -Session ($(if ($Stream.Started) { 'end' } else { 'single' }))
-}
-
-function Write-Step { param([string]$Msg) Write-Host "  → $Msg" -ForegroundColor DarkGray }
 
 $Script:phaseErrors = [System.Collections.Generic.List[string]]::new()
-function Add-PhaseError { param([string]$Phase, [string]$Msg)
-    Write-Host "  $Phase failed: $Msg" -ForegroundColor Red
-    $Script:phaseErrors.Add("${Phase}: $Msg")
-}
 
 # ── Lightweight performance instrumentation (behaviour-neutral) ──────────────
 # Master wall-clock, per-ingest-endpoint latency, and midPoint read timings, so a
@@ -199,39 +97,6 @@ function Add-PhaseError { param([string]$Phase, [string]$Msg)
 $Script:swMaster    = [System.Diagnostics.Stopwatch]::StartNew()
 $Script:ingestStats = [ordered]@{}   # endpoint → @{ seconds; calls; records }
 $Script:fetchStats  = [ordered]@{}   # read label → @{ seconds; count }
-function Add-IngestStat { param([string]$Endpoint, [double]$Seconds, [int]$Records)
-    if (-not $Script:ingestStats.Contains($Endpoint)) { $Script:ingestStats[$Endpoint] = @{ seconds = 0.0; calls = 0; records = 0 } }
-    $Script:ingestStats[$Endpoint].seconds += $Seconds
-    $Script:ingestStats[$Endpoint].calls++
-    $Script:ingestStats[$Endpoint].records += $Records
-}
-function Measure-MidpointFetch { param([string]$Label, [scriptblock]$Script)
-    $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    $result = & $Script
-    $sw.Stop()
-    $n = @($result).Count
-    $Script:fetchStats[$Label] = @{ seconds = $sw.Elapsed.TotalSeconds; count = $n }
-    return $result
-}
-
-# Build a human-readable label for a shadow account. Some connectors (e.g. DatabaseTable)
-# name shadows by a numeric key; prefer a readable attribute, then the owner's name +
-# resource, and only fall back to the raw (possibly numeric) shadow name as a last resort.
-function Get-MidpointShadowLabel {
-    param($Shadow, [string]$ShadowOid, [string]$ResourceOid)
-    $readable = Get-MidpointAttrValue -Shadow $Shadow -Keys @('fullName', 'cn', 'displayName', 'sAMAccountName', 'login', 'name')
-    if (-not $readable) { $readable = Format-AccountLabel (Get-MidpointString $Shadow.name '') }
-    else { $readable = Format-AccountLabel $readable }
-    if ($readable -and $readable -match '[A-Za-z]') { return $readable }
-    if ($ShadowOidToUserOid.ContainsKey($ShadowOid)) {
-        $ownerOid = $ShadowOidToUserOid[$ShadowOid]
-        if ($UserOidToName.ContainsKey($ownerOid)) {
-            $rn = if ($ResourceOidToName.ContainsKey($ResourceOid)) { $ResourceOidToName[$ResourceOid] } else { 'account' }
-            return ($UserOidToName[$ownerOid] + ' (' + $rn + ')')
-        }
-    }
-    return (Get-MidpointString $Shadow.name $ShadowOid)
-}
 
 # ── Type-mapping configuration ───────────────────────────────────────────────
 # Lets an operator override how midPoint objects are classified into Identity Atlas types:


### PR DESCRIPTION
## What

Level-3 crawler refactor — **one of four, split per crawler** (the same mechanical change applied to csv, omada, midpoint, and entra-id, each as its own PR).

Extracts the functions out of `Start-MidpointCrawler.ps1`'s top-level body into a sibling **`MidpointCrawler.Functions.ps1`**, dot-sourced into the entry point's own scope. No behavior change.

## Why

Those functions were trapped inside the script's top-level execution body (which runs a live crawl on load), so they couldn't be unit-tested. Moving them to a loadable library makes them testable without running a crawl — the path to raising PowerShell coverage past the ceiling the monolithic crawlers imposed.

## Safety

The Main execution body is **byte-for-byte unchanged** (verified via `git diff`: only function definitions removed + one dot-source line added). Functions are moved verbatim and read their script-scope vars at call time exactly as before, so runtime behavior is identical.

## Verification

AST-parsed clean; functions load; full `test/unit` Pester suite green (0 failures) under `$ErrorActionPreference='Stop'`. New tests cover `MidpointCrawler.Functions.ps1` to **100%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)