### PR TITLE
refactor(crawler): make Start-OmadaCrawler.ps1 testable — extract pure record-shapers

### DIFF
--- a/changes/refactor-omada-crawler.md
+++ b/changes/refactor-omada-crawler.md
@@ -1,0 +1,1 @@
+- Internal: Omada crawler identity record-shaping extracted into unit-tested pure functions (no functional change).

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -28,7 +28,8 @@ BeforeAll {
     # Context-type mapping the Orgunit mapper resolves through, mirroring the
     # Start script's Configuration-region defaults.
     $script:TypeMappings = @{
-        contextTypeToIdentityAtlas = @{ 'OrgUnit' = 'OrgUnit'; 'Organisational Unit' = 'OrgUnit'; Department = 'Department' }
+        contextTypeToIdentityAtlas  = @{ 'OrgUnit' = 'OrgUnit'; 'Organisational Unit' = 'OrgUnit'; Department = 'Department' }
+        identityTypeToIdentityAtlas = @{ Employee = 'User'; Contractor = 'ExternalUser'; 'Service Account' = 'ServicePrincipal' }
     }
 }
 
@@ -159,5 +160,48 @@ Describe 'Sort-OmadaContextsTopologically' {
 
     It 'returns an empty array for no records' {
         @(Sort-OmadaContextsTopologically -Records @()).Count | Should -Be 0
+    }
+}
+
+Describe 'ConvertTo-OmadaAccountRecord' {
+
+    It 'maps an account and resolves principalType from the linked identity' {
+        $lookup = @{ 'ID-1' = @{ uid = 'idu-1'; identityType = 'Contractor' } }
+        $acc = [pscustomobject]@{
+            UId = 'acc-1'; FIRSTNAME = 'Eve'; LASTNAME = 'Jones'; EMAIL = 'eve@contoso.com'
+            JOBTITLE = 'Consultant'; UserName = 'evej'
+            IDENTITYREF = [pscustomobject]@{ IDENTITYID = 'ID-1' }
+        }
+        $rec = ConvertTo-OmadaAccountRecord -Account $acc -IdentityLookup $lookup
+        $rec.id             | Should -Be 'acc-1'
+        $rec.displayName    | Should -Be 'Eve Jones'
+        $rec.principalType  | Should -Be 'ExternalUser'   # Contractor -> ExternalUser
+        $rec.accountEnabled | Should -BeTrue
+        $rec.extendedAttributes.userName | Should -Be 'evej'
+    }
+
+    It 'defaults principalType to User when the identity is not in the lookup' {
+        $acc = [pscustomobject]@{ UId = 'acc-2'; FIRSTNAME = 'No'; LASTNAME = 'Link' }
+        (ConvertTo-OmadaAccountRecord -Account $acc -IdentityLookup @{}).principalType | Should -Be 'User'
+    }
+}
+
+Describe 'ConvertTo-OmadaIdentityMemberRecord' {
+
+    It 'links an account to its identity when the identity type is person-stored' {
+        $lookup = @{ 'ID-1' = @{ uid = 'idu-1'; identityType = 'Employee' } }
+        $acc = [pscustomobject]@{ UId = 'acc-1'; IDENTITYREF = [pscustomobject]@{ IDENTITYID = 'ID-1' } }
+        $rec = ConvertTo-OmadaIdentityMemberRecord -Account $acc -IdentityLookup $lookup -IdentityTypesForIdentityTable @('Employee')
+        $rec.identityId  | Should -Be 'idu-1'
+        $rec.principalId | Should -Be 'acc-1'
+        $rec.accountType | Should -Be 'Primary'
+    }
+
+    It 'returns $null for inactive accounts, unknown identities, or non-person types' {
+        $lookup = @{ 'ID-1' = @{ uid = 'idu-1'; identityType = 'Machine' } }
+        $person = @('Employee')
+        ConvertTo-OmadaIdentityMemberRecord -Account ([pscustomobject]@{ UId = 'a'; Inactive = $true }) -IdentityLookup $lookup -IdentityTypesForIdentityTable $person | Should -BeNullOrEmpty
+        ConvertTo-OmadaIdentityMemberRecord -Account ([pscustomobject]@{ UId = 'a' }) -IdentityLookup $lookup -IdentityTypesForIdentityTable $person | Should -BeNullOrEmpty
+        ConvertTo-OmadaIdentityMemberRecord -Account ([pscustomobject]@{ UId = 'a'; IDENTITYREF = [pscustomobject]@{ IDENTITYID = 'ID-1' } }) -IdentityLookup $lookup -IdentityTypesForIdentityTable $person | Should -BeNullOrEmpty
     }
 }

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -316,3 +316,14 @@ Describe 'ConvertTo-OmadaCraAssignmentRecord' {
         (ConvertTo-OmadaCraAssignmentRecord -CalculatedAssignment $cra -ResourceUid 'r' -PrincipalId 'p').extendedAttributes.status | Should -Be 'Disabled'
     }
 }
+
+Describe 'New-OmadaContextMemberRecord' {
+
+    It 'builds an Identity context-member link' {
+        $rec = New-OmadaContextMemberRecord -ContextId 'ctx-1' -MemberId 'idu-1'
+        $rec.contextId  | Should -Be 'ctx-1'
+        $rec.memberId   | Should -Be 'idu-1'
+        $rec.memberType | Should -Be 'Identity'
+        $rec.addedBy    | Should -Be 'sync'
+    }
+}

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -260,3 +260,59 @@ Describe 'ConvertTo-OmadaEntitlementRelationships' {
         @(ConvertTo-OmadaEntitlementRelationships -Resource ([pscustomobject]@{ UId = 'p' })).Count | Should -Be 0
     }
 }
