### PR TITLE
ci: bump codeql-action to 4.36.3 (all steps) + group future bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+    groups:
+      # codeql-action's init/autobuild/analyze steps are separate action paths
+      # but MUST run at the same version — a mismatch fails the Analyze job with
+      # "Loaded a configuration file for version X, but running version Y".
+      # Group them so Dependabot bumps all three in a single PR instead of one
+      # PR per sub-action (which is never internally consistent).
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # Worker container (PowerShell)
   - package-ecosystem: "docker"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,16 +42,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: /language:javascript-typescript


### PR DESCRIPTION
## Problem

Dependabot opened a separate PR per `codeql-action` sub-action — #547 (`autobuild`) and #555 (`init`) — each bumping only **one** of the three steps (`init` / `autobuild` / `analyze`). CodeQL requires all three to run at the **same** version (`init` writes a config that `autobuild`/`analyze` read), so every single-step bump fails the **Analyze (javascript)** job with:

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

Neither #547 nor #555 is internally consistent, and there's no PR for `analyze` at all — so even merging both would still leave a mismatch.

## Fix

1. **Resolve now** — bump `init`, `autobuild`, and `analyze` together to **4.36.3** (`54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`, the SHA Dependabot itself proposed) so all three match and Analyze passes.
2. **Prevent recurrence** — add a Dependabot `codeql-action` group so all `github/codeql-action*` bumps land in a single PR, the same grouping pattern the repo already uses for `react`/`react-dom` and `vite` in the npm block.

Supersedes #547 and #555 (Dependabot will auto-close them once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
