### PR TITLE
fix(ui): stop list pagination crashing on Next past page 1

### DIFF
--- a/app/ui/src/components/EntityListPage.mount.test.jsx
+++ b/app/ui/src/components/EntityListPage.mount.test.jsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  renderWithProviders,
+  makeAuthFetch,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@ui/test-utils/renderWithProviders';
+import EntityListPage from '@ui/components/EntityListPage';
+
+const LIST = '/api/users';
+const COLUMNS = '/api/users/columns';
+
+// useEntityPage persists filters/sort to sessionStorage — isolate each test.
+beforeEach(() => sessionStorage.clear());
+
+function renderPage(authFetch) {
+  return renderWithProviders(
+    <EntityListPage
+      title="Users"
+      entityType="user"
+      listEndpoint={LIST}
+      columnsEndpoint={COLUMNS}
+      tagFilterKey="__userTag"
+      tableColumns={[{ key: 'displayName', label: 'Name' }]}
+      fieldLabels={{}}
+      renderEntityCell={(item) => <td>{item.displayName}</td>}
+      renderDataCells={() => <td />}
+      searchPlaceholder="Search"
+      onOpenDetail={() => {}}
+    />,
+    { auth: { authFetch } }
+  );
+}
+
+describe('EntityListPage pagination', () => {
+  it('clicking Next does not crash when the endpoint omits total on later pages', async () => {
+    // Mirrors the real list endpoints: total is returned only on page 1 (offset 0);
+    // later pages send total:null to skip a redundant COUNT. Regression guard for
+    // the `null.toLocaleString()` crash that broke the Next button.
+    const af = makeAuthFetch((url) => {
+      const s = String(url);
+      if (s.includes(COLUMNS)) return [];
+      if (s.includes('/api/tags')) return [];
+      if (s.includes(LIST)) {
+        const offset = new URLSearchParams(s.split('?')[1] || '').get('offset');
+        return offset === '0'
+          ? { data: [{ id: '1', displayName: 'Bob' }], total: 250 }
+          : { data: [{ id: '2', displayName: 'Al' }], total: null };
+      }
+      return undefined;
+    });
+
+    renderPage(af);
+
+    // Page 1 renders with the total and pager.
+    expect(await screen.findByText('250 total')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+
+    // Click Next → offset=100 → response has total:null. Pre-fix this threw.
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(screen.getByText('Page 2 of 3')).toBeInTheDocument());
+    // Total is preserved (still a number), header + pager still render.
+    expect(screen.getByText('250 total')).toBeInTheDocument();
+    expect(screen.getByText('Al')).toBeInTheDocument();
+  });
+});

--- a/app/ui/src/hooks/useEntityPage.js
+++ b/app/ui/src/hooks/useEntityPage.js
@@ -124,7 +124,13 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
       .then((json) => {
         if (json && version === fetchVersion.current) {
           setItems(json.data);
-          setTotal(json.total);
+          // The list endpoints only return `total` on the first page (offset 0)
+          // and send `total: null` on later pages to skip a redundant COUNT (the
+          // Excel export reads the count once and then pages by row count). The
+          // total doesn't change while paging, so keep the known value instead of
+          // clobbering it with null — otherwise the pager/header crash on
+          // `null.toLocaleString()` the moment you click Next.
+          if (json.total != null) setTotal(json.total);
         }
       })
       .catch((err) => console.error(`Failed to fetch ${entityType}s:`, err))

--- a/app/ui/src/hooks/useEntityPage.test.jsx
+++ b/app/ui/src/hooks/useEntityPage.test.jsx
@@ -99,6 +99,48 @@ describe('useEntityPage', () => {
     });
   });
 
+  it('keeps the known total when a later page returns total:null (no Next-button crash)', async () => {
+    // The list endpoints only send `total` on page 1; later pages return
+    // total:null to skip a redundant COUNT. The hook must not clobber the known
+    // total — otherwise the pager/header hit `null.toLocaleString()` on Next.
+    const af = makeAuthFetch((url) => {
+      const s = String(url);
+      if (s.includes(COLUMNS)) return [];
+      if (s.includes('/api/tags')) return [];
+      if (s.includes(LIST)) {
+        const offset = new URLSearchParams(s.split('?')[1] || '').get('offset');
+        return offset === '0'
+          ? { data: [{ id: '1', displayName: 'Bob' }], total: 250 }
+          : { data: [{ id: '2', displayName: 'Al' }], total: null };
+      }
+      return undefined;
+    });
+    const { wrapper } = makeWrapper({ auth: { authFetch: af } });
+    const { result } = renderHook(
+      () =>
+        useEntityPage({
+          authFetch: af,
+          entityType: 'user',
+          listEndpoint: LIST,
+          columnsEndpoint: COLUMNS,
+          tagFilterKey: '__userTag',
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.total).toBe(250);
+
+    act(() => result.current.setPage(1));
+    await waitFor(() => expect(lastListUrl(af)).toContain('offset=100'));
+    await waitFor(() =>
+      expect(result.current.items).toEqual([{ id: '2', displayName: 'Al' }])
+    );
+
+    // total survives the page change — stays a number, never becomes null.
+    expect(result.current.total).toBe(250);
+    expect(result.current.totalPages).toBe(3);
+  });
+
   it('includeDeleted adds the query flag', async () => {
     const { af, result } = setup();
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/changes/list-pagination-total-null.md
+++ b/changes/list-pagination-total-null.md
@@ -1,0 +1,1 @@
+- Fixed the **Next** button on the Users, Resources (Groups) and Identities list pages throwing an error when paging past the first page. The page count is only sent on the first page for export efficiency, and the UI was mishandling its absence on later pages — it now keeps the known total so pagination works across every page.


### PR DESCRIPTION
## Problem

On the **Users**, **Resources** (Groups) and **Identities** pages, clicking the **Next** button to load the next page throws an error and the page crashes.

## Root cause

The list endpoints (`/api/users`, `/api/resources`, `/api/identities`) return `total` **only on the first page** (`offset 0`) and send `total: null` on later pages — a deliberate optimization so the Excel/Power Query export doesn't re-run a full `COUNT(*)` on every page.

`useEntityPage` called `setTotal(json.total)` on **every** fetch, so clicking Next set `total` to `null`. `EntityListPage` then rendered `ep.total.toLocaleString()` in the header and pager → `TypeError: Cannot read properties of null` → the page crashes. It only reproduces on page ≥ 2, which is exactly "click Next → error".

## Fix

Keep the known `total` when a later page omits it. The total doesn't change while paging, and it's re-established whenever the page resets to 0 (any filter/search change). One-line change in the shared hook, so it fixes all three pages at once.

## Tests (the "add it to CI" ask)

- `useEntityPage.test.jsx`: paging to a later page whose response has `total: null` keeps the total (250) and `totalPages` (3).
- `EntityListPage.mount.test.jsx` (new): renders the real page, **clicks Next**, and asserts it doesn't crash — the total and pager still render. This reproduces the exact crash at the render layer and fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)