### PR TITLE
fix(contexts): stop plugin refresh spawning duplicate trees each crawl

### DIFF
--- a/app/api/contract-tests/runner.refresh.contract.test.js
+++ b/app/api/contract-tests/runner.refresh.contract.test.js
@@ -1,0 +1,97 @@
+// Contract test — refreshGeneratedContexts (post-crawl tree refresh) against a
+// real PostgreSQL schema.
+//
+// Regression guard for the "context plugins spawn a new tree on every crawl"
+// bug: legacy trees (created before migration 034) have a NULL sourceInstanceKey.
+// The refresh must backfill a stable key and reconcile onto the EXISTING tree,
+// never mint a fresh key that inserts a duplicate tree each run. We simulate a
+// legacy tree (NULL key), run the refresh twice, and assert the tree count is
+// still one.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { randomUUID } from 'crypto';
+import pg from 'pg';
+
+const PLUGIN_NAME = 'principal-type-tree';
+
+let enqueueRun, refreshGeneratedContexts;
+let pool;
+let systemId;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.CONTRACT_DB_URL;
+  ({ enqueueRun, refreshGeneratedContexts } = await import('../src/contexts/plugins/runner.js'));
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+});
+
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+beforeEach(cleanup);
+
+async function cleanup() {
+  await pool.query(`DELETE FROM "Contexts" WHERE "sourceAlgorithmId" IN (SELECT id FROM "ContextAlgorithms" WHERE name = $1)`, [PLUGIN_NAME]);
+  await pool.query(`DELETE FROM "ContextAlgorithms" WHERE name = $1`, [PLUGIN_NAME]);
+  await pool.query(`DELETE FROM "Principals" WHERE "displayName" LIKE 'refresh-ct-%'`);
+  await pool.query(`DELETE FROM "Systems" WHERE "displayName" = 'refresh-contract'`);
+}
+
+async function seed() {
+  await pool.query(
+    `INSERT INTO "ContextAlgorithms" ("id", "name", "displayName", "targetType")
+     VALUES ($1, $2, 'Principal Type Tree', 'Principal')`,
+    [randomUUID(), PLUGIN_NAME],
+  );
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'refresh-contract') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+  for (let i = 0; i < 3; i++) {
+    await pool.query(
+      `INSERT INTO "Principals" ("systemId", "displayName", "principalType") VALUES ($1, $2, 'ServicePrincipal')`,
+      [systemId, `refresh-ct-${i}`],
+    );
+  }
+}
+
+const rootCount = async () =>
+  (await pool.query(
+    `SELECT COUNT(*)::int AS n FROM "Contexts" c
+       JOIN "ContextAlgorithms" a ON a.id = c."sourceAlgorithmId"
+      WHERE a.name = $1 AND c."externalId" = 'ptype-root'`,
+    [PLUGIN_NAME],
+  )).rows[0].n;
+
+describe('refreshGeneratedContexts — legacy NULL-key tree', () => {
+  it('updates the existing tree in place across repeated crawls (never duplicates)', async () => {
+    await seed();
+
+    // Build the initial tree, then knock its instance key back to NULL to
+    // impersonate a tree created before migration 034.
+    await enqueueRun(PLUGIN_NAME, { systemId, values: ['ServicePrincipal'] }, 'initial', { awaitCompletion: true });
+    await pool.query(
+      `UPDATE "Contexts" SET "sourceInstanceKey" = NULL
+        WHERE "sourceAlgorithmId" IN (SELECT id FROM "ContextAlgorithms" WHERE name = $1)`,
+      [PLUGIN_NAME],
+    );
+    expect(await rootCount()).toBe(1);
+
+    // Two post-crawl refreshes. Pre-fix, each would spawn another root.
+    await refreshGeneratedContexts('crawl-refresh', { awaitCompletion: true });
+    await refreshGeneratedContexts('crawl-refresh', { awaitCompletion: true });
+
+    expect(await rootCount()).toBe(1);
+
+    // And the surviving tree now carries a real (non-null) instance key.
+    const keys = (await pool.query(
+      `SELECT DISTINCT "sourceInstanceKey" FROM "Contexts" c
+         JOIN "ContextAlgorithms" a ON a.id = c."sourceAlgorithmId"
+        WHERE a.name = $1`,
+      [PLUGIN_NAME],
+    )).rows;
+    expect(keys).toHaveLength(1);
+    expect(keys[0].sourceInstanceKey).toBeTruthy();
+  });
+});

