### PR TITLE
fix(llm): provider call timeouts + body caps; stop leaking provider errors (audit M-1/M-2)

### DIFF
--- a/app/api/src/llm/providers.js
+++ b/app/api/src/llm/providers.js
@@ -46,6 +46,59 @@ const DEFAULT_MODELS = {
   'azure-openai': null, // must be supplied by config (the deployment name)
 };
 
+// ─── Shared fetch hardening (M-1) ───────────────────────────────────
+// Every outbound provider call goes through llmFetch so a hung or runaway
+// provider can't tie up a request indefinitely or exhaust memory:
+//   - An AbortController timeout bounds the whole call — connect AND body read,
+//     so a slow-drip body is caught too, not just stalled headers.
+//   - The body is read with a hard byte cap, so a malicious/buggy provider
+//     can't stream an unbounded response into memory.
+// Returns { ok, status, bodyText } so each adapter keeps its own status/JSON
+// handling (callers JSON.parse bodyText on success, slice it for error text).
+const LLM_TIMEOUT_MS = Number(process.env.LLM_TIMEOUT_MS) || 120_000;
+const LLM_MAX_RESPONSE_BYTES = 16 * 1024 * 1024; // 16 MB — far above any real chat / model-list payload
+
+async function readCappedBody(resp, maxBytes) {
+  // Fast reject if the server advertises an over-cap body.
+  const declared = Number(resp.headers?.get?.('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(`LLM response too large (${declared} bytes > ${maxBytes}-byte cap)`);
+  }
+  const reader = resp.body?.getReader?.();
+  if (!reader) return resp.text(); // no readable stream; platform already bounded it
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) throw new Error(`LLM response exceeded ${maxBytes}-byte cap`);
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+export async function llmFetch(url, options = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, { ...options, signal: controller.signal });
+    const bodyText = await readCappedBody(resp, LLM_MAX_RESPONSE_BYTES);
+    return { ok: resp.ok, status: resp.status, bodyText };
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      throw new Error(`LLM request timed out after ${Math.round(LLM_TIMEOUT_MS / 1000)}s`);
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // ─── Anthropic ──────────────────────────────────────────────────────
 async function chatAnthropic({ apiKey, model, system, messages, temperature, maxTokens }) {
   const url = 'https://api.anthropic.com/v1/messages';
@@ -56,7 +109,7 @@ async function chatAnthropic({ apiKey, model, system, messages, temperature, max
     system,
     messages: messages.map(m => ({ role: m.role, content: m.content })),
   };
-  const r = await fetch(url, {
+  const { ok, status, bodyText } = await llmFetch(url, {
     method: 'POST',
     headers: {
       'x-api-key': apiKey,
@@ -65,11 +118,8 @@ async function chatAnthropic({ apiKey, model, system, messages, temperature, max
     },
     body: JSON.stringify(body),
   });
-  if (!r.ok) {
-    const errBody = await r.text().catch(() => '');
-    throw new Error(`Anthropic API error ${r.status}: ${errBody.slice(0, 500)}`);
-  }
-  const json = await r.json();
+  if (!ok) throw new Error(`Anthropic API error ${status}: ${bodyText.slice(0, 500)}`);
+  const json = JSON.parse(bodyText);
   const text = (json.content || [])
     .filter(c => c.type === 'text')
     .map(c => c.text)
@@ -97,7 +147,7 @@ async function chatOpenAI({ apiKey, model, system, messages, temperature, maxTok
     temperature: temperature ?? DEFAULT_TEMPERATURE,
     messages: fullMessages,
   };
-  const r = await fetch(url, {
+  const { ok, status, bodyText } = await llmFetch(url, {
     method: 'POST',
     headers: {
       'authorization': `Bearer ${apiKey}`,
@@ -105,11 +155,8 @@ async function chatOpenAI({ apiKey, model, system, messages, temperature, maxTok
     },
     body: JSON.stringify(body),
   });
-  if (!r.ok) {
-    const errBody = await r.text().catch(() => '');
-    throw new Error(`OpenAI API error ${r.status}: ${errBody.slice(0, 500)}`);
-  }
-  const json = await r.json();
+  if (!ok) throw new Error(`OpenAI API error ${status}: ${bodyText.slice(0, 500)}`);
+  const json = JSON.parse(bodyText);
   return {
     text: json.choices?.[0]?.message?.content || '',
     model: json.model || body.model,
@@ -139,7 +186,7 @@ async function chatAzureOpenAI({ apiKey, model, system, messages, temperature, m
     temperature: temperature ?? DEFAULT_TEMPERATURE,
     messages: fullMessages,
   };
-  const r = await fetch(requestUrl.href, {
+  const { ok, status, bodyText } = await llmFetch(requestUrl.href, {
     method: 'POST',
     headers: {
       'api-key': apiKey,
@@ -147,11 +194,8 @@ async function chatAzureOpenAI({ apiKey, model, system, messages, temperature, m
     },
     body: JSON.stringify(body),
   });
-  if (!r.ok) {
-    const errBody = await r.text().catch(() => '');
-    throw new Error(`Azure OpenAI error ${r.status}: ${errBody.slice(0, 500)}`);
-  }
-  const json = await r.json();
+  if (!ok) throw new Error(`Azure OpenAI error ${status}: ${bodyText.slice(0, 500)}`);
+  const json = JSON.parse(bodyText);
   return {
     text: json.choices?.[0]?.message?.content || '',
     model: json.model || dep,
@@ -251,14 +295,11 @@ function anthropicSpeedHint(id) {
 }
 
 async function listModelsAnthropic({ apiKey }) {
-  const r = await fetch('https://api.anthropic.com/v1/models', {
+  const { ok, status, bodyText } = await llmFetch('https://api.anthropic.com/v1/models', {
     headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
   });
-  if (!r.ok) {
-    const err = await r.text().catch(() => '');
-    throw new Error(`Anthropic models API error ${r.status}: ${err.slice(0, 300)}`);
-  }
-  const json = await r.json();
+  if (!ok) throw new Error(`Anthropic models API error ${status}: ${bodyText.slice(0, 300)}`);
+  const json = JSON.parse(bodyText);
   const models = (json.data || [])
     .filter(m => m.id)
     .map(m => {
@@ -309,14 +350,11 @@ function openAISpeedHint(id) {
 }
 
 async function listModelsOpenAI({ apiKey }) {
-  const r = await fetch('https://api.openai.com/v1/models', {
+  const { ok, status, bodyText } = await llmFetch('https://api.openai.com/v1/models', {
     headers: { 'authorization': `Bearer ${apiKey}` },
   });
-  if (!r.ok) {
-    const err = await r.text().catch(() => '');
-    throw new Error(`OpenAI models API error ${r.status}: ${err.slice(0, 300)}`);
-  }
-  const json = await r.json();
+  if (!ok) throw new Error(`OpenAI models API error ${status}: ${bodyText.slice(0, 300)}`);
+  const json = JSON.parse(bodyText);
   // Filter to chat-capable models
   const models = (json.data || [])
     .filter(m => m.id && /^(gpt-|o[1-9])/i.test(m.id))
@@ -333,12 +371,9 @@ async function listModelsAzureOpenAI({ apiKey, endpoint, apiVersion }) {
   const ver = apiVersion || '2024-08-01-preview';
   const requestUrl = new URL('/openai/deployments', baseUrl.origin);
   requestUrl.searchParams.set('api-version', ver);
-  const r = await fetch(requestUrl.href, { headers: { 'api-key': apiKey } });
-  if (!r.ok) {
-    const err = await r.text().catch(() => '');
-    throw new Error(`Azure OpenAI deployments API error ${r.status}: ${err.slice(0, 300)}`);
-  }
-  const json = await r.json();
+  const { ok, status, bodyText } = await llmFetch(requestUrl.href, { headers: { 'api-key': apiKey } });
+  if (!ok) throw new Error(`Azure OpenAI deployments API error ${status}: ${bodyText.slice(0, 300)}`);
+  const json = JSON.parse(bodyText);
   // Azure returns deployments — each `id` is the deployment name to use as `model`
   const models = (json.data || [])
     .filter(d => d.id)

--- a/app/api/src/llm/providers.test.js
+++ b/app/api/src/llm/providers.test.js
@@ -5,7 +5,7 @@
 // calls are intentionally avoided so the test suite stays fast and runs offline.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { chat, SUPPORTED_PROVIDERS, DEFAULT_MODELS } from './providers.js';
+import { chat, llmFetch, SUPPORTED_PROVIDERS, DEFAULT_MODELS } from './providers.js';
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -114,6 +114,40 @@ describe('chat: azure-openai', () => {
     await expect(
       chat({ provider: 'azure-openai', apiKey: 'k', endpoint: 'https://myresource.openai.azure.com' }, { system: '', messages: [{ role: 'user', content: 'hi' }] })
     ).rejects.toThrow(/deployment is required/);
+  });
+});
+
+// M-1 — every outbound provider call goes through llmFetch, which bounds the
+// call with an AbortController timeout and caps the response body size.
+describe('llmFetch hardening (M-1)', () => {
+  it('passes an AbortSignal so the call is time-bounded, and returns {ok,status,bodyText}', async () => {
+    let sawSignal = false;
+    global.fetch = vi.fn(async (_url, opts) => {
+      sawSignal = opts.signal instanceof AbortSignal;
+      return { ok: true, status: 200, headers: { get: () => null }, text: async () => '{"x":1}' };
+    });
+    const r = await llmFetch('https://api.example/v1');
+    expect(sawSignal).toBe(true);
+    expect(r).toEqual({ ok: true, status: 200, bodyText: '{"x":1}' });
+  });
+
+  it('maps an AbortError (timeout) to a clear "timed out" error, not the raw abort', async () => {
+    global.fetch = vi.fn(async () => {
+      const e = new Error('The operation was aborted');
+      e.name = 'AbortError';
+      throw e;
+    });
+    await expect(llmFetch('https://api.example/v1')).rejects.toThrow(/timed out/i);
+  });
+
+  it('rejects a response whose Content-Length exceeds the cap (no unbounded read)', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: (k) => (k === 'content-length' ? String(64 * 1024 * 1024) : null) },
+      text: async () => 'should-not-be-read',
+    }));
+    await expect(llmFetch('https://api.example/v1')).rejects.toThrow(/too large/i);
   });
 });
 

--- a/app/api/src/llm/service.js
+++ b/app/api/src/llm/service.js
@@ -92,6 +92,18 @@ export async function chatWithSavedConfig(args) {
   return chat(cfg, args);
 }
 
+// Strip the raw upstream response body out of a provider error before it reaches
+// the client (M-2 — info leak). Provider adapters throw
+// "<Provider> API error <status>: <body>"; we keep the actionable
+// "<Provider> API error <status>" and drop the body. Our own messages (timeout,
+// "no config") carry no upstream body and pass through unchanged. Callers log the
+// full detail server-side.
+function clientSafeLlmError(err) {
+  const msg = String(err?.message || 'LLM request failed');
+  const m = msg.match(/^(.*?\berror \d{3})\b/);
+  return m ? m[1] : msg;
+}
+
 // Test the configuration with a tiny request. Used by the "Test" button in the
 // admin UI. Returns { ok: true, model, latencyMs } or { ok: false, error }.
 export async function testLLMConfig({ provider, model, endpoint, deployment, apiVersion, apiKey }) {
@@ -113,7 +125,8 @@ export async function testLLMConfig({ provider, model, endpoint, deployment, api
     });
     return { ok: true, model: r.model, latencyMs: Date.now() - start, sample: r.text.slice(0, 80) };
   } catch (err) {
-    return { ok: false, error: err.message };
+    console.error('LLM test failed:', err.message);
+    return { ok: false, error: clientSafeLlmError(err) };
   }
 }
 
@@ -144,7 +157,8 @@ export async function listModelsForConfig({ provider, apiKey, endpoint, apiVersi
     });
     return { ok: true, models: r.models };
   } catch (err) {
-    return { ok: false, error: err.message };
+    console.error('LLM model list failed:', err.message);
+    return { ok: false, error: clientSafeLlmError(err) };
   }
 }
 

--- a/app/api/src/llm/service.test.js
+++ b/app/api/src/llm/service.test.js
@@ -1,0 +1,49 @@
+// Unit tests for the LLM service layer — focused on M-2 (don't leak upstream
+// provider error bodies to the client). db, vault, and the provider dispatcher
+// are mocked so these run offline.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockChat, mockListModels } = vi.hoisted(() => ({ mockChat: vi.fn(), mockListModels: vi.fn() }));
+
+vi.mock('../db/connection.js', () => ({ query: vi.fn(), queryOne: vi.fn() }));
+vi.mock('../secrets/vault.js', () => ({
+  putSecret: vi.fn(), getSecret: vi.fn(), hasSecret: vi.fn(), deleteSecret: vi.fn(),
+}));
+vi.mock('./providers.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, chat: mockChat, listModels: mockListModels };
+});
+
+const { testLLMConfig } = await import('./service.js');
+
+beforeEach(() => {
+  mockChat.mockReset();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('testLLMConfig — client-safe errors (M-2)', () => {
+  it('strips the raw upstream body from a provider error, keeping provider + status', async () => {
+    mockChat.mockRejectedValueOnce(
+      new Error('Anthropic API error 401: {"error":{"message":"invalid x-api-key sk-leakedsecret"}}')
+    );
+    const r = await testLLMConfig({ provider: 'anthropic', apiKey: 'k' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('Anthropic API error 401');
+    expect(r.error).not.toMatch(/sk-leakedsecret|invalid x-api-key/);
+  });
+
+  it('passes our own (non-upstream) error messages through unchanged', async () => {
+    mockChat.mockRejectedValueOnce(new Error('LLM request timed out after 120s'));
+    const r = await testLLMConfig({ provider: 'openai', apiKey: 'k' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('LLM request timed out after 120s');
+  });
+
+  it('returns ok:true with the model on success', async () => {
+    mockChat.mockResolvedValueOnce({ text: 'OK', model: 'claude-x', usage: null });
+    const r = await testLLMConfig({ provider: 'anthropic', apiKey: 'k' });
+    expect(r.ok).toBe(true);
+    expect(r.model).toBe('claude-x');
+  });
+});

--- a/app/api/src/routes/llm.js
+++ b/app/api/src/routes/llm.js
@@ -61,7 +61,7 @@ router.put('/admin/llm/config', gate, async (req, res) => {
     res.json({ ok: true, config: saved });
   } catch (err) {
     console.error('PUT /admin/llm/config failed:', err.message);
-    res.status(500).json({ error: err.message || 'Failed to save LLM config' });
+    res.status(500).json({ error: 'Failed to save LLM config' });
   }
 });
 
@@ -105,7 +105,7 @@ router.post('/admin/llm/test', gate, async (req, res) => {
     res.json(result);
   } catch (err) {
     console.error('POST /admin/llm/test failed:', err.message);
-    res.status(500).json({ ok: false, error: err.message });
+    res.status(500).json({ ok: false, error: 'LLM test failed' });
   }
 });
 
@@ -126,7 +126,7 @@ router.post('/admin/llm/models', gate, async (req, res) => {
     res.json(result);
   } catch (err) {
     console.error('POST /admin/llm/models failed:', err.message);
-    res.status(500).json({ ok: false, error: err.message });
+    res.status(500).json({ ok: false, error: 'Failed to list models' });
   }
 });
 
@@ -137,7 +137,8 @@ router.get('/admin/llm/status', gate, async (_req, res) => {
     const configured = await isLLMConfigured();
     res.json({ configured });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    console.error('GET /admin/llm/status failed:', err.message);
+    res.status(500).json({ error: 'Failed to check LLM status' });
   }
 });
 

--- a/app/api/src/routes/riskProfiles.js
+++ b/app/api/src/routes/riskProfiles.js
@@ -83,7 +83,7 @@ router.post('/risk-profiles/scrape', gate, async (req, res) => {
     res.json({ results: summary, count: summary.length });
   } catch (err) {
     console.error('scrape failed:', err.message);
-    res.status(500).json({ error: 'Scrape failed', message: err.message });
+    res.status(500).json({ error: 'Scrape failed' });
   }
 });
 
@@ -152,7 +152,7 @@ router.post('/risk-profiles/generate', gate, async (req, res) => {
     });
   } catch (err) {
     console.error('profile generate failed:', err.message);
-    res.status(500).json({ error: 'Profile generation failed', message: err.message });
+    res.status(500).json({ error: 'Profile generation failed' });
   }
 });
 
@@ -208,7 +208,7 @@ router.post('/risk-profiles/refine', gate, async (req, res) => {
     });
   } catch (err) {
     console.error('profile refine failed:', err.message);
-    res.status(500).json({ error: 'Profile refinement failed', message: err.message });
+    res.status(500).json({ error: 'Profile refinement failed' });
   }
 });
 
@@ -255,7 +255,7 @@ router.post('/risk-profiles', gate, async (req, res) => {
     res.status(201).json({ id: ins.id, version: ins.version, createdAt: ins.createdAt, isActive: !!makeActive });
   } catch (err) {
     console.error('profile save failed:', err.message);
-    res.status(500).json({ error: 'Save failed', message: err.message });
+    res.status(500).json({ error: 'Save failed' });
   }
 });
 
@@ -400,7 +400,7 @@ router.post('/risk-classifiers/generate', gate, async (req, res) => {
     res.json({ classifiers: parsed, llmModel: llmResp.model, usage: llmResp.usage });
   } catch (err) {
     console.error('classifier generate failed:', err.message);
-    res.status(500).json({ error: 'Generation failed', message: err.message });
+    res.status(500).json({ error: 'Generation failed' });
   }
 });
 
@@ -436,7 +436,7 @@ router.post('/risk-classifiers', gate, async (req, res) => {
     res.status(201).json({ id: ins.id, version: ins.version, createdAt: ins.createdAt });
   } catch (err) {
     console.error('classifier save failed:', err.message);
-    res.status(500).json({ error: 'Save failed', message: err.message });
+    res.status(500).json({ error: 'Save failed' });
   }
 });
 

--- a/changes/m1-m2-llm-hardening.md
+++ b/changes/m1-m2-llm-hardening.md
@@ -1,0 +1,2 @@
+- Outbound AI/LLM provider calls now have a request timeout and a response-size cap, so a hung or runaway provider can no longer hold a request open indefinitely or exhaust server memory.
+- LLM and risk-profile endpoints no longer return raw upstream provider error details to the browser — failures now show a generic message (the full detail is logged server-side). The Admin → LLM Settings "Test" button still reports the provider and HTTP status so a bad key/endpoint is diagnosable, without echoing the raw provider response.


### PR DESCRIPTION
Two Medium findings from the June maintenance audit (`docs/security/maintenance-audit-2026-06.md`), both in the LLM layer — Tier-1 slice #7.

## M-1 — Availability: no timeout / size cap on outbound LLM calls
Every provider fetch (chat + model discovery × anthropic / openai / azure-openai — 6 call sites) used bare `fetch` with no `AbortSignal` and no response-size limit. A hung or runaway provider could hold a request open indefinitely or stream an unbounded body into memory.

**Fix:** a shared `llmFetch(url, opts)` helper that all 6 sites route through:
- `AbortController` timeout (`LLM_TIMEOUT_MS`, default 120s, env-overridable) bounding the **whole** call — connect *and* body read, so a slow-drip body is caught too.
- Hard byte cap on the response (`content-length` fast-reject + capped streaming read), so a malicious/buggy provider can't exhaust memory.
- Returns `{ ok, status, bodyText }`; each adapter keeps its own status/JSON handling.

## M-2 — Info leak: upstream provider error bodies returned to the client
`routes/llm.js`, `routes/riskProfiles.js`, and the `service.js` test/model helpers returned raw `err.message` (which embeds the upstream provider response body) to the browser — A09, and a violation of the project's own "generic messages to clients" rule.

**Fix:**
- Unexpected 500s and the generate / refine / scrape / save paths → generic message to the client, full detail `console.error`'d server-side.
- The admin **test** / **models** diagnostics stay useful but safe: a small sanitizer keeps the actionable `"<Provider> API error <status>"` and **drops the raw upstream body** (our own messages — timeout, "no config" — pass through unchanged).

## Tests
- `providers.test.js` — `llmFetch` wires an `AbortSignal`, maps `AbortError` → a clear "timed out" error, and rejects an over-cap `Content-Length`.
- `service.test.js` (new) — `testLLMConfig` strips the upstream body (incl. a planted fake secret) while keeping provider+status, and passes our own messages through.
- Full API unit suite green locally (1446 pass; the one failure is the pre-existing Linux-only `/etc/passwd` path-traversal test that can't pass on a Windows checkout).

Remaining LLM-layer audit items after this: M-3 (SSRF residual on the Azure redirect path), M-5/M-6 (prompt-injection delimiting + classifier-regex validation) — defense-in-depth, separate slices.