### PR TITLE
refactor(ui): convert Contexts data hooks to useFetch (part of #417, stacked on #501)

### DIFF
--- a/app/ui/src/hooks/useContextTrees.js
+++ b/app/ui/src/hooks/useContextTrees.js
@@ -2,60 +2,33 @@
 // root's subtree. A single hook for the Contexts tab — the tree selector
 // and the tree/list view both consume its output.
 
-import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useFetch } from '@ui/hooks/useFetch';
 
 export function useContextRoots() {
   const { authFetch } = useAuth();
-  const [roots, setRoots] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  const reload = useCallback(async () => {
-    setLoading(true); setError(null);
-    try {
-      const r = await authFetch('/api/contexts');
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const body = await r.json();
-      setRoots(body.data || []);
-    } catch (err) {
-      console.error('Failed to load context roots:', err);
-      setError(err.message || 'Failed to load contexts');
-    } finally {
-      setLoading(false);
-    }
-  }, [authFetch]);
-
-  useEffect(() => { reload(); }, [reload]);
-
-  return { roots, loading, error, reload };
+  const { data: roots, loading, error, reload } = useFetch('/api/contexts', {
+    authFetch,
+    initialData: [],
+    transform: (body) => body.data || [],
+    onError: (err) => console.error('Failed to load context roots:', err),
+  });
+  return { roots, loading, error: error ? (error.message || 'Failed to load contexts') : null, reload };
 }
 
 export function useContextSubtree(rootId) {
   const { authFetch } = useAuth();
-  const [nodes, setNodes] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-
-  const reload = useCallback(async () => {
-    if (!rootId) { setNodes([]); return; }
-    setLoading(true); setError(null);
-    try {
-      const r = await authFetch(`/api/contexts/tree?root=${encodeURIComponent(rootId)}`);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const body = await r.json();
-      setNodes(Array.isArray(body) ? body : []);
-    } catch (err) {
-      console.error('Failed to load subtree:', err);
-      setError(err.message || 'Failed to load subtree');
-    } finally {
-      setLoading(false);
-    }
-  }, [authFetch, rootId]);
-
-  useEffect(() => { reload(); }, [reload]);
-
-  return { nodes, loading, error, reload };
+  const { data: nodes, loading, error, reload } = useFetch(
+    rootId ? `/api/contexts/tree?root=${encodeURIComponent(rootId)}` : null,
+    {
+      authFetch,
+      enabled: !!rootId,
+      initialData: [],
+      transform: (body) => (Array.isArray(body) ? body : []),
+      onError: (err) => console.error('Failed to load subtree:', err),
+    },
+  );
+  return { nodes, loading, error: error ? (error.message || 'Failed to load subtree') : null, reload };
 }
 
 // Flattens a nested tree (children-of-children) into an indent-aware list.

--- a/app/ui/src/hooks/useContextTrees.test.js
+++ b/app/ui/src/hooks/useContextTrees.test.js
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor, makeWrapper, makeAuthFetch } from '@ui/test-utils/renderWithProviders';
+import { useContextRoots, useContextSubtree, flattenTree } from './useContextTrees';
+
+// authFetch is read from AuthContext inside these hooks, so wrap with makeWrapper.
+function rootsWrapper(handler) {
+  return makeWrapper({ auth: { authFetch: makeAuthFetch(handler) } }).wrapper;
+}
+
+describe('useContextRoots', () => {
+  it('loads roots from /api/contexts (body.data)', async () => {
+    const wrapper = rootsWrapper({ '/api/contexts': { data: [{ id: 'r1' }, { id: 'r2' }] } });
+    const { result } = renderHook(() => useContextRoots(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.roots).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes a string error on failure', async () => {
+    const wrapper = rootsWrapper(() => undefined); // unmatched → 404
+    const { result } = renderHook(() => useContextRoots(), { wrapper });
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(typeof result.current.error).toBe('string');
+  });
+});
+
+describe('useContextSubtree', () => {
+  it('does not fetch when rootId is falsy', () => {
+    const authFetch = makeAuthFetch({});
+    const wrapper = makeWrapper({ auth: { authFetch } }).wrapper;
+    const { result } = renderHook(() => useContextSubtree(null), { wrapper });
+    expect(authFetch).not.toHaveBeenCalled();
+    expect(result.current.nodes).toEqual([]);
+  });
+
+  it('loads the subtree for a rootId', async () => {
+    const wrapper = rootsWrapper((url) =>
+      url.includes('/api/contexts/tree') ? [{ id: 'n1' }, { id: 'n2' }] : undefined,
+    );
+    const { result } = renderHook(() => useContextSubtree('root-1'), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.nodes).toHaveLength(2);
+  });
+});
+
+describe('flattenTree', () => {
+  it('flattens nested children with depth markers', () => {
+    const flat = flattenTree([
+      { id: 'a', children: [{ id: 'b', children: [{ id: 'c' }] }] },
+      { id: 'd' },
+    ]);
+    expect(flat.map((n) => [n.id, n._depth])).toEqual([['a', 0], ['b', 1], ['c', 2], ['d', 0]]);
+  });
+});

--- a/changes/setstate-in-effect-2.md
+++ b/changes/setstate-in-effect-2.md
@@ -1,0 +1,1 @@
+- Internal code-quality: converted the Contexts data hooks (`useContextRoots`, `useContextSubtree`) to the shared `useFetch` hook, clearing more `react-hooks/set-state-in-effect` warnings. No user-facing behaviour change.


### PR DESCRIPTION
## Summary
**Part of #417**, **stacked on #501** (targets that branch — review/merge #501 first, then retarget this to `main`).

Continues the bespoke conversions: `useContextRoots` and `useContextSubtree` (in `hooks/useContextTrees.js`) now use the shared `useFetch` hook from #501.

- They preserve their existing **string-`error` contract** (mapping `useFetch`'s `Error` → message), so consumers (`ContextsPage`, `ContextListView`) are unchanged.
- The subtree fetch uses `enabled`/`url` gating for the no-root case (was an early-return + `setNodes([])`).
- `react-hooks/set-state-in-effect`: **53 → 51**.

## Verification
ContextsPage mount tests pass (11). Full UI suite green on CI (the 2 local failures are the unrelated #495 locale tests, fixed in #502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)