### PR TITLE
fix(ui): Identity (and run) detail-tab badge — closes #208

### DIFF
--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -5,6 +5,7 @@ import { useCanSeeAdminTab } from './auth/usePermissions';
 import { useTheme } from './hooks/useTheme';
 import { ThemeContext } from './contexts/ThemeContext';
 import { computeNavTabs, availableOptionalTabs } from './utils/navTabs';
+import { tabBadge } from './utils/tabBadge';
 import ErrorBoundary from './components/ErrorBoundary';
 
 // Lazy-load page components (route-based code splitting)
@@ -539,7 +540,7 @@ export default function App() {
           {detailTabs.map(tab => {
             const tabKey = `${tab.type}:${tab.id}`;
             const isActive = page === tabKey;
-            const icon = tab.type === 'user' ? 'U' : tab.type === 'resource' ? 'R' : tab.type === 'group' ? 'G' : tab.type === 'department' ? 'D' : tab.type === 'context' ? 'C' : 'AP';
+            const icon = tabBadge(tab.type);
             const iconBg = tab.type === 'user' ? 'bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300' : tab.type === 'resource' ? 'bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300' : tab.type === 'group' ? 'bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300' : tab.type === 'department' ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300' : tab.type === 'context' ? 'bg-sky-100 dark:bg-sky-900/50 text-sky-700 dark:text-sky-300' : 'bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300';
             return (
               <button

--- a/app/ui/src/utils/tabBadge.js
+++ b/app/ui/src/utils/tabBadge.js
@@ -1,0 +1,18 @@
+// Short badge shown at the start of an open detail tab, keyed by entity type.
+// Kept out of App.jsx so the mapping can be unit-tested in isolation.
+//
+// #208: identity tabs previously fell through to the 'AP' (access-package)
+// fallback and showed "AP" instead of "ID"; 'run' tabs hit the same fallback.
+export function tabBadge(type) {
+  switch (type) {
+    case 'user':        return 'U';
+    case 'resource':    return 'R';
+    case 'group':       return 'G';
+    case 'department':  return 'D';
+    case 'context':     return 'C';
+    case 'identity':    return 'ID';
+    case 'run':         return 'RUN';
+    case 'access-package':
+    default:            return 'AP';
+  }
+}

--- a/app/ui/src/utils/tabBadge.test.js
+++ b/app/ui/src/utils/tabBadge.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { tabBadge } from './tabBadge';
+
+describe('tabBadge', () => {
+  it('maps each known detail-tab type to its badge', () => {
+    expect(tabBadge('user')).toBe('U');
+    expect(tabBadge('resource')).toBe('R');
+    expect(tabBadge('group')).toBe('G');
+    expect(tabBadge('department')).toBe('D');
+    expect(tabBadge('context')).toBe('C');
+    expect(tabBadge('access-package')).toBe('AP');
+  });
+
+  it('shows ID (not AP) for identity tabs — #208', () => {
+    expect(tabBadge('identity')).toBe('ID');
+  });
+
+  it('shows RUN (not AP) for run tabs', () => {
+    expect(tabBadge('run')).toBe('RUN');
+  });
+
+  it('falls back to AP for an unknown type', () => {
+    expect(tabBadge('something-else')).toBe('AP');
+  });
+});

--- a/changes/identity-tab-badge-208.md
+++ b/changes/identity-tab-badge-208.md
@@ -1,0 +1,1 @@
+- Fixed the badge shown at the start of an open detail tab: Identity tabs now show "ID" (they previously showed "AP", the access-package badge), and run tabs show "RUN" instead of "AP".


### PR DESCRIPTION
Closes #208.

## Bug
Opening an **Identity** detail tab showed the badge **"AP"** (the access-package badge) instead of **"ID"**. Cause: the badge ternary in `App.jsx` had cases for user/resource/group/department/context and an `'AP'` fallback — but **no `identity` case**, so identity tabs fell through to `'AP'`. `run` tabs hit the same fallback.

## Fix
Extracted the type→badge mapping into a small, unit-testable `tabBadge()` util (`src/utils/tabBadge.js`):
- `identity` → **ID**
- `run` → **RUN**
- `access-package` → **AP** (explicit now)
- user/resource/group/department/context unchanged (U/R/G/D/C)

Adds `tabBadge.test.js` (4 tests, incl. the #208 case). The badge background colour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)