### PR TITLE
ci: drop buildx GHA cache export to unblock docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -119,7 +119,6 @@ jobs:
           tags: identity-atlas-web:qa
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -130,7 +129,6 @@ jobs:
           load: true
           tags: identity-atlas-worker:qa
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker
 
       # ── Smoke test: start the stack and verify it boots ─────────────
       - name: Start stack
@@ -201,7 +199,6 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Push worker image (release tag → latest)
         if: steps.config.outputs.channel == 'release'
@@ -214,7 +211,6 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:latest
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker
 
       - name: Push web image (pre-release tag → beta)
         if: steps.config.outputs.channel == 'beta'
@@ -228,7 +224,6 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Push worker image (pre-release tag → beta)
         if: steps.config.outputs.channel == 'beta'
@@ -241,7 +236,6 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:beta
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker
 
       - name: Push web image (main → edge)
         if: steps.config.outputs.channel == 'main'
@@ -255,7 +249,6 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Push worker image (main → edge)
         if: steps.config.outputs.channel == 'main'
@@ -268,4 +261,3 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:edge
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -241,7 +241,6 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -252,7 +251,6 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d
@@ -711,7 +709,6 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -722,7 +719,6 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d
@@ -819,7 +815,6 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -830,7 +825,6 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d


### PR DESCRIPTION
Follow-up to #520. `mode=min` did **not** fix docker-publish — it still fails on cache **export**:
```
#24 ERROR: error writing layer blob: failed to reserve cache
```
So the problem is the **GitHub Actions Cache export path itself** (`cache-to: type=gha`), not merely the 10 GiB quota (which was also pruned). The `cache-from` *import* works fine in the logs.

## Fix
Remove `cache-to` from every build step in `docker-publish.yml` and `pr-integration.yml`. With no export step there is nothing to "reserve", so the publish completes. `cache-from` is kept for warm reads.

Trade-off: builds no longer write new layer cache (somewhat slower over time). If we want fast caching back, the robust path is `cache-to/from: type=registry` storing the cache as a `ghcr.io/fortigi/identity-atlas:buildcache-*` image — happy to do that as a follow-up once this confirms green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)