### PR TITLE
ci: fix docker-publish 'failed to reserve cache' (10 GiB cache quota)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -119,7 +119,7 @@ jobs:
           tags: identity-atlas-web:qa
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -130,7 +130,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:qa
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker
 
       # ── Smoke test: start the stack and verify it boots ─────────────
       - name: Start stack
@@ -201,7 +201,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Push worker image (release tag → latest)
         if: steps.config.outputs.channel == 'release'
@@ -214,7 +214,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:latest
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker
 
       - name: Push web image (pre-release tag → beta)
         if: steps.config.outputs.channel == 'beta'
@@ -228,7 +228,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Push worker image (pre-release tag → beta)
         if: steps.config.outputs.channel == 'beta'
@@ -241,7 +241,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:beta
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker
 
       - name: Push web image (main → edge)
         if: steps.config.outputs.channel == 'main'
@@ -255,7 +255,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Push worker image (main → edge)
         if: steps.config.outputs.channel == 'main'
@@ -268,4 +268,4 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:edge
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -241,7 +241,7 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -252,7 +252,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d
@@ -711,7 +711,7 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -722,7 +722,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d
@@ -819,7 +819,7 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=max,scope=web
+          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -830,7 +830,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=max,scope=worker
+          cache-to: type=gha,mode=min,scope=worker
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d


### PR DESCRIPTION
## Problem
Docker publish has failed on every run since this morning with:
```
#24 ERROR: error writing layer blob: failed to reserve cache
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```
The failure is on cache **export** (`#24 exporting to GitHub Actions Cache`) — import works fine, so it's **not** a deprecated-backend issue. The repo's Actions cache was at **~9.98 GiB against the 10 GiB hard quota** (1,195 caches). With the quota full, BuildKit can't reserve space for new layer blobs.

## Root cause
`cache-to: type=gha,mode=max` stores **every intermediate build layer** as its own cache entry (72 `buildkit-blob-*` here). Combined with ~1,100 per-PR `node-cache-*` entries, the repo crept to the 10 GiB ceiling and exports started failing.

## Fix
- Switch all buildx cache exports from `mode=max` → **`mode=min`** (caches only the final/exported image layers). This keeps the Docker cache small and bounded so it can't overflow the quota. Trade-off: marginally fewer cache hits on partial rebuilds.
- Operationally, the over-quota caches were also pruned to unblock the next run immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)