+
+Describe 'New-OmadaRoleAssignmentRecord' {
+
+    It 'builds a governed Direct assignment with validity in extendedAttributes' {
+        $item = [pscustomobject]@{ VALIDFROM = '2026-01-01'; VALIDTO = '2026-12-31' }
+        $rec = New-OmadaRoleAssignmentRecord -ResourceUid 'res-1' -PrincipalId 'usr-1' -RoleAssignment $item
+        $rec.resourceId     | Should -Be 'res-1'
+        $rec.principalId    | Should -Be 'usr-1'
+        $rec.assignmentType | Should -Be 'Direct'
+        $rec.governed       | Should -BeTrue
+        $rec.extendedAttributes.validFrom | Should -Be '2026-01-01'
+    }
+}
+
+Describe 'ConvertTo-OmadaCraPrincipalRecord' {
+
+    It 'derives a connected-system principal, building displayName from CRA attributes' {
+        $cra = [pscustomobject]@{
+            Status = $true
+            Attributes = [pscustomobject]@{ FIRSTNAME = @('Frank'); LASTNAME = @('Ng'); EMAIL = @('frank@x.com') }
+        }
+        $rec = ConvertTo-OmadaCraPrincipalRecord -CalculatedAssignment $cra -AccountKey 'acct-key' -AccountName 'frankng' -ResType 'AD Account'
+        $rec.id             | Should -Be 'acct-key'
+        $rec.externalId     | Should -Be 'frankng'
+        $rec.displayName    | Should -Be 'Frank Ng'
+        $rec.email          | Should -Be 'frank@x.com'
+        $rec.accountEnabled | Should -BeTrue
+        $rec.extendedAttributes.accountType | Should -Be 'AD Account'
+    }
+
+    It 'falls back to AccountName when no name attributes are present' {
+        $cra = [pscustomobject]@{ Status = $false; Attributes = [pscustomobject]@{} }
+        (ConvertTo-OmadaCraPrincipalRecord -CalculatedAssignment $cra -AccountKey 'k' -AccountName 'svc_acct').displayName | Should -Be 'svc_acct'
+    }
+}
+
+Describe 'ConvertTo-OmadaCraAssignmentRecord' {
+
+    It 'builds a governed Direct assignment, flattening reasons and status' {
+        $cra = [pscustomobject]@{
+            ValidFrom = '2026-01-01'; ValidTo = '2026-12-31'; Status = $true; IsManaged = $true
+            Reasons = @([pscustomobject]@{ Description = 'Role X' }, [pscustomobject]@{ Description = 'Policy Y' })
+        }
+        $rec = ConvertTo-OmadaCraAssignmentRecord -CalculatedAssignment $cra -ResourceUid 'res-9' -PrincipalId 'prn-9' -ResType 'AD' -AccountName 'a'
+        $rec.assignmentType | Should -Be 'Direct'
+        $rec.governed       | Should -BeTrue
+        $rec.extendedAttributes.status    | Should -Be 'Enabled'
+        $rec.extendedAttributes.reasons   | Should -Be 'Role X; Policy Y'
+        $rec.extendedAttributes.isManaged | Should -BeTrue
+    }
+
+    It 'records status Disabled when the CRA status is false' {
+        $cra = [pscustomobject]@{ Status = $false }
+        (ConvertTo-OmadaCraAssignmentRecord -CalculatedAssignment $cra -ResourceUid 'r' -PrincipalId 'p').extendedAttributes.status | Should -Be 'Disabled'
+    }
+}

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -20,8 +20,16 @@ BeforeAll {
 
     # Omada reference helpers used by the transforms.
     . (Join-Path $script:omadaRoot 'Get-OmadaHelpers.ps1')
+    # Map-ContextTypeToAtlas (reads $script:TypeMappings) — used by the Orgunit mapper.
+    . (Join-Path $script:omadaRoot 'OmadaCrawler.Functions.ps1')
     # The unit under test.
     . (Join-Path $script:omadaRoot 'OmadaCrawler.Transform.ps1')
+
+    # Context-type mapping the Orgunit mapper resolves through, mirroring the
+    # Start script's Configuration-region defaults.
+    $script:TypeMappings = @{
+        contextTypeToIdentityAtlas = @{ 'OrgUnit' = 'OrgUnit'; 'Organisational Unit' = 'OrgUnit'; Department = 'Department' }
+    }
 }
 
 Describe 'Get-OmadaIdentityType' {
@@ -92,5 +100,64 @@ Describe 'ConvertTo-OmadaIdentityRecord' {
         $rec = ConvertTo-OmadaIdentityRecord -Identity $id
         $rec.extendedAttributes.manager        | Should -Be 'Boss A; Boss B'
         $rec.extendedAttributes.explicitOwners | Should -Be 'Owner X'
+    }
+}
+
+Describe 'ConvertTo-OmadaOrgUnitContextRecord' {
+
+    It 'maps an Orgunit to a synced context, resolving type and parent link' {
+        $ou = [pscustomobject]@{
+            UId = 'ou-1'; NAME = 'Sales'
+            OUTYPE = [pscustomobject]@{ Value = 'Organisational Unit' }
+            PARENTOU = [pscustomobject]@{ UId = 'ou-root' }
+        }
+        $rec = ConvertTo-OmadaOrgUnitContextRecord -OrgUnit $ou -DefaultContextType 'OrgUnit'
+        $rec.id              | Should -Be 'ou-1'
+        $rec.displayName     | Should -Be 'Sales'
+        $rec.contextType     | Should -Be 'OrgUnit'
+        $rec.variant         | Should -Be 'synced'
+        $rec.targetType      | Should -Be 'Identity'
+        $rec.parentContextId | Should -Be 'ou-root'
+    }
+
+    It 'leaves parentContextId null for a root Orgunit' {
+        $ou = [pscustomobject]@{ UId = 'ou-root'; NAME = 'Root' }
+        (ConvertTo-OmadaOrgUnitContextRecord -OrgUnit $ou -DefaultContextType 'OrgUnit').parentContextId | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'ConvertTo-OmadaFlatContextRecord' {
+
+    It 'maps a flat context entity, falling back to DisplayName when NAME is empty' {
+        $rec = ConvertTo-OmadaFlatContextRecord -Item ([pscustomobject]@{ UId = 'l-1'; DisplayName = 'HQ' }) -ContextType 'Location'
+        $rec.id          | Should -Be 'l-1'
+        $rec.displayName | Should -Be 'HQ'
+        $rec.contextType | Should -Be 'Location'
+        $rec.targetType  | Should -Be 'Identity'
+    }
+}
+
+Describe 'Sort-OmadaContextsTopologically' {
+
+    It 'orders parents before their children regardless of input order' {
+        $records = @(
+            [pscustomobject]@{ id = 'c'; parentContextId = 'b' }
+            [pscustomobject]@{ id = 'b'; parentContextId = 'a' }
+            [pscustomobject]@{ id = 'a'; parentContextId = $null }
+        )
+        $sorted = Sort-OmadaContextsTopologically -Records $records
+        ($sorted | ForEach-Object { $_.id }) -join '' | Should -Be 'abc'
+    }
+
+    It 'still emits every record even when a parent reference forms a cycle' {
+        $records = @(
+            [pscustomobject]@{ id = 'x'; parentContextId = 'y' }
+            [pscustomobject]@{ id = 'y'; parentContextId = 'x' }
+        )
+        @(Sort-OmadaContextsTopologically -Records $records).Count | Should -Be 2
+    }
+
+    It 'returns an empty array for no records' {
+        @(Sort-OmadaContextsTopologically -Records @()).Count | Should -Be 0
     }
 }

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -31,6 +31,11 @@ BeforeAll {
         contextTypeToIdentityAtlas  = @{ 'OrgUnit' = 'OrgUnit'; 'Organisational Unit' = 'OrgUnit'; Department = 'Department' }
         identityTypeToIdentityAtlas = @{ Employee = 'User'; Contractor = 'ExternalUser'; 'Service Account' = 'ServicePrincipal' }
     }
+    # Map-ResourceCategory iterates this ordered list; '' is the catch-all.
+    $script:ResourceCategoryMapping = @(
+        @{ category = 'Business Role'; resourceType = 'BusinessRole' }
+        @{ category = '';             resourceType = 'Resource' }
+    )
 }
 
 Describe 'Get-OmadaIdentityType' {
@@ -203,5 +208,55 @@ Describe 'ConvertTo-OmadaIdentityMemberRecord' {
         ConvertTo-OmadaIdentityMemberRecord -Account ([pscustomobject]@{ UId = 'a'; Inactive = $true }) -IdentityLookup $lookup -IdentityTypesForIdentityTable $person | Should -BeNullOrEmpty
         ConvertTo-OmadaIdentityMemberRecord -Account ([pscustomobject]@{ UId = 'a' }) -IdentityLookup $lookup -IdentityTypesForIdentityTable $person | Should -BeNullOrEmpty
         ConvertTo-OmadaIdentityMemberRecord -Account ([pscustomobject]@{ UId = 'a'; IDENTITYREF = [pscustomobject]@{ IDENTITYID = 'ID-1' } }) -IdentityLookup $lookup -IdentityTypesForIdentityTable $person | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'ConvertTo-OmadaResourceRecord' {
+
+    It 'maps a resource, resolves category, owners and usergroup name' {
+        $res = [pscustomobject]@{
+            UId = 'res-1'; NAME = 'Finance Role'; DESCRIPTION = 'd'
+            ROLECATEGORY = [pscustomobject]@{ Value = 'Business Role' }
+            USERGROUPREF = [pscustomobject]@{ UId = 'ug-1' }
+            EXPLICITOWNER = @([pscustomobject]@{ DisplayName = 'Owner A' })
+            RESOURCESTATUS = [pscustomobject]@{ Value = 'Active' }
+        }
+        $rec = ConvertTo-OmadaResourceRecord -Resource $res -UserGroupMap @{ 'ug-1' = 'Finance Group' }
+        $rec.id                 | Should -Be 'res-1'
+        $rec.resourceType       | Should -Be 'BusinessRole'
+        $rec.governanceResource | Should -BeTrue
+        $rec.enabled            | Should -BeTrue
+        $rec.extendedAttributes.userGroupName | Should -Be 'Finance Group'
+        $rec.extendedAttributes.explicitOwner | Should -Be 'Owner A'
+    }
+
+    It 'marks resources with an inactive status as disabled' {
+        $res = [pscustomobject]@{ UId = 'res-2'; NAME = 'Old'; RESOURCESTATUS = [pscustomobject]@{ Value = 'Disabled' } }
+        (ConvertTo-OmadaResourceRecord -Resource $res).enabled | Should -BeFalse
+    }
+
+    It 'returns $null when the resource has no UId or name' {
+        ConvertTo-OmadaResourceRecord -Resource ([pscustomobject]@{ NAME = 'No id' }) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'ConvertTo-OmadaEntitlementRelationships' {
+
+    It 'emits one Contains relationship per CHILDROLES child' {
+        $res = [pscustomobject]@{
+            UId = 'parent-1'
+            CHILDROLES = @([pscustomobject]@{ UId = 'child-1' }, [pscustomobject]@{ UId = 'child-2' })
+        }
+        $rels = ConvertTo-OmadaEntitlementRelationships -Resource $res
+        @($rels).Count | Should -Be 2
+        $rels | ForEach-Object {
+            $_.parentResourceId | Should -Be 'parent-1'
+            $_.relationshipType | Should -Be 'Contains'
+        }
+        ($rels | ForEach-Object { $_.childResourceId } | Sort-Object) -join ',' | Should -Be 'child-1,child-2'
+    }
+
+    It 'returns an empty array when the resource has no CHILDROLES' {
+        @(ConvertTo-OmadaEntitlementRelationships -Resource ([pscustomobject]@{ UId = 'p' })).Count | Should -Be 0
     }
 }

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -1,0 +1,96 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Pester unit tests for the pure record-shaping functions extracted into
+    tools/crawlers/omada/OmadaCrawler.Transform.ps1.
+
+.DESCRIPTION
+    Covers the per-entity mapping logic moved verbatim out of
+    Start-OmadaCrawler.ps1's Main body. These are pure (no HTTP, no script-scope
+    writes), so they run against in-memory OData fixtures with no mocks.
+    Get-OmadaRefValue / Get-OmadaRefUid come from Get-OmadaHelpers.ps1.
+
+.USAGE
+    Invoke-Pester -Path test/unit/OmadaCrawlerTransform.Tests.ps1 -Output Detailed
+#>
+
+BeforeAll {
+    $script:repoRoot  = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:omadaRoot = Join-Path $script:repoRoot 'tools\crawlers\omada'
+
+    # Omada reference helpers used by the transforms.
+    . (Join-Path $script:omadaRoot 'Get-OmadaHelpers.ps1')
+    # The unit under test.
+    . (Join-Path $script:omadaRoot 'OmadaCrawler.Transform.ps1')
+}
+
+Describe 'Get-OmadaIdentityType' {
+
+    It 'returns the IDENTITYTYPE set-value label when present' {
+        $id = [pscustomobject]@{ IDENTITYTYPE = [pscustomobject]@{ Value = 'Contractor' } }
+        Get-OmadaIdentityType -Identity $id | Should -Be 'Contractor'
+    }
+
+    It 'defaults to Employee when IDENTITYTYPE is absent' {
+        Get-OmadaIdentityType -Identity ([pscustomobject]@{ UId = 'x' }) | Should -Be 'Employee'
+    }
+}
+
+Describe 'ConvertTo-OmadaIdentityRecord' {
+
+    It 'maps core fields and builds displayName from first + last name' {
+        $id = [pscustomobject]@{
+            UId = '11111111-1111-1111-1111-111111111111'
+            FIRSTNAME = 'Alice'; LASTNAME = 'Smith'; EMAIL = 'alice@contoso.com'
+            EMPLOYEEID = 'E1'; JOBTITLE = 'Engineer'
+            IDENTITYTYPE = [pscustomobject]@{ Value = 'Employee' }
+        }
+        $rec = ConvertTo-OmadaIdentityRecord -Identity $id
+        $rec.id          | Should -Be '11111111-1111-1111-1111-111111111111'
+        $rec.externalId  | Should -Be '11111111-1111-1111-1111-111111111111'
+        $rec.displayName | Should -Be 'Alice Smith'
+        $rec.givenName   | Should -Be 'Alice'
+        $rec.surname     | Should -Be 'Smith'
+        $rec.email       | Should -Be 'alice@contoso.com'
+        $rec.extendedAttributes.identityType | Should -Be 'Employee'
+    }
+
+    It 'falls back to DisplayName when first/last name are empty' {
+        $id = [pscustomobject]@{ UId = 'u2'; DisplayName = 'Service Account 7' }
+        (ConvertTo-OmadaIdentityRecord -Identity $id).displayName | Should -Be 'Service Account 7'
+    }
+
+    It 'resolves reference values (company/country) via Get-OmadaRefValue' {
+        $id = [pscustomobject]@{
+            UId = 'u3'; FIRSTNAME = 'Bob'
+            COMPANY = [pscustomobject]@{ Value = 'Contoso Ltd' }
+            COUNTRY = [pscustomobject]@{ UId = 'c-1'; DisplayName = 'Netherlands' }
+        }
+        $rec = ConvertTo-OmadaIdentityRecord -Identity $id
+        $rec.companyName                      | Should -Be 'Contoso Ltd'
+        $rec.country                          | Should -Be 'Netherlands'
+        $rec.extendedAttributes.countryId     | Should -Be 'c-1'
+        $rec.extendedAttributes.countryName   | Should -Be 'Netherlands'
+    }
+
+    It 'resolves org-reference UIds into extendedAttributes' {
+        $id = [pscustomobject]@{
+            UId = 'u4'; FIRSTNAME = 'Carol'
+            OUREF = [pscustomobject]@{ UId = 'ou-9'; DisplayName = 'Sales' }
+        }
+        $rec = ConvertTo-OmadaIdentityRecord -Identity $id
+        $rec.extendedAttributes.ouRefId   | Should -Be 'ou-9'
+        $rec.extendedAttributes.ouRefName | Should -Be 'Sales'
+    }
+
+    It 'joins MANAGER / EXPLICITOWNER display names with a semicolon' {
+        $id = [pscustomobject]@{
+            UId = 'u5'; FIRSTNAME = 'Dan'
+            MANAGER = @([pscustomobject]@{ DisplayName = 'Boss A' }, [pscustomobject]@{ DisplayName = 'Boss B' })
+            EXPLICITOWNER = @([pscustomobject]@{ DisplayName = 'Owner X' })
+        }
+        $rec = ConvertTo-OmadaIdentityRecord -Identity $id
+        $rec.extendedAttributes.manager        | Should -Be 'Boss A; Boss B'
+        $rec.extendedAttributes.explicitOwners | Should -Be 'Owner X'
+    }
+}

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -89,3 +89,68 @@ function ConvertTo-OmadaIdentityRecord {
         }
     }
 }
+
+# Maps one Omada Orgunit entity → a synced context record, carrying the parent
+# hierarchy link. Map-ContextTypeToAtlas (OmadaCrawler.Functions.ps1) resolves the
+# context type. Verbatim from the inline Orgunit `ForEach-Object { ... }` block.
+function ConvertTo-OmadaOrgUnitContextRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $OrgUnit,
+        [string]$DefaultContextType
+    )
+    $CtxType   = Map-ContextTypeToAtlas -OmadaType (Get-OmadaRefValue -Ref $OrgUnit.OUTYPE -Fallback $DefaultContextType)
+    $ParentUid = Get-OmadaRefUid -Ref $OrgUnit.PARENTOU
+    return [PSCustomObject]@{
+        id              = [string]$OrgUnit.UId
+        externalId      = [string]$OrgUnit.UId
+        displayName     = if ($OrgUnit.NAME) { $OrgUnit.NAME } else { $OrgUnit.DisplayName }
+        contextType     = $CtxType
+        variant         = 'synced'
+        targetType      = 'Identity'
+        parentContextId = if ($ParentUid) { $ParentUid } else { $Null }
+    }
+}
+
+# Maps one flat (non-hierarchical) Omada context entity → a synced context record.
+# Verbatim from the inline flat-context `ForEach-Object { ... }` block.
+function ConvertTo-OmadaFlatContextRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Item,
+        [string]$ContextType
+    )
+    return [PSCustomObject]@{
+        id          = [string]$Item.UId
+        externalId  = [string]$Item.UId
+        displayName = if ($Item.NAME) { $Item.NAME } else { $Item.DisplayName }
+        contextType = $ContextType
+        variant     = 'synced'
+        targetType  = 'Identity'
+    }
+}
+
+# Topologically sorts context records so a parent always precedes its children
+# (records with an unresolved/absent parent come first). Any records left in a
+# cycle after MaxPasses are appended as-is. Verbatim from the inline sort.
+function Sort-OmadaContextsTopologically {
+    [CmdletBinding()]
+    param($Records)
+    $Sorted    = [System.Collections.Generic.List[object]]::new()
+    $Remaining = [System.Collections.Generic.List[object]]::new(@($Records))
+    $Inserted  = [System.Collections.Generic.HashSet[string]]::new()
+    $Pass = 0; $MaxPasses = @($Records).Count + 1
+    while ($Remaining.Count -gt 0 -and $Pass -lt $MaxPasses) {
+        $Pass++
+        $NextRem = [System.Collections.Generic.List[object]]::new()
+        foreach ($Rec in $Remaining) {
+            $ParentId = $Rec.parentContextId
+            if (-not $ParentId -or $Inserted.Contains($ParentId)) {
+                $Sorted.Add($Rec); $Inserted.Add($Rec.id) | Out-Null
+            } else { $NextRem.Add($Rec) }
+        }
+        $Remaining = $NextRem
+    }
+    foreach ($Rec in $Remaining) { $Sorted.Add($Rec) }
+    return @($Sorted)
+}

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -207,3 +207,79 @@ function ConvertTo-OmadaIdentityMemberRecord {
         accountType = 'Primary'
     }
 }
