### PR TITLE
fix(admin): repair curated tag import (write Contexts, not read-only views)

### DIFF
--- a/app/api/contract-tests/importCurated.integration.test.js
+++ b/app/api/contract-tests/importCurated.integration.test.js
@@ -1,0 +1,200 @@
+// HTTP integration test — POST /api/admin/import/curated against the real PG16
+// container, exercising the actual route handler end-to-end.
+//
+// Regression coverage for two bugs a DB-mocked unit test cannot catch:
+//   1. The tag + assignment writes targeted "GraphTags" / "GraphTagAssignments",
+//      which the Contexts-v6 migration turned into multi-table JOIN VIEWs.
+//      Postgres refuses INSERT into such a view (no INSTEAD OF trigger), so any
+//      curated import carrying tags threw and returned 500 "Import failed".
+//      The fix writes Contexts (contextType='Tag') + ContextMembers directly,
+//      mirroring routes/tags.js.
+//   2. resolveEntity filtered `AND ValidTo = '9999-...'`, a SQL-Server-era
+//      system-versioned column that no longer exists — the predicate threw,
+//      the catch swallowed it, and EVERY assignment resolved to "not found".
+//
+// With either bug present this test fails (500, or assignmentsInserted === 0);
+// with both fixed it is 200 and rows land in Contexts / ContextMembers, and the
+// read-compat GraphTags views reflect them.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+vi.mock('../src/config/authConfig.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isAuthEnabled: () => true,
+  getTenantId: () => 'test-tenant',
+  getClientId: () => 'test-client',
+  getJwksClient: () => ({}),
+  getRequiredRoles: () => null,
+  getRolePermissions: () => ({ 'role-admin': ['*'] }),
+}));
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: (token, _key, _opts, cb) => {
+      const roles = token.startsWith('roles:') ? token.slice(6).split(',').filter(Boolean) : [];
+      cb(null, { roles, tid: 'test-tenant' });
+    },
+  },
+}));
+
+let agent;
+let pool;
+let systemId;
+const adminToken = 'Bearer roles:role-admin';
+
+// Seeded entities (lowercase uuids — how ContextMembers stores them).
+const USER_GUID   = '11111111-1111-1111-1111-111111111111'; // resolved by GUID
+const USER2_GUID  = '22222222-2222-2222-2222-222222222222'; // resolved by displayName (soft-match)
+const GROUP_GUID  = '33333333-3333-3333-3333-333333333333'; // resource/group tag target
+const USER2_NAME  = 'Curated Import Soft Match User';
+const GROUP_NAME  = 'Curated Import Group';
+const USER_TAG    = 'CuratedImportUserTag';
+const GROUP_TAG   = 'CuratedImportGroupTag';
+
+async function tagContext(displayName, targetType) {
+  return pool.query(
+    `SELECT * FROM "Contexts"
+       WHERE "contextType" = 'Tag' AND "variant" = 'manual'
+         AND "targetType" = $1 AND "displayName" = $2`,
+    [targetType, displayName],
+  );
+}
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType","displayName") VALUES ('test','import-curated') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+  await pool.query(
+    `INSERT INTO "Principals" ("id","systemId","displayName","principalType")
+     VALUES ($1,$2,'Curated Import GUID User','User'), ($3,$2,$4,'User')`,
+    [USER_GUID, systemId, USER2_GUID, USER2_NAME],
+  );
+  await pool.query(
+    `INSERT INTO "Resources" ("id","systemId","resourceType","displayName")
+     VALUES ($1,$2,'EntraGroup',$3)`,
+    [GROUP_GUID, systemId, GROUP_NAME],
+  );
+});
+
+afterAll(async () => {
+  // Scope deletes to our own rows (singleFork shared DB). Deleting the tag
+  // Contexts cascades to their ContextMembers (FK ON DELETE CASCADE).
+  await pool?.query(
+    `DELETE FROM "Contexts" WHERE "contextType" = 'Tag' AND "displayName" = ANY($1)`,
+    [[USER_TAG, GROUP_TAG]],
+  );
+  await pool?.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool?.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+describe('POST /api/admin/import/curated (tags → Contexts/ContextMembers)', () => {
+  it('401 without auth', async () => {
+    const res = await agent.post('/api/admin/import/curated').send({ tags: [], categories: [] });
+    expect(res.status).toBe(401);
+  });
+
+  it('200: creates a Tag context and resolves assignments by GUID and by displayName', async () => {
+    const res = await agent
+      .post('/api/admin/import/curated')
+      .set('Authorization', adminToken)
+      .send({
+        tags: [{
+          name: USER_TAG,
+          entityType: 'user',
+          color: '#abcdef',
+          assignments: [
+            { entityId: USER_GUID },                                  // GUID match
+            { entityId: '00000000-0000-0000-0000-000000000000', displayName: USER2_NAME }, // soft-match
+          ],
+        }],
+        categories: [],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.stats.tagsInserted).toBe(1);
+    expect(res.body.stats.assignmentsInserted).toBe(2);
+    expect(res.body.stats.assignmentsSoftMatched).toBe(1);
+    expect(res.body.stats.assignmentsNotFound).toBe(0);
+
+    // Tag persisted as a manual Contexts row with the colour in extendedAttributes.
+    const ctx = await tagContext(USER_TAG, 'Principal');
+    expect(ctx.rows).toHaveLength(1);
+    expect(ctx.rows[0].extendedAttributes.tagColor).toBe('#abcdef');
+    const tagId = ctx.rows[0].id;
+
+    // Both assignments landed in ContextMembers, keyed by the resolved uuids.
+    const members = await pool.query(
+      `SELECT "memberId","memberType" FROM "ContextMembers" WHERE "contextId" = $1 ORDER BY "memberId"`,
+      [tagId],
+    );
+    expect(members.rows.map((r) => r.memberId)).toEqual([USER_GUID, USER2_GUID]);
+    expect(members.rows.every((r) => r.memberType === 'Principal')).toBe(true);
+
+    // Read-compat: the GraphTags / GraphTagAssignments VIEWS reflect the writes.
+    const viewTag = await pool.query(`SELECT id,name,"entityType" FROM "GraphTags" WHERE name = $1`, [USER_TAG]);
+    expect(viewTag.rows).toHaveLength(1);
+    expect(viewTag.rows[0].entityType).toBe('user');
+    const viewAssign = await pool.query(`SELECT COUNT(*)::int AS n FROM "GraphTagAssignments" WHERE "tagId" = $1`, [tagId]);
+    expect(viewAssign.rows[0].n).toBe(2);
+  });
+
+  it('re-import upserts colour and is idempotent (no duplicate members)', async () => {
+    const res = await agent
+      .post('/api/admin/import/curated')
+      .set('Authorization', adminToken)
+      .send({
+        tags: [{
+          name: USER_TAG,
+          entityType: 'user',
+          color: '#123456',
+          assignments: [{ entityId: USER_GUID }],
+        }],
+        categories: [],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.stats.tagsInserted).toBe(0);
+    expect(res.body.stats.tagsSkipped).toBe(1);           // existing tag → update path
+    expect(res.body.stats.assignmentsInserted).toBe(0);   // already a member
+    expect(res.body.stats.assignmentsSkipped).toBe(1);
+
+    const ctx = await tagContext(USER_TAG, 'Principal');
+    expect(ctx.rows[0].extendedAttributes.tagColor).toBe('#123456'); // colour updated
+    const members = await pool.query(`SELECT COUNT(*)::int AS n FROM "ContextMembers" WHERE "contextId" = $1`, [ctx.rows[0].id]);
+    expect(members.rows[0].n).toBe(2); // still 2 — no duplication
+  });
+
+  it('resolves a group/resource tag assignment against Resources', async () => {
+    const res = await agent
+      .post('/api/admin/import/curated')
+      .set('Authorization', adminToken)
+      .send({
+        tags: [{
+          name: GROUP_TAG,
+          entityType: 'group',
+          assignments: [{ entityId: GROUP_GUID, displayName: GROUP_NAME, resourceType: 'EntraGroup' }],
+        }],
+        categories: [],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.stats.tagsInserted).toBe(1);
+    expect(res.body.stats.assignmentsInserted).toBe(1);
+
+    const ctx = await tagContext(GROUP_TAG, 'Resource');
+    expect(ctx.rows).toHaveLength(1);
+    const members = await pool.query(
+      `SELECT "memberId","memberType" FROM "ContextMembers" WHERE "contextId" = $1`,
+      [ctx.rows[0].id],
+    );
+    expect(members.rows).toHaveLength(1);
+    expect(members.rows[0].memberId).toBe(GROUP_GUID);
+    expect(members.rows[0].memberType).toBe('Resource');
+  });
+});

--- a/app/api/src/routes/admin.coverage.test.js
+++ b/app/api/src/routes/admin.coverage.test.js
@@ -40,9 +40,17 @@ vi.mock('../config/authConfig.js', () => ({
 const purgeExpiredTombstones = vi.fn(async () => ({ purged: { Principals: 3 } }));
 vi.mock('../ingest/tombstonePurge.js', () => ({ purgeExpiredTombstones: (...a) => purgeExpiredTombstones(...a) }));
 
-// tags.js / categories.js are dynamically imported by the curated-import handler.
-vi.mock('./tags.js', () => ({ ensureTagTables: vi.fn(async () => {}) }));
+// tags.js / categories.js / bootstrap / memberCounts are dynamically imported by
+// the curated-import handler. Tags are written to Contexts + ContextMembers
+// (GraphTags/GraphTagAssignments are read-only views), reusing tags.js helpers.
+vi.mock('./tags.js', () => ({
+  ensureTagTables: vi.fn(async () => {}),
+  ENTITY_TO_TARGET: { user: 'Principal', group: 'Resource', resource: 'Resource', identity: 'Identity' },
+  UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+}));
 vi.mock('./categories.js', () => ({ ensureCategoryTables: vi.fn(async () => {}) }));
+vi.mock('../bootstrap.js', () => ({ getOrCreateTagRoot: vi.fn(async () => 'tag-root') }));
+vi.mock('../contexts/memberCounts.js', () => ({ recalcMemberCountsForChain: vi.fn(async () => {}) }));
 
 const { default: router } = await import('./admin.js');
 const app = mountRouter(router);
@@ -277,17 +285,19 @@ describe('POST /admin/import/curated', () => {
   it('imports tags + categories and returns stats', async () => {
     // tableExists() calls (Principals, Resources) -> default poolQuery returns
     // empty recordset, so resolveEntity treats entities as non-existent.
-    // db.query is used for: to_regclass checks, tag upsert, category upsert,
-    // assignment lookups/inserts. Drive them through a default + specific mocks.
+    // db.query is used for: to_regclass checks, tag upsert (Contexts), category
+    // upsert, assignment lookups/inserts (ContextMembers). queryOne is used for
+    // the existing-tag lookup. Drive them through a default + specific mocks.
     query.mockImplementation(async (sql) => {
-      if (/to_regclass/i.test(sql)) return { rows: [{ oid: 1 }] };          // tables exist
-      if (/INSERT INTO "GraphTags"/i.test(sql)) return { rows: [{ id: 'tag1', wasInsert: true }] };
+      if (/to_regclass/i.test(sql)) return { rows: [{ oid: 1 }] };            // tables exist
+      if (/INSERT INTO "Contexts"/i.test(sql)) return { rows: [{ id: 'tag1' }] };
       if (/INSERT INTO "GovernanceCategories"/i.test(sql)) return { rows: [{ id: 'cat1' }] };
-      if (/INSERT INTO "GraphTagAssignments"/i.test(sql)) return { rows: [{ inserted: 1 }] };
-      if (/FROM "Resources"/i.test(sql)) return { rows: [{ id: 'apid' }] };  // GUID match
+      if (/INSERT INTO "ContextMembers"/i.test(sql)) return { rows: [{ inserted: 1 }] };
+      if (/FROM "Resources"/i.test(sql)) return { rows: [{ id: 'apid' }] };    // GUID match
       if (/INSERT INTO "GovernanceCategoryAssignments"/i.test(sql)) return { rows: [{ inserted: 1 }] };
       return { rows: [] };
     });
+    queryOne.mockResolvedValue(undefined); // no existing tag → insert path
     // resolveEntity uses pool.request().query -> return a hit so the tag
     // assignment resolves via GUID match.
     poolQuery = vi.fn(async () => ({ recordset: [{ n: 1 }] }));
@@ -295,7 +305,7 @@ describe('POST /admin/import/curated', () => {
     const body = {
       tags: [{
         name: 'Sensitive', entityType: 'user', color: '#abcdef',
-        assignments: [{ entityId: 'guid-1', displayName: 'Alice' }],
+        assignments: [{ entityId: '11111111-1111-1111-1111-111111111111', displayName: 'Alice' }],
       }],
       categories: [{
         name: 'Finance', color: 'bad-color',
@@ -306,6 +316,7 @@ describe('POST /admin/import/curated', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.stats.tagsInserted).toBe(1);
+    expect(res.body.stats.assignmentsInserted).toBe(1);
     expect(res.body.stats.catsInserted).toBe(1);
   });
 

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -256,8 +256,11 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
     const pool = await db.getPool();
 
     // Ensure tag + category tables exist
-    const { ensureTagTables }      = await import('./tags.js');
+    const { ensureTagTables, ENTITY_TO_TARGET, UUID_RE } = await import('./tags.js');
     const { ensureCategoryTables } = await import('./categories.js');
+    const { getOrCreateTagRoot }         = await import('../bootstrap.js');
+    const { recalcMemberCountsForChain } = await import('../contexts/memberCounts.js');
+    const { randomUUID }                 = await import('crypto');
     await ensureTagTables(pool);
     await ensureCategoryTables(pool);
 
@@ -266,25 +269,21 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
     const hasResources  = await tableExists(pool, 'Resources');
 
     // ── Helper: resolve entity GUID ──────────────────────────────
+    // NB: no temporal (ValidTo) filter — the SQL-Server-era system-versioned
+    // columns were dropped in the postgres migration, so a `ValidTo` predicate
+    // here throws "column does not exist", which the catch swallowed, making
+    // every lookup silently miss (all assignments landed as "not found").
     async function resolveEntity(entityId, entityType, displayName, resourceType) {
       // 1. GUID match — check if the entity still exists with this ID
       let exists = false;
       try {
-        if (entityType === 'user') {
-          const tbl = hasPrincipals ? 'Principals' : 'GraphUsers';
-          const vtFilter = hasPrincipals ? `AND ValidTo = '9999-12-31 23:59:59.9999999'` : '';
-          const r = await pool.request()
-            .input('id', entityId)
-            .query(`SELECT COUNT(*) AS n FROM ${tbl} WHERE UPPER((id)::text) = UPPER(@id) ${vtFilter}`);
-          exists = r.recordset[0].n > 0;
-        } else {
-          const tbl = hasResources ? 'Resources' : 'GraphGroups';
-          const vtFilter = hasResources ? `AND ValidTo = '9999-12-31 23:59:59.9999999'` : '';
-          const r = await pool.request()
-            .input('id', entityId)
-            .query(`SELECT COUNT(*) AS n FROM ${tbl} WHERE UPPER((id)::text) = UPPER(@id) ${vtFilter}`);
-          exists = r.recordset[0].n > 0;
-        }
+        const tbl = entityType === 'user'
+          ? (hasPrincipals ? 'Principals' : 'GraphUsers')
+          : (hasResources ? 'Resources' : 'GraphGroups');
+        const r = await pool.request()
+          .input('id', entityId)
+          .query(`SELECT COUNT(*) AS n FROM "${tbl}" WHERE UPPER((id)::text) = UPPER(@id)`);
+        exists = r.recordset[0].n > 0;
       } catch { /* table might not exist */ }
 
       if (exists) return { id: entityId.toUpperCase(), softMatched: false };
@@ -294,25 +293,23 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
       try {
         if (entityType === 'user') {
           const tbl = hasPrincipals ? 'Principals' : 'GraphUsers';
-          const vtFilter = hasPrincipals ? `AND ValidTo = '9999-12-31 23:59:59.9999999'` : '';
           const r = await pool.request()
             .input('displayName', displayName)
-            .query(`SELECT UPPER((id)::text) AS id FROM ${tbl}
-                    WHERE "displayName" = @displayName ${vtFilter}`);
+            .query(`SELECT UPPER((id)::text) AS id FROM "${tbl}"
+                    WHERE "displayName" = @displayName`);
           if (r.recordset.length > 0) return { id: r.recordset[0].id, softMatched: true };
         } else {
           // group / resource — match on displayName + resourceType if available
           const tbl = hasResources ? 'Resources' : 'GraphGroups';
-          const vtFilter = hasResources ? `AND ValidTo = '9999-12-31 23:59:59.9999999'` : '';
           let req2 = pool.request().input('displayName', displayName);
           let rtClause = '';
           if (resourceType && hasResources) {
             req2 = req2.input('resourceType', resourceType);
-            rtClause = 'AND resourceType = @resourceType';
+            rtClause = 'AND "resourceType" = @resourceType';
           }
           const r = await req2.query(
-            `SELECT UPPER((id)::text) AS id FROM ${tbl}
-             WHERE "displayName" = @displayName ${rtClause} ${vtFilter}`
+            `SELECT UPPER((id)::text) AS id FROM "${tbl}"
+             WHERE "displayName" = @displayName ${rtClause}`
           );
           if (r.recordset.length > 0) return { id: r.recordset[0].id, softMatched: true };
         }
@@ -322,42 +319,78 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
     }
 
     // ── Tags ─────────────────────────────────────────────────────
+    // Tags are Contexts rows (contextType='Tag') and assignments are
+    // ContextMembers — GraphTags / GraphTagAssignments are read-only VIEWs
+    // over those tables and cannot be INSERTed into, so we write the base
+    // tables directly, exactly as routes/tags.js does.
     for (const tag of tags) {
       if (!tag.name || !tag.entityType) continue;
+      const targetType = ENTITY_TO_TARGET[tag.entityType];
+      if (!targetType) { stats.tagsSkipped++; continue; }
+      const name = String(tag.name).trim().slice(0, 100);
+      if (!name) { stats.tagsSkipped++; continue; }
       const color = HEX_COLOR_RE.test(tag.color || '') ? tag.color : '#3b82f6';
 
-      // Upsert tag (name + entityType unique). xmax = 0 → fresh INSERT, otherwise UPDATE.
-      const upsert = await db.query(
-        `INSERT INTO "GraphTags" (name, color, "entityType")
-         VALUES ($1, $2, $3)
-         ON CONFLICT (name, "entityType") DO UPDATE SET color = EXCLUDED.color
-         RETURNING id, (xmax = 0) AS "wasInsert"`,
-        [String(tag.name).slice(0, 100), color, tag.entityType]
+      // Upsert the tag (name unique per targetType — the old
+      // UQ_GraphTags_Name_Type constraint): update colour if it exists,
+      // otherwise create it under the shared Tag root.
+      let tagId;
+      const existingTag = await db.queryOne(
+        `SELECT id FROM "Contexts"
+           WHERE "contextType" = 'Tag' AND "variant" = 'manual'
+             AND "targetType" = $1 AND "displayName" = $2`,
+        [targetType, name]
       );
-      const tagId = upsert.rows[0]?.id;
-      if (!tagId) continue;
-      if (upsert.rows[0].wasInsert) stats.tagsInserted++;
-      else stats.tagsSkipped++;
+      if (existingTag) {
+        tagId = existingTag.id;
+        await db.query(
+          `UPDATE "Contexts"
+              SET "extendedAttributes" = COALESCE("extendedAttributes", '{}'::jsonb) || $2::jsonb
+            WHERE id = $1`,
+          [tagId, JSON.stringify({ tagColor: color })]
+        );
+        stats.tagsSkipped++;
+      } else {
+        const parentId  = await getOrCreateTagRoot(targetType);
+        const createdBy = (req.user && (req.user.email || req.user.upn || req.user.name)) || 'import';
+        const ins = await db.query(
+          `INSERT INTO "Contexts"
+             (id, variant, "targetType", "contextType", "displayName", "parentContextId", "createdByUser", "extendedAttributes")
+           VALUES ($1, 'manual', $2, 'Tag', $3, $4, $5, $6::jsonb)
+           RETURNING id`,
+          [randomUUID(), targetType, name, parentId, createdBy, JSON.stringify({ tagColor: color })]
+        );
+        tagId = ins.rows[0]?.id;
+        if (!tagId) continue;
+        stats.tagsInserted++;
+      }
 
+      let assignedAny = false;
       for (const a of (tag.assignments || [])) {
         if (!a.entityId) continue;
         const resolved = await resolveEntity(a.entityId, tag.entityType, a.displayName, a.resourceType);
         if (!resolved) { stats.assignmentsNotFound++; continue; }
+        // ContextMembers.memberId is a uuid column; a non-uuid id can't be a
+        // member, so skip it rather than let the ::uuid cast abort the import.
+        const memberId = String(resolved.id).toLowerCase();
+        if (!UUID_RE.test(memberId)) { stats.assignmentsNotFound++; continue; }
 
         const ins = await db.query(
-          `INSERT INTO "GraphTagAssignments" ("tagId", "entityId")
-           VALUES ($1, $2)
-           ON CONFLICT ("tagId", "entityId") DO NOTHING
+          `INSERT INTO "ContextMembers" ("contextId", "memberType", "memberId", "addedBy")
+           VALUES ($1, $2, $3::uuid, 'analyst')
+           ON CONFLICT ("contextId", "memberId") DO NOTHING
            RETURNING 1 AS inserted`,
-          [tagId, resolved.id]
+          [tagId, targetType, memberId]
         );
         if (ins.rows.length > 0) {
+          assignedAny = true;
           stats.assignmentsInserted++;
           if (resolved.softMatched) stats.assignmentsSoftMatched++;
         } else {
           stats.assignmentsSkipped++;
         }
       }
+      if (assignedAny) await recalcMemberCountsForChain(tagId);
     }
 
     // ── Categories ───────────────────────────────────────────────

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -38,6 +38,85 @@ async function tableExists(_pool, tableName) {
   return r.rows[0].oid !== null;
 }
 
+// Colour validation shared by the curated import + category handlers.
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+// Import one curated tag and its assignments into Contexts / ContextMembers.
+// Extracted from POST /admin/import/curated to keep that handler within its
+// complexity budget and to make the tag path independently testable. `deps`
+// carries the handler-local bindings (dynamic imports + the pool-bound
+// resolveEntity closure); persistence uses the module-level db pool.
+// GraphTags / GraphTagAssignments are read-only views, so writes target the
+// base Contexts / ContextMembers tables directly, exactly as routes/tags.js does.
+async function importCuratedTag(tag, deps, stats) {
+  const { ENTITY_TO_TARGET, UUID_RE, resolveEntity, getOrCreateTagRoot, recalcMemberCountsForChain, randomUUID, createdBy } = deps;
+  if (!tag.name || !tag.entityType) return;
+  const targetType = ENTITY_TO_TARGET[tag.entityType];
+  if (!targetType) { stats.tagsSkipped++; return; }
+  const name = String(tag.name).trim().slice(0, 100);
+  if (!name) { stats.tagsSkipped++; return; }
+  const color = HEX_COLOR_RE.test(tag.color || '') ? tag.color : '#3b82f6';
+
+  // Upsert the tag (name unique per targetType — the old UQ_GraphTags_Name_Type
+  // constraint): update colour if it exists, else create it under the Tag root.
+  let tagId;
+  const existingTag = await db.queryOne(
+    `SELECT id FROM "Contexts"
+       WHERE "contextType" = 'Tag' AND "variant" = 'manual'
+         AND "targetType" = $1 AND "displayName" = $2`,
+    [targetType, name]
+  );
+  if (existingTag) {
+    tagId = existingTag.id;
+    await db.query(
+      `UPDATE "Contexts"
+          SET "extendedAttributes" = COALESCE("extendedAttributes", '{}'::jsonb) || $2::jsonb
+        WHERE id = $1`,
+      [tagId, JSON.stringify({ tagColor: color })]
+    );
+    stats.tagsSkipped++;
+  } else {
+    const parentId = await getOrCreateTagRoot(targetType);
+    const ins = await db.query(
+      `INSERT INTO "Contexts"
+         (id, variant, "targetType", "contextType", "displayName", "parentContextId", "createdByUser", "extendedAttributes")
+       VALUES ($1, 'manual', $2, 'Tag', $3, $4, $5, $6::jsonb)
+       RETURNING id`,
+      [randomUUID(), targetType, name, parentId, createdBy, JSON.stringify({ tagColor: color })]
+    );
+    tagId = ins.rows[0]?.id;
+    if (!tagId) return;
+    stats.tagsInserted++;
+  }
+
+  // Resolve + attach each assignment as a ContextMember.
+  let assignedAny = false;
+  for (const a of (tag.assignments || [])) {
+    if (!a.entityId) continue;
+    const resolved = await resolveEntity(a.entityId, tag.entityType, a.displayName, a.resourceType);
+    if (!resolved) { stats.assignmentsNotFound++; continue; }
+    // ContextMembers.memberId is a uuid column; a non-uuid id can't be a member,
+    // so skip it rather than let the ::uuid cast abort the import.
+    const memberId = String(resolved.id).toLowerCase();
+    if (!UUID_RE.test(memberId)) { stats.assignmentsNotFound++; continue; }
+    const ins = await db.query(
+      `INSERT INTO "ContextMembers" ("contextId", "memberType", "memberId", "addedBy")
+       VALUES ($1, $2, $3::uuid, 'analyst')
+       ON CONFLICT ("contextId", "memberId") DO NOTHING
+       RETURNING 1 AS inserted`,
+      [tagId, targetType, memberId]
+    );
+    if (ins.rows.length > 0) {
+      assignedAny = true;
+      stats.assignmentsInserted++;
+      if (resolved.softMatched) stats.assignmentsSoftMatched++;
+    } else {
+      stats.assignmentsSkipped++;
+    }
+  }
+  if (assignedAny) await recalcMemberCountsForChain(tagId);
+}
+
 // ── GET /api/admin/risk-profile ───────────────────────────────────
 // Returns the active v5 risk profile (or the most recent one if none is active).
 // v5 moved off the legacy GraphRiskProfiles table — profiles now live in
@@ -242,7 +321,6 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
     return res.status(400).json({ error: 'tags and categories must be arrays' });
   }
 
-  const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
   const stats = {
     tagsInserted: 0, tagsSkipped: 0,
     assignmentsInserted: 0, assignmentsSkipped: 0,
@@ -319,79 +397,14 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
     }
 
     // ── Tags ─────────────────────────────────────────────────────
-    // Tags are Contexts rows (contextType='Tag') and assignments are
-    // ContextMembers — GraphTags / GraphTagAssignments are read-only VIEWs
-    // over those tables and cannot be INSERTed into, so we write the base
-    // tables directly, exactly as routes/tags.js does.
-    for (const tag of tags) {
-      if (!tag.name || !tag.entityType) continue;
-      const targetType = ENTITY_TO_TARGET[tag.entityType];
-      if (!targetType) { stats.tagsSkipped++; continue; }
-      const name = String(tag.name).trim().slice(0, 100);
-      if (!name) { stats.tagsSkipped++; continue; }
-      const color = HEX_COLOR_RE.test(tag.color || '') ? tag.color : '#3b82f6';
-
-      // Upsert the tag (name unique per targetType — the old
-      // UQ_GraphTags_Name_Type constraint): update colour if it exists,
-      // otherwise create it under the shared Tag root.
-      let tagId;
-      const existingTag = await db.queryOne(
-        `SELECT id FROM "Contexts"
-           WHERE "contextType" = 'Tag' AND "variant" = 'manual'
-             AND "targetType" = $1 AND "displayName" = $2`,
-        [targetType, name]
-      );
-      if (existingTag) {
-        tagId = existingTag.id;
-        await db.query(
-          `UPDATE "Contexts"
-              SET "extendedAttributes" = COALESCE("extendedAttributes", '{}'::jsonb) || $2::jsonb
-            WHERE id = $1`,
-          [tagId, JSON.stringify({ tagColor: color })]
-        );
-        stats.tagsSkipped++;
-      } else {
-        const parentId  = await getOrCreateTagRoot(targetType);
-        const createdBy = (req.user && (req.user.email || req.user.upn || req.user.name)) || 'import';
-        const ins = await db.query(
-          `INSERT INTO "Contexts"
-             (id, variant, "targetType", "contextType", "displayName", "parentContextId", "createdByUser", "extendedAttributes")
-           VALUES ($1, 'manual', $2, 'Tag', $3, $4, $5, $6::jsonb)
-           RETURNING id`,
-          [randomUUID(), targetType, name, parentId, createdBy, JSON.stringify({ tagColor: color })]
-        );
-        tagId = ins.rows[0]?.id;
-        if (!tagId) continue;
-        stats.tagsInserted++;
-      }
-
-      let assignedAny = false;
-      for (const a of (tag.assignments || [])) {
-        if (!a.entityId) continue;
-        const resolved = await resolveEntity(a.entityId, tag.entityType, a.displayName, a.resourceType);
-        if (!resolved) { stats.assignmentsNotFound++; continue; }
-        // ContextMembers.memberId is a uuid column; a non-uuid id can't be a
-        // member, so skip it rather than let the ::uuid cast abort the import.
-        const memberId = String(resolved.id).toLowerCase();
-        if (!UUID_RE.test(memberId)) { stats.assignmentsNotFound++; continue; }
-
-        const ins = await db.query(
-          `INSERT INTO "ContextMembers" ("contextId", "memberType", "memberId", "addedBy")
-           VALUES ($1, $2, $3::uuid, 'analyst')
-           ON CONFLICT ("contextId", "memberId") DO NOTHING
-           RETURNING 1 AS inserted`,
-          [tagId, targetType, memberId]
-        );
-        if (ins.rows.length > 0) {
-          assignedAny = true;
-          stats.assignmentsInserted++;
-          if (resolved.softMatched) stats.assignmentsSoftMatched++;
-        } else {
-          stats.assignmentsSkipped++;
-        }
-      }
-      if (assignedAny) await recalcMemberCountsForChain(tagId);
-    }
+    // Per-tag work lives in importCuratedTag() (module scope) to keep this
+    // handler within its complexity budget. Hand it the handler-local bindings.
+    const tagDeps = {
+      ENTITY_TO_TARGET, UUID_RE, resolveEntity, getOrCreateTagRoot,
+      recalcMemberCountsForChain, randomUUID,
+      createdBy: (req.user && (req.user.email || req.user.upn || req.user.name)) || 'import',
+    };
+    for (const tag of tags) await importCuratedTag(tag, tagDeps, stats);
 
     // ── Categories ───────────────────────────────────────────────
     for (const cat of categories) {

--- a/app/api/src/routes/tags.js
+++ b/app/api/src/routes/tags.js
@@ -94,8 +94,8 @@ router.get('/tags', async (req, res) => {
 // ContextMembers directly because Postgres views are not updatable by
 // default.
 
-const ENTITY_TO_TARGET = { user: 'Principal', group: 'Resource', resource: 'Resource', identity: 'Identity' };
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const ENTITY_TO_TARGET = { user: 'Principal', group: 'Resource', resource: 'Resource', identity: 'Identity' };
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Reverse map for emitting back the entityType value the UI sends in.
 const TARGET_TO_ENTITY = { Principal: 'user', Resource: 'resource', Identity: 'identity' };

--- a/changes/fix-curated-import-tag-views.md
+++ b/changes/fix-curated-import-tag-views.md
@@ -1,0 +1,2 @@
+- Fixed curated data import so tags and their assignments are saved again. Previously, importing a curated JSON file that contained tags failed with a server error, and even when the import appeared to succeed, tag assignments were never attached to any user, group, or resource.
+- Curated tag imports now resolve entities both by ID and by display name, and re-importing an existing tag updates its colour without creating duplicate assignments.


### PR DESCRIPTION
## Changes

- Fixed curated data import so tags and their assignments are saved again. Previously, importing a curated JSON file that contained tags failed with a server error, and even when the import appeared to succeed, tag assignments were never attached to any user, group, or resource.
- Curated tag imports now resolve entities both by ID and by display name, and re-importing an existing tag updates its colour without creating duplicate assignments.

## Why

`POST /api/admin/import/curated` was broken on three independent axes, all fixed here:

1. **View insert** — tags/assignments were `INSERT`ed into `GraphTags` / `GraphTagAssignments`, which the Contexts v6 migration turned into non-updatable JOIN **views** → every import carrying tags 500'd. Rewritten to write `Contexts` / `ContextMembers` directly, reusing the `routes/tags.js` idiom.
2. **Stale `ValidTo` filter** in `resolveEntity` (system-versioning column dropped in the postgres migration) threw and was swallowed → every assignment resolved to "not found".
3. **Unquoted `Principals` / `Resources` / `resourceType`** identifiers → postgres lower-cased them to non-existent relations/columns (also thrown and swallowed).

## Testing

- New real-PostgreSQL contract test `app/api/contract-tests/importCurated.integration.test.js` — GUID + soft-match resolution, upsert idempotency, the resource-tag path, and read-compat through the `GraphTags` views.
- Updated the mocked `admin.coverage.test.js` that had been masking the view-insert failure.
- Green locally: 4 import contract + 2 export contract + 31 admin unit + 8 tags unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)