### PR TITLE
refactor(entra-id): extract nested helpers + make parallel fetch testable

### DIFF
--- a/changes/extract-entra-id-nested-helpers.md
+++ b/changes/extract-entra-id-nested-helpers.md
@@ -1,1 +1,2 @@
 - Extracted the Entra ID crawler's remaining inline helper functions (filter-value coercion, ownership/OAuth2-scope/app-role resource-id generation, directory-role principal-type resolution) into the loadable helper library so they can be unit-tested in isolation; the crawler's behaviour is unchanged.
+- Refactored the parallel group-children fetch so the per-group fetch/retry/pagination logic is a testable function and the parallel execution is isolated behind a thin seam; the crawler's behaviour is unchanged.

--- a/changes/extract-entra-id-nested-helpers.md
+++ b/changes/extract-entra-id-nested-helpers.md
@@ -1,0 +1,1 @@
+- Extracted the Entra ID crawler's remaining inline helper functions (filter-value coercion, ownership/OAuth2-scope/app-role resource-id generation, directory-role principal-type resolution) into the loadable helper library so they can be unit-tested in isolation; the crawler's behaviour is unchanged.

--- a/test/unit/EntraIDCrawlerFunctions.Tests.ps1
+++ b/test/unit/EntraIDCrawlerFunctions.Tests.ps1
@@ -312,3 +312,101 @@ Describe 'Write-Phase' {
         $script:phases[0].records.inserted | Should -Be 9
     }
 }
