### PR TITLE
refactor(azure-rm): extract crawler helpers into a loadable library

### DIFF
--- a/changes/refactor-azure-rm-crawler.md
+++ b/changes/refactor-azure-rm-crawler.md
@@ -1,0 +1,1 @@
+- Extracted the Azure RM crawler's reusable scope/ingest helper functions into a separate loadable library so they can be unit-tested in isolation; the crawler's behaviour is unchanged.

--- a/test/unit/AzureRMCrawlerFunctions.Tests.ps1
+++ b/test/unit/AzureRMCrawlerFunctions.Tests.ps1
@@ -1,0 +1,187 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Pester unit tests for the Azure RM crawler helper functions.
+
+.DESCRIPTION
+    Tests the pure/standalone functions extracted into
+    tools/crawlers/azure-rm/AzureRMCrawler.Functions.ps1:
+        Get-ScopeNodeId, Send-IngestBatch, Write-PhaseTiming,
+        Get-ScopeTypeLabel, Get-AzureResourceType, Get-ResourceAttributes,
+        Get-ParentScopePath.
+
+    Get-ScopeNodeId calls Get-CapabilityId; Send-IngestBatch calls
+    Invoke-IngestAPI / ConvertTo-JsonArray — both shared helpers are
+    dot-sourced here exactly as they are into Start-AzureRMCrawler.ps1.
+    Only the Ingest API boundary (Invoke-IngestAPI) is mocked.
+
+.USAGE
+    Invoke-Pester -Path test/unit/AzureRMCrawlerFunctions.Tests.ps1 -Output Detailed
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    . (Join-Path $script:repoRoot 'tools' 'crawlers' 'shared' 'Get-CapabilityId.ps1')
+    . (Join-Path $script:repoRoot 'tools' 'crawlers' 'shared' 'Invoke-CrawlerIngest.ps1')
+    . (Join-Path $script:repoRoot 'tools' 'crawlers' 'azure-rm' 'AzureRMCrawler.Functions.ps1')
+}
+
+Describe 'Get-ScopeNodeId' {
+    It 'is deterministic for the same ARM path' {
+        $a = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/resourceGroups/rg1'
+        $b = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/resourceGroups/rg1'
+        $a | Should -Be $b
+    }
+
+    It 'is case-insensitive (same id regardless of ARM-path casing)' {
+        $lower = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/resourcegroups/foo'
+        $mixed = Get-ScopeNodeId -ArmScopePath '/subscriptions/ABC/resourceGroups/Foo'
+        $lower | Should -Be $mixed
+    }
+
+    It 'produces distinct ids for distinct paths' {
+        $a = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/resourceGroups/rg1'
+        $b = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/resourceGroups/rg2'
+        $a | Should -Not -Be $b
+    }
+
+    It 'does not collide for paths differing only by a reserved | / % character' {
+        # The percent-then-pipe encoding must keep the hash input injective.
+        $pipe    = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/providers/foo|bar'
+        $percent = Get-ScopeNodeId -ArmScopePath '/subscriptions/abc/providers/foo%7Cbar'
+        $pipe | Should -Not -Be $percent
+    }
+}
+
+Describe 'Send-IngestBatch' {
+    It 'posts an empty records array when there are no records' {
+        Mock Invoke-IngestAPI { @{ ok = $true } }
+        Send-IngestBatch -Endpoint 'ingest/resources' -SystemId 7 -SyncMode 'full' -Records @() | Out-Null
+        Should -Invoke Invoke-IngestAPI -Times 1 -ParameterFilter {
+            $Endpoint -eq 'ingest/resources' -and
+            $Body.systemId -eq 7 -and
+            $Body.syncMode -eq 'full' -and
+            $Body.records.Count -eq 0
+        }
+    }
+
+    It 'wraps non-empty records and forwards systemId / syncMode / scope' {
+        Mock Invoke-IngestAPI { @{ ok = $true } }
+        $records = @(@{ id = 'r1' }, @{ id = 'r2' })
+        Send-IngestBatch -Endpoint 'ingest/resources' -SystemId 3 -SyncMode 'delta' -Scope @{ resourceType = 'AzureScope' } -Records $records | Out-Null
+        Should -Invoke Invoke-IngestAPI -Times 1 -ParameterFilter {
+            $Endpoint -eq 'ingest/resources' -and
+            $Body.systemId -eq 3 -and
+            $Body.syncMode -eq 'delta' -and
+            $Body.scope.resourceType -eq 'AzureScope' -and
+            $null -ne $Body.records
+        }
+    }
+
+    It 'returns the Ingest API result' {
+        Mock Invoke-IngestAPI { @{ inserted = 2 } }
+        $r = Send-IngestBatch -Endpoint 'ingest/resources' -SystemId 1 -Records @(@{ id = 'x' })
+        $r.inserted | Should -Be 2
+    }
+}
+
+Describe 'Write-PhaseTiming' {
+    It 'reports the phase name and the delta of Azure calls since the phase start' {
+        Mock Write-Host { }
+        $Global:AzCallCount = 10
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $sw.Stop()
+        Write-PhaseTiming -Name 'role definitions' -Sw $sw -CallsBefore 4
+        Should -Invoke Write-Host -Times 1 -ParameterFilter {
+            $Object -like '*role definitions*' -and $Object -like '*6 Azure call(s)*'
+        }
+        $Global:AzCallCount = $null
+    }
+}
+
+Describe 'Get-ScopeTypeLabel' {
+    It 'maps each scope kind to its short label' {
+        Get-ScopeTypeLabel -ScopeKind 'ManagementGroup' | Should -Be 'MG'
+        Get-ScopeTypeLabel -ScopeKind 'Subscription'    | Should -Be 'Sub'
+        Get-ScopeTypeLabel -ScopeKind 'ResourceGroup'   | Should -Be 'RG'
+        Get-ScopeTypeLabel -ScopeKind 'Resource'        | Should -Be 'Res'
+    }
+
+    It 'returns an empty string for an unknown kind' {
+        Get-ScopeTypeLabel -ScopeKind 'Nope' | Should -Be ''
+    }
+}
+
+Describe 'Get-AzureResourceType' {
+    It 'parses provider namespace + type from a resource id' {
+        $path = '/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1'
+        Get-AzureResourceType -ArmPath $path | Should -Be 'Microsoft.Compute/virtualMachines'
+    }
+
+    It 'keeps only type segments for nested (sub-resource) types' {
+        $path = '/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa/blobServices/default'
+        Get-AzureResourceType -ArmPath $path | Should -Be 'Microsoft.Storage/storageAccounts/blobServices'
+    }
+
+    It 'returns an empty string when there is no provider segment' {
+        Get-AzureResourceType -ArmPath '/subscriptions/s/resourceGroups/rg' | Should -Be ''
+    }
+}
+
+Describe 'Get-ResourceAttributes' {
+    It 'lifts location, tags, and managed identity into extended attributes' {
+        $res = [pscustomobject]@{
+            location = 'westeurope'
+            tags     = [pscustomobject]@{ Prio = 'High'; Env = 'Prod' }
+            identity = [pscustomobject]@{ type = 'SystemAssigned'; principalId = 'mi-123' }
+        }
+        $ext = Get-ResourceAttributes -Resource $res
+        $ext['azureLocation']              | Should -Be 'westeurope'
+        $ext['tag.Prio']                   | Should -Be 'High'
+        $ext['tag.Env']                    | Should -Be 'Prod'
+        $ext['managedIdentity']            | Should -Be 'SystemAssigned'
+        $ext['managedIdentityPrincipalId'] | Should -Be 'mi-123'
+    }
+
+    It 'returns an empty hashtable for a bare resource' {
+        $ext = Get-ResourceAttributes -Resource ([pscustomobject]@{ name = 'x' })
+        $ext.Keys.Count | Should -Be 0
+    }
+
+    It 'ignores an identity of type None' {
+        $res = [pscustomobject]@{ identity = [pscustomobject]@{ type = 'None' } }
+        $ext = Get-ResourceAttributes -Resource $res
+        $ext.ContainsKey('managedIdentity') | Should -BeFalse
+    }
+
+    It 'omits the principalId attribute when the managed identity has none' {
+        $res = [pscustomobject]@{ identity = [pscustomobject]@{ type = 'UserAssigned' } }
+        $ext = Get-ResourceAttributes -Resource $res
+        $ext['managedIdentity'] | Should -Be 'UserAssigned'
+        $ext.ContainsKey('managedIdentityPrincipalId') | Should -BeFalse
+    }
+}
+
+Describe 'Get-ParentScopePath' {
+    It 'returns the resource group for a resource' {
+        $r = '/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1'
+        Get-ParentScopePath -ScopePath $r | Should -Be '/subscriptions/s/resourceGroups/rg'
+    }
+
+    It 'returns the subscription for a resource group' {
+        Get-ParentScopePath -ScopePath '/subscriptions/s/resourceGroups/rg' | Should -Be '/subscriptions/s'
+    }
+
+    It 'returns the subscription for a subscription-level provider resource' {
+        $r = '/subscriptions/s/providers/Microsoft.Authorization/policyAssignments/pa1'
+        Get-ParentScopePath -ScopePath $r | Should -Be '/subscriptions/s'
+    }
+
+    It 'returns $null for a bare subscription scope' {
+        Get-ParentScopePath -ScopePath '/subscriptions/s' | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for a management-group scope' {
+        Get-ParentScopePath -ScopePath '/providers/Microsoft.Management/managementGroups/mg1' | Should -BeNullOrEmpty
+    }
+}

