### PR TITLE
fix(ui): persist list-page filters across detail navigation (#192)

### DIFF
--- a/app/ui/src/hooks/useEntityPage.js
+++ b/app/ui/src/hooks/useEntityPage.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useReducer, useCallback, useMemo, useRef } from 'react';
 import { useDebouncedValue } from './useDebouncedValue';
+import usePersistedState from './usePersistedState';
 import { useDialog } from '@ui/components/dialogContext';
 
 const PAGE_SIZE = 100;
@@ -21,6 +22,11 @@ const PAGE_SIZE = 100;
  */
 export default function useEntityPage({ authFetch, entityType, listEndpoint, columnsEndpoint, tagFilterKey, baseFilters }) {
   const dialog = useDialog();
+  // Filter/search/sort state is persisted per entity type so it survives the
+  // list page unmounting when a result is opened in a detail tab and remounting
+  // when the user comes back (issue #192). `entityType` is stable for the life
+  // of the page, so these keys are stable across renders.
+  const skey = (k) => (entityType ? `iatlas.list.${entityType}.${k}` : null);
   // Data state
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
@@ -32,21 +38,23 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
   // Column discovery for filters
   const [availableColumns, setAvailableColumns] = useState([]);
   const [columnsLoading, setColumnsLoading] = useState(true);
-  const [activeFilters, setActiveFilters] = useState([]);
+  const [activeFilters, setActiveFilters] = usePersistedState(skey('filters'), []);
 
   // Filter state
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = usePersistedState(skey('search'), '');
   const debouncedSearch = useDebouncedValue(search, 400);
+  // Page resets to 0 on return — the persisted filters/search are what matter,
+  // and starting at page 1 avoids landing on a now-empty page if the data moved.
   const [page, setPage] = useState(0);
   // Soft-deleted (tombstoned) entities are hidden by default; this reveals them.
-  const [includeDeleted, setIncludeDeleted] = useState(false);
+  const [includeDeleted, setIncludeDeleted] = usePersistedState(skey('includeDeleted'), false);
 
-  // Selection state
+  // Selection state (transient — never persisted)
   const [selected, setSelected] = useState(new Set());
 
   // Sort state
-  const [sortCol, setSortCol] = useState(null);
-  const [sortDir, setSortDir] = useState('asc');
+  const [sortCol, setSortCol] = usePersistedState(skey('sortCol'), null);
+  const [sortDir, setSortDir] = usePersistedState(skey('sortDir'), 'asc');
 
   // Tag creation state
   const [showCreateTag, setShowCreateTag] = useState(false);
@@ -165,11 +173,11 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
   // Filter helpers
   const addFilter = useCallback((field, value) => {
     setActiveFilters(prev => [...prev.filter(f => f.field !== field), { field, value }]);
-  }, []);
+  }, [setActiveFilters]);
 
   const removeFilter = useCallback((field) => {
     setActiveFilters(prev => prev.filter(f => f.field !== field));
-  }, []);
+  }, [setActiveFilters]);
 
   const clearAllFilters = () => {
     setActiveFilters([]);

--- a/app/ui/src/hooks/useEntityPage.test.jsx
+++ b/app/ui/src/hooks/useEntityPage.test.jsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   renderHook,
   act,
@@ -13,7 +13,11 @@ import useEntityPage from '@ui/hooks/useEntityPage';
 const LIST = '/api/users';
 const COLUMNS = '/api/users/columns';
 
-function setup({ handler, baseFilters } = {}) {
+// useEntityPage now persists search/filters/sort to sessionStorage (issue #192),
+// so each test must start from a clean slate to stay isolated.
+beforeEach(() => sessionStorage.clear());
+
+function setup({ handler, baseFilters, entityType = 'user' } = {}) {
   const af = makeAuthFetch(
     handler || {
       [COLUMNS]: [
@@ -27,11 +31,11 @@ function setup({ handler, baseFilters } = {}) {
     }
   );
   const { wrapper } = makeWrapper({ auth: { authFetch: af } });
-  const { result } = renderHook(
+  const { result, unmount } = renderHook(
     () =>
       useEntityPage({
         authFetch: af,
-        entityType: 'user',
+        entityType,
         listEndpoint: LIST,
         columnsEndpoint: COLUMNS,
         tagFilterKey: '__userTag',
@@ -39,7 +43,7 @@ function setup({ handler, baseFilters } = {}) {
       }),
     { wrapper }
   );
-  return { af, result };
+  return { af, result, unmount };
 }
 
 // Pull the last list request URL out of the mock's call list.
@@ -269,5 +273,46 @@ describe('useEntityPage', () => {
 
     act(() => result.current.addFilter('__userTag', 'VIP'));
     await waitFor(() => expect(result.current.activeTagFilter).toBe('VIP'));
+  });
+
+  it('persists search, filters and sort across an unmount and restores them on remount (#192)', async () => {
+    // Apply a search + filter + sort, then unmount the page (as happens when a
+    // result is opened in a detail tab).
+    const first = setup();
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    act(() => first.result.current.setSearch('alice'));
+    act(() => first.result.current.addFilter('department', 'Sales'));
+    act(() => first.result.current.setIncludeDeleted(true));
+    act(() => first.result.current.toggleSort('displayName'));
+    await waitFor(() => expect(first.result.current.debouncedSearch).toBe('alice'));
+    first.unmount();
+
+    // Remount a fresh hook for the same entity type — state comes back.
+    const second = setup();
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+    expect(second.result.current.search).toBe('alice');
+    expect(second.result.current.activeFilters).toEqual([{ field: 'department', value: 'Sales' }]);
+    expect(second.result.current.includeDeleted).toBe(true);
+    expect(second.result.current.sortCol).toBe('displayName');
+
+    // ...and the restored search drives the list query on remount.
+    await waitFor(() => {
+      const url = lastListUrl(second.af);
+      expect(url).toContain('search=alice');
+      expect(decodeURIComponent(url)).toContain('"department":"Sales"');
+    });
+  });
+
+  it('keeps persisted state isolated per entity type', async () => {
+    const users = setup({ entityType: 'user' });
+    await waitFor(() => expect(users.result.current.loading).toBe(false));
+    act(() => users.result.current.setSearch('only-users'));
+    await waitFor(() => expect(users.result.current.debouncedSearch).toBe('only-users'));
+    users.unmount();
+
+    // A different entity type must not inherit the user-page search.
+    const groups = setup({ entityType: 'group' });
+    await waitFor(() => expect(groups.result.current.loading).toBe(false));
+    expect(groups.result.current.search).toBe('');
   });
 });

--- a/app/ui/src/hooks/usePersistedState.js
+++ b/app/ui/src/hooks/usePersistedState.js
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Drop-in replacement for useState whose value is mirrored to sessionStorage
+ * under `key`, so it survives the component unmounting and remounting within
+ * the same browser session.
+ *
+ * This is what keeps a list page's search/filter state alive when the user
+ * opens a result (which unmounts the list to show the detail) and then comes
+ * back to the list — see useEntityPage.
+ *
+ * Values are JSON-serialised, so this only fits serialisable state (strings,
+ * numbers, booleans, plain objects/arrays). Don't use it for Sets, Maps, or
+ * anything carrying functions. A falsy `key` disables persistence and the hook
+ * behaves like a plain useState.
+ *
+ * @template T
+ * @param {string|null|undefined} key - sessionStorage key (null/'' disables persistence)
+ * @param {T} initialValue - value used when nothing is stored yet
+ * @returns {[T, import('react').Dispatch<import('react').SetStateAction<T>>]}
+ */
+export default function usePersistedState(key, initialValue) {
+  const [value, setValue] = useState(() => {
+    if (!key) return initialValue;
+    try {
+      const raw = sessionStorage.getItem(key);
+      return raw == null ? initialValue : JSON.parse(raw);
+    } catch {
+      // Corrupt JSON or storage disabled — fall back to the default.
+      return initialValue;
+    }
+  });
+
+  // Persist on every change. Writing to storage is a side effect (not a
+  // setState), so this does not trip react-hooks/set-state-in-effect.
+  useEffect(() => {
+    if (!key) return;
+    try {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Quota exceeded or storage unavailable — persistence is best-effort.
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/app/ui/src/hooks/usePersistedState.test.jsx
+++ b/app/ui/src/hooks/usePersistedState.test.jsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@ui/test-utils/renderWithProviders';
+import usePersistedState from '@ui/hooks/usePersistedState';
+
+describe('usePersistedState', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('uses the initial value when nothing is stored', () => {
+    const { result } = renderHook(() => usePersistedState('k.a', 'init'));
+    expect(result.current[0]).toBe('init');
+  });
+
+  it('hydrates from sessionStorage on mount', () => {
+    sessionStorage.setItem('k.b', JSON.stringify('stored'));
+    const { result } = renderHook(() => usePersistedState('k.b', 'init'));
+    expect(result.current[0]).toBe('stored');
+  });
+
+  it('writes updates back to sessionStorage', () => {
+    const { result } = renderHook(() => usePersistedState('k.c', ''));
+    act(() => result.current[1]('typed'));
+    expect(result.current[0]).toBe('typed');
+    expect(JSON.parse(sessionStorage.getItem('k.c'))).toBe('typed');
+  });
+
+  it('restores state across an unmount/remount (the #192 scenario)', () => {
+    const first = renderHook(() => usePersistedState('k.d', []));
+    act(() => first.result.current[1]([{ field: 'department', value: 'Sales' }]));
+    first.unmount();
+
+    const second = renderHook(() => usePersistedState('k.d', []));
+    expect(second.result.current[0]).toEqual([{ field: 'department', value: 'Sales' }]);
+  });
+
+  it('keeps different keys isolated', () => {
+    const a = renderHook(() => usePersistedState('k.e1', 'a'));
+    const b = renderHook(() => usePersistedState('k.e2', 'b'));
+    act(() => a.result.current[1]('changed'));
+    expect(b.result.current[0]).toBe('b');
+  });
+
+  it('falls back to the initial value when stored JSON is corrupt', () => {
+    sessionStorage.setItem('k.f', '{not json');
+    const { result } = renderHook(() => usePersistedState('k.f', 'safe'));
+    expect(result.current[0]).toBe('safe');
+  });
+
+  it('behaves like plain useState (no persistence) when key is falsy', () => {
+    const { result } = renderHook(() => usePersistedState(null, 'x'));
+    act(() => result.current[1]('y'));
+    expect(result.current[0]).toBe('y');
+    expect(sessionStorage.getItem('null')).toBeNull();
+    expect(sessionStorage.length).toBe(0);
+  });
+});

--- a/changes/persist-list-filters.md
+++ b/changes/persist-list-filters.md
@@ -1,0 +1,1 @@
+- Fixed search and filters being lost on list pages (Identities, Users, Groups, Resources) after opening one of the results and returning to the list — your search, column filters, "include deleted" toggle, and sort are now kept for the rest of the session.


### PR DESCRIPTION
## What

Fixes #192 — search and filters on list pages were reset after opening one of the results and returning to the list.

- Fixed search and filters being lost on list pages (Identities, Users, Groups, Resources) after opening one of the results and returning to the list — your search, column filters, "include deleted" toggle, and sort are now kept for the rest of the session.

## Why it happened

Opening a result switches `App.jsx` to render the detail view, which **unmounts** the list page. All filter state lived in `useEntityPage`'s local `useState` with no persistence, so returning to the list remounted it fresh with defaults.

## Fix

- New `usePersistedState` hook — a sessionStorage-backed `useState` drop-in (lazy-hydrate on mount, write-on-change side effect; no `set-state-in-effect`).
- `useEntityPage` now uses it for `search`, `activeFilters`, `includeDeleted`, `sortCol`, `sortDir`, keyed per entity type (`iatlas.list.<type>.*`). Selection and page stay transient — page returns to 1 so you never land on a now-empty page.

## Tests

- `usePersistedState.test.jsx` — hydrate/persist/isolation/corrupt-JSON/disabled-key (7 cases).
- `useEntityPage.test.jsx` — new unmount→remount restore test and per-entity-type isolation test; added `sessionStorage.clear()` between cases.
- Verified empirically against the running Docker stack: typed a search on Identities, opened a result, returned to the list — search is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)