### PR TITLE
ci(codeql): ignore generated coverage reports (resolves #477)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -16,3 +16,10 @@ paths-ignore:
   # endpoint + object search) on behalf of the admin wizard. Same rationale as
   # omada/discover.js: admin-supplied URL, scheme-validated, admin auth required.
   - tools/crawlers/midpoint/discover.js
+
+  # docs/coverage/** is generated JavaScript — ReportGenerator's HTML coverage
+  # report, committed to the docs tree by coverage.yml on every merge to main.
+  # It's not our source and is regenerated each run, so CodeQL findings in it
+  # (e.g. js/trivial-conditional in class.js) can't be meaningfully fixed — any
+  # edit is overwritten on the next coverage build. Exclude the whole tree.
+  - docs/coverage/**


### PR DESCRIPTION
## Summary
Resolves #477. CodeQL reports three `js/trivial-conditional` alerts (#242–#244), all in **generated** coverage-report JavaScript committed under `docs/coverage/` (`api/class.js`, `powershell/class.js`, `ui/class.js` — ReportGenerator output). They're severity:none and pointless to edit — the coverage pipeline regenerates these files on every merge to `main`, so any manual fix is overwritten.

## Change
Added `docs/coverage/**` to the CodeQL `paths-ignore` list (`.github/codeql/codeql-config.yml`), alongside the existing intentional exclusions.

## Follow-up (manual, needs Security write access)
After this merges and CodeQL re-runs, alerts #242–#244 should stop being reported. Any that linger from the pre-ignore scan can be dismissed in the Security tab as **"Won't fix (generated code)"** — I can't do that from a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
