### PR TITLE
ci(security): fix expression-injection sink in issue-autofix.yml; SHA-pin setup-node

### DIFF
--- a/.github/workflows/cut-hotfix.yml
+++ b/.github/workflows/cut-hotfix.yml
@@ -65,7 +65,7 @@ jobs:
           echo "✅ Tagged ${TAG} on ${COMMIT}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 

--- a/.github/workflows/issue-autofix.yml
+++ b/.github/workflows/issue-autofix.yml
@@ -206,6 +206,12 @@ jobs:
         id: create-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The issue title is attacker-controlled (any outside contributor can set
+          # it). Pass it through the environment and reference it as a quoted shell
+          # variable below — NEVER interpolate ${{ matrix.title }} directly into a
+          # run: script, which is GitHub Actions expression injection (arbitrary code
+          # execution on a runner that holds contents:write + pull-requests:write).
+          ISSUE_TITLE: ${{ matrix.title }}
         run: |
           # Check for changes
           HAS_UNCOMMITTED=$(git diff --quiet HEAD && echo "no" || echo "yes")
@@ -221,7 +227,7 @@ jobs:
           if [ "$HAS_UNCOMMITTED" = "yes" ]; then
             echo "Found uncommitted changes — committing them"
             git add -A
-            git commit -m "Fix #${{ matrix.number }}: ${{ matrix.title }}"
+            git commit -m "Fix #${{ matrix.number }}: ${ISSUE_TITLE}"
           fi
 
           echo "Changes detected — creating branch and PR"
@@ -229,7 +235,7 @@ jobs:
 
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-          SLUG=$(echo "${{ matrix.title }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 40)
+          SLUG=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 40)
           BRANCH="bugfixes/autofix-issue-${{ matrix.number }}-${SLUG}"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
@@ -241,7 +247,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --draft \
-            --title "Fix #${{ matrix.number }}: ${{ matrix.title }}" \
+            --title "Fix #${{ matrix.number }}: ${ISSUE_TITLE}" \
             --body "$(cat <<EOF
           ## Summary
 


### PR DESCRIPTION
## Security fix — GitHub Actions expression injection

`issue-autofix.yml`'s "Create branch and PR" step interpolated the **attacker-controlled** `${{ matrix.title }}` (the GitHub issue title — any outside contributor can set it) directly into `run:` shell commands:

- `git commit -m "Fix #…: ${{ matrix.title }}"`
- `SLUG=$(echo "${{ matrix.title }}" | …)`
- `gh pr create --title "Fix #…: ${{ matrix.title }}"`

Because `${{ }}` is substituted **before** the shell runs, an issue titled with `` `…` `` or `$(…)` executes arbitrary commands on a runner that holds `contents:write` + `pull-requests:write` + `id-token`. This is the canonical Actions script-injection vuln.

**Fix:** pass the title via an `ISSUE_TITLE` env var and reference the quoted shell variable (`"$ISSUE_TITLE"` / `${ISSUE_TITLE}`), so the shell treats it as data, never code. Dormant today (the `issues`/`schedule` triggers are commented out) — fixed now, before they're re-enabled.

## Also
- SHA-pin the repo's one floating action tag: `cut-hotfix.yml` `actions/setup-node@v6` → `@48b55a01…` (v6.4.0), matching every other `setup-node` pin.

## Out of scope (noted)
`${{ matrix.title }}` still appears in two `claude-code-action` **`prompt:`** inputs — that's prompt-injection, a different/lower-severity class that can't be env-substituted the same way. Left as a documented follow-up.

CI/workflow-only change (no app code, no changelog fragment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)