--- a/tools/crawlers/azure-rm/AzureRMCrawler.Functions.ps1
+++ b/tools/crawlers/azure-rm/AzureRMCrawler.Functions.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Reusable Azure RM crawler helper functions, extracted from Start-AzureRMCrawler.ps1.
+
+.DESCRIPTION
+    These functions are dot-sourced into Start-AzureRMCrawler.ps1's own scope, which
+    is equivalent to defining them inline. The pure/standalone helpers were moved
+    here so they can be unit-tested in isolation with Pester
+    (see test/unit/AzureRMCrawlerFunctions.Tests.ps1). Function bodies are unchanged
+    from their original inline definitions.
+
+    The state-coupled Main helpers (Add-Scope, Add-ContainsEdge, Get-MgDisplayName,
+    Ensure-AssignmentScope) stay inline in Start-AzureRMCrawler.ps1 because they
+    mutate the crawler's scope-level accumulators ($ScopeResources, $ContainsEdges,
+    $ScopePaths, $KnownPaths, $mgNameCache).
+
+    Get-ScopeNodeId calls Get-CapabilityId from tools/crawlers/shared/Get-CapabilityId.ps1;
+    Send-IngestBatch calls Invoke-IngestAPI / ConvertTo-JsonArray from
+    tools/crawlers/shared/Invoke-CrawlerIngest.ps1 — dot-source those files too.
+#>
+
+# A scope's stable Identity Atlas node id = deterministic UUID of its ARM path.
+# ARM resource IDs can legitimately contain '|' (e.g. some Insights / alert resources), which
+# Get-CapabilityId reserves as its field separator. Percent-encode '%' then '|' so the id-hash
+# input stays injective (no two distinct ARM paths collide) and pipe-free. Only the hash input
+# is encoded — the raw armPath / externalId is stored unchanged. Subscription/RG/MG paths never
+# contain either character, so their ids are unaffected.
+function Get-ScopeNodeId {
+    [CmdletBinding()]
+    param([string]$ArmScopePath)
+    # Lower-case the path before hashing so the node id is stable regardless of casing. Azure Resource
+    # Graph lower-cases every id, and Azure itself is inconsistent about ARM-path casing (a role
+    # assignment's properties.scope may read ".../resourceGroups/Foo" while a resource id reads
+    # ".../resourcegroups/foo"). Canonicalising here means the same physical scope never splits into
+    # two nodes because of casing. Only the hash input is canonicalised; the raw armPath / externalId
+    # is still stored as received.
+    $safe = $ArmScopePath.ToLowerInvariant() -replace '%', '%25' -replace '\|', '%7C'
+    Get-CapabilityId -TargetNodeId $safe -CapabilityId 'azure-scope'
+}
+
+function Send-IngestBatch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [Parameter(Mandatory)] [int]$SystemId,
+        [string]$SyncMode = 'full',
+        [hashtable]$Scope = @{},
+        [array]$Records = @()
+    )
+    if (-not $Records -or $Records.Count -eq 0) {
+        return Invoke-IngestAPI -Endpoint $Endpoint -Body @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = @() }
+    }
+    $body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Records }
+    Invoke-IngestAPI -Endpoint $Endpoint -Body $body
+}
+
+# Per-phase wall-clock + round-trip report — the call counts make the cross-subscription savings of
+# the Resource Graph queries visible (a few paged queries instead of per-subscription fan-out).
+function Write-PhaseTiming {
+    [CmdletBinding()]
+    param([string]$Name, [System.Diagnostics.Stopwatch]$Sw, [int]$CallsBefore)
+    Write-Host ("  [timing] {0}: {1:n1}s, {2} Azure call(s)" -f $Name, $Sw.Elapsed.TotalSeconds, ($Global:AzCallCount - $CallsBefore)) -ForegroundColor DarkGray
+}
+
+# Short type label shown in capability names ("Owner @ RG: name") and stored on the scope node so
+# the effective-access engine labels synthesized inherited rows the same way.
+function Get-ScopeTypeLabel {
+    [CmdletBinding()]
+    param([string]$ScopeKind)
+    switch ($ScopeKind) {
+        'ManagementGroup' { 'MG' }
+        'Subscription'    { 'Sub' }
+        'ResourceGroup'   { 'RG' }
+        'Resource'        { 'Res' }
+        default { '' }
+    }
+}
+
+# The Azure resource type (provider namespace + type) parsed out of an ARM resource id, e.g.
+# /subscriptions/../resourceGroups/../providers/Microsoft.Compute/virtualMachines/vm1
+#   -> "Microsoft.Compute/virtualMachines". Lets the UI/matrix answer "who can touch any VM?".
+function Get-AzureResourceType {
+    [CmdletBinding()]
+    param([string]$ArmPath)
+    if ($ArmPath -match '/providers/(.+)$') {
+        $segs = $matches[1] -split '/'              # ns / type / name [ / subtype / subname ... ]
+        $parts = @($segs[0])
+        for ($i = 1; $i -lt $segs.Count; $i += 2) { $parts += $segs[$i] }   # type segments only
+        return ($parts -join '/')
+    }
+    return ''
+}
+
+# Governance/filtering attributes lifted off a resource object (from the Resource Graph resources query):
+#   azureLocation              – region, e.g. "westeurope"  -> "access to any resource in West Europe"
+#   tag.<Key>                  – each portal tag as its own key -> "access to anything tagged Prio High"
+#   managedIdentity            – identity type (SystemAssigned/UserAssigned) when the resource has one
+#                                -> the "resources that have a managed identity" context
+#   managedIdentityPrincipalId – the system-assigned identity's principal id, soft-linking the resource
+#                                to its managed-identity principal (no model change; attribute only)
+# Everything here is generic extendedAttributes the context plugins group by — no new core needed.
+function Get-ResourceAttributes {
+    [CmdletBinding()]
+    param($Resource)
+    $ext = @{}
+    if ($Resource.location) { $ext['azureLocation'] = [string]$Resource.location }
+    if ($Resource.tags) {
+        foreach ($p in $Resource.tags.PSObject.Properties) {
+            if ($p.Name) { $ext["tag.$($p.Name)"] = [string]$p.Value }
+        }
+    }
+    if ($Resource.identity -and $Resource.identity.type -and $Resource.identity.type -ne 'None') {
+        $ext['managedIdentity'] = [string]$Resource.identity.type
+        if ($Resource.identity.principalId) { $ext['managedIdentityPrincipalId'] = [string]$Resource.identity.principalId }
+    }
+    return $ext
+}
+
+# Parent of a sub-subscription scope: a resource → its resource group, a resource group → its
+# subscription, a subscription-level resource → its subscription. $null for subscription / management
+# group / tenant-root scopes (those are handled as "above the subscription").
+function Get-ParentScopePath {
+    [CmdletBinding()]
+    param([string]$ScopePath)
+    if ($ScopePath -match '^(/subscriptions/[^/]+/resourceGroups/[^/]+)/providers/') { return $matches[1] }
+    if ($ScopePath -match '^(/subscriptions/[^/]+)/resourceGroups/[^/]+$')           { return $matches[1] }
+    if ($ScopePath -match '^(/subscriptions/[^/]+)/providers/')                       { return $matches[1] }
+    return $null
+}

