### PR TITLE
feat(export): add Contexts + Context Members to the Power Query workbook

### DIFF
--- a/app/api/contract-tests/exportEndpoints.integration.test.js
+++ b/app/api/contract-tests/exportEndpoints.integration.test.js
@@ -130,4 +130,20 @@ describe('Power Query export endpoints — paging contract', () => {
     expect(p2.status).toBe(200);
     expect(p2.body.total).toBeNull();
   });
+
+  it('/api/context-list + /api/context-members: flat lists page with the total-on-page-1 contract', async () => {
+    const cl = await agent.get('/api/context-list?limit=100&offset=0').set('Authorization', tok);
+    expect(cl.status).toBe(200);
+    expect(typeof cl.body.total).toBe('number');
+    expect(cl.body.data.some(c => c.displayName === 'ExportVIP' && c.contextType === 'Tag')).toBe(true);
+
+    const cm = await agent.get('/api/context-members?limit=100&offset=0').set('Authorization', tok);
+    expect(cm.status).toBe(200);
+    expect(typeof cm.body.total).toBe('number');
+    expect(cm.body.data.some(m => m.memberId === firstPrincipalId && m.memberType === 'Principal')).toBe(true);
+
+    const cl2 = await agent.get('/api/context-list?limit=1&offset=1').set('Authorization', tok);
+    expect(cl2.status).toBe(200);
+    expect(cl2.body.total).toBeNull(); // count-on-page-1
+  });
 });

--- a/app/api/src/export/queryTemplates.js
+++ b/app/api/src/export/queryTemplates.js
@@ -145,4 +145,6 @@ export const QUERIES = [
   { sheet: 'Identities',             endpoint: 'identities',             m: paginatedQuery('identities') },
   { sheet: 'IdentityMembers',        endpoint: 'identity-members',       m: paginatedQuery('identity-members') },
   { sheet: 'ResourceRelationships',  endpoint: 'resource-relationships', m: paginatedQuery('resource-relationships') },
+  { sheet: 'Contexts',               endpoint: 'context-list',           m: paginatedQuery('context-list') },
+  { sheet: 'ContextMembers',         endpoint: 'context-members',        m: paginatedQuery('context-members') },
 ];

--- a/app/api/src/routes/bulkLists.js
+++ b/app/api/src/routes/bulkLists.js
@@ -133,4 +133,53 @@ router.get('/resource-relationships', async (req, res) => {
   }
 });
 
+// ─── GET /api/context-list ───────────────────────────────────────
+// Flat listing of ALL contexts (departments, OUs, tags, clusters, ...). The
+// per-root /api/contexts endpoint returns only top-level contexts; the export
+// needs every row. Optional ?systemId filters synced contexts by scope system.
+router.get('/context-list', async (req, res) => {
+  const { limit, offset, systemId } = parsePaging(req);
+  try {
+    const where = systemId !== null ? `WHERE c."scopeSystemId" = $1` : '';
+    const result = await runListAndCount({
+      table: 'Contexts',
+      alias: 'c',
+      columns: `c.id, c.variant, c."targetType", c."contextType", c."displayName",
+                c.description, c."parentContextId", c."scopeSystemId",
+                c."directMemberCount", c."totalMemberCount", c."extendedAttributes"`,
+      orderBy: `c."contextType", c."displayName"`,
+      dataWhere: where, countWhere: where,
+      systemId, limit, offset,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('GET /context-list failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ─── GET /api/context-members ────────────────────────────────────
+// Flat listing of context membership — which entity (by memberType + memberId)
+// belongs to which context. Optional ?systemId filters via the context's scope.
+router.get('/context-members', async (req, res) => {
+  const { limit, offset, systemId } = parsePaging(req);
+  try {
+    const where = systemId !== null
+      ? `WHERE EXISTS (SELECT 1 FROM "Contexts" c WHERE c.id = cm."contextId" AND c."scopeSystemId" = $1)`
+      : '';
+    const result = await runListAndCount({
+      table: 'ContextMembers',
+      alias: 'cm',
+      columns: `cm."contextId", cm."memberType", cm."memberId", cm."addedBy", cm."addedAt"`,
+      orderBy: `cm."contextId", cm."memberId"`,
+      dataWhere: where, countWhere: where,
+      systemId, limit, offset,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('GET /context-members failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 export default router;

--- a/changes/export-contexts.md
+++ b/changes/export-contexts.md
@@ -1,0 +1,1 @@
+- The Excel / Power Query data export now includes **Contexts** and **Context Members** sheets — so you can export every context (departments, OUs, administrative units, tags, generated clusters) and the membership rows showing which entity belongs to which context, alongside the existing Principals / Resources / Assignments data.


### PR DESCRIPTION
Adds the **Contexts** model to the Excel / Power Query export (requested). **Stacked on #507** (reuses its paged `runListAndCount`); retarget to `main` once #507 merges.

## What
- Two new flat, paginated bulk endpoints (same shape + count-on-page-1 as the other export endpoints):
  - `GET /api/context-list` — every context (departments, OUs, administrative units, tags, generated clusters). The existing `/api/contexts` returns **roots only**, so the export needs this.
  - `GET /api/context-members` — the membership rows (`contextId`, `memberType`, `memberId`, `addedBy`, `addedAt`).
- Wired into the workbook as two new sheets: **Contexts** and **ContextMembers**.

## Test
Extends `exportEndpoints.integration.test.js` to page both new endpoints, assert the seeded tag-context + its member come back, and verify the total-on-page-1 contract. Both queries verified against SK3's real schema (Contexts 4k+ rows, ContextMembers populated).

Depends on #507 (the paginate-first/count-once fix). The two new endpoints inherit that behavior, so they're fast at scale from the start.