### PR TITLE
fix(ui): reset matrix filter wizard during render (set-state-in-effect) — part of #417

### DIFF
--- a/app/ui/src/components/matrix/MatrixFilterWizard.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.jsx
@@ -173,14 +173,19 @@ export default function MatrixFilterWizard({
   const [saving, setSaving]   = useState(false);
   const [saveError, setSaveError] = useState(null);
 
-  // Reset state when reopened.
-  useEffect(() => {
-    if (!open) return;
-    setFilter(structuredClone(initialFilter || EMPTY_FILTER));
-    setManaged(initialManaged);
-    setStep('setup');
-    setError(null);
-  }, [open, initialFilter, initialManaged]);
+  // Reset state when reopened. Done during render on the closed→open
+  // transition (React's "adjusting state when a prop changes" pattern) rather
+  // than in an effect, so it doesn't trip react-hooks/set-state-in-effect.
+  const [wasOpen, setWasOpen] = useState(false);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setFilter(structuredClone(initialFilter || EMPTY_FILTER));
+      setManaged(initialManaged);
+      setStep('setup');
+      setError(null);
+    }
+  }
 
   // Load saved filters and column schemas when the modal opens.
   useEffect(() => {

--- a/app/ui/src/components/matrix/MatrixFilterWizard.mount.test.jsx
+++ b/app/ui/src/components/matrix/MatrixFilterWizard.mount.test.jsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
-import { createElement as h } from 'react';
+import { createElement as h, useState } from 'react';
 import MatrixFilterWizard from './MatrixFilterWizard';
 import {
   renderWithProviders, makeAuthFetch, jsonResponse,
@@ -132,6 +132,32 @@ describe('MatrixFilterWizard (mounted)', () => {
     // Back → Resources.
     await user.click(screen.getByText('Back'));
     expect(await screen.findByText(/appear as columns/i)).toBeInTheDocument();
+  });
+
+  it('resets back to the Setup step when reopened after navigating away', async () => {
+    // A stateful harness toggles `open` so the closed→open reset (now done
+    // during render rather than in an effect) runs through React normally.
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return h('div', null,
+        h('button', { onClick: () => setOpen((o) => !o) }, 'toggle'),
+        h(MatrixFilterWizard, { open, onApply: vi.fn(), onClose: () => setOpen(false) }),
+      );
+    }
+    renderWithProviders(h(Harness), { auth: { authFetch: makeFetch() } });
+    const user = userEvent.setup();
+
+    // Advance from Setup → Subjects.
+    await screen.findByText('User accounts');
+    await user.click(screen.getByText('Next'));
+    expect(await screen.findByText(/appear as rows/i)).toBeInTheDocument();
+
+    // Close then reopen — the wizard must be back on the Setup step.
+    await user.click(screen.getByText('toggle')); // close
+    await user.click(screen.getByText('toggle')); // reopen
+    expect(await screen.findByText('Create matrix')).toBeInTheDocument();
+    expect(screen.getByText('User accounts')).toBeInTheDocument();
+    expect(screen.queryByText(/appear as rows/i)).not.toBeInTheDocument();
   });
 
   it('toggles the "Include inherited access" checkbox on the Resources step', async () => {

--- a/changes/setstate-in-effect-matrix-wizard.md
+++ b/changes/setstate-in-effect-matrix-wizard.md
@@ -1,0 +1,1 @@
+- The matrix filter wizard's reset-on-reopen logic was reworked to remove a React Compiler set-state-in-effect warning. Reopening the wizard still returns it to the first (Setup) step with a fresh copy of the active filter, exactly as before.


### PR DESCRIPTION
Part of #417 (React Compiler `set-state-in-effect` cleanup). One small, self-contained fix.

## What
- `MatrixFilterWizard` reset its internal state (`filter`/`managed`/`step`/`error`) in a `useEffect` that fired synchronously when the `open` prop flipped true — the exact shape `react-hooks/set-state-in-effect` flags.
- Replaced it with React's documented **"adjusting state when a prop changes"** render-time pattern: track the previous `open` value and, on the closed→open transition, reset during render. No effect, no warning.
- Behaviour is unchanged — reopening the wizard still lands on the Setup step with a fresh `structuredClone` of the active filter.

## Tests
- Added a **reopen-reset** mount test: navigate Setup → Subjects, close, reopen, assert the wizard is back on Setup (driven through a small stateful harness that toggles `open`).
- All 14 `MatrixFilterWizard.mount.test.jsx` tests pass (+ the 4 contentStep tests); ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)