+
+# Maps one Omada Resource entity → an ingest/resources record, or $null when it has
+# no UId/name. Map-ResourceCategory (OmadaCrawler.Functions.ps1) resolves the Atlas
+# resourceType; $UserGroupMap resolves USERGROUPREF -> display name. The caller keeps
+# the system-grouping. Verbatim from the inline `foreach ($Item in $AllResources)`.
+function ConvertTo-OmadaResourceRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Resource,
+        [hashtable]$UserGroupMap = @{}
+    )
+    $OmadaCat   = if ($Resource.ROLECATEGORY)   { [string]$Resource.ROLECATEGORY.Value }   else { '' }
+    $AtlasType  = Map-ResourceCategory -Category $OmadaCat
+    $SysName    = Get-OmadaRefValue -Ref $Resource.SYSTEMREF   -Fallback ''
+    $RoleType   = Get-OmadaRefValue -Ref $Resource.ROLETYPEREF -Fallback ''
+    $FolderName = Get-OmadaRefValue -Ref $Resource.ROLEFOLDER  -Fallback ''
+    $Status     = if ($Resource.RESOURCESTATUS) { [string]$Resource.RESOURCESTATUS.Value } else { 'Active' }
+    $Enabled    = $Status -notin @('Inactive', 'Disabled', 'Deleted')
+    $ExtId      = [string]$Resource.UId
+    $DispName   = if ($Resource.NAME) { $Resource.NAME } else { $Resource.DisplayName }
+    if (-not $ExtId -or -not $DispName) { return $null }
+
+    $UgUId  = Get-OmadaRefUid -Ref $Resource.USERGROUPREF
+    $UgName = if ($UgUId -and $UserGroupMap.ContainsKey($UgUId)) { $UserGroupMap[$UgUId] } else { '' }
+
+    $ExplicitOwner = ''
+    if ($Resource.EXPLICITOWNER -and $Resource.EXPLICITOWNER.Count -gt 0) {
+        $ExplicitOwner = ($Resource.EXPLICITOWNER | ForEach-Object { $_.DisplayName }) -join '; '
+    }
+    $ManualOwner = ''
+    if ($Resource.MANUALOWNER -and $Resource.MANUALOWNER.Count -gt 0) {
+        $ManualOwner = ($Resource.MANUALOWNER | ForEach-Object { $_.DisplayName }) -join '; '
+    }
+
+    return [PSCustomObject]@{
+        id                 = $ExtId
+        externalId         = $ExtId
+        displayName        = $DispName
+        resourceType       = $AtlasType
+        governanceResource = ($AtlasType -eq 'BusinessRole')
+        description        = $Resource.DESCRIPTION
+        enabled            = $Enabled
+        extendedAttributes = @{
+            resourceCategory  = $OmadaCat
+            resourceType      = $RoleType          # ROLETYPEREF.DisplayName
+            roleFolder        = $FolderName        # ROLEFOLDER.DisplayName
+            skipProvisioning  = if ($Null -ne $Resource.SKIPPROVISIONING) { [bool]$Resource.SKIPPROVISIONING } else { $False }
+            userGroupName     = $UgName            # USERGROUPREF → Usergroup.DisplayName
+            explicitOwner     = $ExplicitOwner     # EXPLICITOWNER collection
+            manualOwner       = $ManualOwner        # MANUALOWNER collection
+            omadaSystem       = $SysName
+        }
+    }
+}
+
+# Extracts the Contains relationships (parent -> each CHILDROLES child) from one
+# Omada Resource. Returns an array (empty when no children). Verbatim from the
+# inline `foreach ($Child in $Item.CHILDROLES)` block.
+function ConvertTo-OmadaEntitlementRelationships {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Resource)
+    if (-not $Resource.CHILDROLES) { return @() }
+    $out = [System.Collections.Generic.List[object]]::new()
+    $ParentUid = [string]$Resource.UId
+    foreach ($Child in $Resource.CHILDROLES) {
+        $ChildUid = Get-OmadaRefUid -Ref $Child
+        if ($ChildUid) {
+            $out.Add([PSCustomObject]@{
+                parentResourceId = $ParentUid   # direct UUID FK to Resources.id
+                childResourceId  = $ChildUid    # direct UUID FK to Resources.id
+                relationshipType = 'Contains'
+            })
+        }
+    }
+    return @($out)
+}

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -360,3 +360,20 @@ function ConvertTo-OmadaCraAssignmentRecord {
         extendedAttributes = $ExtAttr
     }
 }
