### PR TITLE
fix(ui): seed matrix row order from storage during render (set-state-in-effect) — part of #417

### DIFF
--- a/app/ui/src/hooks/useMatrixRowOrder.js
+++ b/app/ui/src/hooks/useMatrixRowOrder.js
@@ -8,25 +8,32 @@ function getStorageKey(department) {
   return `fgraph-roworder-${department || 'all'}`;
 }
 
-export function useMatrixRowOrder(department, defaultGroupIds) {
-  const [rowOrder, setRowOrder] = useState(null);
+// Read a saved row order for a department from localStorage, discarding any
+// order written by an older ROW_ORDER_VERSION. Returns the order or null.
+function readStoredOrder(department) {
+  try {
+    const raw = localStorage.getItem(getStorageKey(department));
+    if (raw) {
+      const saved = JSON.parse(raw);
+      if (saved.order && saved.version === ROW_ORDER_VERSION) return saved.order;
+      // Discard stale order from an older version
+      localStorage.removeItem(getStorageKey(department));
+    }
+  } catch {}
+  return null;
+}
 
-  // Load from localStorage when department changes
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem(getStorageKey(department));
-      if (raw) {
-        const saved = JSON.parse(raw);
-        if (saved.order && saved.version === ROW_ORDER_VERSION) {
-          setRowOrder(saved.order);
-          return;
-        }
-        // Discard stale order from older version
-        localStorage.removeItem(getStorageKey(department));
-      }
-    } catch {}
-    setRowOrder(null);
-  }, [department]);
+export function useMatrixRowOrder(department, defaultGroupIds) {
+  const [rowOrder, setRowOrder] = useState(() => readStoredOrder(department));
+
+  // Reload the saved order when the department changes. Done during render
+  // (prev-value tracking) rather than in an effect, so it doesn't trip
+  // react-hooks/set-state-in-effect.
+  const [seenDept, setSeenDept] = useState(department);
+  if (department !== seenDept) {
+    setSeenDept(department);
+    setRowOrder(readStoredOrder(department));
+  }
 
   // Save when order changes
   useEffect(() => {

--- a/app/ui/src/hooks/useMatrixRowOrder.test.js
+++ b/app/ui/src/hooks/useMatrixRowOrder.test.js
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@ui/test-utils/renderWithProviders';
+import { useMatrixRowOrder } from './useMatrixRowOrder';
+
+const VERSION = 6; // must match ROW_ORDER_VERSION in the hook
+const key = (d) => `fgraph-roworder-${d || 'all'}`;
+
+// jsdom in this project runs without an origin, so window.localStorage is
+// absent. Back it with a simple in-memory Map for these tests.
+function makeLocalStorage() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
+describe('useMatrixRowOrder', () => {
+  beforeEach(() => vi.stubGlobal('localStorage', makeLocalStorage()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns groups unchanged when no saved order exists', () => {
+    const { result } = renderHook(() => useMatrixRowOrder('all'));
+    expect(result.current.hasCustomOrder).toBe(false);
+    const groups = [{ id: 'a' }, { id: 'b' }];
+    expect(result.current.getOrderedGroups(groups)).toEqual(groups);
+  });
+
+  it('seeds the saved order from localStorage on first render and applies it', () => {
+    localStorage.setItem(key('all'), JSON.stringify({ order: ['b', 'a'], version: VERSION }));
+    const { result } = renderHook(() => useMatrixRowOrder('all'));
+    expect(result.current.hasCustomOrder).toBe(true);
+    expect(result.current.getOrderedGroups([{ id: 'a' }, { id: 'b' }]).map((g) => g.id)).toEqual(['b', 'a']);
+  });
+
+  it('appends groups not present in the saved order at the end', () => {
+    localStorage.setItem(key('all'), JSON.stringify({ order: ['b'], version: VERSION }));
+    const { result } = renderHook(() => useMatrixRowOrder('all'));
+    expect(result.current.getOrderedGroups([{ id: 'a' }, { id: 'b' }, { id: 'c' }]).map((g) => g.id))
+      .toEqual(['b', 'a', 'c']);
+  });
+
+  it('discards (and removes) a saved order from an older version', () => {
+    localStorage.setItem(key('all'), JSON.stringify({ order: ['b', 'a'], version: 1 }));
+    const { result } = renderHook(() => useMatrixRowOrder('all'));
+    expect(result.current.hasCustomOrder).toBe(false);
+    expect(localStorage.getItem(key('all'))).toBeNull();
+  });
+
+  it('reloads the saved order when the department changes', () => {
+    localStorage.setItem(key('sales'), JSON.stringify({ order: ['s1'], version: VERSION }));
+    const { result, rerender } = renderHook(({ dept }) => useMatrixRowOrder(dept), { initialProps: { dept: 'eng' } });
+    expect(result.current.hasCustomOrder).toBe(false); // eng has no saved order
+    rerender({ dept: 'sales' });
+    expect(result.current.hasCustomOrder).toBe(true);
+    expect(result.current.getOrderedGroups([{ id: 's1' }]).map((g) => g.id)).toEqual(['s1']);
+  });
+
+  it('persists updateOrder to localStorage and clears it via resetOrder', () => {
+    const { result } = renderHook(() => useMatrixRowOrder('all'));
+    act(() => result.current.updateOrder(['x', 'y']));
+    expect(result.current.hasCustomOrder).toBe(true);
+    const saved = JSON.parse(localStorage.getItem(key('all')));
+    expect(saved.order).toEqual(['x', 'y']);
+    expect(saved.version).toBe(VERSION);
+
+    act(() => result.current.resetOrder());
+    expect(result.current.hasCustomOrder).toBe(false);
+    expect(localStorage.getItem(key('all'))).toBeNull();
+  });
+});

--- a/changes/setstate-in-effect-row-order.md
+++ b/changes/setstate-in-effect-row-order.md
@@ -1,0 +1,1 @@
+- The matrix custom row-order hook was reworked to remove a React Compiler set-state-in-effect warning. Saved row orders are now read from storage on first render and reloaded when the department changes, with the same persistence and "reset to default" behavior as before.


### PR DESCRIPTION
Part of #417 (React Compiler `set-state-in-effect` cleanup). One small, self-contained fix.

## What
- `useMatrixRowOrder` loaded the saved row order in a `useEffect` that called `setRowOrder` synchronously — the shape `react-hooks/set-state-in-effect` flags.
- Reworked to:
  - **lazy-initialise** `rowOrder` from a new `readStoredOrder(department)` helper, so the saved order is present on the first render (no flash of default order), and
  - **reload on department change** via render-time prev-value tracking instead of an effect.
- The save effect (a plain `localStorage.setItem`, no `setState`) is unchanged, as is `getOrderedGroups` / `updateOrder` / `resetOrder` / `hasCustomOrder`.

## Tests
- New `useMatrixRowOrder.test.js` (`renderHook`): seed-on-mount + apply order, append-new-groups-at-end, stale-`version` discard (and removal), reload-on-department-change, and `updateOrder`/`resetOrder` persistence.
- jsdom runs here without an origin (no `window.localStorage`), so the test stubs `localStorage` with a Map-backed mock.
- All 6 tests pass; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)