### PR TITLE
docs(midpoint): fix retired `Governed` assignmentType in data-model docs

### DIFF
--- a/tools/crawlers/midpoint/CLAUDE.md
+++ b/tools/crawlers/midpoint/CLAUDE.md
@@ -31,8 +31,8 @@ A crawler is a folder under `tools/crawlers/<type>/` with a `crawler.json` manif
 | `ShadowType kind=entitlement` | **Resources** (`resourceType=Entitlement`) | e.g. AD groups |
 | `ShadowType kind=generic`/other | **Skipped** | OU/container/DB rows — no user account |
 | Account → entitlement membership | **ResourceAssignments** (`assignmentType=Direct`) | Via `association[]` or (4.9+) `referenceAttributes.<name>[]`, consolidated on the owner focus principal, `viaAccount` in `extendedAttributes` |
-| `user.assignment[]` → Role/Service | **ResourceAssignments** (`assignmentType=Governed`, `extendedAttributes.grant=direct`) | Directly-assigned roles/services |
-| `user.roleMembershipRef[]` → Role/Service | **ResourceAssignments** (`assignmentType=Governed`, `extendedAttributes.grant=inherited`) | midPoint's fully-computed membership (role nesting, archetype/org inducements, …). Default-relation refs only — manager/owner/approver/meta are governance, not access. Direct OIDs keep `grant=direct` (first-pass wins) |
+| `user.assignment[]` → Role/Service | **ResourceAssignments** (`assignmentType=Direct`, `governed=true`, `extendedAttributes.grant=direct`) | Directly-assigned roles/services |
+| `user.roleMembershipRef[]` → Role/Service | **ResourceAssignments** (`assignmentType=Direct`, `governed=true`, `extendedAttributes.grant=inherited`) | midPoint's fully-computed membership (role nesting, archetype/org inducements, …). Default-relation refs only — manager/owner/approver/meta are governance, not access. Direct OIDs keep `grant=direct` (first-pass wins) |
 | `user.parentOrgRef[]` | **ContextMembers** | All org memberships |
 | `user.parentOrgRef` (default relation) | **Identity.department** + focus **Principal.department** | The user's primary org-unit name; see `Resolve-MidpointDepartment` |
 | `accessCertificationCampaigns` | **CertificationDecisions** | Requires `?include=case` |
@@ -47,7 +47,7 @@ midPoint OIDs are UUIDs and are reused 1-to-1 as `id`/`externalId` — every rec
 4. **Users** — `UserType` → Identities + focus Principals + IdentityMembers
 5. **Shadows** — `ShadowType` → account Principals + entitlement Resources + memberships (ResourceAssignments `Direct`)
 6. **Org membership** — `user.parentOrgRef[]` → ContextMembers
-7. **Assignments** — `user.assignment[]` (`grant=direct`) + `user.roleMembershipRef[]` (`grant=inherited`) → ResourceAssignments `Governed`. Two passes so birthright / nested / archetype-inherited memberships are captured, not just direct ones; default-relation refs only
+7. **Assignments** — `user.assignment[]` (`grant=direct`) + `user.roleMembershipRef[]` (`grant=inherited`) → ResourceAssignments `Direct` (`governed=true`). Two passes so birthright / nested / archetype-inherited memberships are captured, not just direct ones; default-relation refs only
 8. **Role nesting** — `RoleType.inducement[]` → ResourceRelationships `Contains`. `targetRef` inducements link to a Role/Service; `construction` inducements link to the Entitlement(s) they grant (the `associationTargetSearch` DN filter is resolved against the entitlement shadows from phase 5 via `$EntitlementByDn`, or a literal `shadowRef` is used directly). Needs the Shadows phase to have run for construction targets to resolve
 9. **Reviews** — certification campaigns → CertificationDecisions
 10. **`refresh-views`** — refreshes matrix materialized views

--- a/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Start-MidpointCrawler.ps1
@@ -12,7 +12,7 @@
       ServiceType                      → Resources (Service)
       UserType (focus / person)        → Identities + a Principal (the midPoint account) + IdentityMembers
       ShadowType (accounts on systems) → Principals (per resource system) + IdentityMembers (via user.linkRef)
-      user.assignment[] → Role/Service → ResourceAssignments (Direct, governed=false)
+      user.assignment[] → Role/Service → ResourceAssignments (Direct, governed=true)
       user.parentOrgRef[]              → ContextMembers (org membership)
 
     midPoint object OIDs are UUIDs, so they are reused directly as Identity Atlas


### PR DESCRIPTION
Stacked on #561 (which owns `Start-MidpointCrawler.ps1`). **Retarget to `main` once #561 merges.**

## Changes

The midPoint data-model docs described `user.assignment[]` / `user.roleMembershipRef[]` role/service assignments as `assignmentType=Governed` — a **retired** type the ingest layer hard-rejects (only `Direct`/`Indirect`/`Eligible` are accepted, and `assignmentTypes.guard.test.js` forbids reintroducing it). The transform actually emits `assignmentType='Direct'` with `governed=$true` (`New-MidpointGovernanceAssignmentRecord`).

- `tools/crawlers/midpoint/CLAUDE.md` — mapping table + phase list: `Governed` → `Direct` (`governed=true`).
- `tools/crawlers/midpoint/Start-MidpointCrawler.ps1` header comment: `governed=false` → `governed=true` (matches the transform).

Docs/comment-only — no behaviour change, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)