### PR TITLE
fix(api): cap crawler file uploads — per-file, count, aggregate (audit M-4)

### DIFF
--- a/app/api/src/routes/crawlerFiles.caps.test.js
+++ b/app/api/src/routes/crawlerFiles.caps.test.js
@@ -1,0 +1,88 @@
+/**
+ * Upload-cap tests for the crawler file-upload route (M-4).
+ *
+ * The caps are read from env at module-load time, so we set deliberately tiny
+ * values BEFORE importing the router (same technique as crawlerFiles.uploads.test.js
+ * for UPLOAD_ROOT): aggregate 10 KB, per-file 50 B, max 3 files. That lets one
+ * module-load exercise all three limits.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const UPLOAD_ROOT_DIR = mkdtempSync(join(tmpdir(), 'iatest-caps-'));
+process.env.UPLOAD_ROOT = UPLOAD_ROOT_DIR;
+process.env.UPLOAD_MAX_TOTAL_BYTES = '10000'; // 10 KB aggregate
+process.env.UPLOAD_MAX_FILE_BYTES = '50';     // 50 B per file
+process.env.UPLOAD_MAX_FILES = '3';
+
+const { mockPool, mockDbQuery } = vi.hoisted(() => {
+  const mockDbQuery = vi.fn();
+  const mockRequest = { input: vi.fn().mockReturnThis(), query: mockDbQuery };
+  const mockPool = { request: vi.fn(() => mockRequest) };
+  return { mockPool, mockDbQuery };
+});
+
+vi.mock('../db/connection.js', () => ({ getPool: async () => mockPool }));
+vi.mock('../middleware/auth.js', () => ({
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
+const { default: crawlerFilesRouter } = await import('./crawlerFiles.js');
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', crawlerFilesRouter);
+  return app;
+}
+
+// Every request first does the config lookup in assertUploadableConfig.
+beforeEach(() => {
+  mockDbQuery.mockReset();
+  mockDbQuery.mockResolvedValue({ recordset: [{ crawlerType: 'csv' }] });
+});
+
+afterAll(() => {
+  rmSync(UPLOAD_ROOT_DIR, { recursive: true, force: true });
+});
+
+describe('crawler upload caps (M-4)', () => {
+  it('accepts a small file within every cap', async () => {
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/601/files')
+      .attach('files', Buffer.from('a;b\n1;2'), 'small.csv'); // 7 B < 50 B
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+  });
+
+  it('rejects a file over the per-file byte cap (413)', async () => {
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/601/files')
+      .attach('files', Buffer.alloc(200, 'a'), 'big.csv'); // 200 B > 50 B, but < 10 KB aggregate
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/per-file/i);
+  });
+
+  it('rejects a request over the aggregate cap before touching disk (413)', async () => {
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/601/files')
+      .attach('files', Buffer.alloc(20000, 'a'), 'huge.csv'); // 20 KB > 10 KB aggregate
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/too large/i);
+  });
+
+  it('rejects more files than the count cap (413)', async () => {
+    const res = await request(makeApp())
+      .post('/api/admin/crawler-configs/601/files')
+      .attach('files', Buffer.from('x'), 'a.csv')
+      .attach('files', Buffer.from('x'), 'b.csv')
+      .attach('files', Buffer.from('x'), 'c.csv')
+      .attach('files', Buffer.from('x'), 'd.csv'); // 4 > 3
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/too many/i);
+  });
+});

--- a/app/api/src/routes/crawlerFiles.js
+++ b/app/api/src/routes/crawlerFiles.js
@@ -23,6 +23,14 @@ const gate = requirePermission('admin.csv-import');
 
 const UPLOAD_ROOT = process.env.UPLOAD_ROOT || '/data/uploads';
 
+// Upload bounds (M-4) — previously 1 GB/file × 50 files = ~50 GB/request to a
+// shared Docker volume, with no aggregate cap. Per-file size + file count are
+// enforced by multer; the aggregate request cap is checked from Content-Length
+// before multer streams anything to disk. All env-overridable for large tenants.
+const MAX_FILE_BYTES  = Number(process.env.UPLOAD_MAX_FILE_BYTES)  || 250 * 1024 * 1024;  // 250 MB / file
+const MAX_FILES       = Number(process.env.UPLOAD_MAX_FILES)       || 20;
+const MAX_TOTAL_BYTES = Number(process.env.UPLOAD_MAX_TOTAL_BYTES) || 1024 * 1024 * 1024; // 1 GB / request
+
 function configFolder(crawlerType, configId) {
   return join(UPLOAD_ROOT, `${crawlerType}-${configId}`);
 }
@@ -96,8 +104,8 @@ const storage = multer.diskStorage({
 const upload = multer({
   storage,
   limits: {
-    fileSize: 1024 * 1024 * 1024, // 1 GB per file
-    files: 50,
+    fileSize: MAX_FILE_BYTES,
+    files: MAX_FILES,
   },
   fileFilter: (req, file, cb) => {
     // Allowed extensions come from the crawler's own manifest. Block anything
@@ -143,12 +151,20 @@ router.post(
     if (configId === null) return;
     const crawlerType = await assertUploadableConfig(configId, res);
     if (!crawlerType) return;
+    // Aggregate request-size cap (M-4) — reject an oversized upload from the
+    // declared Content-Length before multer streams anything to the shared volume.
+    const declaredBytes = Number(req.headers['content-length']);
+    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_TOTAL_BYTES) {
+      return res.status(413).json({ error: `Upload too large — maximum ${Math.round(MAX_TOTAL_BYTES / 1024 / 1024)} MB per request` });
+    }
     req._crawlerType = crawlerType;
     next();
   },
   (req, res) => {
-    upload.array('files', 50)(req, res, (err) => {
+    upload.array('files', MAX_FILES)(req, res, (err) => {
       if (err) {
+        if (err.code === 'LIMIT_FILE_SIZE')  return res.status(413).json({ error: `File exceeds the ${Math.round(MAX_FILE_BYTES / 1024 / 1024)} MB per-file limit` });
+        if (err.code === 'LIMIT_FILE_COUNT') return res.status(413).json({ error: `Too many files — maximum ${MAX_FILES} per request` });
         return res.status(400).json({ error: err.message });
       }
       const uploaded = (req.files || []).map(f => ({ name: f.filename, sizeBytes: f.size }));

--- a/changes/m4-upload-caps.md
+++ b/changes/m4-upload-caps.md
@@ -1,0 +1,1 @@
+- Crawler file uploads now enforce sensible size limits — 250 MB per file, 20 files per request, and a 1 GB total per request — instead of allowing up to ~50 GB to be written to the shared storage volume in a single request. An over-limit upload is rejected up front with a clear message. The limits are configurable via environment variables for large tenants.


### PR DESCRIPTION
Medium finding **M-4** from the June maintenance audit (`docs/security/maintenance-audit-2026-06.md`).

## Problem
The crawler file-upload endpoint (`routes/crawlerFiles.js`) allowed **1 GB/file × 50 files = ~50 GB per request** to be written to the shared Docker volume (`job_data`), with no aggregate cap. Admin-only, but still a trivial way to fill the shared volume and impact both the web and worker containers.

## Fix
- **Per-file:** 1 GB → **250 MB** (`fileSize`).
- **File count:** 50 → **20** (`files`).
- **Aggregate request cap (new):** **1 GB** total, checked from `Content-Length` in the route guard *before* multer streams anything to disk.
- Over-limit uploads now return **413** with a clear message (per-file / too-many / too-large) instead of a generic 400.
- All three bounds are env-overridable for large tenants: `UPLOAD_MAX_FILE_BYTES`, `UPLOAD_MAX_FILES`, `UPLOAD_MAX_TOTAL_BYTES`.

## Tests
`crawlerFiles.caps.test.js` (new) sets tiny caps via env before import and exercises all three limits (per-file, aggregate, count) plus a within-limits happy path. Existing upload-cycle tests still pass (the one failure in `crawlerFiles.uploads.test.js` is the pre-existing Linux-only `/etc/passwd` path-traversal assertion that can't pass on a Windows checkout).

## Deferred
The audit paired this with **L-8** (CSV parser loads the whole file into memory with no row cap → worker OOM). That lives in the CSV crawler (a different layer), so it's a separate follow-up rather than bundling it into this API-side change.