### PR TITLE
feat(contexts): add Entra Group Category Tree context plugin

### DIFF
--- a/app/api/src/contexts/plugins/entra-group-category-tree.js
+++ b/app/api/src/contexts/plugins/entra-group-category-tree.js
@@ -1,0 +1,74 @@
+// entra-group-category-tree plugin.
+//
+// Groups Entra groups by their crawler-derived `groupCategory` (Team,
+// Microsoft365, SecurityGroup, DistributionList, MailEnabledSecurity and the
+// Dynamic* variants) into a two-level tree: a single "EntraID Groups" root with
+// one child context per distinct category, each holding the matching EntraGroup
+// resources as members. Lets an analyst browse/filter "all the Teams", "all the
+// dynamic security groups", etc.
+//
+// The groupCategory value is stamped once by the Entra crawler transform
+// (see tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1 →
+// Get-EntraGroupClassification), so this plugin only reads it — it never
+// re-derives the classification from the raw Graph flags.
+
+import * as db from '../../db/connection.js';
+
+/** @type {import('./types.js').ContextPlugin} */
+export default {
+  name: 'entra-group-category-tree',
+  displayName: 'Entra Group Category Tree',
+  description:
+    'Groups Entra groups by their derived groupCategory (Team, Microsoft365, SecurityGroup, ' +
+    'DistributionList, … and the Dynamic* variants) under a single "EntraID Groups" root, one ' +
+    'child context per category holding the matching groups. Lets you browse or filter by the ' +
+    'kind of group.',
+  targetType: 'Resource',
+  parametersSchema: {
+    type: 'object',
+    properties: {
+      rootName: { type: 'string', default: 'EntraID Groups', description: 'Display name of the synthetic root node.' },
+      scopeSystemId: { type: 'integer', description: 'Optional Systems.id to restrict to one Entra system. Blank = all EntraGroup resources.' },
+    },
+  },
+  async run(params, ctx) {
+    const rootName = (params.rootName || 'EntraID Groups').slice(0, 500);
+    const hasScope = params.scopeSystemId !== undefined && params.scopeSystemId !== null && params.scopeSystemId !== '';
+    const scopeSystemId = hasScope ? parseInt(params.scopeSystemId, 10) : null;
+    if (hasScope && !Number.isFinite(scopeSystemId)) {
+      throw new Error('scopeSystemId must be an integer when provided');
+    }
+
+    const conds = [`"resourceType" = 'EntraGroup'`, `"extendedAttributes" ->> 'groupCategory' IS NOT NULL`];
+    const qp = [];
+    if (scopeSystemId !== null) { qp.push(scopeSystemId); conds.push(`"systemId" = $${qp.length}`); }
+
+    const rows = (await db.query(
+      `SELECT id::text AS id, "extendedAttributes" ->> 'groupCategory' AS val
+         FROM "Resources" WHERE ${conds.join(' AND ')}`,
+      qp,
+    )).rows;
+    if (rows.length === 0) {
+      ctx.log?.('No EntraGroup resources carry a groupCategory attribute yet — run the Entra crawler first.');
+      return { contexts: [], members: [] };
+    }
+
+    const rootExt = 'entra-groups-root';
+    const contexts = [{ externalId: rootExt, displayName: rootName, contextType: 'EntraGroupRoot' }];
+    const members = [];
+    const seen = new Map(); // category → externalId
+    for (const r of rows) {
+      const val = (r.val || '').trim();
+      if (!val) continue;
+      if (!seen.has(val)) {
+        const ext = `category:${val}`;
+        seen.set(val, ext);
+        contexts.push({ externalId: ext, displayName: val, contextType: 'EntraGroupCategory', parentExternalId: rootExt });
+      }
+      members.push({ contextExternalId: seen.get(val), memberId: r.id });
+    }
+
+    ctx.log?.(`Grouped ${members.length} Entra group(s) into ${seen.size} category context(s).`);
+    return { contexts, members };
+  },
+};