--- a/tools/crawlers/azure-rm/Start-AzureRMCrawler.ps1
+++ b/tools/crawlers/azure-rm/Start-AzureRMCrawler.ps1
@@ -40,6 +40,7 @@ $Global:AzCallCount = 0
 # ─── Shared helpers ──────────────────────────────────────────────
 . (Join-Path $PSScriptRoot '..' 'shared' 'Invoke-CrawlerIngest.ps1')
 . (Join-Path $PSScriptRoot '..' 'shared' 'Get-CapabilityId.ps1')
+. (Join-Path $PSScriptRoot 'AzureRMCrawler.Functions.ps1')
 # Get-AzureRMHelpers.ps1 (ARM auth + enumeration) and Get-AzureRGHelpers.ps1 (Resource Graph reads)
 # are dot-sourced automatically by the dispatcher (same-folder libraries).
 
@@ -48,45 +49,6 @@ $Global:AzCallCount = 0
 # role definitions and role assignments all come from Azure Resource Graph.
 $API_SUBS = '2022-12-01'
 $API_MG   = '2021-04-01'
-
-# A scope's stable Identity Atlas node id = deterministic UUID of its ARM path.
-# ARM resource IDs can legitimately contain '|' (e.g. some Insights / alert resources), which
-# Get-CapabilityId reserves as its field separator. Percent-encode '%' then '|' so the id-hash
-# input stays injective (no two distinct ARM paths collide) and pipe-free. Only the hash input
-# is encoded — the raw armPath / externalId is stored unchanged. Subscription/RG/MG paths never
-# contain either character, so their ids are unaffected.
-function Get-ScopeNodeId { param([string]$ArmScopePath)
-    # Lower-case the path before hashing so the node id is stable regardless of casing. Azure Resource
-    # Graph lower-cases every id, and Azure itself is inconsistent about ARM-path casing (a role
-    # assignment's properties.scope may read ".../resourceGroups/Foo" while a resource id reads
-    # ".../resourcegroups/foo"). Canonicalising here means the same physical scope never splits into
-    # two nodes because of casing. Only the hash input is canonicalised; the raw armPath / externalId
-    # is still stored as received.
-    $safe = $ArmScopePath.ToLowerInvariant() -replace '%', '%25' -replace '\|', '%7C'
-    Get-CapabilityId -TargetNodeId $safe -CapabilityId 'azure-scope'
-}
-
-function Send-IngestBatch {
-    param(
-        [Parameter(Mandatory)] [string]$Endpoint,
-        [Parameter(Mandatory)] [int]$SystemId,
-        [string]$SyncMode = 'full',
-        [hashtable]$Scope = @{},
-        [array]$Records = @()
-    )
-    if (-not $Records -or $Records.Count -eq 0) {
-        return Invoke-IngestAPI -Endpoint $Endpoint -Body @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = @() }
-    }
-    $body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Records }
-    Invoke-IngestAPI -Endpoint $Endpoint -Body $body
-}
-
-# Per-phase wall-clock + round-trip report — the call counts make the cross-subscription savings of
-# the Resource Graph queries visible (a few paged queries instead of per-subscription fan-out).
-function Write-PhaseTiming {
-    param([string]$Name, [System.Diagnostics.Stopwatch]$Sw, [int]$CallsBefore)
-    Write-Host ("  [timing] {0}: {1:n1}s, {2} Azure call(s)" -f $Name, $Sw.Elapsed.TotalSeconds, ($Global:AzCallCount - $CallsBefore)) -ForegroundColor DarkGray
-}
 
 Write-Host "`n=== Azure RM Crawler (Resource Graph) ===" -ForegroundColor Cyan
 
