### PR TITLE
docs(testing): note npm rebuild re2 fix (resolves #413)

### DIFF
--- a/test/TESTING-GUIDE.md
+++ b/test/TESTING-GUIDE.md
@@ -147,6 +147,19 @@ npm ci
 npm test
 ```
 
+> **Troubleshooting — `Cannot find module './build/Release/re2.node'`:**
+> `re2` is a native addon that must be compiled for your OS + Node version. If
+> `node_modules` were installed on a different platform (e.g. inside the
+> Docker/Linux image and then opened on a Windows/macOS host) or with
+> `--ignore-scripts`, its binary won't match and every test that imports it
+> (e.g. `src/contexts/plugins/manager-hierarchy.test.js`) fails at load time.
+> Fix it by rebuilding the binary for your machine:
+> ```bash
+> cd app/api && npm rebuild re2
+> ```
+> This is a local-setup issue only — production builds `re2` inside the target
+> Linux image, so the binary always matches there.
+
 **What it tests** (`src/ingest/validation.test.js`, 53 test cases):
 - `validateEnvelope`: required fields, array bounds (0–50 000), `syncMode`/`idGeneration` enums, `idPrefix` requirement, `systems` endpoint skips `systemId`
 - `validateRecords` for `principals`: required `displayName`, UUID enforcement on `id`/`managerId`, all `principalType` enum values, `maxLength` on string fields, non-string rejection

--- a/test/TESTING-GUIDE.md
+++ b/test/TESTING-GUIDE.md
@@ -157,8 +157,11 @@ npm test
 > ```bash
 > cd app/api && npm rebuild re2
 > ```
-> This is a local-setup issue only — production builds `re2` inside the target
-> Linux image, so the binary always matches there.
+> This is a local-setup issue only — every production distribution ships a
+> `re2` binary that matches its target: the Docker image builds/fetches it for
+> Linux during `npm ci`, and the portable desktop ZIP downloads the
+> `win32-x64` prebuilt for its bundled Node at build time. Only a local
+> checkout whose `node_modules` came from a different platform is affected.
 
 **What it tests** (`src/ingest/validation.test.js`, 53 test cases):
 - `validateEnvelope`: required fields, array bounds (0–50 000), `syncMode`/`idGeneration` enums, `idPrefix` requirement, `systems` endpoint skips `systemId`


### PR DESCRIPTION
## Summary
Resolves #413. The manager-hierarchy test (and any other `re2` consumer) fails with `Cannot find module './build/Release/re2.node'` when `re2`'s native binary doesn't match the host — `node_modules` installed under Docker/Linux then opened on Windows, or installed with `--ignore-scripts`.

## Why this is a doc fix, not a code fix
This is a **local-setup** artifact, not a code bug:
- In production the API image (`node:24-slim`, linux/amd64) installs `re2` via `npm ci` **inside the target platform**, downloading a matching prebuilt binary — so the binary always matches the runtime. The bug cannot occur there.
- A code-level RegExp fallback was considered and rejected: it would silently drop RE2's linear-time (ReDoS-safe) guarantee for admin-supplied patterns, and the sibling consumer `riskscoring/engine.js` deliberately relies on RE2's stricter grammar for save-time pattern validation.

## Change
Adds a troubleshooting note to `test/TESTING-GUIDE.md` (API Unit Tests section) pointing devs at the one-line fix:
```bash
cd app/api && npm rebuild re2
```

Docs-only; no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
