### PR TITLE
fix(db): clean up resource-orphaned fact-table rows (migration 051)

### DIFF
--- a/app/api/contract-tests/factTableIntegrity.contract.test.js
+++ b/app/api/contract-tests/factTableIntegrity.contract.test.js
@@ -1,0 +1,126 @@
+// Contract test — fact-table referential integrity (migration 051).
+//
+// The fact tables carry no DB-level FK on purpose (see 051 for why: chunked
+// multi-transaction ingest + legitimate external/guest/service-principal members
+// that are not in "Principals"). This test enforces the integrity guarantee we
+// DO make: migration 051's cleanup removes rows whose RESOURCE is gone, while
+// leaving valid rows — including an assignment to an external principal that is
+// deliberately absent from "Principals" — untouched. It re-executes the shipped
+// migration SQL verbatim against a seeded scenario, and asserts idempotency.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import pg from 'pg';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLEANUP_SQL = readFileSync(
+  join(__dirname, '../src/db/migrations/051_fact_table_orphan_cleanup.sql'),
+  'utf8',
+);
+
+let pool;
+let systemId;
+
+// Resources: two live, one that is never inserted (the orphan target).
+const R_LIVE_A = 'a1a1a1a1-0000-0000-0000-000000000001';
+const R_LIVE_B = 'a1a1a1a1-0000-0000-0000-000000000002';
+const R_GONE   = 'dead0000-0000-0000-0000-000000000001';
+// Principals: one live, one external (a real group member NOT synced into Principals).
+const P_LIVE     = 'b2b2b2b2-0000-0000-0000-000000000001';
+const P_EXTERNAL = 'e0e0e0e0-0000-0000-0000-000000000001';
+
+async function raKeys() {
+  const r = await pool.query(
+    `SELECT "resourceId","principalId","assignmentType" FROM "ResourceAssignments"
+       WHERE "systemId" = $1 ORDER BY "assignmentType"`,
+    [systemId],
+  );
+  return r.rows;
+}
+async function rrKeys() {
+  const r = await pool.query(
+    `SELECT "parentResourceId","childResourceId" FROM "ResourceRelationships"
+       WHERE "systemId" = $1 ORDER BY "parentResourceId"`,
+    [systemId],
+  );
+  return r.rows;
+}
+
+beforeAll(async () => {
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType","displayName") VALUES ('test','fact-integrity') RETURNING id`,
+  );
+  systemId = sys.rows[0].id;
+
+  await pool.query(
+    `INSERT INTO "Resources" ("id","systemId","resourceType","displayName")
+     VALUES ($1,$3,'EntraGroup','Live A'), ($2,$3,'EntraGroup','Live B')`,
+    [R_LIVE_A, R_LIVE_B, systemId],
+  );
+  await pool.query(
+    `INSERT INTO "Principals" ("id","systemId","displayName","principalType")
+     VALUES ($1,$2,'Live User','User')`,
+    [P_LIVE, systemId],
+  );
+
+  // Assignments: clean row, an external-member (resource present, principal
+  // absent -> keep), and a resource-orphan (resource gone -> delete).
+  await pool.query(
+    `INSERT INTO "ResourceAssignments" ("resourceId","principalId","assignmentType","systemId") VALUES
+       ($1,$2,'Direct',$5),
+       ($1,$3,'Indirect',$5),
+       ($4,$2,'Eligible',$5)
+    `,
+    [R_LIVE_A, P_LIVE, P_EXTERNAL, R_GONE, systemId],
+  );
+  // Relationships: clean row (-> keep) and a parent-orphan (parent gone -> delete).
+  await pool.query(
+    `INSERT INTO "ResourceRelationships" ("parentResourceId","childResourceId","relationshipType","systemId") VALUES
+       ($1,$2,'Contains',$4),
+       ($3,$1,'Contains',$4)
+    `,
+    [R_LIVE_A, R_LIVE_B, R_GONE, systemId],
+  );
+});
+
+afterAll(async () => {
+  await pool?.query(`DELETE FROM "ResourceAssignments"   WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Resources"  WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Systems"    WHERE id = $1`, [systemId]);
+  await pool?.end();
+});
+
+describe('migration 051 — fact-table orphan cleanup', () => {
+  it('starts with the seeded rows (3 assignments incl. the orphan, 2 relationships)', async () => {
+    expect(await raKeys()).toHaveLength(3);
+    expect(await rrKeys()).toHaveLength(2);
+  });
+
+  it('removes resource-orphans but keeps clean rows and external-member assignments', async () => {
+    await pool.query(CLEANUP_SQL);
+
+    const ra = await raKeys();
+    // The resource-orphan (Eligible, R_GONE) is gone; the clean and the
+    // external-member (Indirect, principal absent) rows survive.
+    expect(ra).toHaveLength(2);
+    expect(ra.map((r) => r.assignmentType).sort()).toEqual(['Direct', 'Indirect']);
+    const external = ra.find((r) => r.assignmentType === 'Indirect');
+    expect(external.principalId).toBe(P_EXTERNAL); // external member preserved
+
+    const rr = await rrKeys();
+    expect(rr).toHaveLength(1);
+    expect(rr[0].parentResourceId).toBe(R_LIVE_A);
+  });
+
+  it('is idempotent — a second run deletes nothing', async () => {
+    const before = { ra: (await raKeys()).length, rr: (await rrKeys()).length };
+    await pool.query(CLEANUP_SQL);
+    expect((await raKeys()).length).toBe(before.ra);
+    expect((await rrKeys()).length).toBe(before.rr);
+  });
+});