@@ -106,54 +68,6 @@ Write-Host "  System ID: $SystemId" -ForegroundColor Green
 $ScopeResources = [System.Collections.Generic.List[object]]::new()   # scope nodes
 $ContainsEdges  = [System.Collections.Generic.List[object]]::new()   # scope → child scope
 $ScopePaths     = [System.Collections.Generic.List[string]]::new()   # all ARM scope paths to read assignments at
-
-# Short type label shown in capability names ("Owner @ RG: name") and stored on the scope node so
-# the effective-access engine labels synthesized inherited rows the same way.
-function Get-ScopeTypeLabel { param([string]$ScopeKind)
-    switch ($ScopeKind) {
-        'ManagementGroup' { 'MG' }
-        'Subscription'    { 'Sub' }
-        'ResourceGroup'   { 'RG' }
-        'Resource'        { 'Res' }
-        default { '' }
-    }
-}
-
-# The Azure resource type (provider namespace + type) parsed out of an ARM resource id, e.g.
-# /subscriptions/../resourceGroups/../providers/Microsoft.Compute/virtualMachines/vm1
-#   -> "Microsoft.Compute/virtualMachines". Lets the UI/matrix answer "who can touch any VM?".
-function Get-AzureResourceType { param([string]$ArmPath)
-    if ($ArmPath -match '/providers/(.+)$') {
-        $segs = $matches[1] -split '/'              # ns / type / name [ / subtype / subname ... ]
-        $parts = @($segs[0])
-        for ($i = 1; $i -lt $segs.Count; $i += 2) { $parts += $segs[$i] }   # type segments only
-        return ($parts -join '/')
-    }
-    return ''
-}
-
-# Governance/filtering attributes lifted off a resource object (from the Resource Graph resources query):
-#   azureLocation              – region, e.g. "westeurope"  -> "access to any resource in West Europe"
-#   tag.<Key>                  – each portal tag as its own key -> "access to anything tagged Prio High"
-#   managedIdentity            – identity type (SystemAssigned/UserAssigned) when the resource has one
-#                                -> the "resources that have a managed identity" context
-#   managedIdentityPrincipalId – the system-assigned identity's principal id, soft-linking the resource
-#                                to its managed-identity principal (no model change; attribute only)
-# Everything here is generic extendedAttributes the context plugins group by — no new core needed.
-function Get-ResourceAttributes { param($Resource)
-    $ext = @{}
-    if ($Resource.location) { $ext['azureLocation'] = [string]$Resource.location }
-    if ($Resource.tags) {
-        foreach ($p in $Resource.tags.PSObject.Properties) {
-            if ($p.Name) { $ext["tag.$($p.Name)"] = [string]$p.Value }
-        }
-    }
-    if ($Resource.identity -and $Resource.identity.type -and $Resource.identity.type -ne 'None') {
-        $ext['managedIdentity'] = [string]$Resource.identity.type
-        if ($Resource.identity.principalId) { $ext['managedIdentityPrincipalId'] = [string]$Resource.identity.principalId }
-    }
-    return $ext
-}
 
 # helper to register a scope node + (optional) parent edge
 function Add-Scope {
@@ -312,16 +226,6 @@ function Add-ContainsEdge { param([string]$ParentPath, [string]$ChildPath)
         childResourceId  = (Get-ScopeNodeId -ArmScopePath $ChildPath)
         relationshipType = 'Contains'; extendedAttributes = @{ propagates = $true }
     })
