### PR TITLE
test(crawlerFiles): make path-traversal test portable (resolves #414)

### DIFF
--- a/app/api/src/routes/crawlerFiles.uploads.test.js
+++ b/app/api/src/routes/crawlerFiles.uploads.test.js
@@ -97,7 +97,11 @@ describe('crawler-configs/:configId/files — real upload/list/delete cycle', ()
     // basename() reduces '../../etc/passwd' to just 'passwd' — confirm the
     // delete can only ever touch a file inside this config's own folder, by
     // planting a decoy 'passwd' file there and confirming only THAT gets
-    // removed — the real /etc/passwd is never touched.
+    // removed. Together these assertions prove containment: had the traversal
+    // escaped, `deleted` would not be the bare 'passwd' and the in-folder decoy
+    // would survive. (We deliberately don't assert on a real OS file like
+    // /etc/passwd — that sentinel is Linux-only and the checks below already
+    // prove the path was sanitised, portably.)
     const configDir = join(UPLOAD_ROOT_DIR, 'csv-501');
     const decoy = join(configDir, 'passwd');
     mkdirSync(configDir, { recursive: true });
@@ -107,9 +111,8 @@ describe('crawler-configs/:configId/files — real upload/list/delete cycle', ()
     const res = await request(makeApp())
       .delete('/api/admin/crawler-configs/501/files/' + encodeURIComponent('../../etc/passwd'));
     expect(res.status).toBe(200);
-    expect(res.body.deleted).toBe('passwd');
-    expect(existsSync(decoy)).toBe(false);
-    expect(existsSync('/etc/passwd')).toBe(true); // the real file, untouched
+    expect(res.body.deleted).toBe('passwd'); // basename stripped '../../etc/'
+    expect(existsSync(decoy)).toBe(false);   // the contained file was the delete target
   });
 
   it('deletes the uploaded file; subsequent list is empty', async () => {


### PR DESCRIPTION
## Summary
Resolves #414. One test in `crawlerFiles.uploads.test.js` asserted `existsSync('/etc/passwd') === true` as a "real file untouched" sentinel after a path-traversal delete. That path doesn't exist on Windows, so the assertion fails there — even though the security behaviour under test is correct.

## Fix
Removed the OS-file assertion. It was both **non-portable** (Linux-only) and **redundant**: the remaining assertions already prove the traversal was contained to the config folder —
- `res.body.deleted === 'passwd'` proves `basename()` stripped the `../../etc/` prefix, and
- the in-folder decoy being deleted proves the delete targeted `configDir/passwd`.

Had the traversal escaped, `deleted` would not be the bare `'passwd'` and the decoy would have survived. No loss of security coverage; the test is now portable.

Verified: the file's 7 tests pass on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