--- a/app/api/src/contexts/plugins/runner.js
+++ b/app/api/src/contexts/plugins/runner.js
@@ -74,6 +74,8 @@ export async function enqueueRun(pluginName, params, triggeredBy, opts = {}) {
 export async function refreshGeneratedContexts(triggeredBy = 'crawl-refresh', { awaitCompletion = false } = {}) {
   const trees = (await db.query(`
     SELECT a.name AS algo,
+           c."sourceAlgorithmId" AS "algorithmId",
+           c."scopeSystemId" AS "scopeSystemId",
            c."sourceInstanceKey" AS ikey,
            (array_agg(r.parameters ORDER BY c."createdAt" DESC))[1] AS params
       FROM "Contexts" c
@@ -88,7 +90,23 @@ export async function refreshGeneratedContexts(triggeredBy = 'crawl-refresh', { 
     if (!t.params) continue;                       // no recoverable parameters
     if (t.params.autoRefresh === false) continue;  // opted out
     try {
-      await enqueueRun(t.algo, { ...t.params, instanceKey: t.ikey || undefined }, triggeredBy, { awaitCompletion });
+      // Legacy trees (created before migration 034) have a NULL instance key.
+      // Passing `undefined` to enqueueRun would make it mint a fresh random key
+      // every crawl — reconcile then matches nothing and inserts a brand-new
+      // duplicate tree each run (the "explode" bug). Backfill a stable key onto
+      // the existing tree first (same as the manual /sync path), so the refresh
+      // reconciles onto it in place instead of spawning a copy.
+      let ikey = t.ikey;
+      if (!ikey) {
+        ikey = randomUUID();
+        await db.query(`
+          UPDATE "Contexts" SET "sourceInstanceKey" = $1
+           WHERE "sourceAlgorithmId" = $2
+             AND ($3::int IS NULL OR "scopeSystemId" = $3)
+             AND "sourceInstanceKey" IS NULL
+        `, [ikey, t.algorithmId, t.scopeSystemId]);
+      }
+      await enqueueRun(t.algo, { ...t.params, instanceKey: ikey }, triggeredBy, { awaitCompletion });
       started++;
     } catch (err) {
       console.error(`[context-refresh] ${t.algo} (${t.ikey || 'no-key'}) failed:`, err.message);

--- a/app/api/src/contexts/plugins/runner.refresh.test.js
+++ b/app/api/src/contexts/plugins/runner.refresh.test.js
@@ -1,0 +1,89 @@
+// Unit tests for refreshGeneratedContexts (runner.js).
+//
+// Focus: the post-crawl refresh must UPDATE existing trees in place and never
+// spawn a new tree. Legacy trees (created before migration 034) have a NULL
+// sourceInstanceKey; the refresh must backfill a stable key onto them first so
+// reconcile matches the existing rows instead of minting a fresh key and
+// inserting a duplicate tree on every crawl.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const query = vi.fn();
+const queryOne = vi.fn();
+vi.mock('../../db/connection.js', () => ({
+  query: (...a) => query(...a),
+  queryOne: (...a) => queryOne(...a),
+  tx: async (fn) => fn({ query: (...a) => query(...a) }),
+  default: {},
+}));
+
+const PLUGIN = { name: 'ad-ou-from-dn', targetType: 'Principal', parametersSchema: {}, run: vi.fn() };
+vi.mock('./registry.js', () => ({ getPlugin: () => PLUGIN }));
+
+const { refreshGeneratedContexts } = await import('./runner.js');
+
+// A row as returned by the "trees to refresh" SELECT.
+function tree({ ikey, scope = 1 }) {
+  return { algo: 'ad-ou-from-dn', algorithmId: 'algo-1', scopeSystemId: scope, ikey, params: { scopeSystemId: scope } };
+}
+
+// Wire the db mock: the trees SELECT returns `trees`; the ContextAlgorithms
+// lookup returns an id; every other query is a harmless no-op.
+function wire(trees) {
+  query.mockReset();
+  queryOne.mockReset();
+  PLUGIN.run.mockReset().mockResolvedValue({ contexts: [], members: [] });
+  query.mockImplementation(async (sql) => {
+    if (/array_agg\(r\.parameters/.test(sql)) return { rows: trees };
+    return { rows: [], rowCount: 0 };
+  });
+  queryOne.mockResolvedValue({ id: 'algo-1' });
+}
+
+const backfillCalls = () => query.mock.calls.filter(([sql]) => /SET "sourceInstanceKey"/.test(sql));
+const runInsert = () => query.mock.calls.find(([sql]) => /INSERT INTO "ContextAlgorithmRuns"/.test(sql));
+
+beforeEach(() => { query.mockReset(); queryOne.mockReset(); });
+
+describe('refreshGeneratedContexts', () => {
+  it('backfills a NULL-key legacy tree and refreshes it in place (no duplicate)', async () => {
+    wire([tree({ ikey: null })]);
+
+    const started = await refreshGeneratedContexts('crawl-refresh', { awaitCompletion: true });
+    expect(started).toBe(1);
+
+    // A backfill UPDATE was issued for the legacy tree, scoped to its algorithm + system.
+    const bf = backfillCalls();
+    expect(bf).toHaveLength(1);
+    const [, bfParams] = bf[0];
+    const backfilledKey = bfParams[0];
+    expect(typeof backfilledKey).toBe('string');
+    expect(backfilledKey.length).toBeGreaterThan(0);
+    expect(bfParams[1]).toBe('algo-1');
+    expect(bfParams[2]).toBe(1);
+
+    // The run reconciles against that same backfilled key — i.e. it targets the
+    // existing tree, it does NOT mint a fresh random key (which would duplicate).
+    const insert = runInsert();
+    expect(insert).toBeTruthy();
+    expect(insert[1][2].instanceKey).toBe(backfilledKey);
+  });
+
+  it('refreshes a keyed tree in place without any backfill', async () => {
+    wire([tree({ ikey: 'existing-key' })]);
+
+    const started = await refreshGeneratedContexts('crawl-refresh', { awaitCompletion: true });
+    expect(started).toBe(1);
+
+    expect(backfillCalls()).toHaveLength(0);
+    expect(runInsert()[1][2].instanceKey).toBe('existing-key');
+  });
+
+  it('skips trees opted out via autoRefresh=false', async () => {
+    wire([{ algo: 'ad-ou-from-dn', algorithmId: 'algo-1', scopeSystemId: 1, ikey: 'k', params: { scopeSystemId: 1, autoRefresh: false } }]);
+
+    const started = await refreshGeneratedContexts('crawl-refresh', { awaitCompletion: true });
+    expect(started).toBe(0);
+    expect(runInsert()).toBeFalsy();
+  });
+});

--- a/changes/context-plugin-refresh-duplicates.md
+++ b/changes/context-plugin-refresh-duplicates.md
@@ -1,0 +1,1 @@
+- Fixed context plugins (e.g. Active Directory OU Tree) spawning a brand-new duplicate tree on every crawl instead of updating the existing one in place. Legacy trees created before per-tree instance keys were introduced now refresh onto themselves, so member counts and analyst edits are preserved and the tree list no longer explodes.


### PR DESCRIPTION
## Problem

We recently changed context-plugin scheduling to refresh generated trees after **every** crawl. Since then, some plugins create a **brand-new duplicate tree on every run** instead of updating the existing one — the tree list and context assignments explode (e.g. 31 identical "Organisational Units" trees).

## Root cause

`refreshGeneratedContexts` passed `instanceKey: t.ikey || undefined` for each tree. Trees created **before** migration 034 (`context_instance_key`) have a `NULL` `sourceInstanceKey`. For those, `undefined` reached `enqueueRun`, which **mints a fresh random key every run** — reconcile then matches nothing and `INSERT`s a whole new tree each crawl.

This is why only *some* plugins were affected (the legacy NULL-key trees) and newer ones weren't. The manual "Sync" button never hit this because it already backfills a stable key before re-running.

## Fix

Mirror the `/sync` path in the post-crawl refresh: backfill a stable instance key onto a legacy tree **first**, then refresh onto that key so reconcile **updates it in place** (member counts + analyst edits preserved). Keyed trees are untouched.

It should only ever update a tree automatically — never generate a new one.

## Tests

- Unit (`runner.refresh.test.js`): asserts a NULL-key tree is backfilled and reconciled against the same key; keyed trees skip the backfill; `autoRefresh=false` opt-out.
- Contract (`runner.refresh.contract.test.js`): against real Postgres — simulate a legacy NULL-key tree, run the refresh twice, assert the tree count stays **1** and the key is backfilled.

## Verified on SK1

Deployed to the `main` stack (real data). Simulated the legacy NULL-key condition, ran the refresh: stayed **1 root, key backfilled, zero duplicates**, stable across repeated runs.

## Follow-up (not in this PR)

Existing duplicate trees already spawned by previous crawls won't self-heal. Cleaning them up is a **data operation** run deliberately against the affected DB (kept out of this code PR so it can't auto-delete intentional multi-trees on other deployments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)