+
+# Builds one context-member link (Identity → context). The three Context Members
+# sources (Contextassignment, direct identity refs, Employment) all emit this exact
+# shape. Verbatim from the inline `$CtxMemberRecords.Add([PSCustomObject]@{ ... })`.
+function New-OmadaContextMemberRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$ContextId,
+        [Parameter(Mandatory)] [string]$MemberId
+    )
+    return [PSCustomObject]@{
+        contextId  = $ContextId
+        memberId   = $MemberId   # Identity.UId → matches Identities table
+        memberType = 'Identity'
+        addedBy    = 'sync'
+    }
+}

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -154,3 +154,56 @@ function Sort-OmadaContextsTopologically {
     foreach ($Rec in $Remaining) { $Sorted.Add($Rec) }
     return @($Sorted)
 }
+
+# Maps one Omada User entity → an ingest/principals record, resolving principalType
+# from the linked Identity's type via $IdentityLookup (IDENTITYID -> { uid; identityType })
+# and Map-IdentityTypeToAtlas. Verbatim from the inline account `ForEach-Object`.
+function ConvertTo-OmadaAccountRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Account,
+        [hashtable]$IdentityLookup = @{}
+    )
+    $ExtId = [string]$Account.UId
+    $Name  = "$($Account.FIRSTNAME) $($Account.LASTNAME)".Trim()
+    if (-not $Name) { $Name = $Account.DisplayName }
+
+    $PrincipalType = 'User'
+    $IdentId = if ($Account.IDENTITYREF) { [string]$Account.IDENTITYREF.IDENTITYID } else { $Null }
+    if ($IdentId -and $IdentityLookup.ContainsKey($IdentId)) {
+        $PrincipalType = Map-IdentityTypeToAtlas -OmadaType $IdentityLookup[$IdentId].identityType
+    }
+
+    return [PSCustomObject]@{
+        id                 = $ExtId  # Omada UId is a valid UUID
+        externalId         = $ExtId
+        displayName        = $Name
+        email              = $Account.EMAIL
+        principalType      = $PrincipalType
+        accountEnabled     = $True
+        jobTitle           = $Account.JOBTITLE
+        extendedAttributes = @{ userName = $Account.UserName }
+    }
+}
+
+# Maps one Omada User entity → an ingest/identity-members link, or $null when the
+# account is inactive, has no resolvable identity, or its identity type isn't stored
+# in the Identities table (avoids FK violations). Verbatim from the inline loop body.
+function ConvertTo-OmadaIdentityMemberRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Account,
+        [hashtable]$IdentityLookup = @{},
+        $IdentityTypesForIdentityTable = @()
+    )
+    if ($Account.Inactive) { return $null }
+    $IdentId = if ($Account.IDENTITYREF) { [string]$Account.IDENTITYREF.IDENTITYID } else { $Null }
+    if (-not $IdentId -or -not $IdentityLookup.ContainsKey($IdentId)) { return $null }
+    $IdentEntry = $IdentityLookup[$IdentId]
+    if ($IdentityTypesForIdentityTable -notcontains $IdentEntry.identityType) { return $null }
+    return [PSCustomObject]@{
+        identityId  = $IdentEntry.uid   # direct UUID FK to Identities.id
+        principalId = [string]$Account.UId   # direct UUID FK to Principals.id
+        accountType = 'Primary'
+    }
+}

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -283,3 +283,80 @@ function ConvertTo-OmadaEntitlementRelationships {
     }
     return @($out)
 }