--- a/app/api/src/contexts/plugins/entra-group-category-tree.test.js
+++ b/app/api/src/contexts/plugins/entra-group-category-tree.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as db from '../../db/connection.js';
+
+vi.mock('../../db/connection.js', () => ({ query: vi.fn() }));
+const { default: plugin } = await import('./entra-group-category-tree.js');
+
+const rows = [
+  { id: 'g1', val: 'Team' },
+  { id: 'g2', val: 'Team' },
+  { id: 'g3', val: 'DynamicSecurityGroup' },
+  { id: 'g4', val: 'DistributionList' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.query.mockResolvedValue({ rows });
+});
+
+const ctx = { log: () => {} };
+
+describe('entra-group-category-tree', () => {
+  it('builds an "EntraID Groups" root with one child context per category', async () => {
+    const { contexts } = await plugin.run({}, ctx);
+    const root = contexts.find((c) => c.externalId === 'entra-groups-root');
+    expect(root).toBeDefined();
+    expect(root.displayName).toBe('EntraID Groups');
+    expect(root.contextType).toBe('EntraGroupRoot');
+
+    const exts = contexts.map((c) => c.externalId);
+    expect(exts).toContain('category:Team');
+    expect(exts).toContain('category:DynamicSecurityGroup');
+    expect(exts).toContain('category:DistributionList');
+    // categories hang off the single root
+    for (const ext of ['category:Team', 'category:DynamicSecurityGroup', 'category:DistributionList']) {
+      expect(contexts.find((c) => c.externalId === ext).parentExternalId).toBe('entra-groups-root');
+      expect(contexts.find((c) => c.externalId === ext).contextType).toBe('EntraGroupCategory');
+    }
+  });
+
+  it('places each group under its category as a member', async () => {
+    const { members } = await plugin.run({}, ctx);
+    expect(
+      members.filter((m) => m.contextExternalId === 'category:Team').map((m) => m.memberId).sort(),
+    ).toEqual(['g1', 'g2']);
+    expect(members).toContainEqual({ contextExternalId: 'category:DistributionList', memberId: 'g4' });
+  });
+
+  it('honours a custom rootName', async () => {
+    const { contexts } = await plugin.run({ rootName: 'My Groups' }, ctx);
+    expect(contexts.find((c) => c.externalId === 'entra-groups-root').displayName).toBe('My Groups');
+  });
+
+  it('scopes the query to a system when scopeSystemId is given', async () => {
+    await plugin.run({ scopeSystemId: 7 }, ctx);
+    const [, qp] = db.query.mock.calls[0];
+    expect(qp).toEqual([7]);
+  });
+
+  it('rejects a non-integer scopeSystemId', async () => {
+    await expect(plugin.run({ scopeSystemId: 'nope' }, ctx)).rejects.toThrow(/integer/);
+  });
+
+  it('returns nothing when no groups carry a groupCategory', async () => {
+    db.query.mockResolvedValue({ rows: [] });
+    const { contexts, members } = await plugin.run({}, ctx);
+    expect(contexts).toEqual([]);
+    expect(members).toEqual([]);
+  });
+});

--- a/app/api/src/contexts/plugins/registry.js
+++ b/app/api/src/contexts/plugins/registry.js
@@ -14,6 +14,7 @@ import orphanedAccounts       from './orphaned-accounts.js';
 import scopeHierarchy        from './scope-hierarchy.js';
 import resourceTypeTree      from './resource-type-tree.js';
 import principalTypeTree     from './principal-type-tree.js';
+import entraGroupCategoryTree from './entra-group-category-tree.js';
 import riskyConsent          from './risky-consent.js';
 
 /** @type {import('./types.js').ContextPlugin[]} */
@@ -26,6 +27,7 @@ export const REGISTERED_PLUGINS = [
   scopeHierarchy,
   resourceTypeTree,
   principalTypeTree,
+  entraGroupCategoryTree,
   riskyConsent,
 ];
 

--- a/changes/entra-group-category-plugin.md
+++ b/changes/entra-group-category-plugin.md
@@ -1,0 +1,1 @@
+- Added an "Entra Group Category Tree" context algorithm that auto-generates a browsable tree — an "EntraID Groups" root with a child context per group category — so you can filter Entra groups by their kind in the web UI and the matrix.

--- a/changes/entra-group-category.md
+++ b/changes/entra-group-category.md
@@ -1,0 +1,3 @@
+- Added a `groupCategory` attribute to every Entra group (Team, Microsoft365, SecurityGroup, DistributionList, MailEnabledSecurity — with a `Dynamic` prefix where dynamic membership applies), so analysts can tell at a glance what kind of group they're dealing with and filter on it in the Excel export.
+- Added supporting group facets: `membershipType` (Assigned/Dynamic), `sourceOfAuthority` (Cloud/OnPremises, i.e. synced from on-prem AD or not), and `accessPackageEligible` (whether the group can be used in an access package).
+- Group dynamic-vs-assigned is now determined from the authoritative Entra flag, so a group that was converted from dynamic back to assigned is classified correctly even if a stale membership rule lingers.

