### PR TITLE
test(ui): locale-agnostic number-format assertions (resolves #495)

### DIFF
--- a/app/ui/src/components/AdminPage.mount.test.jsx
+++ b/app/ui/src/components/AdminPage.mount.test.jsx
@@ -162,7 +162,7 @@ describe('AdminPage (mounted)', () => {
     // Locale-agnostic: the component formats via toLocaleString(), so build the
     // expected text the same way (the thousands separator differs per locale —
     // en-US "12,345" vs en-NL "12.345"). Escape it for the regex.
-    const rows = (12345).toLocaleString().replace(/[.,]/g, '\\$&');
+    const rows = (12345).toLocaleString().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     expect(await screen.findByText(new RegExp(`${rows} history rows stored`))).toBeInTheDocument();
     expect(screen.getByText('Danger Zone')).toBeInTheDocument();
   });

--- a/app/ui/src/components/AdminPage.mount.test.jsx
+++ b/app/ui/src/components/AdminPage.mount.test.jsx
@@ -159,7 +159,11 @@ describe('AdminPage (mounted)', () => {
     // Curated data + history + danger zone all render in the Data tab
     expect(screen.getByText('Curated Data')).toBeInTheDocument();
     expect(screen.getByText(/History Retention/)).toBeInTheDocument();
-    expect(await screen.findByText(/12,345 history rows stored/)).toBeInTheDocument();
+    // Locale-agnostic: the component formats via toLocaleString(), so build the
+    // expected text the same way (the thousands separator differs per locale —
+    // en-US "12,345" vs en-NL "12.345"). Escape it for the regex.
+    const rows = (12345).toLocaleString().replace(/[.,]/g, '\\$&');
+    expect(await screen.findByText(new RegExp(`${rows} history rows stored`))).toBeInTheDocument();
     expect(screen.getByText('Danger Zone')).toBeInTheDocument();
   });
 

--- a/app/ui/src/components/matrix/MatrixFilterWizard.mount.test.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.mount.test.jsx
@@ -288,7 +288,7 @@ describe('MatrixFilterWizard (mounted)', () => {
     // Wait for the oversized preview to land, then Apply should be disabled.
     // Locale-agnostic: the count is rendered via toLocaleString() (en-US "99,999"
     // vs en-NL "99.999"), so match the same formatting, escaped for the regex.
-    const count = (99999).toLocaleString().replace(/[.,]/g, '\\$&');
+    const count = (99999).toLocaleString().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     expect(await screen.findByText(new RegExp(count))).toBeInTheDocument();
     const applyBtn = await screen.findByText('Apply');
     expect(applyBtn).toBeDisabled();

--- a/app/ui/src/components/matrix/MatrixFilterWizard.mount.test.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.mount.test.jsx
@@ -286,7 +286,10 @@ describe('MatrixFilterWizard (mounted)', () => {
     if (next) await user.click(next);
 
     // Wait for the oversized preview to land, then Apply should be disabled.
-    expect(await screen.findByText(/99,999/)).toBeInTheDocument();
+    // Locale-agnostic: the count is rendered via toLocaleString() (en-US "99,999"
+    // vs en-NL "99.999"), so match the same formatting, escaped for the regex.
+    const count = (99999).toLocaleString().replace(/[.,]/g, '\\$&');
+    expect(await screen.findByText(new RegExp(count))).toBeInTheDocument();
     const applyBtn = await screen.findByText('Apply');
     expect(applyBtn).toBeDisabled();
     expect(onApply).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Resolves #495. Two mount tests asserted comma-grouped numbers (`12,345`, `99,999`) but the components render via `toLocaleString()`, so they failed on any non-`en-US` locale (e.g. `en-NL` → `12.345` / `99.999`) while passing on CI's `en-US` runners.

## Fix
Build the expected text the same way the component does — `(n).toLocaleString()`, with the separator escaped for the regex — so the assertion matches whatever the runtime locale produces.

## Verification
Run on **en-NL** (where these previously failed): the full UI suite is now **651 passed, 0 failed** (was 2 failing). Still passes on `en-US`.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)