+
+# Builds one governed Direct assignment from an Omada Resourceassignment (fanned
+# out to a specific user account). Verbatim from the inline `$RaBySys[...].Add(...)`.
+function New-OmadaRoleAssignmentRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$ResourceUid,
+        [Parameter(Mandatory)] [string]$PrincipalId,
+        [Parameter(Mandatory)] $RoleAssignment
+    )
+    return [PSCustomObject]@{
+        resourceId         = $ResourceUid
+        principalId        = $PrincipalId
+        assignmentType     = 'Direct'
+        governed           = $true
+        extendedAttributes = @{ validFrom = $RoleAssignment.VALIDFROM; validTo = $RoleAssignment.VALIDTO }
+    }
+}
+
+# Maps a Calculated Resource Assignment (connected-system account) → a derived
+# Principal record, building the display name from CRA Attributes.
+# Verbatim from the inline `$CaPrincipalsBySys[...].Add(...)` block.
+function ConvertTo-OmadaCraPrincipalRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $CalculatedAssignment,
+        [string]$AccountKey,
+        [string]$AccountName,
+        [string]$ResType
+    )
+    $Fn    = if ($CalculatedAssignment.Attributes.'FIRSTNAME') { ($CalculatedAssignment.Attributes.'FIRSTNAME' -join ' ').Trim() } else { '' }
+    $Ln    = if ($CalculatedAssignment.Attributes.'LASTNAME')  { ($CalculatedAssignment.Attributes.'LASTNAME'  -join ' ').Trim() } else { '' }
+    $Email = if ($CalculatedAssignment.Attributes.'EMAIL')     { ($CalculatedAssignment.Attributes.'EMAIL'     | Select-Object -First 1) } else { $Null }
+    $DName = "$Fn $Ln".Trim(); if (-not $DName) { $DName = $AccountName }
+    return [PSCustomObject]@{
+        id             = $AccountKey
+        externalId     = $AccountName
+        displayName    = $DName
+        email          = $Email
+        principalType  = 'User'
+        accountEnabled = ($CalculatedAssignment.Status -eq $True)
+        extendedAttributes = @{ accountType = $ResType }
+    }
+}
+
+# Maps a Calculated Resource Assignment → a governed Direct assignment, flattening
+# reasons and preserving status/isManaged in extendedAttributes.
+# Verbatim from the inline CRA `$Rec = [PSCustomObject]@{ ... }` block.
+function ConvertTo-OmadaCraAssignmentRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $CalculatedAssignment,
+        [Parameter(Mandatory)] [string]$ResourceUid,
+        [Parameter(Mandatory)] [string]$PrincipalId,
+        [string]$ResType,
+        [string]$AccountName
+    )
+    $Reasons = if ($CalculatedAssignment.Reasons) {
+        @($CalculatedAssignment.Reasons | ForEach-Object { $_.Description }) -join '; '
+    } else { '' }
+    $ExtAttr = @{
+        validFrom   = $CalculatedAssignment.ValidFrom
+        validTo     = $CalculatedAssignment.ValidTo
+        status      = if ($CalculatedAssignment.Status -eq $True) { 'Enabled' } else { 'Disabled' }
+        reasons     = $Reasons
+        accountType = $ResType
+        accountName = $AccountName
+        isManaged   = [bool]$CalculatedAssignment.IsManaged
+    }
+    return [PSCustomObject]@{
+        resourceId         = $ResourceUid
+        principalId        = $PrincipalId
+        assignmentType     = 'Direct'
+        governed           = $true
+        extendedAttributes = $ExtAttr
+    }
+}

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+    Pure record-shaping functions for the Omada crawler, extracted from
+    Start-OmadaCrawler.ps1's Main body.
+
+.DESCRIPTION
+    Each ConvertTo-* function maps a single Omada OData entity to the hashtable /
+    PSCustomObject record shape the Ingest API expects. They are PURE: no HTTP, no
+    script-scope writes, all inputs passed as explicit parameters — so they can be
+    unit-tested with in-memory fixtures and no mocks (see
+    test/unit/OmadaCrawlerTransform.Tests.ps1).
+
+    The function bodies are moved verbatim from the inline
+    `... | ForEach-Object { ... }` blocks in Start-OmadaCrawler.ps1.
+
+    These call Get-OmadaRefValue / Get-OmadaRefUid (Get-OmadaHelpers.ps1) — dot-source
+    that alongside this file.
+#>
+
+# Resolves an Omada Identity's type label (the OIS.SetValue discriminator),
+# defaulting to 'Employee'. Used by the lookup, the person-table filter, and the
+# record mapper — extracted so the three sites can't drift.
+function Get-OmadaIdentityType {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Identity)
+    if ($Identity.IDENTITYTYPE) { return [string]$Identity.IDENTITYTYPE.Value }
+    return 'Employee'
+}
+
+# Maps one Omada Identity entity → an ingest/identities record.
+# Verbatim from the inline `$PersonIdentities | ForEach-Object { ... }` block.
+function ConvertTo-OmadaIdentityRecord {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Identity)
+    $IdType = Get-OmadaIdentityType -Identity $Identity
+    $IdCat  = if ($Identity.IDENTITYCATEGORY) { [string]$Identity.IDENTITYCATEGORY.Value } else { '' }
+    $FName  = if ($Identity.FIRSTNAME)        { [string]$Identity.FIRSTNAME } else { '' }
+    $LName  = if ($Identity.LASTNAME)         { [string]$Identity.LASTNAME  } else { '' }
+    $Name   = "$FName $LName".Trim()
+    if (-not $Name) { $Name = $Identity.DisplayName }
+    return [PSCustomObject]@{
+        id                 = [string]$Identity.UId  # Omada UId is a valid UUID
+        externalId         = [string]$Identity.UId
+        displayName        = $Name
+        givenName          = $FName
+        surname            = $LName
+        email              = $Identity.EMAIL
+        employeeId         = $Identity.EMPLOYEEID
+        jobTitle           = $Identity.JOBTITLE
+        companyName        = Get-OmadaRefValue -Ref $Identity.COMPANY -Fallback ''
+        city               = if ($Identity.CITY)    { [string]$Identity.CITY    } else { '' }
+        country            = Get-OmadaRefValue -Ref $Identity.COUNTRY -Fallback ''
+        extendedAttributes = @{
+            # Identity type/category/status
+            identityType     = $IdType
+            identityCategory = $IdCat
+            identityStatus   = if ($Identity.IDENTITYSTATUS)   { [string]$Identity.IDENTITYSTATUS.Value }   else { '' }
+            identityId       = if ($Identity.IDENTITYID)        { [string]$Identity.IDENTITYID }             else { '' }
+            oisId            = if ($Identity.OISID)             { [string]$Identity.OISID }                  else { '' }
+            # Contact / location
+            email2           = if ($Identity.EMAIL2)            { [string]$Identity.EMAIL2 }                 else { '' }
+            city             = if ($Identity.CITY)              { [string]$Identity.CITY }                   else { '' }
+            zipCode          = if ($Identity.ZIPCODE)           { [string]$Identity.ZIPCODE }                else { '' }
+            # Validity
+            validFrom        = $Identity.VALIDFROM
+            validTo          = $Identity.VALIDTO
+            # Org references (UIds for use as context IDs)
+            ouRefId          = Get-OmadaRefUid -Ref $Identity.OUREF
+            countryId        = Get-OmadaRefUid -Ref $Identity.COUNTRY
+            locationId       = Get-OmadaRefUid -Ref $Identity.LOCATION
+            buildingId       = Get-OmadaRefUid -Ref $Identity.BUILDING
+            businessUnitId   = Get-OmadaRefUid -Ref $Identity.BUSINESSUNIT
+            costCenterId     = Get-OmadaRefUid -Ref $Identity.COSTCENTER
+            divisionId       = Get-OmadaRefUid -Ref $Identity.DIVISION
+            subAreaId        = Get-OmadaRefUid -Ref $Identity.SUBAREA
+            jobTitleRefId    = Get-OmadaRefUid -Ref $Identity.JOBTITLE_REF
+            # Org display names (human-readable counterparts)
+            company          = Get-OmadaRefValue -Ref $Identity.COMPANY       -Fallback ''
+            ouRefName        = Get-OmadaRefValue -Ref $Identity.OUREF         -Fallback ''
+            countryName      = Get-OmadaRefValue -Ref $Identity.COUNTRY       -Fallback ''
+            jobTitleRef      = Get-OmadaRefValue -Ref $Identity.JOBTITLE_REF  -Fallback ''
+            # Risk
+            riskScore        = if ($Identity.RISKSCORE)         { [string]$Identity.RISKSCORE }              else { '' }
+            riskLevel        = Get-OmadaRefValue -Ref $Identity.RISKLEVEL     -Fallback ''
+            # People references
+            manager          = ($Identity.MANAGER        | ForEach-Object { $_.DisplayName }) -join '; '
+            identityOwner    = Get-OmadaRefValue -Ref $Identity.IDENTITYOWNER  -Fallback ''
+            explicitOwners   = ($Identity.EXPLICITOWNER   | ForEach-Object { $_.DisplayName }) -join '; '
+        }
+    }
+}

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -684,54 +684,13 @@ if ($SyncResources) {
 
         Write-Step "Building resource records from $($AllResources.Count) Omada resources..."
         # Group resources by connected system (SYSTEMREF) for correct scoped-delete
+        # Per-resource record shaping lives in ConvertTo-OmadaResourceRecord
+        # (OmadaCrawler.Transform.ps1); the system grouping stays here.
         $BySysUId = @{}
         foreach ($Item in $AllResources) {
-            $OmadaCat    = if ($Item.ROLECATEGORY)    { [string]$Item.ROLECATEGORY.Value }   else { '' }
-            $AtlasType   = Map-ResourceCategory -Category $OmadaCat
-
-            $SysUId      = Get-OmadaRefUid  -Ref $Item.SYSTEMREF
-            $SysName     = Get-OmadaRefValue -Ref $Item.SYSTEMREF   -Fallback ''
-            $RoleType    = Get-OmadaRefValue -Ref $Item.ROLETYPEREF  -Fallback ''
-            $FolderName  = Get-OmadaRefValue -Ref $Item.ROLEFOLDER   -Fallback ''
-            $Status      = if ($Item.RESOURCESTATUS) { [string]$Item.RESOURCESTATUS.Value } else { 'Active' }
-            $Enabled     = $Status -notin @('Inactive', 'Disabled', 'Deleted')
-            $ExtId       = [string]$Item.UId
-            $DispName    = if ($Item.NAME) { $Item.NAME } else { $Item.DisplayName }
-            if (-not $ExtId -or -not $DispName) { continue }
-
-            # USERGROUPREF — look up name from pre-fetched map
-            $UgUId   = Get-OmadaRefUid -Ref $Item.USERGROUPREF
-            $UgName  = if ($UgUId -and $UserGroupMap.ContainsKey($UgUId)) { $UserGroupMap[$UgUId] } else { '' }
-
-            # Owner references (EXPLICITOWNER, MANUALOWNER) — take first if collection
-            $ExplicitOwner = ''
-            if ($Item.EXPLICITOWNER -and $Item.EXPLICITOWNER.Count -gt 0) {
-                $ExplicitOwner = ($Item.EXPLICITOWNER | ForEach-Object { $_.DisplayName }) -join '; '
-            }
-            $ManualOwner = ''
-            if ($Item.MANUALOWNER -and $Item.MANUALOWNER.Count -gt 0) {
-                $ManualOwner = ($Item.MANUALOWNER | ForEach-Object { $_.DisplayName }) -join '; '
-            }
-
-            $Rec = [PSCustomObject]@{
-                id                 = $ExtId
-                externalId         = $ExtId
-                displayName        = $DispName
-                resourceType       = $AtlasType
-                governanceResource = ($AtlasType -eq 'BusinessRole')
-                description        = $Item.DESCRIPTION
-                enabled            = $Enabled
-                extendedAttributes = @{
-                    resourceCategory  = $OmadaCat
-                    resourceType      = $RoleType          # ROLETYPEREF.DisplayName
-                    roleFolder        = $FolderName        # ROLEFOLDER.DisplayName
-                    skipProvisioning  = if ($Null -ne $Item.SKIPPROVISIONING) { [bool]$Item.SKIPPROVISIONING } else { $False }
-                    userGroupName     = $UgName            # USERGROUPREF → Usergroup.DisplayName
-                    explicitOwner     = $ExplicitOwner     # EXPLICITOWNER collection
-                    manualOwner       = $ManualOwner        # MANUALOWNER collection
-                    omadaSystem       = $SysName
-                }
-            }
+            $Rec = ConvertTo-OmadaResourceRecord -Resource $Item -UserGroupMap $UserGroupMap
+            if (-not $Rec) { continue }
+            $SysUId = Get-OmadaRefUid -Ref $Item.SYSTEMREF
             $Key = if ($SysUId -and $OmadaSystemMap.ContainsKey($SysUId)) { $SysUId } else { '__main__' }
             if (-not $BySysUId.ContainsKey($Key)) { $BySysUId[$Key] = [System.Collections.Generic.List[object]]::new() }
             $BySysUId[$Key].Add($Rec)
@@ -773,19 +732,12 @@ if ($SyncEntitlements) {
             Write-Phase -Name 'Entitlements' -Duration ([datetime]::UtcNow - $T) -Records @{ relationships = 0 }
         } else {
             Write-Step "Extracting entitlements (CHILDROLES) from $($AllResources.Count) resources..."
+            # CHILDROLES → Contains relationship extraction lives in
+            # ConvertTo-OmadaEntitlementRelationships (OmadaCrawler.Transform.ps1).
             $RelRecords = [System.Collections.Generic.List[object]]::new()
             foreach ($Item in $AllResources) {
-                if (-not $Item.CHILDROLES) { continue }
-                $ParentUid = [string]$Item.UId
-                foreach ($Child in $Item.CHILDROLES) {
-                    $ChildUid = Get-OmadaRefUid -Ref $Child
-                    if ($ChildUid) {
-                        $RelRecords.Add([PSCustomObject]@{
-                            parentResourceId = $ParentUid   # direct UUID FK to Resources.id
-                            childResourceId  = $ChildUid    # direct UUID FK to Resources.id
-                            relationshipType = 'Contains'
-                        })
-                    }
+                foreach ($Rel in (ConvertTo-OmadaEntitlementRelationships -Resource $Item)) {
+                    $RelRecords.Add($Rel)
                 }
             }
 

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -205,6 +205,7 @@ $DefaultTypeMappings = @{
 # Dot-sourced into this script's own scope so they read script-scope vars
 # (e.g. $TypeMappings, $ResourceCategoryMapping, $Script:phases) at call time.
 . (Join-Path $PSScriptRoot 'OmadaCrawler.Functions.ps1')
+. (Join-Path $PSScriptRoot 'OmadaCrawler.Transform.ps1')
 
 $TypeMappings = Merge-TypeMappings -Defaults $DefaultTypeMappings -Overrides $Cfg.typeMappings
 $IdentityTypesForIdentityTable = @($TypeMappings['identityTypesForIdentityTable'])
@@ -449,74 +450,20 @@ if ($SyncIdentities) {
         foreach ($Id in $AllIdentities) {
             $Key = [string]$Id.IDENTITYID
             if ($Key) {
-                $IdType = if ($Id.IDENTITYTYPE) { [string]$Id.IDENTITYTYPE.Value } else { 'Employee' }
+                $IdType = Get-OmadaIdentityType -Identity $Id
                 $IdentityLookup[$Key] = @{ uid = [string]$Id.UId; identityType = $IdType }
             }
         }
 
         # Person-type identities go to the Identities table
         $PersonIdentities = @($AllIdentities | Where-Object {
-            $IdType = if ($_.IDENTITYTYPE) { [string]$_.IDENTITYTYPE.Value } else { 'Employee' }
-            $IdentityTypesForIdentityTable -contains $IdType
+            $IdentityTypesForIdentityTable -contains (Get-OmadaIdentityType -Identity $_)
         })
 
+        # Per-identity record shaping lives in ConvertTo-OmadaIdentityRecord
+        # (OmadaCrawler.Transform.ps1) so it can be unit-tested without a live API.
         $IdentRecords = @($PersonIdentities | ForEach-Object {
-            $IdType = if ($_.IDENTITYTYPE)     { [string]$_.IDENTITYTYPE.Value }     else { 'Employee' }
-            $IdCat  = if ($_.IDENTITYCATEGORY) { [string]$_.IDENTITYCATEGORY.Value } else { '' }
-            $FName  = if ($_.FIRSTNAME)        { [string]$_.FIRSTNAME } else { '' }
-            $LName  = if ($_.LASTNAME)         { [string]$_.LASTNAME  } else { '' }
-            $Name   = "$FName $LName".Trim()
-            if (-not $Name) { $Name = $_.DisplayName }
-            [PSCustomObject]@{
-                id                 = [string]$_.UId  # Omada UId is a valid UUID
-                externalId         = [string]$_.UId
-                displayName        = $Name
-                givenName          = $FName
-                surname            = $LName
-                email              = $_.EMAIL
-                employeeId         = $_.EMPLOYEEID
-                jobTitle           = $_.JOBTITLE
-                companyName        = Get-OmadaRefValue -Ref $_.COMPANY -Fallback ''
-                city               = if ($_.CITY)    { [string]$_.CITY    } else { '' }
-                country            = Get-OmadaRefValue -Ref $_.COUNTRY -Fallback ''
-                extendedAttributes = @{
-                    # Identity type/category/status
-                    identityType     = $IdType
-                    identityCategory = $IdCat
-                    identityStatus   = if ($_.IDENTITYSTATUS)   { [string]$_.IDENTITYSTATUS.Value }   else { '' }
-                    identityId       = if ($_.IDENTITYID)        { [string]$_.IDENTITYID }             else { '' }
-                    oisId            = if ($_.OISID)             { [string]$_.OISID }                  else { '' }
-                    # Contact / location
-                    email2           = if ($_.EMAIL2)            { [string]$_.EMAIL2 }                 else { '' }
-                    city             = if ($_.CITY)              { [string]$_.CITY }                   else { '' }
-                    zipCode          = if ($_.ZIPCODE)           { [string]$_.ZIPCODE }                else { '' }
-                    # Validity
-                    validFrom        = $_.VALIDFROM
-                    validTo          = $_.VALIDTO
-                    # Org references (UIds for use as context IDs)
-                    ouRefId          = Get-OmadaRefUid -Ref $_.OUREF
-                    countryId        = Get-OmadaRefUid -Ref $_.COUNTRY
-                    locationId       = Get-OmadaRefUid -Ref $_.LOCATION
-                    buildingId       = Get-OmadaRefUid -Ref $_.BUILDING
-                    businessUnitId   = Get-OmadaRefUid -Ref $_.BUSINESSUNIT
-                    costCenterId     = Get-OmadaRefUid -Ref $_.COSTCENTER
-                    divisionId       = Get-OmadaRefUid -Ref $_.DIVISION
-                    subAreaId        = Get-OmadaRefUid -Ref $_.SUBAREA
-                    jobTitleRefId    = Get-OmadaRefUid -Ref $_.JOBTITLE_REF
-                    # Org display names (human-readable counterparts)
-                    company          = Get-OmadaRefValue -Ref $_.COMPANY       -Fallback ''
-                    ouRefName        = Get-OmadaRefValue -Ref $_.OUREF         -Fallback ''
-                    countryName      = Get-OmadaRefValue -Ref $_.COUNTRY       -Fallback ''
-                    jobTitleRef      = Get-OmadaRefValue -Ref $_.JOBTITLE_REF  -Fallback ''
-                    # Risk
-                    riskScore        = if ($_.RISKSCORE)         { [string]$_.RISKSCORE }              else { '' }
-                    riskLevel        = Get-OmadaRefValue -Ref $_.RISKLEVEL     -Fallback ''
-                    # People references
-                    manager          = ($_.MANAGER        | ForEach-Object { $_.DisplayName }) -join '; '
-                    identityOwner    = Get-OmadaRefValue -Ref $_.IDENTITYOWNER  -Fallback ''
-                    explicitOwners   = ($_.EXPLICITOWNER   | ForEach-Object { $_.DisplayName }) -join '; '
-                }
-            }
+            ConvertTo-OmadaIdentityRecord -Identity $_
         } | Where-Object { $_.externalId -and $_.displayName })
 
         Write-Step "Ingesting $($IdentRecords.Count) identity records..."

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -577,12 +577,7 @@ if ($SyncContextMembers) {
             # empty, causing FK violations if the Contexts table is empty (e.g. cloud with no Orgunit entity set).
             if ($SyncedContextIds.Count -eq 0 -or -not $SyncedContextIds.Contains($ContextUid)) { continue }
             if (-not $IdentityUidInIdentitiesTable.Contains($IdentUid)) { continue }
-            $CtxMemberRecords.Add([PSCustomObject]@{
-                contextId  = $ContextUid
-                memberId   = $IdentUid   # Identity.UId → matches Identities table
-                memberType = 'Identity'
-                addedBy    = 'sync'
-            })
+            $CtxMemberRecords.Add((New-OmadaContextMemberRecord -ContextId $ContextUid -MemberId $IdentUid))
         }
 
         # ── Source 2: Direct context reference fields on Identity (OUREF, COUNTRY, etc.) ──
@@ -599,12 +594,7 @@ if ($SyncContextMembers) {
                 foreach ($Field in $FieldsToCheck.Keys) {
                     $ContextUid = Get-OmadaRefUid -Ref $Ident.$Field
                     if (-not $ContextUid -or -not $SyncedContextIds.Contains($ContextUid)) { continue }
-                    $CtxMemberRecords.Add([PSCustomObject]@{
-                        contextId  = $ContextUid
-                        memberId   = $IdentUid
-                        memberType = 'Identity'
-                        addedBy    = 'sync'
-                    })
+                    $CtxMemberRecords.Add((New-OmadaContextMemberRecord -ContextId $ContextUid -MemberId $IdentUid))
                 }
             }
         }
@@ -621,12 +611,7 @@ if ($SyncContextMembers) {
                     if (-not $IdentUid -or -not $ContextUid) { continue }
                     if (-not $SyncedContextIds.Contains($ContextUid)) { continue }
                     if (-not $IdentityUidInIdentitiesTable.Contains($IdentUid)) { continue }
-                    $CtxMemberRecords.Add([PSCustomObject]@{
-                        contextId  = $ContextUid
-                        memberId   = $IdentUid
-                        memberType = 'Identity'
-                        addedBy    = 'sync'
-                    })
+                    $CtxMemberRecords.Add((New-OmadaContextMemberRecord -ContextId $ContextUid -MemberId $IdentUid))
                 }
                 Write-Host "  Employment-based context links added from $($EmpItems.Count) employment records" -ForegroundColor Gray
             } catch {

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -793,13 +793,7 @@ if ($SyncAssignments) {
             if (-not $RaBySys.ContainsKey($SysKey)) { $RaBySys[$SysKey] = [System.Collections.Generic.List[object]]::new() }
 
             foreach ($UserUid in $UserUids) {
-                $RaBySys[$SysKey].Add([PSCustomObject]@{
-                    resourceId         = $ResourceUid
-                    principalId        = $UserUid
-                    assignmentType     = 'Direct'
-                    governed           = $true
-                    extendedAttributes = @{ validFrom = $Item.VALIDFROM; validTo = $Item.VALIDTO }
-                })
+                $RaBySys[$SysKey].Add((New-OmadaRoleAssignmentRecord -ResourceUid $ResourceUid -PrincipalId $UserUid -RoleAssignment $Item))
             }
         }
 
@@ -857,23 +851,10 @@ if ($SyncAssignments) {
                 if (-not $AccountKey) { continue }
                 $PrincipalUid = $AccountKey
 
-                $Fn    = if ($Item.Attributes.'FIRSTNAME') { ($Item.Attributes.'FIRSTNAME' -join ' ').Trim() } else { '' }
-                $Ln    = if ($Item.Attributes.'LASTNAME')  { ($Item.Attributes.'LASTNAME'  -join ' ').Trim() } else { '' }
-                $Email = if ($Item.Attributes.'EMAIL')     { ($Item.Attributes.'EMAIL'     | Select-Object -First 1) } else { $Null }
-                $DName = "$Fn $Ln".Trim(); if (-not $DName) { $DName = $AccountName }
-
                 if (-not $CaPrincipalsBySys.ContainsKey($SysKey)) {
                     $CaPrincipalsBySys[$SysKey] = [System.Collections.Generic.List[object]]::new()
                 }
-                $CaPrincipalsBySys[$SysKey].Add([PSCustomObject]@{
-                    id             = $AccountKey
-                    externalId     = $AccountName
-                    displayName    = $DName
-                    email          = $Email
-                    principalType  = 'User'
-                    accountEnabled = ($Item.Status -eq $True)
-                    extendedAttributes = @{ accountType = $ResType }
-                })
+                $CaPrincipalsBySys[$SysKey].Add((ConvertTo-OmadaCraPrincipalRecord -CalculatedAssignment $Item -AccountKey $AccountKey -AccountName $AccountName -ResType $ResType))
 
                 # IdentityMember: link this account to its Identity (person-type only — FK guard)
                 if ($IdentityUidInIdentitiesTable.Contains($IdentityUid)) {
@@ -887,30 +868,10 @@ if ($SyncAssignments) {
 
             if (-not $PrincipalUid) { continue }
 
-            # extendedAttributes: status, reasons, validFrom, validTo, accountType
-            $Reasons = if ($Item.Reasons) {
-                @($Item.Reasons | ForEach-Object { $_.Description }) -join '; '
-            } else { '' }
-            $ExtAttr = @{
-                validFrom   = $Item.ValidFrom
-                validTo     = $Item.ValidTo
-                status      = if ($Item.Status -eq $True) { 'Enabled' } else { 'Disabled' }
-                reasons     = $Reasons
-                accountType = $ResType
-                accountName = $AccountName
-            }
-
             # CRA rows are effective provisioning configured in Omada's governance
-            # structure → real Direct memberships, flagged governed=true. IsManaged
-            # is preserved in extendedAttributes for reference.
-            $ExtAttr.isManaged = [bool]$Item.IsManaged
-            $Rec = [PSCustomObject]@{
-                resourceId         = $ResourceUid
-                principalId        = $PrincipalUid
-                assignmentType     = 'Direct'
-                governed           = $true
-                extendedAttributes = $ExtAttr
-            }
+            # structure → real Direct memberships, flagged governed=true. Record
+            # shaping lives in ConvertTo-OmadaCraAssignmentRecord.
+            $Rec = ConvertTo-OmadaCraAssignmentRecord -CalculatedAssignment $Item -ResourceUid $ResourceUid -PrincipalId $PrincipalUid -ResType $ResType -AccountName $AccountName
             if (-not $CaAssignmentsBySys.ContainsKey($SysKey)) { $CaAssignmentsBySys[$SysKey] = [System.Collections.Generic.List[object]]::new() }
             $CaAssignmentsBySys[$SysKey].Add($Rec)
         }  # end foreach $Item in $CaPage

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -468,28 +468,10 @@ if ($SyncAccounts) {
         Write-Host "  $($AllAccounts.Count) account records from Omada" -ForegroundColor Gray
 
         Write-Step "Building $($AllAccounts.Count) account records..."
+        # Per-account record shaping lives in ConvertTo-OmadaAccountRecord
+        # (OmadaCrawler.Transform.ps1).
         $AccountRecords = @($AllAccounts | Where-Object { -not $_.Inactive } | ForEach-Object {
-            $ExtId = [string]$_.UId
-            $Name  = "$($_.FIRSTNAME) $($_.LASTNAME)".Trim()
-            if (-not $Name) { $Name = $_.DisplayName }
-
-            # Resolve principalType from the linked Identity's IDENTITYTYPE
-            $PrincipalType = 'User'
-            $IdentId = if ($_.IDENTITYREF) { [string]$_.IDENTITYREF.IDENTITYID } else { $Null }
-            if ($IdentId -and $IdentityLookup.ContainsKey($IdentId)) {
-                $PrincipalType = Map-IdentityTypeToAtlas -OmadaType $IdentityLookup[$IdentId].identityType
-            }
-
-            [PSCustomObject]@{
-                id                 = $ExtId  # Omada UId is a valid UUID
-                externalId         = $ExtId
-                displayName        = $Name
-                email              = $_.EMAIL
-                principalType      = $PrincipalType
-                accountEnabled     = $True
-                jobTitle           = $_.JOBTITLE
-                extendedAttributes = @{ userName = $_.UserName }
-            }
+            ConvertTo-OmadaAccountRecord -Account $_ -IdentityLookup $IdentityLookup
         } | Where-Object { $_.externalId -and $_.displayName })
 
         foreach ($PType in @('User', 'ExternalUser', 'ServicePrincipal')) {
@@ -541,20 +523,12 @@ if ($SyncIdentities -and $AllIdentities -and $SyncAccounts -and $AllAccounts) {
     $T = [datetime]::UtcNow
     Write-Host "`nIdentity Members:" -ForegroundColor Cyan
     try {
+        # Per-account link shaping lives in ConvertTo-OmadaIdentityMemberRecord
+        # (OmadaCrawler.Transform.ps1); it returns $null for accounts to skip.
         $MemberRecords = [System.Collections.Generic.List[object]]::new()
         foreach ($Acc in $AllAccounts) {
-            if ($Acc.Inactive) { continue }
-            $IdentId = if ($Acc.IDENTITYREF) { [string]$Acc.IDENTITYREF.IDENTITYID } else { $Null }
-            if (-not $IdentId -or -not $IdentityLookup.ContainsKey($IdentId)) { continue }
-            # Only link accounts whose identity type is stored in the Identities table.
-            # Non-person identities (Machine, etc.) are not in Identities → skip to avoid FK errors.
-            $IdentEntry = $IdentityLookup[$IdentId]
-            if ($IdentityTypesForIdentityTable -notcontains $IdentEntry.identityType) { continue }
-            $MemberRecords.Add([PSCustomObject]@{
-                identityId  = $IdentEntry.uid                 # direct UUID FK to Identities.id
-                principalId = [string]$Acc.UId                # direct UUID FK to Principals.id
-                accountType = 'Primary'
-            })
+            $Member = ConvertTo-OmadaIdentityMemberRecord -Account $Acc -IdentityLookup $IdentityLookup -IdentityTypesForIdentityTable $IdentityTypesForIdentityTable
+            if ($Member) { $MemberRecords.Add($Member) }
         }
 
         Write-Step "Ingesting $($MemberRecords.Count) identity-member links..."

--- a/tools/crawlers/omada/Start-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Start-OmadaCrawler.ps1
@@ -360,49 +360,16 @@ if ($SyncContexts) {
             Write-Host "  $($Items.Count) $EntitySet records from Omada" -ForegroundColor Gray
 
             if ($EntitySet -eq 'Orgunit') {
-                # Orgunit has a parent hierarchy — topological sort required
+                # Orgunit has a parent hierarchy — topological sort required.
+                # Per-record shaping + the sort live in OmadaCrawler.Transform.ps1.
                 $RawRecords = @($Items | ForEach-Object {
-                    $CtxType   = Map-ContextTypeToAtlas -OmadaType (Get-OmadaRefValue -Ref $_.OUTYPE -Fallback $ContextType)
-                    $ParentUid = Get-OmadaRefUid -Ref $_.PARENTOU
-                    [PSCustomObject]@{
-                        id              = [string]$_.UId
-                        externalId      = [string]$_.UId
-                        displayName     = if ($_.NAME) { $_.NAME } else { $_.DisplayName }
-                        contextType     = $CtxType
-                        variant         = 'synced'
-                        targetType      = 'Identity'
-                        parentContextId = if ($ParentUid) { $ParentUid } else { $Null }
-                    }
+                    ConvertTo-OmadaOrgUnitContextRecord -OrgUnit $_ -DefaultContextType $ContextType
                 } | Where-Object { $_.externalId -and $_.displayName })
-
-                # Topological sort — parents before children
-                $Records   = [System.Collections.Generic.List[object]]::new()
-                $Remaining = [System.Collections.Generic.List[object]]::new($RawRecords)
-                $Inserted  = [System.Collections.Generic.HashSet[string]]::new()
-                $Pass = 0; $MaxPasses = $RawRecords.Count + 1
-                while ($Remaining.Count -gt 0 -and $Pass -lt $MaxPasses) {
-                    $Pass++
-                    $NextRem = [System.Collections.Generic.List[object]]::new()
-                    foreach ($Rec in $Remaining) {
-                        $ParentId = $Rec.parentContextId
-                        if (-not $ParentId -or $Inserted.Contains($ParentId)) {
-                            $Records.Add($Rec); $Inserted.Add($Rec.id) | Out-Null
-                        } else { $NextRem.Add($Rec) }
-                    }
-                    $Remaining = $NextRem
-                }
-                foreach ($Rec in $Remaining) { $Records.Add($Rec) }
+                $Records = Sort-OmadaContextsTopologically -Records $RawRecords
             } else {
                 # Flat context type — no hierarchy
                 $Records = @($Items | ForEach-Object {
-                    [PSCustomObject]@{
-                        id          = [string]$_.UId
-                        externalId  = [string]$_.UId
-                        displayName = if ($_.NAME) { $_.NAME } else { $_.DisplayName }
-                        contextType = $ContextType
-                        variant     = 'synced'
-                        targetType  = 'Identity'
-                    }
+                    ConvertTo-OmadaFlatContextRecord -Item $_ -ContextType $ContextType
                 } | Where-Object { $_.externalId -and $_.displayName })
             }
 


### PR DESCRIPTION
PR 2 of the crawler complexity refactor (after EntraID #536). Refactors the monolithic `Start-OmadaCrawler.ps1` (started at 1,193 lines, **CC 235**) into a thinner orchestrator + dot-sourced **pure** record-shapers in `OmadaCrawler.Transform.ps1`, one phase per commit. Same recipe as #536: move each phase's inline mapping *verbatim* into a pure, explicit-param function, unit-test against in-memory OData fixtures (no mocks), replace the inline block with a call.

### Result

| | Start | Now |
|---|---|---|
| `Start-OmadaCrawler.ps1` cyclomatic complexity | 235 | **184** |
| Lines | 1,193 | 979 |
| Pure functions in `OmadaCrawler.Transform.ps1` | 0 | **13** |
| Transform unit tests | 0 | **28** (no mocks) |

All Omada sync phases now delegate their record-shaping to tested pure functions:
- **Identities** — `ConvertTo-OmadaIdentityRecord`, `Get-OmadaIdentityType`
- **Contexts** — Orgunit + flat mappers + `Sort-OmadaContextsTopologically` (parent-before-child)
- **Accounts/Principals + IdentityMembers** — `ConvertTo-OmadaAccountRecord`, `ConvertTo-OmadaIdentityMemberRecord`
- **Resources + Entitlements** — `ConvertTo-OmadaResourceRecord`, `ConvertTo-OmadaEntitlementRelationships`
- **Assignments** — `New-OmadaRoleAssignmentRecord`, `ConvertTo-OmadaCraPrincipalRecord`, `ConvertTo-OmadaCraAssignmentRecord`
- **Context Members** — `New-OmadaContextMemberRecord` (deduped 3 identical inline blocks)

**Verification:** full Pester suite **1091 passed / 0 failed**; `assignmentTypes` static guard green on the assignment slice; PSScriptAnalyzer clean at the CI Warning/Error threshold.

The residual CC 184 is orchestration scaffolding (per-phase try/catch, OData pagination/streaming, per-system grouping, dedup) — intentionally left in the entry point. Independent of #536 (different file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)