### PR TITLE
ci: restore buildx caching via Actions Cache Service v2 (type=gha)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,6 +107,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          # Pin a current BuildKit so the type=gha cache uses the GitHub Actions
+          # Cache Service v2. The legacy v1 service was retired, which is what
+          # broke cache export with "failed to reserve cache".
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       # ── Build images locally (don't push yet) ───────────────────────
       - name: Build web image
@@ -119,6 +124,7 @@ jobs:
           tags: identity-atlas-web:qa
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -129,6 +135,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:qa
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
 
       # ── Smoke test: start the stack and verify it boots ─────────────
       - name: Start stack
@@ -199,6 +206,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Push worker image (release tag → latest)
         if: steps.config.outputs.channel == 'release'
@@ -211,6 +219,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:latest
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
 
       - name: Push web image (pre-release tag → beta)
         if: steps.config.outputs.channel == 'beta'
@@ -224,6 +233,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Push worker image (pre-release tag → beta)
         if: steps.config.outputs.channel == 'beta'
@@ -236,6 +246,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:beta
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
 
       - name: Push web image (main → edge)
         if: steps.config.outputs.channel == 'main'
@@ -249,6 +260,7 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
           build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Push worker image (main → edge)
         if: steps.config.outputs.channel == 'main'
@@ -261,3 +273,4 @@ jobs:
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:edge
             ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -231,6 +231,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          # Current BuildKit → type=gha uses the Actions Cache Service v2 (the
+          # legacy v1 service was retired). See docker-publish.yml.
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Build web image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -241,6 +245,7 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -251,6 +256,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d
@@ -699,6 +705,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          # Current BuildKit → type=gha uses the Actions Cache Service v2 (the
+          # legacy v1 service was retired). See docker-publish.yml.
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Build web image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -709,6 +719,7 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -719,6 +730,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d
@@ -805,6 +817,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          # Current BuildKit → type=gha uses the Actions Cache Service v2 (the
+          # legacy v1 service was retired). See docker-publish.yml.
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Build web image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -815,6 +831,7 @@ jobs:
           load: true
           tags: identity-atlas-web:ci
           cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=min,scope=web,ignore-error=true
 
       - name: Build worker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -825,6 +842,7 @@ jobs:
           load: true
           tags: identity-atlas-worker:ci
           cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
 
       - name: Start stack
         run: docker compose -f docker-compose.ci.yml up -d


### PR DESCRIPTION
Follow-up to #521 (which dropped the cache export to unblock publishing). This restores layer caching the **native** way — via the GitHub **Actions Cache Service v2** — instead of switching to `type=registry`.

## Why
`failed to reserve cache` was the legacy **v1** Actions Cache Service being retired this morning, which `type=gha` depended on. The fix is to make `type=gha` use **v2**, not to abandon it.

## Changes
- **Pin a current BuildKit** (`moby/buildkit:buildx-stable-1`) on every `setup-buildx-action` step. The action already passes the v2 cache env vars; the bottleneck was the pinned BuildKit being too old to use them. A current BuildKit auto-uses Cache Service v2.
- **Re-add `cache-to`** as `type=gha,mode=min,ignore-error=true`:
  - `mode=min` keeps the cache small (well under the 10 GiB quota — `mode=max` bloat was a contributing factor).
  - **`ignore-error=true`** is the safety net: if the cache export still fails for any reason, the build **succeeds anyway**, so this cannot re-break the now-green publish.
- Applied to `docker-publish.yml` and `pr-integration.yml`; `cache-from` kept.

## Risk
Low — `ignore-error=true` guarantees the publish can't regress. Worst case is "no caching" (current state); best case is fast cached builds back via v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)