### PR TITLE
feat(export): expose governance layer in Excel Power Query workbook

### DIFF
--- a/app/api/src/export/excelWorkbook.test.js
+++ b/app/api/src/export/excelWorkbook.test.js
@@ -102,6 +102,16 @@ describe('generateWorkbook', () => {
     expect(principals).not.toMatch(/off\s*=\s*\[off\]/);             // old record-self-ref
   });
 
+  it('pins includeBusinessRoles=true on the Resources feed so governance resources export', () => {
+    // The /api/resources endpoint hides BusinessRole (access package / business
+    // role) resources by default for the UI grid. Without this fixed query
+    // param the export's Resources tab would silently omit the whole governance
+    // (SOLL) layer, and the Contains edges in ResourceRelationships would point
+    // at parent rows that aren't in the workbook.
+    const resources = wb.getWorksheet('Resources').getCell('A6').value;
+    expect(resources).toContain('includeBusinessRoles = "true"');
+  });
+
   it('auto-expands the extendedAttributes JSONB column', () => {
     // Users of the workbook expect sub-keys (userType, onPremisesSyncEnabled,
     // etc.) to appear as first-class columns, not "Record" cells they have

--- a/app/api/src/export/queryTemplates.js
+++ b/app/api/src/export/queryTemplates.js
@@ -44,7 +44,7 @@ let
   FetchPage = (offset as number) =>
       Json.Document(Web.Contents(BaseUrl, [
           RelativePath = "ENDPOINT_PATH",
-          Query = [limit = Text.From(PageSize), offset = Text.From(offset)],
+          Query = [limit = Text.From(PageSize), offset = Text.From(offset)EXTRA_QUERY],
           Headers = Headers
       ])),
   First = FetchPage(0),
@@ -97,8 +97,19 @@ in
   ExtExpanded
 `.trim();
 
-function paginatedQuery(endpointPath) {
-  return PAGINATED_FETCH.replace('ENDPOINT_PATH', endpointPath);
+// `extraQuery` lets a feed pin extra fixed query-string params into every page
+// fetch (e.g. Resources passes includeBusinessRoles=true so the governance
+// resources the UI hides are included in the export). Keys are emitted as M
+// record fields alongside limit/offset; values are sent as strings.
+function paginatedQuery(endpointPath, extraQuery) {
+  const extra = extraQuery
+    ? Object.entries(extraQuery)
+        .map(([k, v]) => `, ${k} = "${v}"`)
+        .join('')
+    : '';
+  return PAGINATED_FETCH
+    .replace('ENDPOINT_PATH', endpointPath)
+    .replace('EXTRA_QUERY', extra);
 }
 
 // `/api/systems` predates the {data,total} convention used by every other
@@ -140,11 +151,18 @@ function arrayQuery(endpointPath) {
 export const QUERIES = [
   { sheet: 'Systems',                endpoint: 'systems',                m: arrayQuery('systems') },
   { sheet: 'Principals',             endpoint: 'users',                  m: paginatedQuery('users') },
-  { sheet: 'Resources',              endpoint: 'resources',              m: paginatedQuery('resources') },
+  { sheet: 'Resources',              endpoint: 'resources',              m: paginatedQuery('resources', { includeBusinessRoles: 'true' }) },
   { sheet: 'Assignments',            endpoint: 'assignments',            m: paginatedQuery('assignments') },
   { sheet: 'Identities',             endpoint: 'identities',             m: paginatedQuery('identities') },
   { sheet: 'IdentityMembers',        endpoint: 'identity-members',       m: paginatedQuery('identity-members') },
   { sheet: 'ResourceRelationships',  endpoint: 'resource-relationships', m: paginatedQuery('resource-relationships') },
   { sheet: 'Contexts',               endpoint: 'context-list',           m: paginatedQuery('context-list') },
   { sheet: 'ContextMembers',         endpoint: 'context-members',        m: paginatedQuery('context-members') },
+  // Governance (SOLL) layer — catalogs that group business roles / access
+  // packages, the policies that govern how they're granted, the request/
+  // approval workflow, and access-review (certification) outcomes.
+  { sheet: 'GovernanceCatalogs',     endpoint: 'governance-catalogs',    m: paginatedQuery('governance-catalogs') },
+  { sheet: 'AssignmentPolicies',     endpoint: 'assignment-policies',    m: paginatedQuery('assignment-policies') },
+  { sheet: 'AssignmentRequests',     endpoint: 'assignment-requests',    m: paginatedQuery('assignment-requests') },
+  { sheet: 'CertificationDecisions', endpoint: 'certification-decisions', m: paginatedQuery('certification-decisions') },
 ];

--- a/app/api/src/routes/bulkLists.coverage.test.js
+++ b/app/api/src/routes/bulkLists.coverage.test.js
@@ -23,7 +23,11 @@ beforeEach(() => {
   queryOne.mockReset();
 });
 
-const endpoints = ['/api/assignments', '/api/identity-members', '/api/resource-relationships'];
+const endpoints = [
+  '/api/assignments', '/api/identity-members', '/api/resource-relationships',
+  '/api/governance-catalogs', '/api/assignment-policies',
+  '/api/assignment-requests', '/api/certification-decisions',
+];
 
 describe('bulkLists happy paths', () => {
   for (const ep of endpoints) {
@@ -58,6 +62,34 @@ describe('bulkLists happy paths', () => {
       queryOne.mockResolvedValueOnce({ total: 0 });
       const res = await request(app).get(ep);
       expect(res.status).toBe(500);
+    });
+  }
+});
+
+describe('bulkLists SQL shape', () => {
+  // The export needs to distinguish governed from non-governed assignments —
+  // the `governed` flag must be in the SELECT or the workbook can't split them.
+  it('GET /api/assignments selects the governed flag', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    queryOne.mockResolvedValueOnce({ total: 0 });
+    await request(app).get('/api/assignments');
+    expect(query.mock.calls[0][0]).toContain('"governed"');
+  });
+
+  // Each governance feed must read its own table — a copy/paste slip would
+  // silently point a feed at the wrong table.
+  const tableByEndpoint = {
+    '/api/governance-catalogs': 'GovernanceCatalogs',
+    '/api/assignment-policies': 'AssignmentPolicies',
+    '/api/assignment-requests': 'AssignmentRequests',
+    '/api/certification-decisions': 'CertificationDecisions',
+  };
+  for (const [ep, table] of Object.entries(tableByEndpoint)) {
+    it(`GET ${ep} reads "${table}"`, async () => {
+      query.mockResolvedValueOnce({ rows: [] });
+      queryOne.mockResolvedValueOnce({ total: 0 });
+      await request(app).get(ep);
+      expect(query.mock.calls[0][0]).toContain(`"${table}"`);
     });
   }
 });

--- a/app/api/src/routes/bulkLists.js
+++ b/app/api/src/routes/bulkLists.js
@@ -68,9 +68,10 @@ router.get('/assignments', async (req, res) => {
     const result = await runListAndCount({
       table: 'ResourceAssignments',
       alias: 'ra',
-      columns: `ra."resourceId", ra."principalId", ra."assignmentType", ra."systemId",
-                ra."principalType", ra."complianceState", ra."policyId", ra."state",
-                ra."assignmentStatus", ra."expirationDateTime", ra."extendedAttributes"`,
+      columns: `ra."resourceId", ra."principalId", ra."assignmentType", ra."governed",
+                ra."systemId", ra."principalType", ra."complianceState", ra."policyId",
+                ra."state", ra."assignmentStatus", ra."expirationDateTime",
+                ra."extendedAttributes"`,
       orderBy: `ra."resourceId", ra."principalId", ra."assignmentType"`,
       dataWhere:  systemId !== null ? `WHERE ra."systemId" = $1` : '',
       countWhere: systemId !== null ? `WHERE ra."systemId" = $1` : '',
@@ -178,6 +179,109 @@ router.get('/context-members', async (req, res) => {
     res.json(result);
   } catch (err) {
     console.error('GET /context-members failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ─── GET /api/governance-catalogs ────────────────────────────────
+// Flat listing of governance catalogs (Entra ID catalogs, SailPoint sources,
+// …) — the containers that group business roles / access packages.
+router.get('/governance-catalogs', async (req, res) => {
+  const { limit, offset, systemId } = parsePaging(req);
+  try {
+    const where = systemId !== null ? `WHERE gc."systemId" = $1` : '';
+    const result = await runListAndCount({
+      table: 'GovernanceCatalogs',
+      alias: 'gc',
+      columns: `gc.id, gc."systemId", gc."displayName", gc.description,
+                gc."catalogType", gc.enabled, gc."isExternallyVisible",
+                gc."externalId", gc."createdDateTime", gc."modifiedDateTime",
+                gc."extendedAttributes"`,
+      orderBy: `gc."displayName"`,
+      dataWhere: where, countWhere: where,
+      systemId, limit, offset,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('GET /governance-catalogs failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ─── GET /api/assignment-policies ────────────────────────────────
+// Flat listing of assignment policies — the rules (auto-add/remove, access
+// review settings) that govern how a business role / access package is granted.
+router.get('/assignment-policies', async (req, res) => {
+  const { limit, offset, systemId } = parsePaging(req);
+  try {
+    const where = systemId !== null ? `WHERE ap."systemId" = $1` : '';
+    const result = await runListAndCount({
+      table: 'AssignmentPolicies',
+      alias: 'ap',
+      columns: `ap.id, ap."systemId", ap."resourceId", ap."displayName",
+                ap.description, ap."allowedTargetScope", ap."hasAutoAddRule",
+                ap."hasAutoRemoveRule", ap."hasAccessReview",
+                ap."createdDateTime", ap."modifiedDateTime", ap."extendedAttributes"`,
+      orderBy: `ap."displayName"`,
+      dataWhere: where, countWhere: where,
+      systemId, limit, offset,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('GET /assignment-policies failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ─── GET /api/assignment-requests ────────────────────────────────
+// Flat listing of access requests — the request/approval workflow rows behind
+// governed assignments.
+router.get('/assignment-requests', async (req, res) => {
+  const { limit, offset, systemId } = parsePaging(req);
+  try {
+    const where = systemId !== null ? `WHERE ar."systemId" = $1` : '';
+    const result = await runListAndCount({
+      table: 'AssignmentRequests',
+      alias: 'ar',
+      columns: `ar.id, ar."systemId", ar."resourceId", ar."requestorId",
+                ar."requestType", ar."requestState", ar."requestStatus",
+                ar."isValidationOnly", ar."justification",
+                ar."createdDateTime", ar."completedDateTime", ar."extendedAttributes"`,
+      orderBy: `ar."createdDateTime"`,
+      dataWhere: where, countWhere: where,
+      systemId, limit, offset,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('GET /assignment-requests failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ─── GET /api/certification-decisions ────────────────────────────
+// Flat listing of access-review decisions (approve/deny/dontKnow) — the
+// outcome rows of governance access reviews / certifications.
+router.get('/certification-decisions', async (req, res) => {
+  const { limit, offset, systemId } = parsePaging(req);
+  try {
+    const where = systemId !== null ? `WHERE cd."systemId" = $1` : '';
+    const result = await runListAndCount({
+      table: 'CertificationDecisions',
+      alias: 'cd',
+      columns: `cd.id, cd."systemId", cd."resourceId", cd."principalId",
+                cd."principalDisplayName", cd."reviewedResourceId",
+                cd."reviewedResourceDisplayName", cd.decision, cd.recommendation,
+                cd.justification, cd."reviewedBy", cd."reviewedByDisplayName",
+                cd."reviewedDateTime", cd."reviewDefinitionId", cd."reviewInstanceId",
+                cd."reviewInstanceStatus", cd."reviewInstanceStartDateTime",
+                cd."reviewInstanceEndDateTime", cd."extendedAttributes"`,
+      orderBy: `cd."reviewedDateTime"`,
+      dataWhere: where, countWhere: where,
+      systemId, limit, offset,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('GET /certification-decisions failed:', err.message);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -91,7 +91,12 @@ router.get('/resources', async (req, res) => {
     if (resourceType) {
       where += ` AND r."resourceType" = @resourceType`;
       request.input('resourceType', resourceType);
-    } else {
+    } else if (req.query.includeBusinessRoles !== 'true') {
+      // The UI grid lists actual-access resources only; business roles /
+      // access packages live on the governance (SOLL) side and are hidden by
+      // default. The Excel export passes ?includeBusinessRoles=true so an
+      // analyst can rebuild the governance matrix — joining a BusinessRole's
+      // `Contains` relationships to the groups it grants — entirely in Excel.
       where += ` AND (r."resourceType" IS NULL OR r."resourceType" <> 'BusinessRole')`;
     }
     if (systemId && /^\d+$/.test(systemId)) {
@@ -126,7 +131,8 @@ router.get('/resources', async (req, res) => {
     // quadratic across an export and slow enough to time out a deep page.)
     const baseSql = `
       WITH page AS (
-        SELECT r.id, r."displayName", r."description", r."resourceType", r."systemId", r."enabled",
+        SELECT r.id, r."displayName", r."description", r."resourceType", r."governanceResource",
+               r."systemId", r."enabled",
                r."createdDateTime", r."extendedAttributes",
                r."mail", r."visibility", r."externalId",
                r."catalogId", r."isHidden", r."modifiedDateTime",

--- a/app/api/src/routes/resources.test.js
+++ b/app/api/src/routes/resources.test.js
@@ -84,6 +84,16 @@ describe('GET /resources — list', () => {
     await request(app).get('/api/resources');
     expect(captured.sql).toContain(`r."resourceType" <> 'BusinessRole'`);
   });
+
+  it('includes BusinessRole resources when ?includeBusinessRoles=true (governance export)', async () => {
+    await request(app).get('/api/resources?includeBusinessRoles=true');
+    expect(captured.sql).not.toContain(`r."resourceType" <> 'BusinessRole'`);
+  });
+
+  it('selects the governanceResource flag so business roles are identifiable', async () => {
+    await request(app).get('/api/resources?includeBusinessRoles=true');
+    expect(captured.sql).toContain('"governanceResource"');
+  });
 });
 
 describe('GET /resources/:id — detail', () => {

--- a/changes/export-governance-parity.md
+++ b/changes/export-governance-parity.md
@@ -1,0 +1,4 @@
+- Excel Power Query export now distinguishes governed from non-governed assignments (the `governed` flag is included on the Assignments tab).
+- Excel Power Query export now includes business roles / access packages on the Resources tab (previously hidden), with a `governanceResource` flag marking governance resources — so the `Contains` links on the ResourceRelationships tab now join to a named business role.
+- Added four governance tabs to the Excel Power Query workbook: Governance Catalogs, Assignment Policies, Assignment Requests, and Certification Decisions (access-review outcomes).
+- Data analysts can now rebuild any governance matrix the web UI shows — including the governed/non-governed split and which resources each business role grants — entirely in Excel.

--- a/docs/admin/excel-powerquery-export.md
+++ b/docs/admin/excel-powerquery-export.md
@@ -24,11 +24,22 @@ One `.xlsx` file with these sheets:
 | Settings               | —                                   | `BaseUrl` + `AuthToken` pre-populated named-range cells  |
 | Systems                | `GET /api/systems`                  | Connected systems (Entra ID, Omada, CSV-backed, …)       |
 | Principals             | `GET /api/users`                    | Every principalType — users, service principals, MIs, AI agents |
-| Resources              | `GET /api/resources`                | Groups, directory roles, app roles, business roles       |
-| Assignments            | `GET /api/assignments`              | Who has access to what (from `ResourceAssignments`)      |
+| Resources              | `GET /api/resources`                | Groups, directory roles, app roles **and** business roles / access packages (the `governanceResource` flag marks the governance ones) |
+| Assignments            | `GET /api/assignments`              | Who has access to what (from `ResourceAssignments`). The `governed` flag splits governed-intent rows from actual access |
 | Identities             | `GET /api/identities`               | Real-person identities aggregated from multiple accounts |
 | IdentityMembers        | `GET /api/identity-members`         | Identity ↔ account links                                 |
-| ResourceRelationships  | `GET /api/resource-relationships`   | Parent↔child resource links (Contains, GrantsAccessTo)   |
+| ResourceRelationships  | `GET /api/resource-relationships`   | Parent↔child resource links (Contains, GrantsAccessTo) — incl. which groups each business role `Contains` |
+| GovernanceCatalogs     | `GET /api/governance-catalogs`      | Catalogs that group business roles / access packages     |
+| AssignmentPolicies     | `GET /api/assignment-policies`      | Rules governing how a business role / access package is granted (auto-add/remove, access-review settings) |
+| AssignmentRequests     | `GET /api/assignment-requests`      | Access request / approval workflow rows                  |
+| CertificationDecisions | `GET /api/certification-decisions`  | Access-review (certification) decisions — approve/deny/dontKnow outcomes |
+
+Between them these tabs carry the full governance (SOLL) layer, so an analyst
+can rebuild **any** matrix the web UI shows — including the governed/non-governed
+split and the business-role → group grants — entirely in Excel: join
+`Assignments` to `Resources` on `resourceId`, and `ResourceRelationships`
+(`relationshipType = "Contains"`) to `Resources` on both `parentResourceId`
+(the business role) and `childResourceId` (the group it grants).
 
 The Principals and Resources tabs auto-expand the `extendedAttributes` JSONB
 column into first-class `ext_*` columns (`ext_userType`,


### PR DESCRIPTION
## Why

Goal: a data analyst should be able to rebuild **any** matrix the web UI shows — fully in Excel via Power Query. Today the export can't represent the governance (SOLL) layer: it omits the `governed` flag, hides business roles / access packages, and exposes no catalogs or access reviews. So the governed/non-governed split and business-role grants are invisible in Excel.

## What

- **Assignments tab** now selects the `governed` flag → governed-intent vs actual access is distinguishable.
- **Resources tab/export** now includes `BusinessRole` resources (access packages / business roles) via `?includeBusinessRoles=true`, and selects the `governanceResource` flag. The UI grid default (hide business roles) is unchanged — only the export opts in. The `Contains` edges already in **ResourceRelationships** now join to a named business-role parent.
- **Four new governance tabs / feeds:**
  - `GovernanceCatalogs` (`GET /api/governance-catalogs`)
  - `AssignmentPolicies` (`GET /api/assignment-policies`)
  - `AssignmentRequests` (`GET /api/assignment-requests`)
  - `CertificationDecisions` (`GET /api/certification-decisions`) — access-review outcomes

With these, an analyst can rebuild the governance matrix in Excel: `Assignments ⨝ Resources` on `resourceId`, and `ResourceRelationships` (`relationshipType = Contains`) ⨝ `Resources` on both `parentResourceId` (business role) and `childResourceId` (group it grants).

## Tests

- `bulkLists.coverage.test.js` — new feeds covered + asserts `governed` is selected and each governance feed reads its own table.
- `resources.test.js` — `includeBusinessRoles=true` drops the BusinessRole exclusion; `governanceResource` is selected.
- `excelWorkbook.test.js` — Resources feed pins `includeBusinessRoles=true`; new tabs auto-covered by the per-`QUERIES` loop.
- 74 unit tests green locally. Contract tests (real Postgres) run in CI — column names cross-checked against migrations 002/047/048.

## Docs

Updated `docs/admin/excel-powerquery-export.md` sheet table (and corrected the prior claim that Resources already included business roles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)