### PR TITLE
fix(ui): track OS theme preference without set-state-in-effect — part of #417

### DIFF
--- a/app/ui/src/hooks/useTheme.js
+++ b/app/ui/src/hooks/useTheme.js
@@ -18,15 +18,17 @@ export function useTheme() {
     () => window.matchMedia('(prefers-color-scheme: dark)').matches
   );
 
-  // Track OS preference changes when in auto mode
+  // Track the OS preference at all times so `osDark` is always fresh — it only
+  // affects the result in 'auto' mode, so subscribing in every mode is
+  // harmless. Subscribing once (rather than re-subscribing per mode and
+  // synchronously catching up with a setState inside the effect) keeps a
+  // setState out of the effect body (react-hooks/set-state-in-effect).
   useEffect(() => {
-    if (mode !== 'auto') return;
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e) => setOsDark(e.matches);
     mq.addEventListener('change', handler);
-    setOsDark(mq.matches);
     return () => mq.removeEventListener('change', handler);
-  }, [mode]);
+  }, []);
 
   const isDark = mode === 'dark' || (mode === 'auto' && osDark);
 

--- a/app/ui/src/hooks/useTheme.test.js
+++ b/app/ui/src/hooks/useTheme.test.js
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@ui/test-utils/renderWithProviders';
+import { useTheme } from './useTheme';
+
+// jsdom here has no origin (no window.localStorage) and does not implement
+// matchMedia, so both are stubbed.
+function makeLocalStorage(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
+// Controllable matchMedia: tests flip the OS preference and fire the listeners.
+function makeMatchMedia(initialMatches = false) {
+  let matches = initialMatches;
+  const listeners = new Set();
+  const mql = {
+    get matches() { return matches; },
+    addEventListener: (_e, h) => listeners.add(h),
+    removeEventListener: (_e, h) => listeners.delete(h),
+  };
+  const fn = vi.fn(() => mql);
+  fn.setMatches = (v) => { matches = v; listeners.forEach((h) => h({ matches: v })); };
+  return fn;
+}
+
+function setup({ storage = {}, osDark = false } = {}) {
+  vi.stubGlobal('localStorage', makeLocalStorage(storage));
+  const mm = makeMatchMedia(osDark);
+  vi.stubGlobal('matchMedia', mm);
+  return mm;
+}
+
+describe('useTheme', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('defaults to light mode with an empty store', () => {
+    setup();
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('light');
+    expect(result.current.isDark).toBe(false);
+    expect(localStorage.getItem('themeMode')).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('migrates the legacy darkMode boolean key to themeMode', () => {
+    setup({ storage: { darkMode: 'true' } });
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('dark');
+    expect(localStorage.getItem('themeMode')).toBe('dark');
+    expect(localStorage.getItem('darkMode')).toBeNull();
+  });
+
+  it('applies the dark class when mode is dark', () => {
+    setup({ storage: { themeMode: 'dark' } });
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('follows the OS preference in auto mode', () => {
+    setup({ storage: { themeMode: 'auto' }, osDark: true });
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('auto');
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('reacts to an OS preference change while in auto mode', () => {
+    const mm = setup({ storage: { themeMode: 'auto' }, osDark: false });
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+
+    act(() => mm.setMatches(true)); // OS flips to dark
+    expect(result.current.isDark).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('cycles light → auto → dark → light and persists each mode', () => {
+    setup();
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('light');
+
+    act(() => result.current.cycleTheme());
+    expect(result.current.mode).toBe('auto');
+    expect(localStorage.getItem('themeMode')).toBe('auto');
+
+    act(() => result.current.cycleTheme());
+    expect(result.current.mode).toBe('dark');
+
+    act(() => result.current.cycleTheme());
+    expect(result.current.mode).toBe('light');
+  });
+});

--- a/changes/setstate-in-effect-theme.md
+++ b/changes/setstate-in-effect-theme.md
@@ -1,0 +1,1 @@
+- The light/auto/dark theme hook was reworked to remove a React Compiler set-state-in-effect warning. Auto mode still follows the operating-system preference live, and switching or cycling the theme persists exactly as before.


### PR DESCRIPTION
Part of #417 (React Compiler `set-state-in-effect` cleanup). One small, self-contained fix.

## What
- `useTheme`'s auto-mode effect re-subscribed to `matchMedia` per `mode` and then synchronously called `setOsDark(mq.matches)` to catch up — the shape `react-hooks/set-state-in-effect` flags.
- Reworked to **subscribe once** (always-on). `osDark` only affects the result in `'auto'` mode, so tracking it in every mode is harmless — and it removes the staleness window the synchronous catch-up existed to close. Initial value still comes from the existing `useState` lazy initialiser.

## Tests
- New `useTheme.test.js` (`renderHook`): default light, legacy `darkMode`→`themeMode` migration, dark-class application, auto-mode follows OS, **live OS-change reaction**, and cycle-and-persist.
- jsdom here implements neither `matchMedia` nor `localStorage`, so both are stubbed (the `matchMedia` stub is controllable so the test can fire a preference-change event).
- All 6 tests pass; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)