### PR TITLE
feat(ui): in-app dialogs replacing native alert/confirm/prompt (resolves #416)

### DIFF
--- a/app/ui/CLAUDE.md
+++ b/app/ui/CLAUDE.md
@@ -94,6 +94,7 @@ Before writing any utility function, helper, constant, or component — **search
 - `auth/AuthGate.js` — `useAuth()` hook and `AuthContext` (component provider is `auth/AuthGateProvider.jsx`)
 - `hooks/useEntityPage.js` — search, filter, tags, and pagination for list pages
 - `hooks/useDebouncedValue.js` — `useDebouncedValue(value, delay)` hook
+- `components/dialogContext.js` + `components/DialogProvider.jsx` — the in-app replacement for the browser's native `alert`/`confirm`/`prompt` (which are blocked by the `local/no-native-dialogs` ESLint rule — they don't theme/dark-mode and block the thread). `DialogProvider` is mounted once at the app root (`main.jsx`); call `const dialog = useDialog()` and use its **async** API. **Never call `window.alert/confirm/prompt`.** See "In-app dialogs" below.
 - `components/ConfidenceBar.jsx` — correlation confidence bar
 - `components/DetailSection.jsx` — `Section` and `CollapsibleSection` for detail pages
 - `components/ScheduleEditor.jsx` — one schedule-entry editor (frequency/hour/minute/day/syncMode), used by every crawler wizard's Schedule step and Risk Scoring; props: `schedule: {frequency, hour?, minute?, day?, syncMode}`, `onChange(updated)`, `onRemove()` — the component is uncontrolled-by-index, so the caller owns the schedules array and supplies one `schedule`/`onChange`/`onRemove` per entry (see `tools/crawlers/omada/ConfigWizard.jsx`'s Schedule step for the list-of-entries pattern)
@@ -108,6 +109,40 @@ Before writing any utility function, helper, constant, or component — **search
 - `utils/crawlerCredentials.js` — `canSubmitCredentials(authMethod, fields, isEdit)`, `buildCredentialFields(authMethod, fields)`, `SECRET_PLACEHOLDER`; covers all auth methods used by crawlers
 
 If the same logic already exists in one file and you're about to write it in a second, stop and extract it instead. Three or more files with the same code is a mandatory extraction — don't leave it for later.
+
+## In-app dialogs (no native `alert`/`confirm`/`prompt`)
+
+The browser's native dialogs are **banned** — the `local/no-native-dialogs` ESLint rule fails the build on `alert()`, `confirm()`, or `prompt()`. They block the main thread and can't be themed (no dark mode). Use the shared `useDialog()` hook instead; its provider is mounted once at the app root in `main.jsx` (and in the mount-test harness `renderWithProviders`, so component tests get it for free).
+
+```jsx
+import { useDialog } from '@ui/components/dialogContext';
+
+function MyThing() {
+  const dialog = useDialog();
+
+  async function onDelete() {
+    // confirm/prompt are ASYNC — they resolve when the user acts.
+    if (!(await dialog.confirm({ message: 'Delete this?', confirmLabel: 'Delete', danger: true }))) return;
+    await authFetch(url, { method: 'DELETE' });
+  }
+
+  async function onRename() {
+    const name = await dialog.prompt({ title: 'Rename', message: 'New name?', defaultValue: cur });
+    if (!name) return;           // null = cancelled
+    // ...
+  }
+
+  function onSaved() {
+    dialog.toast('Saved', { variant: 'success' });   // non-blocking, auto-dismiss top-right
+    dialog.alert('Something went wrong');             // alert() → an error-variant toast
+  }
+}
+```
+
+- `confirm(opts) → Promise<boolean>` and `prompt(opts) → Promise<string|null>` render as modals (reusing `ModalPrimitives`). Always `await` them; converting a handler that called `confirm()` means making it `async`.
+- `toast(message, opts)` / `alert(message, opts)` are fire-and-forget toasts (`variant`: `info`/`success`/`error`/`warning`).
+- `opts`: `message`, `title?`, `confirmLabel?`, `cancelLabel?`, `danger?` (red confirm button), `defaultValue?`/`placeholder?` (prompt), `width?`.
+- **Testing**: drive the dialog like a real user — click the confirm button by its `confirmLabel`, or type into the prompt's textbox then click confirm. See `components/DialogProvider.mount.test.jsx`.
 
 ## Key UI Behaviors
 