+
+Describe 'ConvertTo-FilterValue' {
+    It 'returns the value unchanged when either value or sample is null' {
+        ConvertTo-FilterValue -Value 'x' -Sample $null | Should -Be 'x'
+        ConvertTo-FilterValue -Value $null -Sample 'y' | Should -BeNullOrEmpty
+    }
+
+    It 'coerces truthy strings to $true against a bool sample' {
+        foreach ($t in 'true', '1', 'yes', 'on', 'TRUE', ' On ') {
+            ConvertTo-FilterValue -Value $t -Sample $true | Should -BeTrue
+        }
+    }
+
+    It 'coerces falsy strings to $false against a bool sample' {
+        foreach ($f in 'false', '0', 'no', 'off', 'FALSE') {
+            ConvertTo-FilterValue -Value $f -Sample $true | Should -BeFalse
+        }
+    }
+
+    It 'passes a real bool through unchanged against a bool sample' {
+        ConvertTo-FilterValue -Value $true -Sample $false | Should -BeTrue
+    }
+
+    It 'coerces a numeric string to an int against an int sample' {
+        $r = ConvertTo-FilterValue -Value '42' -Sample 7
+        $r | Should -Be 42
+        $r | Should -BeOfType [int]
+    }
+
+    It 'returns the original value for a non-numeric string against an int sample' {
+        ConvertTo-FilterValue -Value 'abc' -Sample 7 | Should -Be 'abc'
+    }
+
+    It 'passes values through unchanged against a string sample' {
+        ConvertTo-FilterValue -Value 'Engineering' -Sample 'Sales' | Should -Be 'Engineering'
+    }
+}
+
+Describe 'New-OwnershipResourceId' {
+    It 'is deterministic and shaped like a GUID' {
+        $a = New-OwnershipResourceId -GroupId 'grp-1'
+        $b = New-OwnershipResourceId -GroupId 'grp-1'
+        $a | Should -Be $b
+        $a | Should -Match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    }
+
+    It 'produces distinct ids for distinct groups' {
+        (New-OwnershipResourceId -GroupId 'grp-1') | Should -Not -Be (New-OwnershipResourceId -GroupId 'grp-2')
+    }
+}
+
+Describe 'New-OAuth2ScopeResourceId' {
+    It 'is deterministic for the same client/api/scope triple' {
+        $a = New-OAuth2ScopeResourceId -ClientSpId 'c' -TargetApiSpId 'api' -Scope 'User.Read'
+        $b = New-OAuth2ScopeResourceId -ClientSpId 'c' -TargetApiSpId 'api' -Scope 'User.Read'
+        $a | Should -Be $b
+        $a | Should -Match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    }
+
+    It 'changes when any component of the triple changes' {
+        $base = New-OAuth2ScopeResourceId -ClientSpId 'c' -TargetApiSpId 'api' -Scope 'User.Read'
+        (New-OAuth2ScopeResourceId -ClientSpId 'c2'  -TargetApiSpId 'api'  -Scope 'User.Read') | Should -Not -Be $base
+        (New-OAuth2ScopeResourceId -ClientSpId 'c'   -TargetApiSpId 'api2' -Scope 'User.Read') | Should -Not -Be $base
+        (New-OAuth2ScopeResourceId -ClientSpId 'c'   -TargetApiSpId 'api'  -Scope 'Mail.Read') | Should -Not -Be $base
+    }
+}
+
+Describe 'New-AppRoleResourceId' {
+    It 'is deterministic for the same SP/appRole pair' {
+        $a = New-AppRoleResourceId -SpId 'sp' -AppRoleId 'role'
+        $b = New-AppRoleResourceId -SpId 'sp' -AppRoleId 'role'
+        $a | Should -Be $b
+        $a | Should -Match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    }
+
+    It 'produces distinct ids for distinct app roles on the same SP' {
+        (New-AppRoleResourceId -SpId 'sp' -AppRoleId 'r1') | Should -Not -Be (New-AppRoleResourceId -SpId 'sp' -AppRoleId 'r2')
+    }
+}
+
+Describe 'Resolve-DirectoryRolePrincipalType' {
+    It 'maps a service principal odata type' {
+        Resolve-DirectoryRolePrincipalType -Principal ([pscustomobject]@{ '@odata.type' = '#microsoft.graph.servicePrincipal' }) | Should -Be 'ServicePrincipal'
+    }
+
+    It 'maps a group odata type' {
+        Resolve-DirectoryRolePrincipalType -Principal ([pscustomobject]@{ '@odata.type' = '#microsoft.graph.group' }) | Should -Be 'Group'
+    }
+
+    It 'maps a user odata type' {
+        Resolve-DirectoryRolePrincipalType -Principal ([pscustomobject]@{ '@odata.type' = '#microsoft.graph.user' }) | Should -Be 'User'
+    }
+
+    It 'defaults to User for an unknown or missing odata type' {
+        Resolve-DirectoryRolePrincipalType -Principal ([pscustomobject]@{ '@odata.type' = '#microsoft.graph.device' }) | Should -Be 'User'
+        Resolve-DirectoryRolePrincipalType -Principal ([pscustomobject]@{ id = 'x' }) | Should -Be 'User'
+    }
+}

--- a/test/unit/EntraIDCrawlerFunctions.Tests.ps1
+++ b/test/unit/EntraIDCrawlerFunctions.Tests.ps1
@@ -264,14 +264,105 @@ Describe 'Invoke-FGGetDeltaRequest' {
     }
 }
 
