### PR TITLE
test(db): allow inserted-migration letter suffix (unblocks main CI)

### DIFF
--- a/test/unit/IdentityAtlas.Tests.ps1
+++ b/test/unit/IdentityAtlas.Tests.ps1
@@ -606,9 +606,12 @@ Describe 'Postgres Schema Files' {
         (Get-ChildItem $script:migrationsDir -Filter '*.sql').Count | Should -BeGreaterOrEqual 1
     }
 
-    It 'all migrations are numbered NNN_*.sql' {
+    It 'all migrations are numbered NNN_*.sql (optional letter suffix for inserts, e.g. 044a_)' {
+        # The optional [a-z] after the 3 digits lets a migration be slotted between two existing
+        # numbers without renumbering — e.g. 044a_ sorts after 044_ and before 045_, so the runner
+        # (which orders by filename) applies it in the right place.
         $bad = Get-ChildItem $script:migrationsDir -Filter '*.sql' | Where-Object {
-            $_.Name -notmatch '^\d{3}_[a-z_]+\.sql$'
+            $_.Name -notmatch '^\d{3}[a-z]?_[a-z_]+\.sql$'
         }
         $bad | Should -BeNullOrEmpty -Because "bad names: $($bad.Name -join ', ')"
     }


### PR DESCRIPTION
## Why
`main`'s `Unit Tests: Pester` job is **red**, and it blocks every open PR (#531, #532, …). The failing assertion is `IdentityAtlas.Tests.ps1` → "all migrations are numbered `NNN_*.sql`". A migration merged to `main` as **`044a_dedup_before_source_collapse.sql`** (from the dedup-before-source-collapse work) has a letter suffix the regex `^\d{3}_…` rejects.

## Fix (option A — agreed)
Relax the regex to `^\d{3}[a-z]?_[a-z_]+\.sql$`, permitting a single-letter **insert** suffix. The `044a_` name is **intentional and correct**: it sorts `044_ < 044a_ < 045_`, and the migration runner orders by filename, so it applies in the right place between 044 and 045. The migration file itself is **untouched**.

Test-only change. Verified locally (Pester 5.7.1) — the assertion passes with `044a` present.

Once this merges, #531 and #532 (both blocked solely by this) should go green on their next run.