### PR TITLE
fix(admin): curated data export + import broke after the Contexts/uuid migrations

### DIFF
--- a/app/api/contract-tests/exportCurated.integration.test.js
+++ b/app/api/contract-tests/exportCurated.integration.test.js
@@ -1,0 +1,83 @@
+// HTTP integration test — GET /api/admin/export/curated against the real PG16
+// container, exercising the actual route handler (not a replicated query).
+//
+// Regression for the categories join: it used `LOWER(ap.id) = ca."resourceId"`,
+// but `Resources.id` is uuid and `LOWER(uuid)` throws
+// "function lower(uuid) does not exist" — so the endpoint returned 500
+// "Export failed" the moment any GovernanceCategories row existed. The fix
+// lowercases `ap.id::text` (matching the import handler), preserving the
+// case-insensitive match. With the bug this test gets 500; with the fix, 200 +
+// the category's business-role displayName resolved.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+vi.mock('../src/config/authConfig.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isAuthEnabled: () => true,
+  getTenantId: () => 'test-tenant',
+  getClientId: () => 'test-client',
+  getJwksClient: () => ({}),
+  getRequiredRoles: () => null,
+  getRolePermissions: () => ({ 'role-admin': ['*'] }),
+}));
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: (token, _key, _opts, cb) => {
+      const roles = token.startsWith('roles:') ? token.slice(6).split(',').filter(Boolean) : [];
+      cb(null, { roles, tid: 'test-tenant' });
+    },
+  },
+}));
+
+let agent;
+let pool;
+let systemId;
+const adminToken = 'Bearer roles:role-admin';
+const BR = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType","displayName") VALUES ('test','export-curated') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+  await pool.query(
+    `INSERT INTO "Resources" ("id","systemId","resourceType","displayName")
+     VALUES ($1,$2,'BusinessRole','Finance Base Access')`,
+    [BR, systemId],
+  );
+  const cat = await pool.query(
+    `INSERT INTO "GovernanceCategories" ("name","color") VALUES ('ExportCuratedTest','#3B82F6') RETURNING "id"`,
+  );
+  // resourceId is stored UPPERCASE on purpose — the join must still match it
+  // case-insensitively against the (lowercase) uuid id.
+  await pool.query(
+    `INSERT INTO "GovernanceCategoryAssignments" ("categoryId","resourceId") VALUES ($1,$2)`,
+    [cat.rows[0].id, BR.toUpperCase()],
+  );
+});
+
+afterAll(async () => {
+  await pool?.query(`DELETE FROM "GovernanceCategoryAssignments" WHERE "resourceId" = $1`, [BR.toUpperCase()]);
+  await pool?.query(`DELETE FROM "GovernanceCategories" WHERE "name" = 'ExportCuratedTest'`);
+  await pool?.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool?.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+describe('GET /api/admin/export/curated', () => {
+  it('401 without auth', async () => {
+    expect((await agent.get('/api/admin/export/curated')).status).toBe(401);
+  });
+
+  it('200 and resolves the category business-role displayName (regression: LOWER(uuid))', async () => {
+    const res = await agent.get('/api/admin/export/curated').set('Authorization', adminToken);
+    expect(res.status).toBe(200);
+    const cat = (res.body.categories || []).find((c) => c.name === 'ExportCuratedTest');
+    expect(cat).toBeTruthy();
+    expect(cat.assignments).toHaveLength(1);
+    expect(cat.assignments[0].accessPackageDisplayName).toBe('Finance Base Access');
+  });
+});

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -189,7 +189,7 @@ router.get('/admin/export/curated', exportBulk, async (req, res) => {
         FROM "GovernanceCategories" c
         LEFT JOIN "GovernanceCategoryAssignments" ca ON ca."categoryId" = c.id
         LEFT JOIN "Resources" ap
-          ON LOWER(ap.id) = ca."resourceId"
+          ON LOWER(ap.id::text) = LOWER(ca."resourceId")
           AND ap."resourceType" = 'BusinessRole'
         ORDER BY c.name, ca."resourceId"
       `);

--- a/changes/export-curated-lower-uuid.md
+++ b/changes/export-curated-lower-uuid.md
@@ -1,0 +1,1 @@
+- Fixed: **Admin → Data → "Export curated data"** failed with a generic "Export failed" error whenever any business-role categories existed. The category export query applied a text-lowercasing function directly to the resource UUID column, which PostgreSQL rejects; it now lowercases the UUID as text (matching the import path), so the export completes.


### PR DESCRIPTION
Two related bugs in **Admin → Data** curated-data, both fallout from the v6 Contexts redesign + the text→uuid id migration. Found via `/investigate`, reproduced against real PG16, fixed, and covered by a round-trip contract test.

## Bug 1 — Export ("Export curated data")
The categories join did `LOWER(ap.id) = ca."resourceId"`, but `Resources.id` is **uuid** and PostgreSQL has no `lower(uuid)` → **`function lower(uuid) does not exist`** → 500 "Export failed" (fires whenever any `GovernanceCategories` row exists).
**Fix:** `LOWER(ap.id::text) = LOWER(ca."resourceId")` (matches the import path; preserves the case-insensitive match).

## Bug 2 — Import ("Import curated data")
The tag path did `INSERT INTO "GraphTags" ... ON CONFLICT ... RETURNING (xmax = 0)`, but `GraphTags` is a **read-only view** now and `xmax` is a table-only system column → **`column "xmax" does not exist`** → 500 "Import failed".
**Fix:** write tags to the **Contexts** model (`contextType='Tag'`, `variant='manual'`, color in `extendedAttributes`) + **ContextMembers**, reusing the same exported helpers as `POST /api/tags` (`getOrCreateTagRoot`, `recalcMemberCountsForChain`). The category import path was already correct (base tables).

## Test
`curatedData.integration.test.js` (boots the real app + DB via `bootContractApp`):
- 401 on both endpoints without auth.
- **Import** a tag + category → 200 + stats; asserts the tag landed as a `Contexts` row with a `ContextMembers` member (not the old view).
- **Export round-trip** → 200; the imported tag (user assignment resolved) and category (business-role name) come back; plus an independently-seeded **uppercase** `resourceId` category resolves, guarding the export's case-insensitive join.

Both write/read paths verified against real PG16 on a sidekick (old SQL → the exact errors; new SQL → works). Runs in the **Contract Tests** CI job.