### PR TITLE
refactor(ui): convert timeline/recent-changes hooks to useFetch (part of #417, stacked on #501)

### DIFF
--- a/app/ui/src/hooks/useRecentChanges.js
+++ b/app/ui/src/hooks/useRecentChanges.js
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useFetch } from '@ui/hooks/useFetch';
 
 // ─── useRecentChanges ────────────────────────────────────────────────
 // Fetches /api/<kind>/:id/recent-changes on mount and exposes it in the
@@ -22,22 +23,13 @@ const ENDPOINT = {
 };
 
 export default function useRecentChanges(entityKind, entityId, authFetch, { sinceDays = 30, limit = 50 } = {}) {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const urlFn = ENDPOINT[entityKind];
-    if (!urlFn || !entityId) { setLoading(false); return; }
-    let cancelled = false;
-    setLoading(true);
-    const url = `${urlFn(entityId)}?sinceDays=${sinceDays}&limit=${limit}`;
-    authFetch(url)
-      .then(r => r.ok ? r.json() : null)
-      .then(d => { if (!cancelled) setData(d || { events: [], addedCount: 0, removedCount: 0, sinceDays }); })
-      .catch(() => { if (!cancelled) setData({ events: [], addedCount: 0, removedCount: 0, sinceDays }); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [entityKind, entityId, authFetch, sinceDays, limit]);
+  const urlFn = ENDPOINT[entityKind];
+  const url = (urlFn && entityId)
+    ? `${urlFn(entityId)}?sinceDays=${sinceDays}&limit=${limit}`
+    : null;
+  // A non-ok/failed fetch leaves `data` null; the derived defaults below render
+  // an empty change set (matches the previous fallback object).
+  const { data, loading } = useFetch(url, { authFetch });
 
   const derived = useMemo(() => {
     if (!data) return { events: [], addedCount: 0, removedCount: 0, added: [], removed: [], addedIds: new Set(), sinceDays };

--- a/app/ui/src/hooks/useRecentChanges.test.js
+++ b/app/ui/src/hooks/useRecentChanges.test.js
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@ui/test-utils/renderWithProviders';
+import useRecentChanges from './useRecentChanges';
+
+const res = (body, ok = true) => ({ ok, json: async () => body });
+
+describe('useRecentChanges', () => {
+  it('fetches and derives added/removed subsets + addedIds', async () => {
+    const events = [
+      { operation: 'added', counterpartyId: 'a' },
+      { operation: 'removed', counterpartyId: 'b' },
+      { operation: 'changed', counterpartyId: 'c' },
+    ];
+    const authFetch = vi.fn().mockResolvedValue(res({ events, sinceDays: 30 }));
+    const { result } = renderHook(() => useRecentChanges('user', 'u1', authFetch));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.events).toHaveLength(3);
+    expect(result.current.added).toHaveLength(1);
+    expect(result.current.removed).toHaveLength(1);
+    expect(result.current.addedCount).toBe(1);
+    expect(result.current.removedCount).toBe(1);
+    expect(result.current.addedIds.has('a')).toBe(true);
+    expect(authFetch).toHaveBeenCalledWith(expect.stringContaining('/api/user/u1/recent-changes'));
+  });
+
+  it('does not fetch for a missing entity or unknown kind', () => {
+    const authFetch = vi.fn();
+    renderHook(() => useRecentChanges('user', null, authFetch));
+    renderHook(() => useRecentChanges('bogus', 'x', authFetch));
+    expect(authFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns empty derived defaults on a non-ok response', async () => {
+    const authFetch = vi.fn().mockResolvedValue(res({}, false));
+    const { result } = renderHook(() => useRecentChanges('resource', 'r1', authFetch));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.events).toEqual([]);
+    expect(result.current.addedIds.size).toBe(0);
+  });
+});

--- a/app/ui/src/hooks/useTimeline.js
+++ b/app/ui/src/hooks/useTimeline.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useFetch } from '@ui/hooks/useFetch';
 
 // ─── useTimeline ─────────────────────────────────────────────────────
 // Fetches /api/<kind>/:id/timeline — the unified attribute + relationship
@@ -17,22 +17,14 @@ const ENDPOINT = {
 };
 
 export default function useTimeline(entityKind, entityId, authFetch, { sinceDays = 90, limit = 200, enabled = true } = {}) {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    const urlFn = ENDPOINT[entityKind];
-    if (!enabled || !entityId || !urlFn) return undefined;
-    let cancelled = false;
-    setLoading(true);
-    const url = `${urlFn(entityId)}?sinceDays=${sinceDays}&limit=${limit}`;
-    authFetch(url)
-      .then(r => (r.ok ? r.json() : null))
-      .then(d => { if (!cancelled) setData(d || { events: [], addedCount: 0, removedCount: 0, changedCount: 0, sinceDays }); })
-      .catch(() => { if (!cancelled) setData({ events: [], addedCount: 0, removedCount: 0, changedCount: 0, sinceDays }); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [entityKind, entityId, authFetch, sinceDays, limit, enabled]);
+  const urlFn = ENDPOINT[entityKind];
+  const url = (enabled && entityId && urlFn)
+    ? `${urlFn(entityId)}?sinceDays=${sinceDays}&limit=${limit}`
+    : null;
+  // A non-ok/failed fetch leaves `data` null; the defaults below render an empty
+  // timeline (matches the previous fallback object). `error` is intentionally
+  // not surfaced — the Timeline tab just shows "no changes".
+  const { data, loading } = useFetch(url, { authFetch });
 
   return {
     events: data?.events || [],

--- a/app/ui/src/hooks/useTimeline.test.js
+++ b/app/ui/src/hooks/useTimeline.test.js
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@ui/test-utils/renderWithProviders';
+import useTimeline from './useTimeline';
+
+const res = (body, ok = true) => ({ ok, json: async () => body });
+
+describe('useTimeline', () => {
+  it('fetches the timeline and exposes events + counts', async () => {
+    const authFetch = vi.fn().mockResolvedValue(
+      res({ events: [{ id: 1 }], addedCount: 2, removedCount: 1, changedCount: 3, sinceDays: 90 }),
+    );
+    const { result } = renderHook(() => useTimeline('user', 'u1', authFetch));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.events).toEqual([{ id: 1 }]);
+    expect(result.current.addedCount).toBe(2);
+    expect(result.current.changedCount).toBe(3);
+    expect(authFetch).toHaveBeenCalledWith(expect.stringContaining('/api/user/u1/timeline'));
+  });
+
+  it('does not fetch when disabled (tab not open)', () => {
+    const authFetch = vi.fn();
+    renderHook(() => useTimeline('user', 'u1', authFetch, { enabled: false }));
+    expect(authFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch for an unknown entity kind or missing id', () => {
+    const authFetch = vi.fn();
+    renderHook(() => useTimeline('nope', 'x', authFetch));
+    renderHook(() => useTimeline('user', null, authFetch));
+    expect(authFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an empty timeline on a non-ok response', async () => {
+    const authFetch = vi.fn().mockResolvedValue(res({}, false));
+    const { result } = renderHook(() => useTimeline('context', 'c1', authFetch, { sinceDays: 45 }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.events).toEqual([]);
+    expect(result.current.sinceDays).toBe(45);
+  });
+});

--- a/changes/setstate-in-effect-timeline-hooks.md
+++ b/changes/setstate-in-effect-timeline-hooks.md
@@ -1,0 +1,1 @@
+- Internal code-quality: converted the `useTimeline` and `useRecentChanges` entity-history hooks to the shared `useFetch` hook, clearing more `react-hooks/set-state-in-effect` warnings. No user-facing behaviour change.


### PR DESCRIPTION
## Summary
**Part of #417**, **stacked on #501**. Converts the two entity-history fetch hooks — `useTimeline` and `useRecentChanges` — to the shared `useFetch` hook.

- URL gating (`enabled` / no-entity) replaces the early-return + manual loading toggle.
- A non-ok/failed fetch leaves `data` null; the existing `?.`/default fallbacks render an empty change set (matches the prior fallback object) — error isn't surfaced (these tabs just show "no changes").
- **Return contracts unchanged**, so consumers (detail pages + entity graph) are untouched.

Verified: detail-page mount tests pass (19). Draft + stacked — retarget to `main` once #501 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)