### PR TITLE
fix(ui): convert PluginsPage to useFetch (set-state-in-effect) — part of #417

### DIFF
--- a/app/ui/src/components/PluginsPage.jsx
+++ b/app/ui/src/components/PluginsPage.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useFetch } from '@ui/hooks/useFetch';
 import { formatRelativeTime as formatTimeAgo } from '@ui/utils/formatters';
 
 const statusColors = {
@@ -87,10 +88,6 @@ function ConfigForm({ schema, params, onChange }) {
 
 export default function PluginsPage() {
   const { authFetch } = useAuth();
-  const [trees, setTrees] = useState([]);
-  const [plugins, setPlugins] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [busy, setBusy] = useState(null);
 
   // Detail view — keyed by tree so it survives reloads; draft holds edits.
@@ -104,24 +101,15 @@ export default function PluginsPage() {
 
   const key = (t) => `${t.algorithmId}:${t.instanceKey}`;
 
-  const load = useCallback(async () => {
-    try {
-      const [tr, pr] = await Promise.all([
-        authFetch('/api/context-plugins/trees'),
-        authFetch('/api/context-plugins').catch(() => null),
-      ]);
-      if (!tr.ok) throw new Error(`HTTP ${tr.status}`);
-      setTrees((await tr.json()).data || []);
-      if (pr && pr.ok) setPlugins((await pr.json()).data || []);
-      setError(null);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [authFetch]);
-
-  useEffect(() => { load(); }, [load]);
+  // Trees drive the page's loading/error. The plugin catalog is best-effort —
+  // its absence never blocks the trees list, so its own error is ignored.
+  const { data: trees, loading, error, reload: reloadTrees } = useFetch('/api/context-plugins/trees', {
+    authFetch, initialData: [], transform: (d) => d.data || [],
+  });
+  const { data: plugins, reload: reloadPlugins } = useFetch('/api/context-plugins', {
+    authFetch, initialData: [], transform: (d) => d.data || [],
+  });
+  const load = useCallback(() => { reloadTrees(); reloadPlugins(); }, [reloadTrees, reloadPlugins]);
 
   const selected = useMemo(() => trees.find((t) => key(t) === selKey) || null, [trees, selKey]);
   const meta = useMemo(() => plugins.find((p) => p.name === selected?.algo) || null, [plugins, selected]);
@@ -271,13 +259,13 @@ export default function PluginsPage() {
             does and adjust or remove it. Trees refresh automatically after every crawl. Create new ones in Contexts → New.
           </p>
         </div>
-        <button onClick={() => { setLoading(true); load(); }} className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
+        <button onClick={load} className="text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
           Refresh
         </button>
       </div>
 
       {loading && <div className="text-center text-gray-500 dark:text-gray-400 py-10">Loading…</div>}
-      {error && <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg p-4 text-red-700 dark:text-red-300 text-sm">{error}</div>}
+      {error && <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-lg p-4 text-red-700 dark:text-red-300 text-sm">{error.message}</div>}
       {!loading && !error && trees.length === 0 && (
         <div className="text-sm text-gray-500 dark:text-gray-400 py-8">No context plugins configured yet. Create one in Contexts → New.</div>
       )}

--- a/app/ui/src/components/PluginsPage.mount.test.jsx
+++ b/app/ui/src/components/PluginsPage.mount.test.jsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createElement as h } from 'react';
 import PluginsPage from './PluginsPage';
 import { renderWithProviders, makeAuthFetch, jsonResponse, screen, userEvent } from '@ui/test-utils/renderWithProviders';
@@ -55,6 +55,27 @@ describe('PluginsPage (mounted)', () => {
   it('shows the empty state when no trees are configured', async () => {
     renderWithProviders(h(PluginsPage), { auth: { authFetch: routes({ 'context-plugins/trees': { data: [] } }) } });
     expect(await screen.findByText(/No context plugins configured yet/i)).toBeInTheDocument();
+  });
+
+  it('re-fetches the trees list when Refresh is clicked', async () => {
+    let treeCalls = 0;
+    const authFetch = vi.fn((url) => {
+      if (url.includes('context-plugins/trees')) {
+        treeCalls += 1;
+        return Promise.resolve(jsonResponse({ data: treeCalls === 1 ? [] : [tree] }));
+      }
+      if (url.includes('context-plugins')) return Promise.resolve(jsonResponse({ data: [plugin] }));
+      return Promise.resolve(jsonResponse({}));
+    });
+    renderWithProviders(h(PluginsPage), { auth: { authFetch } });
+    const user = userEvent.setup();
+
+    // First load yields the empty state; Refresh re-fetches and the tree appears.
+    await screen.findByText(/No context plugins configured yet/i);
+    await user.click(screen.getByText('Refresh'));
+
+    expect(await screen.findByText('Org Chart')).toBeInTheDocument();
+    expect(treeCalls).toBe(2);
   });
 
   it('surfaces a load error', async () => {

--- a/changes/setstate-in-effect-plugins.md
+++ b/changes/setstate-in-effect-plugins.md
@@ -1,0 +1,1 @@
+- Context Plugins admin page now loads its plugin trees and catalog through the shared fetch lifecycle, removing a React Compiler set-state-in-effect warning. The list, empty state, load-error message, and Refresh button behave as before.


### PR DESCRIPTION
Part of #417 (React Compiler `set-state-in-effect` cleanup). One small, self-contained conversion.

## What
- `PluginsPage` (Context Plugins admin) replaced its hand-rolled `Promise.all` load effect (the `useEffect(() => { load(); })` whose `load` set state synchronously) with two `useFetch` calls:
  - **trees** (`/api/context-plugins/trees`) drives the page's `loading`/`error`.
  - **plugins** catalog (`/api/context-plugins`) is best-effort — its own error is ignored, matching the prior `.catch(() => null)` / `if (pr && pr.ok)` guard.
- The Refresh button and post-mutation refreshes now call a combined `reload()` (refetches both). The load-error render switches from a raw string to `error.message` — same `HTTP 500` text.

## Tests
- Existing mount tests (list, empty state, load error → `HTTP 500`, detail form, save & re-run) still pass unchanged — they already cover the converted paths.
- Added a **Refresh-button** mount test (empty first load → click Refresh → tree appears, trees endpoint hit twice) covering the new combined reload.
- All 6 `PluginsPage.mount.test.jsx` tests pass; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)