### PR TITLE
test(ui): remove unused vi import (CodeQL #254)

### DIFF
--- a/app/ui/src/hooks/useContextTrees.test.js
+++ b/app/ui/src/hooks/useContextTrees.test.js
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { renderHook, waitFor, makeWrapper, makeAuthFetch } from '@ui/test-utils/renderWithProviders';
 import { useContextRoots, useContextSubtree, flattenTree } from './useContextTrees';
 


### PR DESCRIPTION
Resolves CodeQL `js/unused-local-variable` alert **#254** — `vi` was imported in `app/ui/src/hooks/useContextTrees.test.js` but never used (ESLint missed it; CodeQL is stricter). Removed it; the 5 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)