-}
-
-# Parent of a sub-subscription scope: a resource → its resource group, a resource group → its
-# subscription, a subscription-level resource → its subscription. $null for subscription / management
-# group / tenant-root scopes (those are handled as "above the subscription").
-function Get-ParentScopePath { param([string]$ScopePath)
-    if ($ScopePath -match '^(/subscriptions/[^/]+/resourceGroups/[^/]+)/providers/') { return $matches[1] }
-    if ($ScopePath -match '^(/subscriptions/[^/]+)/resourceGroups/[^/]+$')           { return $matches[1] }
-    if ($ScopePath -match '^(/subscriptions/[^/]+)/providers/')                       { return $matches[1] }
-    return $null
 }
 
 # Resolve a management group's friendly display name (cached). On-demand MG nodes would otherwise


### PR DESCRIPTION
> **Draft — coordinate before merge.** This crawler is being actively worked on by another contributor. Opened as a draft so the extraction can be reviewed in isolation; mark ready once it won't conflict with that in-flight work.

## Summary
Applies the established crawler-refactor pattern (csv/omada/midpoint/entra-id) to **azure-rm**: extract the pure/standalone helper functions out of the procedural `Start-AzureRMCrawler.ps1` into a dot-sourced `AzureRMCrawler.Functions.ps1` so they can be unit-tested in isolation.

## Changes
- **`AzureRMCrawler.Functions.ps1`** (new) — 7 functions: `Get-ScopeNodeId`, `Send-IngestBatch`, `Write-PhaseTiming`, `Get-ScopeTypeLabel`, `Get-AzureResourceType`, `Get-ResourceAttributes`, `Get-ParentScopePath`.
- **`Start-AzureRMCrawler.ps1`** — one dot-source line added, those 7 defs removed. Procedural Main is byte-identical otherwise (**+1 / −97**). The state-coupled helpers (`Add-Scope`, `Add-ContainsEdge`, `Get-MgDisplayName`, `Ensure-AssignmentScope`) stay inline since they mutate the crawler's scope accumulators.
- **`AzureRMCrawlerFunctions.Tests.ps1`** (new) — 22 Pester tests, **100%** of the new Functions file.

## Verification
- Both files parse clean (AST); the extracted functions resolve via dot-source exactly as before.
- Full unit suite: **1012 passed, 0 failed**.
- New Functions file passes the crawler quality gate (`[CmdletBinding()]` on each; encoding matches existing crawler files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