--- a/app/api/src/db/migrations/051_fact_table_orphan_cleanup.sql
+++ b/app/api/src/db/migrations/051_fact_table_orphan_cleanup.sql
@@ -1,0 +1,39 @@
+-- Identity Atlas — idempotent cleanup of resource-orphaned rows in the fact
+-- tables (ResourceAssignments, ResourceRelationships), and documentation of why
+-- these tables intentionally carry NO database-level foreign keys.
+--
+-- ── Why no FK (and why the matview NOT EXISTS guards stay) ───────────────────
+-- The fact tables are ingested by crawlers in SEPARATE, chunked HTTP batches
+-- (ingest/resources, ingest/resource-assignments, ingest/resource-relationships),
+-- each its own transaction — so an assignment can be committed before the batch
+-- carrying its Resource/Principal has run. Assignments can also LEGITIMATELY
+-- reference principals that are not in "Principals": external / guest / service-
+-- principal group members that the Users phase never returns, and cross-system
+-- references resolved from *ExternalId. A hard FK with immediate enforcement
+-- would REJECT those real ingest rows, not merely backstop bugs — which is why
+-- there is no FK. The matrix matview already hides orphans at read time via
+-- NOT EXISTS sub-selects (migration 049); this migration reconciles the STORED
+-- state to match, for the one class of orphan that is never legitimate.
+--
+-- ── What this cleans ────────────────────────────────────────────────────────
+-- Only rows whose RESOURCE is entirely gone. Resources are always same-system
+-- and crawled, so a missing "Resources" row is an unambiguous orphan (a tombstone
+-- purge that outran its assignments, or a partial-sync bug) — never a valid
+-- cross-system reference. We deliberately do NOT delete rows on a missing
+-- principalId / identityId, which can be a valid external member.
+--
+-- A soft-deleted Resource still EXISTS as a row (stamped deletedAt), so its
+-- assignments are NOT treated as orphans here — only a hard-absent "Resources"
+-- row triggers cleanup.
+--
+-- Idempotent and side-effect-free (DELETEs only, no DDL): after this runs, and
+-- on fresh installs, there are no resource-orphans, so re-running is a precise
+-- no-op. The fact-table integrity contract test re-executes this file verbatim
+-- against a seeded scenario, which is why it must stay DELETE-only.
+
+DELETE FROM "ResourceAssignments" ra
+ WHERE NOT EXISTS (SELECT 1 FROM "Resources" r WHERE r.id = ra."resourceId");
+
+DELETE FROM "ResourceRelationships" rr
+ WHERE NOT EXISTS (SELECT 1 FROM "Resources" r WHERE r.id = rr."parentResourceId")
+    OR NOT EXISTS (SELECT 1 FROM "Resources" r WHERE r.id = rr."childResourceId");

--- a/changes/fk-core-fact-tables.md
+++ b/changes/fk-core-fact-tables.md
@@ -1,0 +1,1 @@
+- Cleaned up orphaned access assignments and resource relationships whose underlying resource no longer exists, so stale rows can no longer linger in storage (they were already hidden from the matrix). Legitimate assignments to external, guest, and service-principal members are preserved.


### PR DESCRIPTION
## Changes

- Cleaned up orphaned access assignments and resource relationships whose underlying resource no longer exists, so stale rows can no longer linger in storage (they were already hidden from the matrix). Legitimate assignments to external, guest, and service-principal members are preserved.

## Context — the "no referential integrity on the fact tables" review finding

The review flagged that `ResourceAssignments` / `ResourceRelationships` have no FK to the entities they reference. The literal recommendation was a hard `FK ... ON DELETE CASCADE`. Investigating the ingest path showed that would be **unsafe**:

- Crawlers ingest `resources`, `resource-assignments`, and `resource-relationships` as **separate, chunked HTTP batches** (separate transactions), so an assignment can commit before the batch carrying its Resource/Principal.
- Assignments can **legitimately** reference principals that are not in `Principals` — external / guest / service-principal group members the Users phase never returns, plus cross-system `*ExternalId` references.

A hard FK with immediate enforcement would therefore **reject real ingest rows**, not merely backstop bugs — which is why there is no FK today.

## Approach (safe)

`migration 051` reconciles **stored** state for the one class of orphan that is never legitimate: rows whose **resource is entirely gone** (a tombstone purge that outran its assignments, or a partial-sync bug). It deliberately:
- leaves **soft-deleted** resources' assignments alone (the resource row still exists);
- leaves **missing-principal** rows alone (may be a valid external member);
- is **idempotent** and `DELETE`-only.

The matrix matview keeps its existing `NOT EXISTS` read-time guards. A new contract test (`factTableIntegrity.contract.test.js`) re-executes the shipped migration SQL against a seeded scenario, proving it removes resource-orphans, preserves clean + external-member rows, and is a no-op on re-run.

## Testing

- New `app/api/contract-tests/factTableIntegrity.contract.test.js` — 3 cases, green against real PG16.
- Full contract suite: no new failures vs. baseline (pre-existing local order-sensitivity is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)