### PR TITLE
feat(updates): Admin → Updates sub-tab (switch, version status, history)

### DIFF
--- a/app/ui/src/components/AdminPage.jsx
+++ b/app/ui/src/components/AdminPage.jsx
@@ -12,6 +12,7 @@ const PerfPage = lazy(() => import('./PerfPage'));
 const AboutPage = lazy(() => import('./AboutPage'));
 const RiskProfileWizard = lazy(() => import('./RiskProfileWizard'));
 const AccountLinkingSettings = lazy(() => import('./AccountLinkingSettings'));
+const UpdatesSettings = lazy(() => import('./UpdatesSettings'));
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -1703,6 +1704,12 @@ export default function AdminPage({ onNavigate, onRefresh, onRiskScoresRefresh }
         {activeTab === 'auth' && (
           <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400 p-6">Loading…</div>}>
             <AuthSettingsPage />
+          </Suspense>
+        )}
+
+        {activeTab === 'updates' && (
+          <Suspense fallback={<div className="text-sm text-gray-500 dark:text-gray-400 p-6">Loading…</div>}>
+            <UpdatesSettings />
           </Suspense>
         )}
 

--- a/app/ui/src/components/AdminPage.mount.test.jsx
+++ b/app/ui/src/components/AdminPage.mount.test.jsx
@@ -140,7 +140,7 @@ describe('AdminPage (mounted)', () => {
   it('renders the admin shell with all sub-tabs visible', async () => {
     renderAdmin();
     expect(await screen.findByRole('heading', { name: 'Admin' })).toBeInTheDocument();
-    for (const label of ['Crawlers', 'Plugins', 'Account Linking', 'Risk Scoring', 'LLM Settings', 'Performance', 'Authentication', 'Data', 'About']) {
+    for (const label of ['Crawlers', 'Plugins', 'Account Linking', 'Risk Scoring', 'LLM Settings', 'Performance', 'Authentication', 'Data', 'Updates', 'About']) {
       expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
     }
   });

--- a/app/ui/src/components/UpdatesSettings.jsx
+++ b/app/ui/src/components/UpdatesSettings.jsx
@@ -1,0 +1,210 @@
+// Admin → Updates.
+//
+// Surfaces the auto-update state from the backend (PR #517): the running version
+// and channel, whether a newer version is available, the auto-update switch, and
+// the history of checks + applied updates. The app never applies updates itself —
+// a deployment-specific agent does that, gated on the switch — so this screen is
+// status + control, not an "install now" button.
+
+import { useState, useEffect, useReducer, useCallback } from 'react';
+import { useAuth } from '@ui/auth/AuthGate';
+import { useDialog } from '@ui/components/dialogContext';
+import { formatDate, formatRelativeTime } from '@ui/utils/formatters';
+
+const STATUS_STYLES = {
+  available:    'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300',
+  'up-to-date': 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300',
+  installed:    'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300',
+  failed:       'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300',
+  applying:     'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300',
+  checked:      'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+};
+
+function StatusBadge({ status }) {
+  const cls = STATUS_STYLES[status] || STATUS_STYLES.checked;
+  return <span className={`inline-block px-2 py-0.5 rounded text-[11px] font-semibold ${cls}`}>{status}</span>;
+}
+
+export default function UpdatesSettings() {
+  const { authFetch } = useAuth();
+  const dialog = useDialog();
+  const [status, setStatus] = useState(null);
+  const [log, setLog] = useState([]);
+  const [loading, setLoading] = useReducer((_, v) => v, true);
+  const [saving, setSaving] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    Promise.all([
+      authFetch('/api/admin/updates/status').then(r => r.json()),
+      authFetch('/api/admin/updates/log').then(r => r.json()),
+    ])
+      .then(([s, l]) => { setStatus(s); setLog(Array.isArray(l?.data) ? l.data : []); })
+      .catch(() => setError('Failed to load update status.'))
+      .finally(() => setLoading(false));
+  }, [authFetch]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const toggleAuto = async (enabled) => {
+    setError(null);
+    setSaving(true);
+    setStatus(s => ({ ...s, autoUpdateEnabled: enabled })); // optimistic
+    try {
+      const r = await authFetch('/api/admin/updates/auto', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `HTTP ${r.status}`);
+      dialog.toast(enabled ? 'Automatic updates enabled' : 'Automatic updates disabled', { variant: 'success' });
+    } catch (e) {
+      setStatus(s => ({ ...s, autoUpdateEnabled: !enabled })); // revert
+      setError(`Could not save setting: ${e.message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const checkNow = async () => {
+    setError(null);
+    setChecking(true);
+    try {
+      const r = await authFetch('/api/admin/updates/check', { method: 'POST' });
+      if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `HTTP ${r.status}`);
+      await load();
+    } catch (e) {
+      setError(`Check failed: ${e.message}`);
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  if (loading) return <p className="mt-4 text-sm text-gray-600 dark:text-gray-400">Loading…</p>;
+
+  const channel = status?.channel || 'unknown';
+  const current = status?.currentVersion || 'unknown';
+  const last = status?.lastCheck || null;
+  const updateAvailable = !!last?.updateAvailable;
+  const latest = last?.latestVersion || null;
+  const enabled = !!status?.autoUpdateEnabled;
+  const pinned = channel === 'pinned';
+
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
+        <div className="text-sm font-medium text-blue-900 dark:text-blue-200">Updates</div>
+        <div className="text-xs text-blue-700 dark:text-blue-300 mt-0.5">
+          Identity Atlas checks once a day for a newer version on its release channel
+          (<span className="font-mono">{channel}</span>). With automatic updates on, a newer version is
+          installed nightly by your deployment's update agent; with it off, the newest available version is
+          shown here so you can update on your own schedule. Updates stay on the same channel — edge stays on
+          edge, beta on beta, latest on latest.
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded p-3">{error}</div>
+      )}
+
+      {/* Current version + availability */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Current version</h3>
+            <p className="text-sm font-mono text-gray-900 dark:text-white mt-0.5">{current}</p>
+            <p className="text-[11px] text-gray-600 dark:text-gray-400 mt-1">
+              Channel <span className="font-mono">{channel}</span>
+              {last?.createdAt && <> · last checked {formatRelativeTime(last.createdAt)}</>}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            {pinned ? (
+              <span className="inline-block px-2.5 py-1 rounded text-xs font-semibold bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                Pinned — auto-update not applicable
+              </span>
+            ) : updateAvailable ? (
+              <span className="inline-block px-2.5 py-1 rounded text-xs font-semibold bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
+                Update available: <span className="font-mono">{latest}</span>
+              </span>
+            ) : (
+              <span className="inline-block px-2.5 py-1 rounded text-xs font-semibold bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300">
+                Up to date
+              </span>
+            )}
+            <button
+              onClick={checkNow}
+              disabled={checking}
+              className="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+            >
+              {checking ? 'Checking…' : 'Check now'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Auto-update switch */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Automatic updates</h3>
+            <p className="text-[11px] text-gray-600 dark:text-gray-400 mt-1">
+              When on, the daily check applies a newer version automatically (via your deployment's update
+              agent). When off, updates are only reported here.
+            </p>
+          </div>
+          <label className="inline-flex items-center gap-2 text-xs text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              role="switch"
+              checked={enabled}
+              disabled={saving || pinned}
+              onChange={e => toggleAuto(e.target.checked)}
+              className="h-4 w-4 accent-blue-600"
+            />
+            {enabled ? 'Enabled' : 'Disabled'}
+          </label>
+        </div>
+      </div>
+
+      {/* History */}
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">Update history</h3>
+        {log.length === 0 ? (
+          <p className="text-xs text-gray-600 dark:text-gray-400">No update checks recorded yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-xs">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 uppercase tracking-wide border-b border-gray-200 dark:border-gray-700">
+                  <th className="py-1.5 pr-4 font-semibold">When</th>
+                  <th className="py-1.5 pr-4 font-semibold">Status</th>
+                  <th className="py-1.5 pr-4 font-semibold">Channel</th>
+                  <th className="py-1.5 pr-4 font-semibold">Version</th>
+                  <th className="py-1.5 pr-4 font-semibold">Source</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                {log.map(row => (
+                  <tr key={row.id} className="text-gray-700 dark:text-gray-300">
+                    <td className="py-1.5 pr-4 whitespace-nowrap" title={formatDate(row.createdAt)}>{formatRelativeTime(row.createdAt)}</td>
+                    <td className="py-1.5 pr-4"><StatusBadge status={row.status} /></td>
+                    <td className="py-1.5 pr-4 font-mono">{row.channel}</td>
+                    <td className="py-1.5 pr-4 font-mono">
+                      {row.status === 'installed' && row.currentVersion && row.latestVersion
+                        ? `${row.currentVersion} → ${row.latestVersion}`
+                        : row.latestVersion || row.currentVersion || '—'}
+                    </td>
+                    <td className="py-1.5 pr-4 text-gray-600 dark:text-gray-400">{row.source || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/src/components/UpdatesSettings.mount.test.jsx
+++ b/app/ui/src/components/UpdatesSettings.mount.test.jsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createElement as h } from 'react';
+import UpdatesSettings from './UpdatesSettings';
+import { renderWithProviders, makeAuthFetch, jsonResponse, screen, waitFor, userEvent } from '@ui/test-utils/renderWithProviders';
+
+const statusAvailable = {
+  channel: 'edge',
+  currentVersion: '5.310.20260629.1221',
+  autoUpdateEnabled: false,
+  lastCheck: {
+    id: 9, status: 'available', channel: 'edge',
+    currentVersion: '5.310.20260629.1221', latestVersion: '5.324.20260630.0743',
+    updateAvailable: true, createdAt: '2026-06-30T07:00:00Z', source: 'scheduler',
+  },
+};
+
+const logData = {
+  data: [
+    { id: 9, status: 'available', channel: 'edge', currentVersion: '5.310.20260629.1221', latestVersion: '5.324.20260630.0743', createdAt: '2026-06-30T07:00:00Z', source: 'scheduler' },
+    { id: 8, status: 'installed', channel: 'edge', currentVersion: '5.300.20260620.0900', latestVersion: '5.310.20260629.1221', createdAt: '2026-06-29T07:00:00Z', source: 'auto-detected' },
+  ],
+};
+
+function fetchFor(status = statusAvailable, log = logData) {
+  return makeAuthFetch((url, opts = {}) => {
+    const u = String(url);
+    const m = opts.method || 'GET';
+    if (u.includes('/api/admin/updates/status')) return status;
+    if (u.includes('/api/admin/updates/log')) return log;
+    if (u.includes('/api/admin/updates/auto') && m === 'PUT') {
+      return jsonResponse({ autoUpdateEnabled: JSON.parse(opts.body).enabled });
+    }
+    if (u.includes('/api/admin/updates/check') && m === 'POST') {
+      return jsonResponse({ status: 'available', updateAvailable: true });
+    }
+    return jsonResponse({ error: 'not stubbed' }, { ok: false, status: 404 });
+  });
+}
+
+describe('UpdatesSettings (mounted)', () => {
+  it('shows current version, channel, an available badge, and the history', async () => {
+    renderWithProviders(h(UpdatesSettings), { auth: { authFetch: fetchFor() } });
+    expect(await screen.findByText('5.310.20260629.1221')).toBeInTheDocument();
+    expect(screen.getAllByText('edge').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Update available:/i)).toBeInTheDocument();
+    expect(screen.getAllByText('5.324.20260630.0743').length).toBeGreaterThan(0);
+    expect(screen.getByText('installed')).toBeInTheDocument();
+    expect(screen.getByText('5.300.20260620.0900 → 5.310.20260629.1221')).toBeInTheDocument();
+  });
+
+  it('shows "Up to date" when no update is available', async () => {
+    const s = { ...statusAvailable, lastCheck: { ...statusAvailable.lastCheck, status: 'up-to-date', updateAvailable: false } };
+    renderWithProviders(h(UpdatesSettings), { auth: { authFetch: fetchFor(s) } });
+    expect(await screen.findByText('Up to date')).toBeInTheDocument();
+  });
+
+  it('enables automatic updates via the switch', async () => {
+    const authFetch = fetchFor();
+    renderWithProviders(h(UpdatesSettings), { auth: { authFetch } });
+    const user = userEvent.setup();
+    const sw = await screen.findByRole('switch');
+    expect(sw).not.toBeChecked();
+    await user.click(sw);
+    await waitFor(() =>
+      expect(authFetch).toHaveBeenCalledWith('/api/admin/updates/auto', expect.objectContaining({ method: 'PUT' }))
+    );
+    expect(sw).toBeChecked();
+  });
+
+  it('runs a check now and reloads status', async () => {
+    const authFetch = fetchFor();
+    renderWithProviders(h(UpdatesSettings), { auth: { authFetch } });
+    const user = userEvent.setup();
+    await screen.findByText('5.310.20260629.1221');
+    authFetch.mockClear();
+    await user.click(screen.getByText('Check now'));
+    await waitFor(() =>
+      expect(authFetch).toHaveBeenCalledWith('/api/admin/updates/check', expect.objectContaining({ method: 'POST' }))
+    );
+    await waitFor(() => expect(authFetch).toHaveBeenCalledWith('/api/admin/updates/status'));
+  });
+
+  it('disables the switch and shows a pinned badge for pinned deployments', async () => {
+    const s = { channel: 'pinned', currentVersion: '5.2.1.0', autoUpdateEnabled: false, lastCheck: { id: 1, status: 'checked', channel: 'pinned', createdAt: '2026-06-30T07:00:00Z' } };
+    renderWithProviders(h(UpdatesSettings), { auth: { authFetch: fetchFor(s, { data: [] }) } });
+    expect(await screen.findByText(/Pinned — auto-update not applicable/i)).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('shows an error when the status load fails', async () => {
+    const authFetch = makeAuthFetch(async () => { throw new Error('boom'); });
+    renderWithProviders(h(UpdatesSettings), { auth: { authFetch } });
+    expect(await screen.findByText('Failed to load update status.')).toBeInTheDocument();
+  });
+});

--- a/app/ui/src/components/admin/adminTabs.js
+++ b/app/ui/src/components/admin/adminTabs.js
@@ -22,6 +22,7 @@ export const ADMIN_TABS = [
 
   { key: 'auth',            label: 'Authentication',   description: 'Single sign-on and role / permission management',                      requires: ['admin.auth'] },
   { key: 'data',            label: 'Data',             description: 'Export/import curated data and clean the database',                    requires: ['data.export.ui', 'admin.csv-import', 'admin.systems', 'admin.read-tokens', 'data.export.apikey'] },
+  { key: 'updates',         label: 'Updates',          description: 'Automatic updates and version history',                                requires: ['admin.systems'] },
   { key: 'about',           label: 'About',            description: 'License, version, and software bill of materials' },
 ];
 

--- a/changes/auto-update-ui.md
+++ b/changes/auto-update-ui.md
@@ -1,0 +1,1 @@
+- Added an **Admin → Updates** screen showing the running version and release channel, whether a newer version is available, a switch to turn **automatic updates** on or off, and a history of update checks and installed updates. A **Check now** button runs an immediate check. (Pinned deployments are detected and the switch is disabled with an explanation.)


### PR DESCRIPTION
PR2 of the auto-update feature — the **Admin → Updates** screen. Backend (#517) is already merged to `main`; this targets `main` directly.

## What you see
- **Current version + channel**, with an **Update available: `<version>`** / **Up to date** / **Pinned** badge.
- A **switch** to turn automatic updates on/off (writes `AUTO_UPDATE_ENABLED`).
- **Check now** — runs an immediate check and refreshes.
- **Update history** table — every check + installed update (status badge, channel, version / from→to, source).

Pinned deployments are detected and the switch disabled with an explanation. Dark-mode + WCAG-compliant; new tab gated on `admin.systems`.

## Tests
`UpdatesSettings.mount.test.jsx` covers the available / up-to-date / pinned states, the switch (PUT), check-now (POST + reload), and the load-error path. `adminTabs` + the AdminPage "all tabs" test updated.

> Note: my local UI `node_modules` is broken (`magic-string` version mismatch, unrelated to this change), so I couldn't run the UI vitest suite locally — the test mirrors the existing `AccountLinkingSettings.mount.test.jsx` harness exactly and runs in CI.

## Next
PR3 — cross-platform apply agents (Docker cron / Azure / local) + docs. Plus a requested follow-up: **web/worker/DB version-skew detection**, surfaced on this same tab.