### PR TITLE
ci: stop unnecessary CodeQL runs (docs/version-bump pushes + superseded PR scans)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,29 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    # Skip the automated, code-free commits that land on main after every PR
+    # merge — they have nothing for CodeQL (JS/TS) to scan, so the run is wasted:
+    #   - coverage.yml's "docs: update test coverage report"  → docs/** + *.md
+    #   - bump-version.yml's "chore: bump version …"          → CHANGES.md + the psd1
+    # paths-ignore skips a push only when EVERY changed file matches, so a real
+    # code merge is never skipped. The pull_request trigger is deliberately left
+    # unfiltered: if CodeQL is a required status check, a paths-ignore there would
+    # leave docs-only PRs without a reported check and block their merge.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'setup/IdentityAtlas.psd1'
   pull_request:
     branches: [main]
   schedule:
     - cron: '0 2 * * 1' # Weekly on Monday at 02:00 UTC
+
+concurrency:
+  # Cancel a superseded CodeQL run when a new commit is pushed to the same PR —
+  # only the latest commit's scan matters. Never cancel on main: cancel-in-progress
+  # is gated to pull_request events, so every code commit on main is still scanned.
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     # merge — they have nothing for CodeQL (JS/TS) to scan, so the run is wasted:
     #   - coverage.yml's "docs: update test coverage report"  → docs/** + *.md
     #   - bump-version.yml's "chore: bump version …"          → CHANGES.md + the psd1
+    #   - complexity-ratchet baseline updates                 → .ci/**
     # paths-ignore skips a push only when EVERY changed file matches, so a real
     # code merge is never skipped. The pull_request trigger is deliberately left
     # unfiltered: if CodeQL is a required status check, a paths-ignore there would
@@ -15,6 +16,7 @@ on:
       - 'docs/**'
       - '**/*.md'
       - 'setup/IdentityAtlas.psd1'
+      - '.ci/**'
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -41,6 +41,7 @@ on:
       - 'mkdocs.yml'
       - 'setup/IdentityAtlas.psd1'
       - '**.md'
+      - '.ci/**'
 
 # Cancel superseded runs when a PR branch is pushed again — these Docker/load
 # suites are expensive, so don't let a stale run keep burning a runner (F4).


### PR DESCRIPTION
**Problem:** CodeQL ran **22 times on `main` in one day**. It's by far the noisiest workflow — every other main-push workflow (Deploy docs, Publish coverage, Publish Docker Images) already has correct `paths`/`workflow_run` gating.

Two sources of waste, both fixed here:

### 1. Triggers on every main push, including code-free auto-commits
`codeql.yml` had `on: push: branches: [main]` with **no path filter**. After every PR merge, two more automated commits land on main and each re-ran CodeQL with nothing to scan:
- `coverage.yml` → `docs: update test coverage report` (docs/** + *.md)
- `bump-version.yml` → `chore: bump version …` (`CHANGES.md` + `setup/IdentityAtlas.psd1`)

Added `paths-ignore: [docs/**, **/*.md, setup/IdentityAtlas.psd1]` on the **push** trigger. `paths-ignore` skips a push only when *every* changed file matches, so a real code merge is never skipped. **PR trigger left unfiltered on purpose** — if CodeQL is a required check, a `paths-ignore` there would leave docs-only PRs without a reported check and block their merge.

### 2. No concurrency group → superseded PR scans pile up
Unlike `pr.yml` / `pr-integration.yml`, CodeQL had no `concurrency`, so each push to a PR branch spawned a fresh scan instead of cancelling the stale one (a slice-heavy PR ran CodeQL 6×). Added a ref-scoped group that cancels superseded runs **on PRs only** (`cancel-in-progress` gated to `pull_request`) — never on main, so every main code commit is still scanned.

### Expected effect
Main-push CodeQL runs drop from ~22/day to roughly the number of actual code merges (~8); redundant in-flight PR scans are cancelled on the next push.

Audited the other main-push / `workflow_run` workflows — all already correctly gated; their counts are legitimate. CI-only change: no changelog fragment, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)