-# ─── Get-FGGroupChildrenParallel ────────────────────────────────────────────────
-Describe 'Get-FGGroupChildrenParallel' {
+# ─── Invoke-FGGroupChildFetch ───────────────────────────────────────────────────
+# The per-group fetch/retry/paginate logic, extracted out of the -Parallel block so
+# it runs (and is coverage-instrumented) in the main runspace. Invoke-RestMethod and
+# Start-Sleep are mocked so no real HTTP / waiting occurs.
+Describe 'Invoke-FGGroupChildFetch' {
 
-    # The parallel ForEach-Object block runs in fresh runspaces that can't see
-    # Pester mocks, so we exercise the parent-thread setup + token guard without
-    # entering the network path: with no token available the function throws
-    # before the parallel block. This covers the loop entry, batch slicing, and
-    # the "no access token" guard.
+    It 'emits one record per child from a single page' {
+        Mock Invoke-RestMethod { [pscustomobject]@{ value = @(
+            [pscustomobject]@{ id = 'm1'; '@odata.type' = '#microsoft.graph.user' }
+            [pscustomobject]@{ id = 'm2'; '@odata.type' = '#microsoft.graph.group' }
+        ) } }
+        $out = @(Invoke-FGGroupChildFetch -Group ([pscustomobject]@{ id = 'g1' }) -Token 'tok' -ChildPath 'members')
+        $out.Count | Should -Be 2
+        $out[0].kind | Should -Be 'record'
+        $out[0].resourceId | Should -Be 'g1'
+        $out[0].principalId | Should -Be 'm1'
+        $out[1].childType | Should -Be '#microsoft.graph.group'
+    }
+
+    It 'follows @odata.nextLink across pages' {
+        $script:page = 0
+        Mock Invoke-RestMethod {
+            $script:page++
+            if ($script:page -eq 1) {
+                [pscustomobject]@{ value = @([pscustomobject]@{ id = 'a' }); '@odata.nextLink' = 'https://graph/next' }
+            } else {
+                [pscustomobject]@{ value = @([pscustomobject]@{ id = 'b' }) }
+            }
+        }
+        $out = @(Invoke-FGGroupChildFetch -Group ([pscustomobject]@{ id = 'g1' }) -Token 'tok' -ChildPath 'members')
+        $out.principalId | Should -Be @('a', 'b')
+        Should -Invoke Invoke-RestMethod -Times 2
+    }
+
+    It 'retries a transient 429 then succeeds' {
+        Mock Start-Sleep { }
+        $script:n = 0
+        Mock Invoke-RestMethod {
+            $script:n++
+            if ($script:n -eq 1) {
+                $resp = [pscustomobject]@{ StatusCode = [pscustomobject]@{ value__ = 429 } }
+                $ex = [System.Exception]::new('Too Many Requests')
+                $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp -Force
+                throw $ex
+            }
+            [pscustomobject]@{ value = @([pscustomobject]@{ id = 'ok' }) }
+        }
+        $out = @(Invoke-FGGroupChildFetch -Group ([pscustomobject]@{ id = 'g1' }) -Token 'tok' -ChildPath 'owners')
+        $out.principalId | Should -Be 'ok'
+        Should -Invoke Start-Sleep -Times 1
+    }
+
+    It 'retries a connection error with no status code' {
+        Mock Start-Sleep { }
+        $script:m = 0
+        Mock Invoke-RestMethod {
+            $script:m++
+            if ($script:m -eq 1) { throw [System.Exception]::new('connection reset') }
+            [pscustomobject]@{ value = @([pscustomobject]@{ id = 'recovered' }) }
+        }
+        $out = @(Invoke-FGGroupChildFetch -Group ([pscustomobject]@{ id = 'g1' }) -Token 'tok' -ChildPath 'members')
+        $out.principalId | Should -Be 'recovered'
+    }
+
+    It 'returns a single error object on a permanent (404) failure' {
+        Mock Start-Sleep { }
+        Mock Invoke-RestMethod {
+            $resp = [pscustomobject]@{ StatusCode = [pscustomobject]@{ value__ = 404 } }
+            $ex = [System.Exception]::new('Not Found')
+            $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp -Force
+            throw $ex
+        }
+        $out = @(Invoke-FGGroupChildFetch -Group ([pscustomobject]@{ id = 'g1' }) -Token 'tok' -ChildPath 'members')
+        $out.Count | Should -Be 1
+        $out[0].kind | Should -Be 'error'
+        $out[0].resourceId | Should -Be 'g1'
+        $out[0].message | Should -Be 'Not Found'
+    }
+
+    It 'gives up with an error object after exhausting retries on a persistent 503' {
+        Mock Start-Sleep { }
+        Mock Invoke-RestMethod {
+            $resp = [pscustomobject]@{ StatusCode = [pscustomobject]@{ value__ = 503 } }
+            $ex = [System.Exception]::new('Service Unavailable')
+            $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp -Force
+            throw $ex
+        }
+        $out = @(Invoke-FGGroupChildFetch -Group ([pscustomobject]@{ id = 'g1' }) -Token 'tok' -ChildPath 'members')
+        $out[0].kind | Should -Be 'error'
+        # initial attempt + 3 retries = 4 calls (maxAttempts)
+        Should -Invoke Invoke-RestMethod -Times 4
+    }
+}
+
+# ─── Get-FGGroupChildrenParallel ────────────────────────────────────────────────
+# The actual -Parallel execution is isolated in Invoke-FGGroupChildBatchParallel
+# (runspace code can't be mocked/instrumented). Mocking that seam lets us cover the
+# batch loop, token refresh, result fold and progress reporting in the main runspace.
+Describe 'Get-FGGroupChildrenParallel' {
 
     AfterEach {
         Remove-Variable -Name AccessToken -Scope Global -ErrorAction SilentlyContinue
@@ -282,6 +373,51 @@ Describe 'Get-FGGroupChildrenParallel' {
         $groups = @([pscustomobject]@{ id = 'g1' })
         { Get-FGGroupChildrenParallel -Groups $groups -ChildPath 'members' `
             -RecordBuilder { param($o) $o } } | Should -Throw '*No Graph access token*'
+    }
+
+    It 'folds parallel records via the RecordBuilder and counts errors' {
+        $Global:AccessToken = 'tok'
+        Mock Invoke-FGGroupChildBatchParallel {
+            @(
+                [pscustomobject]@{ kind = 'record'; resourceId = 'g1'; principalId = 'm1' }
+                [pscustomobject]@{ kind = 'record'; resourceId = 'g1'; principalId = 'm2' }
+                [pscustomobject]@{ kind = 'error';  resourceId = 'g2'; message = 'boom' }
+            )
+        }
+        $groups = @([pscustomobject]@{ id = 'g1' }, [pscustomobject]@{ id = 'g2' })
+        $result = Get-FGGroupChildrenParallel -Groups $groups -ChildPath 'members' `
+            -RecordBuilder { param($o) @{ resourceId = $o.resourceId; principalId = $o.principalId } }
+
+        $result.records.Count | Should -Be 2
+        $result.errorCount | Should -Be 1
+        $result.records[0].principalId | Should -Be 'm1'
+    }
+
+    It 'processes the groups in batches of BatchSize' {
+        $Global:AccessToken = 'tok'
+        Mock Invoke-FGGroupChildBatchParallel { @() }
+        $groups = 1..5 | ForEach-Object { [pscustomobject]@{ id = "g$_" } }
+        Get-FGGroupChildrenParallel -Groups $groups -ChildPath 'members' -BatchSize 2 `
+            -RecordBuilder { param($o) $o } | Out-Null
+        # 5 groups / batch size 2 = 3 batches
+        Should -Invoke Invoke-FGGroupChildBatchParallel -Times 3
+    }
+
+    It 'refreshes the token and reports progress (with an error tag) for each batch' {
+        $Global:AccessToken = 'tok'
+        # Include an error so the "· N errors" progress-detail branch is exercised.
+        Mock Invoke-FGGroupChildBatchParallel {
+            @([pscustomobject]@{ kind = 'error'; resourceId = 'g1'; message = 'boom' })
+        }
+        Mock Update-FGAccessTokenIfExpired { }
+        Mock Update-CrawlerProgress { }
+        $groups = @([pscustomobject]@{ id = 'g1' })
+        $result = Get-FGGroupChildrenParallel -Groups $groups -ChildPath 'members' `
+            -ProgressStep 'Sync' -ProgressStartPct 10 -ProgressEndPct 20 `
+            -RecordBuilder { param($o) $o }
+        $result.errorCount | Should -Be 1
+        Should -Invoke Update-FGAccessTokenIfExpired -Times 1
+        Should -Invoke Update-CrawlerProgress -Times 1 -ParameterFilter { $Detail -like '*1 errors*' }
     }
 }
 

--- a/tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1
@@ -426,3 +426,78 @@ function Get-UserAttrValue {
     }
     return $User.$AttrName
 }
+
+# Coerce a configured filter value to the type of the sample attribute value, so a
+# JSON-string config ("true", "42") compares correctly against a typed Graph value.
+function ConvertTo-FilterValue {
+    [CmdletBinding()]
+    param($Value, $Sample)
+    if ($null -eq $Value -or $null -eq $Sample) { return $Value }
+    if ($Sample -is [bool]) {
+        if ($Value -is [bool]) { return $Value }
+        $s = "$Value".Trim().ToLower()
+        if ($s -in @('true','1','yes','on'))  { return $true }
+        if ($s -in @('false','0','no','off')) { return $false }
+    }
+    if ($Sample -is [int] -or $Sample -is [long]) {
+        $n = 0; if ([int]::TryParse("$Value", [ref]$n)) { return $n }
+    }
+    return $Value
+}
+
+# Deterministic UUID for a group's synthetic "Owner @ <group>" GroupOwnership resource.
+function New-OwnershipResourceId {
+    [CmdletBinding()]
+    param([string]$GroupId)
+    $seed = "entraid-ownership:${GroupId}"
+    $md5 = [System.Security.Cryptography.MD5]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($seed)
+        $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
+    } finally {
+        $md5.Dispose()
+    }
+    return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
+}
+
+# Deterministic UUID for a (clientSP, targetApiSP, scope) DelegatedPermission resource.
+function New-OAuth2ScopeResourceId {
+    [CmdletBinding()]
+    param([string]$ClientSpId, [string]$TargetApiSpId, [string]$Scope)
+    $hashInput = "entraid-oauth2-scope:${ClientSpId}:${TargetApiSpId}:${Scope}"
+    $md5 = [System.Security.Cryptography.MD5]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($hashInput)
+        $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
+    } finally {
+        $md5.Dispose()
+    }
+    return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
+}
+
+# Deterministic UUID for a (servicePrincipal, appRole) AppRole resource.
+function New-AppRoleResourceId {
+    [CmdletBinding()]
+    param([string]$SpId, [string]$AppRoleId)
+    $seed = "entraid-approle:${SpId}:${AppRoleId}"
+    $md5 = [System.Security.Cryptography.MD5]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($seed)
+        $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
+    } finally {
+        $md5.Dispose()
+    }
+    return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
+}
+
+# Map a directory-role member's @odata.type to a principalType.
+function Resolve-DirectoryRolePrincipalType {
+    [CmdletBinding()]
+    param($Principal)
+    switch -Wildcard ($Principal.'@odata.type') {
+        '*servicePrincipal' { 'ServicePrincipal'; break }
+        '*group'            { 'Group'; break }
+        '*user'             { 'User'; break }
+        default             { 'User' }
+    }
+}

--- a/tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1
@@ -290,6 +290,81 @@ function Invoke-FGGetDeltaRequest {
 #     reports progress to the UI
 #
 # Output: a hashtable @{ records = @(...); errorCount = N }
+# Fetch one group's children (members/owners) with pagination + transient-error
+# retry. Returns one [pscustomobject] per child (kind='record') or a single
+# kind='error' object if the group fails after maxAttempts. Pulled out of the
+# ForEach-Object -Parallel block in Get-FGGroupChildrenParallel so the retry /
+# pagination / error logic is unit-testable in the main runspace (code running
+# inside -Parallel runspaces cannot be reached by mocks or coverage).
+function Invoke-FGGroupChildFetch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Group,
+        [Parameter(Mandatory)] [string]$Token,
+        [Parameter(Mandatory)] [string]$ChildPath
+    )
+
+    $headers = @{ Authorization = "Bearer $Token" }
+    $uri     = "https://graph.microsoft.com/beta/groups/$($Group.id)/$ChildPath`?`$select=id&`$top=999"
+
+    $items = [System.Collections.Generic.List[object]]::new()
+    $attempt = 0
+    $maxAttempts = 4
+
+    while ($uri) {
+        $attempt++
+        try {
+            $resp = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -TimeoutSec 60 -ErrorAction Stop
+            if ($resp.value) { foreach ($v in $resp.value) { $items.Add($v) } }
+            $uri = $resp.'@odata.nextLink'
+            $attempt = 0  # reset on success for nextLink retries
+        }
+        catch {
+            $status = $null
+            try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+            # Retry transient errors with backoff. Skip the group entirely
+            # if we're still failing after maxAttempts.
+            if (($status -eq 429 -or ($status -ge 500 -and $status -lt 600) -or -not $status) -and $attempt -lt $maxAttempts) {
+                Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+                continue
+            }
+            # Permanent failure — surface but don't break the whole batch
+            [pscustomobject]@{ kind = 'error'; resourceId = $Group.id; message = $_.Exception.Message }
+            return
+        }
+    }
+
+    foreach ($child in $items) {
+        [pscustomobject]@{
+            kind        = 'record'
+            resourceId  = $Group.id
+            principalId = $child.id
+            childType   = $child.'@odata.type'
+        }
+    }
+}
+
+# Run Invoke-FGGroupChildFetch across a batch of groups in parallel runspaces.
+# The fetch function is re-established inside each runspace via $using (runspaces
+# don't inherit the caller's functions). Isolated behind its own function so the
+# batch loop / fold logic in Get-FGGroupChildrenParallel can be tested by mocking
+# this (the -Parallel body itself can't be mocked or coverage-instrumented).
+function Invoke-FGGroupChildBatchParallel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [array]$Batch,
+        [Parameter(Mandatory)] [string]$Token,
+        [Parameter(Mandatory)] [string]$ChildPath,
+        [int]$ThrottleLimit = 16
+    )
+
+    $fetchDef = ${function:Invoke-FGGroupChildFetch}.ToString()
+    $Batch | ForEach-Object -Parallel {
+        ${function:Invoke-FGGroupChildFetch} = $using:fetchDef
+        Invoke-FGGroupChildFetch -Group $_ -Token $using:Token -ChildPath $using:ChildPath
+    } -ThrottleLimit $ThrottleLimit
+}
+
 function Get-FGGroupChildrenParallel {
     [CmdletBinding()]
     param(
@@ -321,53 +396,10 @@ function Get-FGGroupChildrenParallel {
         $end = [Math]::Min($i + $BatchSize - 1, $totalGroups - 1)
         $batch = $Groups[$i..$end]
 
-        # Run the batch in parallel. Each runspace returns an array of [pscustomobject]:
-        #   - { kind='record';  resourceId; principalId; childType; ... } for each child
-        #   - { kind='error';   resourceId; message } when a group fails after retries
-        $batchOutput = $batch | ForEach-Object -Parallel {
-            $g            = $_
-            $token        = $using:token
-            $childPathLoc = $using:ChildPath
-
-            $headers = @{ Authorization = "Bearer $token" }
-            $uri     = "https://graph.microsoft.com/beta/groups/$($g.id)/$childPathLoc`?`$select=id&`$top=999"
-
-            $items = [System.Collections.Generic.List[object]]::new()
-            $attempt = 0
-            $maxAttempts = 4
-
-            while ($uri) {
-                $attempt++
-                try {
-                    $resp = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -TimeoutSec 60 -ErrorAction Stop
-                    if ($resp.value) { foreach ($v in $resp.value) { $items.Add($v) } }
-                    $uri = $resp.'@odata.nextLink'
-                    $attempt = 0  # reset on success for nextLink retries
-                }
-                catch {
-                    $status = $null
-                    try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
-                    # Retry transient errors with backoff. Skip the group entirely
-                    # if we're still failing after maxAttempts.
-                    if (($status -eq 429 -or ($status -ge 500 -and $status -lt 600) -or -not $status) -and $attempt -lt $maxAttempts) {
-                        Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
-                        continue
-                    }
-                    # Permanent failure — surface but don't break the whole batch
-                    [pscustomobject]@{ kind = 'error'; resourceId = $g.id; message = $_.Exception.Message }
-                    return
-                }
-            }
-
-            foreach ($child in $items) {
-                [pscustomobject]@{
-                    kind        = 'record'
-                    resourceId  = $g.id
-                    principalId = $child.id
-                    childType   = $child.'@odata.type'
-                }
-            }
-        } -ThrottleLimit $ThrottleLimit
+        # Fetch each group's children in parallel. Each result is a [pscustomobject]
+        # with kind='record' (a child) or kind='error' (a group that failed after
+        # retries). See Invoke-FGGroupChildBatchParallel / Invoke-FGGroupChildFetch.
+        $batchOutput = Invoke-FGGroupChildBatchParallel -Batch $batch -Token $token -ChildPath $ChildPath -ThrottleLimit $ThrottleLimit
 
         # Fold parallel results into the totals (parent thread, not parallel).
         # Note: PowerShell's parser rejects `$list.Add(& $sb $arg)` because the

--- a/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1
+++ b/tools/crawlers/entra-id/Start-EntraIDCrawler.ps1
@@ -431,21 +431,6 @@ if ($SyncPrincipals) {
 
         # Coerce filter value to match the attribute's runtime type — booleans
         # need a real $true/$false (PowerShell -eq is type-strict for booleans)
-        function ConvertTo-FilterValue {
-            param($Value, $Sample)
-            if ($null -eq $Value -or $null -eq $Sample) { return $Value }
-            if ($Sample -is [bool]) {
-                if ($Value -is [bool]) { return $Value }
-                $s = "$Value".Trim().ToLower()
-                if ($s -in @('true','1','yes','on'))  { return $true }
-                if ($s -in @('false','0','no','off')) { return $false }
-            }
-            if ($Sample -is [int] -or $Sample -is [long]) {
-                $n = 0; if ([int]::TryParse("$Value", [ref]$n)) { return $n }
-            }
-            return $Value
-        }
-
         $identityUsers = $users | Where-Object {
             $val = Get-UserAttrValue -User $_ -AttrName $attr
             $coercedValue = ConvertTo-FilterValue -Value $filterValue -Sample $val
@@ -968,19 +953,6 @@ if ($SyncAssignments) {
     # upsert the same rows.
     Write-Host "`n[$(Get-Date -Format 'HH:mm:ss')] Syncing assignments (group owners)..." -ForegroundColor Cyan
     Update-CrawlerProgress -Step 'Syncing group owners' -Pct 51 -Detail "0 of $totalGroups groups"
-
-    function New-OwnershipResourceId {
-        param([string]$GroupId)
-        $seed = "entraid-ownership:${GroupId}"
-        $md5 = [System.Security.Cryptography.MD5]::Create()
-        try {
-            $bytes = [System.Text.Encoding]::UTF8.GetBytes($seed)
-            $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
-        } finally {
-            $md5.Dispose()
-        }
-        return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
-    }
 
     $ownerResult = Get-FGGroupChildrenParallel `
         -Groups $groups -ChildPath 'owners' -ThrottleLimit 16 `
@@ -1537,19 +1509,6 @@ if ($SyncOAuth2Grants) {
     # Deterministic UUID v3-style over MD5 — mirrors normalizeRecords in
     # app/api/src/ingest/normalization.js so the same input always yields the
     # same ID whether generated here or server-side.
-    function New-OAuth2ScopeResourceId {
-        param([string]$ClientSpId, [string]$TargetApiSpId, [string]$Scope)
-        $hashInput = "entraid-oauth2-scope:${ClientSpId}:${TargetApiSpId}:${Scope}"
-        $md5 = [System.Security.Cryptography.MD5]::Create()
-        try {
-            $bytes = [System.Text.Encoding]::UTF8.GetBytes($hashInput)
-            $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
-        } finally {
-            $md5.Dispose()
-        }
-        return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
-    }
-
     try {
         $grants = Invoke-FGGetRequest -URI "https://graph.microsoft.com/beta/oauth2PermissionGrants?`$top=999"
         $total = @($grants).Count
@@ -1749,19 +1708,6 @@ if ($SyncAppRoles) {
 
     # Deterministic UUID v3-style over MD5 — same approach as the OAuth2
     # scope IDs. Mirrors normalizeRecords in app/api/src/ingest/normalization.js.
-    function New-AppRoleResourceId {
-        param([string]$SpId, [string]$AppRoleId)
-        $seed = "entraid-approle:${SpId}:${AppRoleId}"
-        $md5 = [System.Security.Cryptography.MD5]::Create()
-        try {
-            $bytes = [System.Text.Encoding]::UTF8.GetBytes($seed)
-            $hex = ([System.BitConverter]::ToString($md5.ComputeHash($bytes)) -replace '-','').ToLower()
-        } finally {
-            $md5.Dispose()
-        }
-        return "$($hex.Substring(0,8))-$($hex.Substring(8,4))-$($hex.Substring(12,4))-$($hex.Substring(16,4))-$($hex.Substring(20,12))"
-    }
-
     $DEFAULT_ROLE_ID = '00000000-0000-0000-0000-000000000000'
 
     try {
@@ -2059,16 +2005,6 @@ if ($SyncDirectoryRoles) {
     Update-CrawlerProgress -Step 'Syncing directory roles' -Pct 75 -Detail 'Fetching role definitions from Microsoft Graph...'
 
     # Map a Graph directory-object @odata.type to our principalType vocabulary.
-    function Resolve-DirectoryRolePrincipalType {
-        param($Principal)
-        switch -Wildcard ($Principal.'@odata.type') {
-            '*servicePrincipal' { 'ServicePrincipal'; break }
-            '*group'            { 'Group'; break }
-            '*user'             { 'User'; break }
-            default             { 'User' }
-        }
-    }
-
     try {
         # 1. Role catalog. /roleDefinitions returns the full set of built-in
         #    roles plus any custom roles. id == templateId for built-ins.


### PR DESCRIPTION
## Summary
Continues the Entra ID crawler refactor: extracts the helper functions the first pass left inline so they become unit-testable, and restructures the parallel group-children fetch so its retry/pagination logic is testable too. No behaviour change.

## Changes

**1. Extract the 5 remaining nested helpers** into the already-dot-sourced `EntraIDCrawler.Functions.ps1`:
`ConvertTo-FilterValue`, `New-OwnershipResourceId`, `New-OAuth2ScopeResourceId`, `New-AppRoleResourceId`, `Resolve-DirectoryRolePrincipalType`. Functions-file change is purely additive; the Main change is removal-only (−64).

**2. Make the parallel group-children fetch testable.** `Get-FGGroupChildrenParallel`'s monolithic `ForEach-Object -Parallel` block is split into:
- `Invoke-FGGroupChildFetch` — per-group fetch/retry/pagination/error logic, now a plain function tested directly (mocked `Invoke-RestMethod`/`Start-Sleep`): single page, `@odata.nextLink` paging, 429/5xx/connection retries, permanent failure, and retry-exhaustion all covered.
- `Invoke-FGGroupChildBatchParallel` — the thin `-Parallel` wrapper that re-imports the fetch function into each runspace via `$using`. Mocking this seam makes the batch loop, token refresh, result fold and progress reporting in `Get-FGGroupChildrenParallel` testable.

## Coverage / verification
- `Get-FGGroupChildrenParallel`: **59 → ~0** uncovered commands (only the irreducible 5-line in-runspace body remains — code inside `-Parallel` runspaces can't be reached by mocks or breakpoint coverage; the real path is integration-tested by `Test-EntraIdCrawler` in CI).
- `EntraIDCrawler.Functions.ps1`: **75.5% → 92.2%**.
- Behaviour unchanged — verified the `$using` function re-import resolves in a real runspace.
- Full unit suite: **1016 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