--- a/test/unit/EntraIDCrawlerTransform.Tests.ps1
+++ b/test/unit/EntraIDCrawlerTransform.Tests.ps1
@@ -222,6 +222,80 @@ Describe 'ConvertTo-EntraSpActivityRecord' {
     }
 }
 
+Describe 'Get-EntraGroupClassification' {
+
+    It 'classifies an assigned cloud security group and marks it access-package eligible' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $false }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'SecurityGroup'
+        $c['membershipType']        | Should -Be 'Assigned'
+        $c['sourceOfAuthority']     | Should -Be 'Cloud'
+        $c['accessPackageEligible'] | Should -BeTrue
+    }
+
+    It 'folds dynamic into the label and blocks access-package eligibility' {
+        $g = [pscustomobject]@{ groupTypes = @('DynamicMembership'); securityEnabled = $true; mailEnabled = $false }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'DynamicSecurityGroup'
+        $c['membershipType']        | Should -Be 'Dynamic'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'classifies a Microsoft 365 group (no team) as Microsoft365, eligible' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified'); securityEnabled = $false; mailEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'Microsoft365'
+        $c['accessPackageEligible'] | Should -BeTrue
+    }
+
+    It 'classifies a dynamic Microsoft 365 group as DynamicMicrosoft365' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified','DynamicMembership'); securityEnabled = $false; mailEnabled = $true }
+        (Get-EntraGroupClassification -Group $g)['groupCategory'] | Should -Be 'DynamicMicrosoft365'
+    }
+
+    It 'classifies a teamified Microsoft 365 group as Team' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified'); securityEnabled = $false; mailEnabled = $true; resourceProvisioningOptions = @('Team') }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'Team'
+        $c['accessPackageEligible'] | Should -BeTrue
+    }
+
+    It 'classifies a dynamic team as DynamicTeam' {
+        $g = [pscustomobject]@{ groupTypes = @('Unified','DynamicMembership'); securityEnabled = $false; mailEnabled = $true; resourceProvisioningOptions = @('Team') }
+        (Get-EntraGroupClassification -Group $g)['groupCategory'] | Should -Be 'DynamicTeam'
+    }
+
+    It 'classifies a distribution list and never marks it dynamic or eligible' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $false; mailEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'DistributionList'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'classifies a mail-enabled security group' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']         | Should -Be 'MailEnabledSecurity'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'reports on-prem-synced source of authority and blocks eligibility' {
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $false; onPremisesSyncEnabled = $true }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['sourceOfAuthority']     | Should -Be 'OnPremises'
+        $c['accessPackageEligible'] | Should -BeFalse
+    }
+
+    It 'treats a group as assigned when only a stale membershipRule lingers (groupTypes has no DynamicMembership)' {
+        # membershipRule is left behind after a dynamic→assigned conversion;
+        # groupTypes is authoritative, so this must NOT classify as dynamic.
+        $g = [pscustomobject]@{ groupTypes = @(); securityEnabled = $true; mailEnabled = $false; membershipRule = 'user.department -eq "IT"' }
+        $c = Get-EntraGroupClassification -Group $g
+        $c['groupCategory']  | Should -Be 'SecurityGroup'
+        $c['membershipType'] | Should -Be 'Assigned'
+    }
+}
+
 Describe 'ConvertTo-EntraGroupResourceRecord' {
 
     It 'maps a group to an EntraGroup resource with joined groupTypes' {
@@ -238,6 +312,33 @@ Describe 'ConvertTo-EntraGroupResourceRecord' {
         $rec['extendedAttributes']['groupTypes']      | Should -Be 'Unified'
         $rec['extendedAttributes']['securityEnabled'] | Should -BeFalse
         $rec['extendedAttributes']['mailEnabled']     | Should -BeTrue
+    }
+
+    It 'stamps the derived groupCategory + facets into extendedAttributes' {
+        $group = [pscustomobject]@{
+            id = 'g1t'; displayName = 'Project Team'
+            groupTypes = @('Unified'); securityEnabled = $false; mailEnabled = $true
+            resourceProvisioningOptions = @('Team')
+        }
+        $ext = (ConvertTo-EntraGroupResourceRecord -Group $group)['extendedAttributes']
+        $ext['groupCategory']               | Should -Be 'Team'
+        $ext['membershipType']              | Should -Be 'Assigned'
+        $ext['sourceOfAuthority']           | Should -Be 'Cloud'
+        $ext['accessPackageEligible']       | Should -BeTrue
+        $ext['resourceProvisioningOptions'] | Should -Be 'Team'
+    }
+
+    It 'carries a lingering membershipRule into ext for display without classifying dynamic' {
+        $group = [pscustomobject]@{
+            id = 'g1r'; displayName = 'Ex-Dynamic'
+            groupTypes = @(); securityEnabled = $true; mailEnabled = $false
+            membershipRule = 'user.department -eq "IT"'; membershipRuleProcessingState = 'Paused'
+        }
+        $ext = (ConvertTo-EntraGroupResourceRecord -Group $group)['extendedAttributes']
+        $ext['membershipRule']                | Should -Be 'user.department -eq "IT"'
+        $ext['membershipRuleProcessingState'] | Should -Be 'Paused'
+        $ext['groupCategory']                 | Should -Be 'SecurityGroup'
+        $ext['membershipType']                | Should -Be 'Assigned'
     }
 
     It 'joins multiple groupTypes into a comma string' {

--- a/tools/crawlers/entra-id/EntraIDCrawler.Phases.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Phases.ps1
@@ -542,7 +542,7 @@ function Sync-EntraResources {
     Update-CrawlerProgress -Step 'Syncing groups' -Pct 20 -Detail 'Fetching groups from Microsoft Graph...'
     $groups = @()
     try {
-        $coreGroupAttrs = @('id','displayName','description','mail','visibility','createdDateTime','groupTypes','securityEnabled','mailEnabled')
+        $coreGroupAttrs = @('id','displayName','description','mail','visibility','createdDateTime','groupTypes','securityEnabled','mailEnabled','membershipRule','membershipRuleProcessingState','onPremisesSyncEnabled','resourceProvisioningOptions')
         $allGroupAttrs = $coreGroupAttrs + $CustomGroupAttributes | Select-Object -Unique
         $groupSelect = $allGroupAttrs -join ','
         $groups = Invoke-FGGetRequest -URI "https://graph.microsoft.com/beta/groups?`$select=$groupSelect&`$top=999"

--- a/tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1
@@ -166,6 +166,68 @@ function ConvertTo-EntraSpActivityRecord {
     return $null
 }
 
+# Classifies a Graph group into a single, analyst-readable `groupCategory` plus a
+# few orthogonal facet fields, derived purely from the raw Graph flags. Returns a
+# hashtable that ConvertTo-EntraGroupResourceRecord folds into extendedAttributes.
+#
+# Two design rules baked in here:
+#   * Dynamic-ness is read ONLY from `groupTypes` containing 'DynamicMembership' —
+#     never from `membershipRule` being non-empty, because that rule text can
+#     linger after a group is converted back to assigned. `groupTypes` is the
+#     operative switch Azure AD itself evaluates, so it can't disagree with the
+#     group's real behaviour.
+#   * The dynamic aspect is folded into the single `groupCategory` label (e.g.
+#     'DynamicSecurityGroup'), but only onto the three categories that actually
+#     support Azure AD dynamic membership — a distribution list can never become
+#     'DynamicDistributionList' even on malformed input.
+function Get-EntraGroupClassification {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Group)
+
+    $types           = @($Group.groupTypes)
+    $isUnified       = $types -contains 'Unified'
+    $isDynamic       = $types -contains 'DynamicMembership'
+    $securityEnabled = [bool]$Group.securityEnabled
+    $mailEnabled     = [bool]$Group.mailEnabled
+    $isTeam          = @($Group.resourceProvisioningOptions) -contains 'Team'
+
+    # Base category — the mutually-exclusive "what kind of group is this".
+    if ($isUnified) {
+        $base = if ($isTeam) { 'Team' } else { 'Microsoft365' }
+    }
+    elseif ($mailEnabled -and $securityEnabled) {
+        $base = 'MailEnabledSecurity'
+    }
+    elseif ($mailEnabled -and -not $securityEnabled) {
+        $base = 'DistributionList'
+    }
+    else {
+        $base = 'SecurityGroup'
+    }
+
+    # Fold the dynamic aspect into the single readable label, guarded to the
+    # categories that support Azure AD dynamic membership.
+    $dynamicCapable = @('Team', 'Microsoft365', 'SecurityGroup')
+    $groupCategory  = if ($isDynamic -and $base -in $dynamicCapable) { "Dynamic$base" } else { $base }
+
+    # Cloud-mastered vs synced from on-prem AD (membership read-only in the cloud).
+    $sourceOfAuthority = if ([bool]$Group.onPremisesSyncEnabled) { 'OnPremises' } else { 'Cloud' }
+
+    # Entitlement-management can only assign membership through an assigned,
+    # cloud-mastered Security or Microsoft 365 group (Teams included). Dynamic,
+    # on-prem-synced, distribution and mail-enabled-security groups are ineligible.
+    $accessPackageEligible = (-not $isDynamic) -and
+                             ($sourceOfAuthority -eq 'Cloud') -and
+                             ($base -in @('SecurityGroup', 'Microsoft365', 'Team'))
+
+    return @{
+        groupCategory         = $groupCategory
+        membershipType        = if ($isDynamic) { 'Dynamic' } else { 'Assigned' }
+        sourceOfAuthority     = $sourceOfAuthority
+        accessPackageEligible = $accessPackageEligible
+    }
+}
+
 # Maps one Graph group → an ingest/resources record (resourceType='EntraGroup').
 # Verbatim from the inline `$groups | ForEach-Object { ... }` block.
 function ConvertTo-EntraGroupResourceRecord {
@@ -179,6 +241,19 @@ function ConvertTo-EntraGroupResourceRecord {
         securityEnabled = $Group.securityEnabled
         mailEnabled     = $Group.mailEnabled
     }
+    # Raw discriminators — kept for display + power-filtering in Excel (ext_*).
+    if ($null -ne $Group.onPremisesSyncEnabled) { $ext['onPremisesSyncEnabled'] = [bool]$Group.onPremisesSyncEnabled }
+    if ($Group.membershipRule)                  { $ext['membershipRule'] = $Group.membershipRule }
+    if ($Group.membershipRuleProcessingState)   { $ext['membershipRuleProcessingState'] = $Group.membershipRuleProcessingState }
+    if (@($Group.resourceProvisioningOptions).Count -gt 0) {
+        $ext['resourceProvisioningOptions'] = (@($Group.resourceProvisioningOptions) -join ',')
+    }
+    # Derived classification: one readable groupCategory + facets, computed once at
+    # the source so the Excel export and the web-portal context plugin read the
+    # same stamped value instead of each re-deriving it from the raw flags.
+    $classification = Get-EntraGroupClassification -Group $Group
+    foreach ($k in $classification.Keys) { $ext[$k] = $classification[$k] }
+
     foreach ($attr in $CustomGroupAttributes) {
         if ($null -ne $Group.$attr) { $ext[$attr] = $Group.$attr }
     }


### PR DESCRIPTION
## What

Adds an **"Entra Group Category Tree"** context-algorithm plugin (`targetType='Resource'`). It builds a two-level tree — an **"EntraID Groups"** root with one child context per `groupCategory` — each holding the matching `EntraGroup` resources as members. Those context nodes become browsable/filterable in the Resources page and usable as column conditions in the Matrix.

## Why

Gives analysts a one-click, browsable way to work with groups by kind ("all the Teams", "all the dynamic security groups") in the web portal — the native counterpart to the Excel `ext_groupCategory` filter.

## Depends on

Stacked on #569 (the crawler change that stamps `groupCategory`). This plugin only **reads** `groupCategory` — it never re-derives the classification. Retarget to `main` once #569 merges.

## Notes

- Optional `scopeSystemId` (blank = all Entra systems) and `rootName` override.
- Additive — no schema change; registered in `registry.js`, seeded into `ContextAlgorithms` at startup.
- If no groups carry `groupCategory` yet (crawl not run), it logs and produces nothing.

## Changelog

- Added an "Entra Group Category Tree" context algorithm that auto-generates a browsable tree — an "EntraID Groups" root with a child context per group category — so you can filter Entra groups by their kind in the web UI and the matrix.

## Test plan

- 6 new vitest cases in `entra-group-category-tree.test.js` (root+children shape, membership grouping, custom rootName, systemId scoping, bad-scope rejection, empty result) — full contexts suite 130/130 green.
- Deployed to a Fortigi dev stack; confirmed the plugin seeds into `ContextAlgorithms` and is runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)