--- a/app/ui/src/components/AccessPackagesPage.jsx
+++ b/app/ui/src/components/AccessPackagesPage.jsx
@@ -5,6 +5,7 @@ import { TAG_COLORS } from '@ui/utils/colors';
 import { useDebouncedValue } from '@ui/hooks/useDebouncedValue';
 import { formatDateOnly as formatDate } from '@ui/utils/formatters';
 import { ASSIGNMENT_TYPE_STYLES } from '@ui/utils/accessPackageStyles';
+import { useDialog } from '@ui/components/dialogContext';
 
 const PAGE_SIZE = 100;
 
@@ -19,6 +20,7 @@ const ASSIGNMENT_TYPES = ['Auto-assigned', 'Request-based', 'Request-based with 
 
 export default function AccessPackagesPage({ onOpenDetail }) {
   const { authFetch } = useAuth();
+  const dialog = useDialog();
   const canExport = useCanExportUi();
 
   // Data state
@@ -148,7 +150,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
         await fetchCategories();
       } else {
         const err = await res.json().catch(() => ({}));
-        alert(err.error || 'Failed to create category');
+        dialog.alert(err.error || 'Failed to create category');
       }
     } finally { setBusy(false); }
   };
@@ -185,7 +187,7 @@ export default function AccessPackagesPage({ onOpenDetail }) {
   };
 
   const deleteCategory = async (catId) => {
-    if (!confirm('Delete this category and all its assignments?')) return;
+    if (!(await dialog.confirm({ message: 'Delete this category and all its assignments?', confirmLabel: 'Delete', danger: true }))) return;
     setBusy(true);
     try {
       await authFetch(`/api/categories/${catId}`, { method: 'DELETE' });

--- a/app/ui/src/components/AccessPackagesPage.mount.test.jsx
+++ b/app/ui/src/components/AccessPackagesPage.mount.test.jsx
@@ -256,7 +256,8 @@ describe('AccessPackagesPage (mounted)', () => {
     const deleteBtns = screen.getAllByTitle('Delete category');
     await user.click(deleteBtns[0]);
 
-    expect(window.confirm).toHaveBeenCalled();
+    // Confirm via the in-app dialog (replaces the native confirm()).
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
     await waitFor(() => {
       expect(authFetch).toHaveBeenCalledWith(
         '/api/categories/1',

--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useDialog } from '@ui/components/dialogContext';
 import { ADMIN_TABS, visibleAdminTabs } from './admin/adminTabs';
 
 // Lazy-load the heavy sub-tab pages so they don't bloat the initial Admin bundle
@@ -405,6 +406,7 @@ function ClassifiersSection() {
 // immediately.
 function PowerQueryExportSection() {
   const { authFetch } = useAuth();
+  const dialog = useDialog();
   const [tokens, setTokens] = useState([]);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
@@ -478,7 +480,7 @@ function PowerQueryExportSection() {
   }
 
   async function revoke(id) {
-    if (!confirm('Revoke this token? Workbooks using it will stop refreshing immediately.')) return;
+    if (!(await dialog.confirm({ message: 'Revoke this token? Workbooks using it will stop refreshing immediately.', confirmLabel: 'Revoke', danger: true }))) return;
     setBusy(true);
     try {
       const r = await authFetch(`/api/admin/read-tokens/${id}`, { method: 'DELETE' });
@@ -1103,6 +1105,7 @@ function DangerZoneSection({ onRefresh }) {
 // so the user can verify credentials before clicking Save.
 function LLMSettingsSection() {
   const { authFetch } = useAuth();
+  const dialog = useDialog();
   const [loading, setLoading] = useState(true);
   const [providers, setProviders] = useState([]);
   const [defaultModels, setDefaultModels] = useState({});
@@ -1207,7 +1210,7 @@ function LLMSettingsSection() {
   };
 
   const handleClear = async () => {
-    if (!confirm('Clear the LLM configuration and stored API key?')) return;
+    if (!(await dialog.confirm({ message: 'Clear the LLM configuration and stored API key?', confirmLabel: 'Clear', danger: true }))) return;
     await authFetch('/api/admin/llm/config', { method: 'DELETE' });
     setConfig({ provider: 'anthropic', model: '', endpoint: '', deployment: '', apiVersion: '', apiKey: '' });
     setApiKeySet(false);

--- a/app/ui/src/components/DialogProvider.jsx
+++ b/app/ui/src/components/DialogProvider.jsx
@@ -1,0 +1,158 @@
+// In-app replacement for the browser's native alert()/confirm()/prompt().
+//
+// Why: native dialogs block the main thread, can't be styled (no dark mode), and
+// are flagged by the local/no-native-dialogs ESLint rule. This provider exposes
+// an async API via useDialog():
+//
+//   const dialog = useDialog();
+//   if (await dialog.confirm({ message: 'Delete this?', danger: true })) { ... }
+//   const name = await dialog.prompt({ message: 'New name?', defaultValue: cur });
+//   dialog.toast('Saved', { variant: 'success' });   // non-blocking, auto-dismiss
+//
+// confirm/prompt render as Modals (resolve when the user acts); alert-style
+// notices surface as auto-dismissing toasts top-right. One provider near the app
+// root keeps a single source of truth so the pattern doesn't re-spread.
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Modal, PrimaryButton, SecondaryButton } from './contexts/ModalPrimitives';
+import { DialogContext } from './dialogContext';
+
+const TOAST_VARIANTS = {
+  info:    'bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:border-blue-700',
+  success: 'bg-green-50 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-200 dark:border-green-700',
+  error:   'bg-red-50 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-200 dark:border-red-700',
+  warning: 'bg-amber-50 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:border-amber-700',
+};
+
+export function DialogProvider({ children }) {
+  // A single confirm/prompt modal at a time; its resolver lives in a ref.
+  const [dialog, setDialog] = useState(null);
+  const [promptValue, setPromptValue] = useState('');
+  const resolverRef = useRef(null);
+
+  const [toasts, setToasts] = useState([]);
+  const toastIdRef = useRef(0);
+
+  const settle = useCallback((result) => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setDialog(null);
+    if (resolve) resolve(result);
+  }, []);
+
+  const confirm = useCallback((opts = {}) => new Promise((resolve) => {
+    resolverRef.current = resolve;
+    setDialog({ kind: 'confirm', ...opts });
+  }), []);
+
+  const prompt = useCallback((opts = {}) => new Promise((resolve) => {
+    resolverRef.current = resolve;
+    setPromptValue(opts.defaultValue != null ? String(opts.defaultValue) : '');
+    setDialog({ kind: 'prompt', ...opts });
+  }), []);
+
+  const dismissToast = useCallback((id) => {
+    setToasts((list) => list.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback((messageOrOpts, maybeOpts) => {
+    const opts = typeof messageOrOpts === 'string'
+      ? { message: messageOrOpts, ...maybeOpts }
+      : (messageOrOpts || {});
+    const id = ++toastIdRef.current;
+    const variant = TOAST_VARIANTS[opts.variant] ? opts.variant : 'info';
+    setToasts((list) => [...list, { id, message: opts.message, title: opts.title, variant }]);
+    const ttl = opts.duration ?? 4500;
+    if (ttl > 0) setTimeout(() => dismissToast(id), ttl);
+    return id;
+  }, [dismissToast]);
+
+  // alert() replacement — an informational toast (error variant when isError).
+  const alert = useCallback((message, opts = {}) => {
+    const text = typeof message === 'string' ? message : (message?.message ?? '');
+    return toast({ message: text, variant: opts.variant || 'error', ...opts });
+  }, [toast]);
+
+  const api = useMemo(() => ({ confirm, prompt, toast, alert }), [confirm, prompt, toast, alert]);
+
+  return (
+    <DialogContext.Provider value={api}>
+      {children}
+
+      {dialog?.kind === 'confirm' && (
+        <Modal
+          title={dialog.title || 'Please confirm'}
+          onClose={() => settle(false)}
+          width={dialog.width || 420}
+          dismissOnBackdrop={false}
+        >
+          {dialog.message && (
+            <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-line">{dialog.message}</p>
+          )}
+          <div className="flex justify-end gap-2 mt-4">
+            <SecondaryButton onClick={() => settle(false)}>{dialog.cancelLabel || 'Cancel'}</SecondaryButton>
+            {dialog.danger ? (
+              <button
+                onClick={() => settle(true)}
+                className="px-3 py-1 text-xs rounded bg-red-600 dark:bg-red-700 text-white hover:bg-red-700 dark:hover:bg-red-600"
+              >
+                {dialog.confirmLabel || 'Confirm'}
+              </button>
+            ) : (
+              <PrimaryButton onClick={() => settle(true)}>{dialog.confirmLabel || 'Confirm'}</PrimaryButton>
+            )}
+          </div>
+        </Modal>
+      )}
+
+      {dialog?.kind === 'prompt' && (
+        <Modal
+          title={dialog.title || 'Enter a value'}
+          onClose={() => settle(null)}
+          width={dialog.width || 420}
+          dismissOnBackdrop={false}
+        >
+          <form onSubmit={(e) => { e.preventDefault(); settle(promptValue); }}>
+            {dialog.message && (
+              <p className="text-sm text-gray-700 dark:text-gray-300 mb-2 whitespace-pre-line">{dialog.message}</p>
+            )}
+            <input
+              autoFocus
+              value={promptValue}
+              onChange={(e) => setPromptValue(e.target.value)}
+              placeholder={dialog.placeholder}
+              className="w-full px-2 py-1 border border-gray-200 dark:border-gray-700 rounded text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:focus:ring-sky-500"
+            />
+            <div className="flex justify-end gap-2 mt-4">
+              <SecondaryButton onClick={() => settle(null)}>{dialog.cancelLabel || 'Cancel'}</SecondaryButton>
+              <PrimaryButton onClick={() => settle(promptValue)}>{dialog.confirmLabel || 'OK'}</PrimaryButton>
+            </div>
+          </form>
+        </Modal>
+      )}
+
+      {/* Toast stack — top-right, above modals. Only mounted when non-empty so
+          an idle provider adds no DOM (keeps "renders nothing" mounts clean). */}
+      {toasts.length > 0 && (
+        <div className="fixed top-4 right-4 z-[60] flex flex-col gap-2 w-80 max-w-[calc(100vw-2rem)] pointer-events-none">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            role="status"
+            className={`pointer-events-auto rounded-lg border shadow-lg px-3 py-2 text-sm flex items-start gap-2 ${TOAST_VARIANTS[t.variant]}`}
+          >
+            <div className="min-w-0 flex-1">
+              {t.title && <p className="font-semibold">{t.title}</p>}
+              <p className="whitespace-pre-line break-words">{t.message}</p>
+            </div>
+            <button
+              onClick={() => dismissToast(t.id)}
+              className="shrink-0 opacity-70 hover:opacity-100"
+              aria-label="Dismiss"
+            >✕</button>
+          </div>
+        ))}
+        </div>
+      )}
+    </DialogContext.Provider>
+  );
+}

--- a/app/ui/src/components/DialogProvider.mount.test.jsx
+++ b/app/ui/src/components/DialogProvider.mount.test.jsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import { createElement as h, useState } from 'react';
-import { renderWithProviders, screen, within, waitFor, userEvent, act } from '@ui/test-utils/renderWithProviders';
+import { renderWithProviders, screen, within, waitFor, userEvent } from '@ui/test-utils/renderWithProviders';
 import { useDialog } from './dialogContext';
 
 // A tiny harness component that exposes each dialog API via buttons and shows

--- a/app/ui/src/components/DialogProvider.mount.test.jsx
+++ b/app/ui/src/components/DialogProvider.mount.test.jsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createElement as h, useState } from 'react';
+import { renderWithProviders, screen, within, waitFor, userEvent, act } from '@ui/test-utils/renderWithProviders';
+import { useDialog } from './dialogContext';
+
+// A tiny harness component that exposes each dialog API via buttons and shows
+// the resolved result, so we can assert the async resolve/reject flow.
+function Harness() {
+  const dialog = useDialog();
+  const [result, setResult] = useState('—');
+  return h('div', null,
+    h('button', { onClick: async () => setResult(String(await dialog.confirm({ message: 'Sure?', confirmLabel: 'Yes', danger: true }))) }, 'ask-confirm'),
+    h('button', { onClick: async () => setResult(String(await dialog.prompt({ message: 'Name?', confirmLabel: 'Save' }))) }, 'ask-prompt'),
+    h('button', { onClick: () => { dialog.toast('Saved!', { variant: 'success' }); } }, 'fire-toast'),
+    h('button', { onClick: () => { dialog.alert('Boom'); } }, 'fire-alert'),
+    h('span', { 'data-testid': 'result' }, result),
+  );
+}
+
+function setup() {
+  renderWithProviders(h(Harness));
+  return userEvent.setup();
+}
+
+describe('DialogProvider / useDialog', () => {
+  it('confirm() resolves true when the confirm button is clicked', async () => {
+    const user = setup();
+    await user.click(screen.getByText('ask-confirm'));
+    await user.click(await screen.findByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('true'));
+  });
+
+  it('confirm() resolves false when cancelled', async () => {
+    const user = setup();
+    await user.click(screen.getByText('ask-confirm'));
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('false'));
+  });
+
+  it('prompt() resolves the typed value', async () => {
+    const user = setup();
+    await user.click(screen.getByText('ask-prompt'));
+    const input = await screen.findByRole('textbox');
+    await user.type(input, 'Alice');
+    await user.click(within(input.closest('form')).getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('Alice'));
+  });
+
+  it('prompt() resolves null when cancelled', async () => {
+    const user = setup();
+    await user.click(screen.getByText('ask-prompt'));
+    const input = await screen.findByRole('textbox');
+    await user.click(within(input.closest('form')).getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.getByTestId('result')).toHaveTextContent('null'));
+  });
+
+  it('toast() shows a message and can be dismissed', async () => {
+    const user = setup();
+    await user.click(screen.getByText('fire-toast'));
+    const toast = await screen.findByText('Saved!');
+    await user.click(within(toast.closest('[role="status"]')).getByRole('button', { name: 'Dismiss' }));
+    await waitFor(() => expect(screen.queryByText('Saved!')).not.toBeInTheDocument());
+  });
+
+  it('alert() surfaces a toast', async () => {
+    const user = setup();
+    await user.click(screen.getByText('fire-alert'));
+    expect(await screen.findByText('Boom')).toBeInTheDocument();
+  });
+
+  it('renders no dialog/toast DOM when idle', () => {
+    renderWithProviders(h('div', { 'data-testid': 'idle' }, 'hi'));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});

--- a/app/ui/src/components/RiskProfileWizard.jsx
+++ b/app/ui/src/components/RiskProfileWizard.jsx
@@ -20,6 +20,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
 import JsonViewer from './JsonViewer';
 import Stepper from './Stepper';
+import { useDialog } from '@ui/components/dialogContext';
 
 const STEPS = [
   { key: 'sources',     label: 'Sources' },
@@ -31,6 +32,7 @@ const STEPS = [
 
 export default function RiskProfileWizard({ onClose, onSaved }) {
   const { authFetch } = useAuth();
+  const dialog = useDialog();
   const [stepIdx, setStepIdx] = useState(0);
   const [llmReady, setLlmReady] = useState(null); // null=loading, bool
 
@@ -221,7 +223,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
         setSavedProfileId(j.id);
         setStepIdx(3);
       } else {
-        alert(j.error || `HTTP ${r.status}`);
+        dialog.alert(j.error || `HTTP ${r.status}`);
       }
     } finally { setSavingProfile(false); }
   }
@@ -271,7 +273,7 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
         setSavedClassifierId(j.id);
         setStepIdx(4);
       } else {
-        alert(j.error || `HTTP ${r.status}`);
+        dialog.alert(j.error || `HTTP ${r.status}`);
       }
     } finally { setSavingClassifiers(false); }
   }

--- a/app/ui/src/components/RolesPermissionsSection.jsx
+++ b/app/ui/src/components/RolesPermissionsSection.jsx
@@ -18,9 +18,11 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useDialog } from '@ui/components/dialogContext';
 
 export default function RolesPermissionsSection() {
   const { authFetch, refreshPermissions } = useAuth();
+  const dialog = useDialog();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [data, setData]   = useState(null);
@@ -135,7 +137,7 @@ export default function RolesPermissionsSection() {
   };
 
   const handleReset = async () => {
-    if (!confirm('Reset to the built-in Admin / RoleMiner / Servicedesk defaults? Any custom roles will be removed.')) return;
+    if (!(await dialog.confirm({ message: 'Reset to the built-in Admin / RoleMiner / Servicedesk defaults? Any custom roles will be removed.', confirmLabel: 'Reset', danger: true }))) return;
     setSaving(true);
     setSaveMessage(null);
     try {
@@ -155,8 +157,8 @@ export default function RolesPermissionsSection() {
     }
   };
 
-  const handleAddRole = () => {
-    const name = prompt('Role name (must match the role string in the Entra app registration):');
+  const handleAddRole = async () => {
+    const name = await dialog.prompt({ title: 'Add role', message: 'Role name (must match the role string in the Entra app registration):', confirmLabel: 'Add' });
     if (!name) return;
     const trimmed = name.trim();
     if (!trimmed) return;
@@ -166,8 +168,8 @@ export default function RolesPermissionsSection() {
     });
   };
 
-  const handleRemoveRole = (role) => {
-    if (!confirm(`Remove role "${role}" from the mapping? Users who only have this role in their token will fall back to having no permissions.`)) return;
+  const handleRemoveRole = async (role) => {
+    if (!(await dialog.confirm({ message: `Remove role "${role}" from the mapping? Users who only have this role in their token will fall back to having no permissions.`, confirmLabel: 'Remove', danger: true }))) return;
     setDraft(prev => {
       const next = { ...prev };
       delete next[role];

--- a/app/ui/src/components/RolesPermissionsSection.mount.test.jsx
+++ b/app/ui/src/components/RolesPermissionsSection.mount.test.jsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createElement as h } from 'react';
 import RolesPermissionsSection from './RolesPermissionsSection';
-import { renderWithProviders, makeAuthFetch, jsonResponse, screen, within, userEvent } from '@ui/test-utils/renderWithProviders';
+import { renderWithProviders, makeAuthFetch, jsonResponse, screen, within, waitFor, userEvent } from '@ui/test-utils/renderWithProviders';
 
 // Shape returned by GET /api/admin/roles.
 function makeData(overrides = {}) {
@@ -191,11 +191,17 @@ describe('RolesPermissionsSection (mounted)', () => {
 
     await screen.findByText('Roles & Permissions');
     await user.click(screen.getByText('+ Add role'));
+    // Prompt is now an in-app modal: type the role name into its (autofocused)
+    // input and confirm.
+    await screen.findByText('Add role');
+    await user.keyboard('Servicedesk');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
     expect(await screen.findByText('Servicedesk')).toBeInTheDocument();
 
-    // Remove the newly-added role via its ✕ button.
+    // Remove the newly-added role via its ✕ button, then confirm in the dialog.
     const removeBtn = screen.getByTitle('Remove role "Servicedesk"');
     await user.click(removeBtn);
+    await user.click(await screen.findByRole('button', { name: 'Remove' }));
     expect(screen.queryByText('Servicedesk')).not.toBeInTheDocument();
   });
 
@@ -206,11 +212,13 @@ describe('RolesPermissionsSection (mounted)', () => {
 
     await screen.findByText('Roles & Permissions');
     await user.click(screen.getByText('Reset to defaults'));
+    // Confirm in the in-app dialog.
+    await user.click(await screen.findByRole('button', { name: 'Reset' }));
 
-    expect(authFetch).toHaveBeenCalledWith(
+    await waitFor(() => expect(authFetch).toHaveBeenCalledWith(
       '/api/admin/roles',
       expect.objectContaining({ method: 'DELETE' }),
-    );
+    ));
     expect(await screen.findByText('Reverted to defaults.')).toBeInTheDocument();
   });
 
@@ -223,18 +231,22 @@ describe('RolesPermissionsSection (mounted)', () => {
 
     await screen.findByText('Roles & Permissions');
     await user.click(screen.getByText('Reset to defaults'));
+    await user.click(await screen.findByRole('button', { name: 'Reset' }));
 
     expect(await screen.findByText('cannot reset')).toBeInTheDocument();
   });
 
-  it('cancelling the Add-role prompt is a no-op', async () => {
-    window.prompt.mockReturnValueOnce('   '); // whitespace-only -> trimmed to nothing
+  it('cancelling the Add-role dialog is a no-op', async () => {
     renderWithProviders(h(RolesPermissionsSection), { auth: { authFetch: routes() } });
     const user = userEvent.setup();
 
     await screen.findByText('Roles & Permissions');
     const before = screen.getAllByText('all (*)').length;
     await user.click(screen.getByText('+ Add role'));
+    // Dismiss the prompt dialog without entering anything (scope to the dialog
+    // form — the page has its own Cancel buttons).
+    const input = await screen.findByRole('textbox');
+    await user.click(within(input.closest('form')).getByRole('button', { name: 'Cancel' }));
     expect(screen.getAllByText('all (*)')).toHaveLength(before);
   });
 });

--- a/app/ui/src/components/dialogContext.js
+++ b/app/ui/src/components/dialogContext.js
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+// Context + hook for the in-app dialog system (see DialogProvider.jsx). Kept in
+// a non-component module so DialogProvider.jsx only exports its component
+// (Vite fast-refresh requirement).
+export const DialogContext = createContext(null);
+
+export function useDialog() {
+  const ctx = useContext(DialogContext);
+  if (!ctx) throw new Error('useDialog must be used within <DialogProvider>');
+  return ctx;
+}

--- a/app/ui/src/components/matrix/MatrixFilterWizard.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.jsx
@@ -19,6 +19,7 @@ import Stepper from '@ui/components/Stepper';
 import { Modal, PrimaryButton, SecondaryButton, ErrorBox } from '@ui/components/contexts/ModalPrimitives';
 import ContextPicker from '@ui/components/contexts/ContextPicker';
 import { variantMeta, targetTypeMeta } from '@ui/utils/contextStyles';
+import { useDialog } from '@ui/components/dialogContext';
 import { friendlyLabel } from '@ui/utils/formatters';
 
 // ─── Constants ──────────────────────────────────────────────────────
@@ -143,6 +144,7 @@ export default function MatrixFilterWizard({
   onClose,
 }) {
   const { authFetch } = useAuth();
+  const dialog = useDialog();
   const [step, setStep] = useState('setup');
   const [filter, setFilter] = useState(() => structuredClone(initialFilter || EMPTY_FILTER));
   // The All / Governed / Non-governed toggle lives in the matrix toolbar, not
@@ -369,7 +371,7 @@ export default function MatrixFilterWizard({
   };
 
   const handleDeleteSaved = async (id) => {
-    if (!confirm('Delete this saved filter? This affects everyone in the org.')) return;
+    if (!(await dialog.confirm({ message: 'Delete this saved filter? This affects everyone in the org.', confirmLabel: 'Delete', danger: true }))) return;
     await authFetch(`/api/matrix/saved-filters/${id}`, { method: 'DELETE' }).catch(() => {});
     setSavedFilters(prev => prev.filter(f => f.id !== id));
   };

--- a/app/ui/src/hooks/useEntityPage.js
+++ b/app/ui/src/hooks/useEntityPage.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useDebouncedValue } from './useDebouncedValue';
+import { useDialog } from '@ui/components/dialogContext';
 
 const PAGE_SIZE = 100;
 
@@ -19,6 +20,7 @@ const PAGE_SIZE = 100;
  *   The caller is expected to memoise this object so its identity is stable per intended value.
  */
 export default function useEntityPage({ authFetch, entityType, listEndpoint, columnsEndpoint, tagFilterKey, baseFilters }) {
+  const dialog = useDialog();
   // Data state
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
@@ -183,7 +185,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
         await fetchTags();
       } else {
         const err = await res.json().catch(() => ({}));
-        alert(err.error || 'Failed to create tag');
+        dialog.alert(err.error || 'Failed to create tag');
       }
     } finally { setBusy(false); }
   };
@@ -217,7 +219,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
       });
       if (res.ok) {
         const json = await res.json();
-        alert(`Tagged ${json.inserted} ${entityType}s`);
+        dialog.toast(`Tagged ${json.inserted} ${entityType}s`, { variant: 'success' });
       }
       setActionTag('');
       await Promise.all([fetchItems(), fetchTags()]);
@@ -239,7 +241,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
   };
 
   const deleteTag = async (tagId) => {
-    if (!confirm('Delete this tag and all its assignments?')) return;
+    if (!(await dialog.confirm({ message: 'Delete this tag and all its assignments?', confirmLabel: 'Delete', danger: true }))) return;
     setBusy(true);
     try {
       await authFetch(`/api/tags/${tagId}`, { method: 'DELETE' });

--- a/app/ui/src/main.jsx
+++ b/app/ui/src/main.jsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import AuthGate from './auth/AuthGateProvider.jsx'
+import { DialogProvider } from './components/DialogProvider.jsx'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthGate>
-      <App />
+      <DialogProvider>
+        <App />
+      </DialogProvider>
     </AuthGate>
   </StrictMode>,
 )

--- a/app/ui/src/test-utils/renderWithProviders.jsx
+++ b/app/ui/src/test-utils/renderWithProviders.jsx
@@ -18,6 +18,7 @@ import { cleanup, render } from '@testing-library/react';
 import { createElement as h } from 'react';
 import { ThemeContext } from '@ui/contexts/ThemeContext';
 import { AuthContext } from '@ui/auth/AuthGate';
+import { DialogProvider } from '@ui/components/DialogProvider';
 
 // @testing-library/react does not auto-clean when vitest `globals` is off (this
 // project imports test fns explicitly), so unmount between tests ourselves.
@@ -98,7 +99,9 @@ const defaultAuth = {
 export function renderWithProviders(ui, { auth = {}, theme = { isDark: false, mode: 'light' } } = {}) {
   const authValue = { ...defaultAuth, ...auth };
   const result = render(
-    h(ThemeContext.Provider, { value: theme }, h(AuthContext.Provider, { value: authValue }, ui)),
+    h(ThemeContext.Provider, { value: theme },
+      h(AuthContext.Provider, { value: authValue },
+        h(DialogProvider, null, ui))),
   );
   return { authFetch: authValue.authFetch, ...result };
 }
@@ -111,7 +114,9 @@ export function renderWithProviders(ui, { auth = {}, theme = { isDark: false, mo
 export function makeWrapper({ auth = {}, theme = { isDark: false, mode: 'light' } } = {}) {
   const authValue = { ...defaultAuth, ...auth };
   function Wrapper({ children }) {
-    return h(ThemeContext.Provider, { value: theme }, h(AuthContext.Provider, { value: authValue }, children));
+    return h(ThemeContext.Provider, { value: theme },
+      h(AuthContext.Provider, { value: authValue },
+        h(DialogProvider, null, children)));
   }
   return { wrapper: Wrapper, authFetch: authValue.authFetch };
 }

--- a/changes/in-app-dialogs.md
+++ b/changes/in-app-dialogs.md
@@ -1,0 +1,1 @@
+- Replaced the browser's native `alert`/`confirm`/`prompt` pop-ups with themed in-app dialogs and toast notifications — dark-mode aware, non-blocking, and consistent with the rest of the UI.


### PR DESCRIPTION
## Summary
Resolves #416. Replaces every native `alert`/`confirm`/`prompt` (13 sites, flagged by `local/no-native-dialogs`) with an in-app dialog system — themed, dark-mode aware, non-blocking.

## What's added
- **`DialogProvider` + `useDialog()`** (`components/DialogProvider.jsx`, `components/dialogContext.js`), mounted once at the app root and in the mount-test harness. Async API:
  - `confirm(opts) → Promise<boolean>` and `prompt(opts) → Promise<string|null>` render as modals (reusing `ModalPrimitives`; `danger` gives a red confirm button).
  - `toast()` / `alert()` surface as auto-dismissing top-right toasts (`info`/`success`/`error`/`warning`).

## Call sites converted (13 → 0 native)
`useEntityPage`, `AccessPackagesPage`, `AdminPage` (×2), `RiskProfileWizard` (×2), `RolesPermissionsSection` (×3: confirm/prompt/confirm), `MatrixFilterWizard`. Handlers that called the synchronous `confirm()`/`prompt()` are now `async`.

## Tests & docs
- **New:** `DialogProvider.mount.test.jsx` — confirm/prompt resolve true/false/value/null, toast show+dismiss, alert→toast, idle-renders-nothing (7 tests).
- **Updated:** the AccessPackages + RolesPermissions mount tests now *drive the in-app dialog* (click the confirm button / type into the prompt) instead of stubbing `window.confirm/prompt`.
- Documented the pattern + "never use native dialogs" rule in `app/ui/CLAUDE.md`.

## Verification
- `local/no-native-dialogs`: **13 → 0**.
- UI suite: **649 passed** (the only 2 failures are the pre-existing, locale-dependent #495 bug — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
