### PR TITLE
fix(ui): render-time resets for Risk/Matrix views (set-state-in-effect) — part of #417

### DIFF
--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -273,8 +273,15 @@ export default function MatrixView({
   const sortHierarchyId = filter?.sortHierarchy?.contextId || null;
   const [hierPaths, setHierPaths] = useState(null); // Map subjectId → short label[]
   const [hierDepth, setHierDepth] = useState(0);
+  // Clear the hierarchy paths when no hierarchy is selected — during render on
+  // the transition, so the fetch effect body holds no synchronous setState.
+  const [seenHierId, setSeenHierId] = useState(sortHierarchyId);
+  if (sortHierarchyId !== seenHierId) {
+    setSeenHierId(sortHierarchyId);
+    if (!sortHierarchyId) { setHierPaths(null); setHierDepth(0); }
+  }
   useEffect(() => {
-    if (!sortHierarchyId) { setHierPaths(null); setHierDepth(0); return; }
+    if (!sortHierarchyId) return undefined;
     let cancelled = false;
     authFetch('/api/matrix/hierarchy-paths', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },

--- a/app/ui/src/components/RiskProfileWizard.jsx
+++ b/app/ui/src/components/RiskProfileWizard.jsx
@@ -57,8 +57,15 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
   // of wondering whether the request is stuck.
   const [elapsedMs, setElapsedMs] = useState(0);
   const isWorking = generating || refining;
+  // Reset the counter when work stops — during render on the transition, so the
+  // effect body holds no synchronous setState (react-hooks/set-state-in-effect).
+  const [wasWorking, setWasWorking] = useState(isWorking);
+  if (isWorking !== wasWorking) {
+    setWasWorking(isWorking);
+    if (!isWorking) setElapsedMs(0);
+  }
   useEffect(() => {
-    if (!isWorking) { setElapsedMs(0); return; }
+    if (!isWorking) return undefined;
     const start = Date.now();
     const interval = setInterval(() => setElapsedMs(Date.now() - start), 500);
     return () => clearInterval(interval);
@@ -90,8 +97,13 @@ export default function RiskProfileWizard({ onClose, onSaved }) {
   // Elapsed-time tracker for the classifier generation step (separate from
   // the Step 2 chat counter so they can run independently).
   const [classifierElapsedMs, setClassifierElapsedMs] = useState(0);
+  const [wasGenClassifiers, setWasGenClassifiers] = useState(genClassifiers);
+  if (genClassifiers !== wasGenClassifiers) {
+    setWasGenClassifiers(genClassifiers);
+    if (!genClassifiers) setClassifierElapsedMs(0);
+  }
   useEffect(() => {
-    if (!genClassifiers) { setClassifierElapsedMs(0); return; }
+    if (!genClassifiers) return undefined;
     const start = Date.now();
     const interval = setInterval(() => setClassifierElapsedMs(Date.now() - start), 500);
     return () => clearInterval(interval);

--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -211,9 +211,17 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
     return () => { cancelled = true; };
   }, [authFetch, cluster.id]);
 
+  // Clear results when the query is too short — during render on the
+  // transition, so the debounce effect body holds no synchronous setState.
+  const ownerTooShort = !ownerSearch || ownerSearch.length < 2;
+  const [seenOwnerTooShort, setSeenOwnerTooShort] = useState(ownerTooShort);
+  if (ownerTooShort !== seenOwnerTooShort) {
+    setSeenOwnerTooShort(ownerTooShort);
+    if (ownerTooShort) setOwnerResults([]);
+  }
   // Search users for owner assignment
   useEffect(() => {
-    if (!ownerSearch || ownerSearch.length < 2) { setOwnerResults([]); return; }
+    if (ownerTooShort) return undefined;
     const timer = setTimeout(async () => {
       try {
         const res = await authFetch(`/api/risk-scores/users?search=${encodeURIComponent(ownerSearch)}&limit=8`);
@@ -224,7 +232,7 @@ function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh })
       } catch { }
     }, 300);
     return () => clearTimeout(timer);
-  }, [authFetch, ownerSearch]);
+  }, [authFetch, ownerSearch, ownerTooShort]);
 
   const handleAssignOwner = async (user) => {
     setSaving(true);
@@ -567,7 +575,14 @@ export default function RiskScoringPage({ onOpenDetail }) {
   useEffect(() => {
     if (view !== 'clusters') fetchEntities();
   }, [view, fetchEntities]);
-  useEffect(() => { setPage(0); }, [view, tierFilter, search, overridesOnly]);
+  // Reset to the first page when the filters change — during render via a
+  // composite-signature compare, so no synchronous setState lives in an effect.
+  const pageFilterSig = `${view}|${tierFilter}|${search}|${overridesOnly}`;
+  const [seenPageFilterSig, setSeenPageFilterSig] = useState(pageFilterSig);
+  if (pageFilterSig !== seenPageFilterSig) {
+    setSeenPageFilterSig(pageFilterSig);
+    setPage(0);
+  }
 
   if (loading && !summary) {
     return (

--- a/app/ui/src/components/RiskScoringPage.mount.test.jsx
+++ b/app/ui/src/components/RiskScoringPage.mount.test.jsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createElement as h } from 'react';
 import RiskScoringPage from './RiskScoringPage';
-import { renderWithProviders, makeAuthFetch, jsonResponse, screen, fireEvent, userEvent } from '@ui/test-utils/renderWithProviders';
+import { renderWithProviders, makeAuthFetch, jsonResponse, screen, fireEvent, waitFor, userEvent } from '@ui/test-utils/renderWithProviders';
 
 // ─── Fixtures ────────────────────────────────────────────────────────
 
@@ -194,6 +194,30 @@ describe('RiskScoringPage (mounted)', () => {
     await user.click(nextBtn);
     const calledUrls = authFetch.mock.calls.map(c => String(c[0]));
     expect(calledUrls.some(u => u.includes('offset=25'))).toBe(true);
+  });
+
+  it('resets to the first page when a filter changes after paginating', async () => {
+    // Regression guard for the render-time page-reset: after paginating to
+    // page 2 (offset 25), changing a filter must drop back to page 1 (offset 0),
+    // not keep the now-stale offset.
+    const authFetch = routes();
+    renderWithProviders(h(RiskScoringPage, { onOpenDetail: () => {} }), { auth: { authFetch } });
+    const user = userEvent.setup();
+    await screen.findByText('Sysadmin');
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(authFetch.mock.calls.some(c => String(c[0]).includes('offset=25'))).toBe(true));
+
+    authFetch.mockClear();
+    fireEvent.change(screen.getByPlaceholderText(/Search users/i), { target: { value: 'alice' } });
+
+    await waitFor(() => {
+      const urls = authFetch.mock.calls.map(c => String(c[0]));
+      expect(urls.some(u => u.includes('search=alice') && u.includes('offset=0'))).toBe(true);
+    });
+    // And crucially NOT the stale page-2 offset.
+    const urls = authFetch.mock.calls.map(c => String(c[0]));
+    expect(urls.some(u => u.includes('search=alice') && u.includes('offset=25'))).toBe(false);
   });
 
   it('invokes onOpenDetail when an entity row is clicked', async () => {

--- a/changes/setstate-in-effect-render-resets.md
+++ b/changes/setstate-in-effect-render-resets.md
@@ -1,0 +1,1 @@
+- Removed React Compiler set-state-in-effect warnings in the risk-scoring page (first-page reset on filter change, owner search), the matrix view (hierarchy-path reset), and the risk-profile wizard (elapsed-time counters), with no change to behavior. The risk-scoring page now also avoids a redundant stale-page fetch when filters change while paginated.


### PR DESCRIPTION
Part of #417. Split out of #514 so the **render-time / timer reset** conversions carry their own before/after verification (separate from #514's well-tested useFetch/useReducer fetch conversions).

## Conversions
- **RiskScoringPage** — first-page reset on filter change + owner-search clear, moved from effects to render-time transition compares.
- **MatrixView** — clear hierarchy paths on the `sortHierarchy → none` transition.
- **RiskProfileWizard** — reset the two elapsed-time counters on the work → idle transition.

## Testing — honest status
- ✅ **RiskScoringPage page-reset is pinned by a before/after test.** It passes on the converted code and **fails on the prior effect-based version**, which fired `setPage(0)` a render late and issued a *stale page-2 fetch* before correcting. The conversion removes that wasted fetch (same final state, one fewer request).
- The other three sites aren't behaviourally observable, so they rely on the broad mount suites (**39 tests green, before and after**):
  - owner-search lives in `ClusterDetail` (legacy — the `/risk-scores/clusters*` routes no longer exist), so it can't be reached in a mount test.
  - the wizard's elapsed counter only renders *while working*, so the reset-to-0 has no visible effect to assert.
- The harder deferred sites in these files (MatrixView fold-seed, RiskScoringPage multi-state summary/entities fetches) are **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)