### PR TITLE
feat(entra): classify groups into a filterable groupCategory attribute

### DIFF
--- a/changes/entra-group-category.md
+++ b/changes/entra-group-category.md
@@ -1,0 +1,3 @@
+- Added a `groupCategory` attribute to every Entra group (Team, Microsoft365, SecurityGroup, DistributionList, MailEnabledSecurity — with a `Dynamic` prefix where dynamic membership applies), so analysts can tell at a glance what kind of group they're dealing with and filter on it in the Excel export.
+- Added supporting group facets: `membershipType` (Assigned/Dynamic), `sourceOfAuthority` (Cloud/OnPremises, i.e. synced from on-prem AD or not), and `accessPackageEligible` (whether the group can be used in an access package).
+- Group dynamic-vs-assigned is now determined from the authoritative Entra flag, so a group that was converted from dynamic back to assigned is classified correctly even if a stale membership rule lingers.

--- a/test/unit/EntraIDCrawlerTransform.Tests.ps1
+++ b/test/unit/EntraIDCrawlerTransform.Tests.ps1
@@ -222,6 +222,80 @@ Describe 'ConvertTo-EntraSpActivityRecord' {
     }
 }
 
+Describe 'Get-EntraGroupClassification' {
+
+    It 'classifies an assigned cloud security group and marks it access-package eligible' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $false }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'SecurityGroup'
+        $c['membershipType']        | Should -Be 'Assigned'
+        $c['sourceOfAuthority']     | Should -Be 'Cloud'
+        $c['accessPackageEligible'] | Should -BeTrue
+    }
+
+    It 'folds dynamic into the label and blocks access-package eligibility' {
+        $g = [pscustomobject]@{ groupTypes = @('DynamicMembership'); securityEnabled = $true; mailEnabled = $false }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'DynamicSecurityGroup'
+        $c['membershipType']        | Should -Be 'Dynamic'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'classifies a Microsoft 365 group (no team) as Microsoft365, eligible' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified'); securityEnabled = $false; mailEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'Microsoft365'
+        $c['accessPackageEligible'] | Should -BeTrue
+    }
+
+    It 'classifies a dynamic Microsoft 365 group as DynamicMicrosoft365' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified','DynamicMembership'); securityEnabled = $false; mailEnabled = $true }
+        (Get-EntraGroupClassification -Group $g)['groupCategory'] | Should -Be 'DynamicMicrosoft365'
+    }
+
+    It 'classifies a teamified Microsoft 365 group as Team' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified'); securityEnabled = $false; mailEnabled = $true; resourceProvisioningOptions = @('Team') }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'Team'
+        $c['accessPackageEligible'] | Should -BeTrue
+    }
+
+    It 'classifies a dynamic team as DynamicTeam' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified','DynamicMembership'); securityEnabled = $false; mailEnabled = $true; resourceProvisioningOptions = @('Team') }
+        (Get-EntraGroupClassification -Group $g)['groupCategory'] | Should -Be 'DynamicTeam'
+    }
+
+    It 'classifies a distribution list and never marks it dynamic or eligible' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $false; mailEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'DistributionList'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'classifies a mail-enabled security group' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'MailEnabledSecurity'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'reports on-prem-synced source of authority and blocks eligibility' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $false; onPremisesSyncEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['sourceOfAuthority']     | Should -Be 'OnPremises'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'treats a group as assigned when only a stale membershipRule lingers (groupTypes has no DynamicMembership)' {
+        # membershipRule is left behind after a dynamic→assigned conversion;
+        # groupTypes is authoritative, so this must NOT classify as dynamic.
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $false; membershipRule = 'user.department -eq "IT"' }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']  | Should -Be 'SecurityGroup'
+        $c['membershipType'] | Should -Be 'Assigned'
+    }
+}
+
 Describe 'ConvertTo-EntraGroupResourceRecord' {
 
     It 'maps a group to an EntraGroup resource with joined groupTypes' {
@@ -238,6 +312,33 @@ Describe 'ConvertTo-EntraGroupResourceRecord' {
         $rec['extendedAttributes']['groupTypes']      | Should -Be 'Unified'
         $rec['extendedAttributes']['securityEnabled'] | Should -BeFalse
         $rec['extendedAttributes']['mailEnabled']     | Should -BeTrue
+    }
+
+    It 'stamps the derived groupCategory + facets into extendedAttributes' {
+        $group = [pscustomobject]@{
+            id = 'g1t'; displayName = 'Project Team'
+            groupTypes = @('Unified'); securityEnabled = $false; mailEnabled = $true
+            resourceProvisioningOptions = @('Team')
+        }
+        $ext = (ConvertTo-EntraGroupResourceRecord -Group $group)['extendedAttributes']
+        $ext['groupCategory']               | Should -Be 'Team'
+        $ext['membershipType']              | Should -Be 'Assigned'
+        $ext['sourceOfAuthority']           | Should -Be 'Cloud'
+        $ext['accessPackageEligible']       | Should -BeTrue
+        $ext['resourceProvisioningOptions'] | Should -Be 'Team'
+    }
+
+    It 'carries a lingering membershipRule into ext for display without classifying dynamic' {
+        $group = [pscustomobject]@{
+            id = 'g1r'; displayName = 'Ex-Dynamic'
+            groupTypes = @(); securityEnabled = $true; mailEnabled = $false
+            membershipRule = 'user.department -eq "IT"'; membershipRuleProcessingState = 'Paused'
+        }
+        $ext = (ConvertTo-EntraGroupResourceRecord -Group $group)['extendedAttributes']
+        $ext['membershipRule']                | Should -Be 'user.department -eq "IT"'
+        $ext['membershipRuleProcessingState'] | Should -Be 'Paused'
+        $ext['groupCategory']                 | Should -Be 'SecurityGroup'
+        $ext['membershipType']                | Should -Be 'Assigned'
     }
 
     It 'joins multiple groupTypes into a comma string' {

--- a/tools/crawlers/entra-id/EntraIDCrawler.Phases.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Phases.ps1
@@ -542,7 +542,7 @@ function Sync-EntraResources {
     Update-CrawlerProgress -Step 'Syncing groups' -Pct 20 -Detail 'Fetching groups from Microsoft Graph...'
     $groups = @()
     try {
-        $coreGroupAttrs = @('id','displayName','description','mail','visibility','createdDateTime','groupTypes','securityEnabled','mailEnabled')
+        $coreGroupAttrs = @('id','displayName','description','mail','visibility','createdDateTime','groupTypes','securityEnabled','mailEnabled','membershipRule','membershipRuleProcessingState','onPremisesSyncEnabled','resourceProvisioningOptions')
         $allGroupAttrs = $coreGroupAttrs + $CustomGroupAttributes | Select-Object -Unique
         $groupSelect = $allGroupAttrs -join ','
         $groups = Invoke-FGGetRequest -URI "https://graph.microsoft.com/beta/groups?`$select=$groupSelect&`$top=999"

--- a/tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1
@@ -166,6 +166,68 @@ function ConvertTo-EntraSpActivityRecord {
     return $null
 }
 
+# Classifies a Graph group into a single, analyst-readable `groupCategory` plus a
+# few orthogonal facet fields, derived purely from the raw Graph flags. Returns a
+# hashtable that ConvertTo-EntraGroupResourceRecord folds into extendedAttributes.
+#
+# Two design rules baked in here:
+#   * Dynamic-ness is read ONLY from `groupTypes` containing 'DynamicMembership' —
+#     never from `membershipRule` being non-empty, because that rule text can
+#     linger after a group is converted back to assigned. `groupTypes` is the
+#     operative switch Azure AD itself evaluates, so it can't disagree with the
+#     group's real behaviour.
+#   * The dynamic aspect is folded into the single `groupCategory` label (e.g.
+#     'DynamicSecurityGroup'), but only onto the three categories that actually
+#     support Azure AD dynamic membership — a distribution list can never become
+#     'DynamicDistributionList' even on malformed input.
+function Get-EntraGroupClassification {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Group)
+
+    $types           = @($Group.groupTypes)
+    $isUnified       = $types -contains 'Unified'
+    $isDynamic       = $types -contains 'DynamicMembership'
+    $securityEnabled = [bool]$Group.securityEnabled
+    $mailEnabled     = [bool]$Group.mailEnabled
+    $isTeam          = @($Group.resourceProvisioningOptions) -contains 'Team'
+
+    # Base category — the mutually-exclusive "what kind of group is this".
+    if ($isUnified) {
+        $base = if ($isTeam) { 'Team' } else { 'Microsoft365' }
+    }
+    elseif ($mailEnabled -and $securityEnabled) {
+        $base = 'MailEnabledSecurity'
+    }
+    elseif ($mailEnabled -and -not $securityEnabled) {
+        $base = 'DistributionList'
+    }
+    else {
+        $base = 'SecurityGroup'
+    }
+
+    # Fold the dynamic aspect into the single readable label, guarded to the
+    # categories that support Azure AD dynamic membership.
+    $dynamicCapable = @('Team', 'Microsoft365', 'SecurityGroup')
+    $groupCategory  = if ($isDynamic -and $base -in $dynamicCapable) { "Dynamic$base" } else { $base }
+
+    # Cloud-mastered vs synced from on-prem AD (membership read-only in the cloud).
+    $sourceOfAuthority = if ([bool]$Group.onPremisesSyncEnabled) { 'OnPremises' } else { 'Cloud' }
+
+    # Entitlement-management can only assign membership through an assigned,
+    # cloud-mastered Security or Microsoft 365 group (Teams included). Dynamic,
+    # on-prem-synced, distribution and mail-enabled-security groups are ineligible.
+    $accessPackageEligible = (-not $isDynamic) -and
+                             ($sourceOfAuthority -eq 'Cloud') -and
+                             ($base -in @('SecurityGroup', 'Microsoft365', 'Team'))
+
+    return @{
+        groupCategory         = $groupCategory
+        membershipType        = if ($isDynamic) { 'Dynamic' } else { 'Assigned' }
+        sourceOfAuthority     = $sourceOfAuthority
+        accessPackageEligible = $accessPackageEligible
+    }
+}
+
 # Maps one Graph group → an ingest/resources record (resourceType='EntraGroup').
 # Verbatim from the inline `$groups | ForEach-Object { ... }` block.
 function ConvertTo-EntraGroupResourceRecord {
@@ -179,6 +241,19 @@ function ConvertTo-EntraGroupResourceRecord {
         securityEnabled = $Group.securityEnabled
         mailEnabled     = $Group.mailEnabled
     }
+    # Raw discriminators — kept for display + power-filtering in Excel (ext_*).
+    if ($null -ne $Group.onPremisesSyncEnabled) { $ext['onPremisesSyncEnabled'] = [bool]$Group.onPremisesSyncEnabled }
+    if ($Group.membershipRule)                  { $ext['membershipRule'] = $Group.membershipRule }
+    if ($Group.membershipRuleProcessingState)   { $ext['membershipRuleProcessingState'] = $Group.membershipRuleProcessingState }
+    if (@($Group.resourceProvisioningOptions).Count -gt 0) {
+        $ext['resourceProvisioningOptions'] = (@($Group.resourceProvisioningOptions) -join ',')
+    }
+    # Derived classification: one readable groupCategory + facets, computed once at
+    # the source so the Excel export and the web-portal context plugin read the
+    # same stamped value instead of each re-deriving it from the raw flags.
+    $classification = Get-EntraGroupClassification -Group $Group
+    foreach ($k in $classification.Keys) { $ext[$k] = $classification[$k] }
+
     foreach ($attr in $CustomGroupAttributes) {
         if ($null -ne $Group.$attr) { $ext[$attr] = $Group.$attr }
     }


### PR DESCRIPTION
## What

Adds a single, analyst-readable **`groupCategory`** attribute to every Entra group, derived once in the crawler transform and stamped into `extendedAttributes` — so it flows automatically to the Excel export (`ext_groupCategory`) and the Resources/Matrix "+ Add filter" controls, with no client-side derivation.

Categories: `Team`, `Microsoft365`, `SecurityGroup`, `DistributionList`, `MailEnabledSecurity` — with a `Dynamic` prefix (`DynamicTeam`, `DynamicMicrosoft365`, `DynamicSecurityGroup`) where Azure AD dynamic membership applies.

Plus three orthogonal facets: `membershipType` (Assigned/Dynamic), `sourceOfAuthority` (Cloud/OnPremises), `accessPackageEligible` (bool).

## Why

Analysts need to tell at a glance what *kind* of group they're dealing with (a dynamic group can't be in an access package, a distribution list is managed in Exchange, some groups are synced from on-prem, etc.) and filter on it in Excel. Deriving it once at the source means the export and the web UI read the same value instead of each re-deriving from the raw Graph flags.

## Notes

- **Dynamic-ness reads only from `groupTypes`** (the authoritative switch Azure evaluates), never from `membershipRule` — which can linger after a dynamic→assigned conversion. Covered by a regression test.
- Adds `membershipRule`, `membershipRuleProcessingState`, `onPremisesSyncEnabled`, `resourceProvisioningOptions` (Teams detection) to the group `$select`.
- No DB migration — `extendedAttributes` is free-form JSON.

## Changelog

- Added a `groupCategory` attribute to every Entra group (Team, Microsoft365, SecurityGroup, DistributionList, MailEnabledSecurity — with a `Dynamic` prefix where dynamic membership applies), so analysts can tell at a glance what kind of group they're dealing with and filter on it in the Excel export.
- Added supporting group facets: `membershipType` (Assigned/Dynamic), `sourceOfAuthority` (Cloud/OnPremises), and `accessPackageEligible` (whether the group can be used in an access package).
- Group dynamic-vs-assigned is now determined from the authoritative Entra flag, so a group converted from dynamic back to assigned is classified correctly even if a stale membership rule lingers.

## Test plan

- 13 new Pester cases in `EntraIDCrawlerTransform.Tests.ps1` covering the full truth table incl. Teams, Dynamic* folding, on-prem source, access-package eligibility, and the stale-`membershipRule` case — 86/86 green.
- Deployed to a Fortigi dev stack; verified `groupCategory` populates and appears as a filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)