### PR TITLE
refactor(ui): convert simple pages to useFetch (part of #417, stacked on #501)

### DIFF
--- a/app/ui/src/components/AuthSettingsPage.jsx
+++ b/app/ui/src/components/AuthSettingsPage.jsx
@@ -1,5 +1,6 @@
-﻿import { useEffect, useState } from 'react';
+﻿import { useState } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useFetch } from '@ui/hooks/useFetch';
 import { useIsAdmin } from '@ui/auth/usePermissions';
 import RolesPermissionsSection from './RolesPermissionsSection';
 
@@ -26,27 +27,9 @@ function CopyableCommand({ command }) {
 export default function AuthSettingsPage() {
   const { authFetch } = useAuth();
   const isAdmin = useIsAdmin();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [state, setState] = useState(null);
+  const { data: state, loading, error, reload } = useFetch('/api/admin/auth-settings', { authFetch });
 
   const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
-
-  const refresh = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const r = await authFetch('/api/admin/auth-settings');
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      setState(await r.json());
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => { refresh(); }, [authFetch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading && !state) {
     return <div className="text-sm text-gray-500 dark:text-gray-400 p-6">Loading authentication settings...</div>;
@@ -111,8 +94,8 @@ export default function AuthSettingsPage() {
           </div>
         </div>
 
-        {error && <div className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</div>}
-        <button onClick={refresh} className="mt-3 text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300">↻ Refresh</button>
+        {error && <div className="mt-3 text-sm text-red-600 dark:text-red-400">{error.message}</div>}
+        <button onClick={reload} className="mt-3 text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300">↻ Refresh</button>
       </div>
 
       {/* ─── Roles & Permissions (visible only with admin.auth) ─── */}

--- a/app/ui/src/components/AuthSettingsPage.mount.test.jsx
+++ b/app/ui/src/components/AuthSettingsPage.mount.test.jsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createElement as h } from 'react';
+import AuthSettingsPage from './AuthSettingsPage';
+import { renderWithProviders, makeAuthFetch, screen } from '@ui/test-utils/renderWithProviders';
+
+// AuthSettingsPage loads /api/admin/auth-settings via useFetch and (for admins)
+// renders RolesPermissionsSection, which loads /api/admin/roles.
+function routes(extra = {}) {
+  return makeAuthFetch((url) => {
+    const u = String(url);
+    if (u.includes('/api/admin/auth-settings')) return { enabled: true, tenantId: 'tid-123', clientId: 'cid-456', requiredRoles: ['Admin'], ...extra };
+    if (u.includes('/api/admin/roles')) return { mapping: {}, groups: [], catalog: [] };
+    return {};
+  });
+}
+
+const admin = (authFetch) => ({ auth: { authFetch, hasWildcard: true, permissions: new Set(['*']) } });
+
+describe('AuthSettingsPage (mounted)', () => {
+  it('loads and renders the auth-settings state card (useFetch path)', async () => {
+    renderWithProviders(h(AuthSettingsPage), admin(routes()));
+    expect(await screen.findByText('Authentication')).toBeInTheDocument();
+    expect(await screen.findByText('ENABLED')).toBeInTheDocument();
+    expect(screen.getByText('tid-123')).toBeInTheDocument();
+  });
+
+  it('shows DISABLED when auth is off', async () => {
+    renderWithProviders(h(AuthSettingsPage), admin(routes({ enabled: false })));
+    expect(await screen.findByText('DISABLED')).toBeInTheDocument();
+  });
+});

--- a/app/ui/src/components/DashboardTrendsTab.jsx
+++ b/app/ui/src/components/DashboardTrendsTab.jsx
@@ -4,8 +4,9 @@
 // The chart series start as a single point on the day the snapshot
 // table was introduced and grow over time. No historical backfill.
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useFetch } from '@ui/hooks/useFetch';
 import TimeSeriesChart from './TimeSeriesChart';
 
 const RANGE_OPTIONS = [
@@ -18,21 +19,7 @@ const RANGE_OPTIONS = [
 export default function DashboardTrendsTab() {
   const { authFetch } = useAuth();
   const [days, setDays] = useState(90);
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    authFetch(`/api/admin/dashboard-timeseries?days=${days}`)
-      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
-      .then(d => { if (!cancelled) setData(d); })
-      .catch(err => { if (!cancelled) setError(err.message); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [authFetch, days]);
+  const { data, loading, error } = useFetch(`/api/admin/dashboard-timeseries?days=${days}`, { authFetch });
 
   const rows = data?.data || [];
 
@@ -81,7 +68,7 @@ export default function DashboardTrendsTab() {
 
       {error && (
         <div className="rounded-lg border border-rose-200 dark:border-rose-700 bg-rose-50 dark:bg-rose-900/20 p-3 text-sm text-rose-700 dark:text-rose-300">
-          Failed to load: {error}
+          Failed to load: {error.message}
         </div>
       )}
 

--- a/app/ui/src/components/GovernancePage.jsx
+++ b/app/ui/src/components/GovernancePage.jsx
@@ -1,4 +1,5 @@
-﻿import { useState, useEffect, useCallback } from 'react';
+﻿import { useState, useCallback } from 'react';
+import { useFetch } from '@ui/hooks/useFetch';
 import { useAuth } from '@ui/auth/AuthGate';
 import { formatDate } from '@ui/utils/formatters';
 
@@ -89,33 +90,15 @@ const STATUS_STYLES = {
 // ═══════════════════════════════════════════════════════════
 export default function GovernancePage() {
   const { authFetch } = useAuth();
-  const [summary, setSummary] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  const [categories, setCategories] = useState(null);
+  // Summary drives the page's loading/error; categories is a best-effort
+  // secondary fetch (feeds the filter dropdown) — its own errors are ignored,
+  // matching the previous Promise.all where a categories failure fell back to [].
+  const { data: summary, loading, error } = useFetch('/api/governance/summary', { authFetch });
+  const { data: categories } = useFetch('/api/governance/categories', { authFetch, initialData: [] });
 
   const [drilldown, setDrilldown] = useState(null);
   const [drilldownOpen, setDrilldownOpen] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('');
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    Promise.all([
-      authFetch('/api/governance/summary').then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }),
-      authFetch('/api/governance/categories').then(r => r.ok ? r.json() : []).catch(() => []),
-    ])
-      .then(([summaryData, cats]) => {
-        if (!cancelled) {
-          setSummary(summaryData);
-          setCategories(cats);
-        }
-      })
-      .catch(e => { if (!cancelled) setError(e.message); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [authFetch]);
 
   const loadDrilldown = useCallback((filter, category) => {
     setDrilldown({ filter, category, data: null, loading: true });
@@ -146,7 +129,7 @@ export default function GovernancePage() {
     return (
       <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg p-6">
         <h2 className="text-red-800 dark:text-red-300 font-semibold">Error loading certification data</h2>
-        <p className="text-red-600 dark:text-red-400 mt-1 text-sm">{error}</p>
+        <p className="text-red-600 dark:text-red-400 mt-1 text-sm">{error.message}</p>
       </div>
     );
   }

--- a/app/ui/src/components/SystemsPage.jsx
+++ b/app/ui/src/components/SystemsPage.jsx
@@ -1,5 +1,6 @@
-﻿import { useState, useEffect, useCallback } from 'react';
+﻿import { useState } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useFetch } from '@ui/hooks/useFetch';
 import EmptyState from './EmptyState';
 
 function formatRelativeTime(dateStr) {
@@ -24,26 +25,12 @@ function parseJsonArray(val) {
 
 export default function SystemsPage() {
   const { authFetch } = useAuth();
-  const [systems, setSystems] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { data: systems, loading, error } = useFetch('/api/systems', {
+    authFetch,
+    initialData: [],
+    transform: (d) => (Array.isArray(d) ? d : d.data || []),
+  });
   const [expandedId, setExpandedId] = useState(null);
-
-  const fetchSystems = useCallback(async () => {
-    try {
-      setLoading(true);
-      const res = await authFetch('/api/systems');
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      setSystems(Array.isArray(data) ? data : data.data || []);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [authFetch]);
-
-  useEffect(() => { fetchSystems(); }, [fetchSystems]);
 
   if (loading) {
     return <div className="flex items-center justify-center h-64 text-gray-500 dark:text-gray-400">Loading systems...</div>;
@@ -54,7 +41,7 @@ export default function SystemsPage() {
       <div className="max-w-4xl mx-auto">
         <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg p-6">
           <h2 className="text-red-800 dark:text-red-300 font-semibold">Error loading systems</h2>
-          <p className="text-red-600 dark:text-red-400 mt-1 text-sm">{error}</p>
+          <p className="text-red-600 dark:text-red-400 mt-1 text-sm">{error.message}</p>
         </div>
       </div>
     );

--- a/changes/setstate-in-effect-pages.md
+++ b/changes/setstate-in-effect-pages.md
@@ -1,0 +1,1 @@
+- Internal code-quality: converted the Systems, Dashboard Trends, Authentication settings, and Governance pages to the shared `useFetch` hook, clearing more `react-hooks/set-state-in-effect` warnings. No user-facing behaviour change.


### PR DESCRIPTION
## Summary
**Part of #417**, **stacked on #501** (the `useFetch` foundation). Converts four simple single-fetch pages to `useFetch`:

- **SystemsPage** — single GET + transform
- **DashboardTrendsTab** — dep-keyed URL (`?days=`)
- **AuthSettingsPage** — `reload()` reused by the Refresh button
- **GovernancePage** — two independent fetches → two `useFetch` calls

`error` is now an `Error` (rendered as `error.message`). Each verified against its mount tests.

Draft + stacked: retarget to `main` once #501 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)