### PR TITLE
fix(db): make the migration runner's "already exists" swallow observable

### DIFF
--- a/app/api/src/db/migrate.js
+++ b/app/api/src/db/migrate.js
@@ -61,6 +61,18 @@ export function stripNativeExtensions(sql) {
   );
 }
 
+// Warning emitted when a migration aborts with "already exists" and is recorded
+// as applied WITHOUT re-running its body. The message names the file and calls
+// out the real hazard: a mixed DDL+DML migration whose DML half (backfill /
+// UPDATE / REFRESH) was silently skipped. It's built here as a pure function so
+// the wording (and the presence of the filename) is unit-tested, and so a
+// skipped backfill is greppable in boot logs by filename or by "SKIPPED".
+export function alreadyExistsWarning(filename) {
+  return `⚠ ${filename}: objects already exist — recorded as applied WITHOUT re-running its body. `
+    + `If this migration also made data changes (backfill / UPDATE / REFRESH), they were SKIPPED — verify manually. `
+    + `Make new migrations idempotent (IF NOT EXISTS) so this branch is never load-bearing.`;
+}
+
 // Apply a single migration file inside a transaction. The transaction wraps
 // the whole file so a failure halfway leaves nothing partial — the next run
 // will see the file as not-applied and try again from the top.
@@ -100,7 +112,7 @@ export async function runMigrations(_pool) {
       // migration (transaction boundary quirk). If objects already exist,
       // record the migration as applied and continue rather than aborting.
       if (/already exists/i.test(err.message)) {
-        console.warn(`    (objects already exist — recording as applied and continuing)`);
+        console.warn(`    ${alreadyExistsWarning(filename)}`);
         await db.query(
           `INSERT INTO _migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
           [filename]

--- a/app/api/src/db/migrate.test.js
+++ b/app/api/src/db/migrate.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { stripNativeExtensions } from './migrate.js';
+import { stripNativeExtensions, alreadyExistsWarning } from './migrate.js';
 
 describe('stripNativeExtensions', () => {
   it('replaces CREATE EXTENSION pg_trgm with a comment', () => {
@@ -34,5 +34,18 @@ describe('stripNativeExtensions', () => {
   it('is a no-op when no CREATE EXTENSION statements are present', () => {
     const sql = 'SELECT 1;';
     expect(stripNativeExtensions(sql)).toBe(sql);
+  });
+});
+
+describe('alreadyExistsWarning', () => {
+  it('names the migration file so a skipped backfill is greppable', () => {
+    const msg = alreadyExistsWarning('038_effective_access_columns.sql');
+    expect(msg).toContain('038_effective_access_columns.sql');
+  });
+
+  it('flags that data changes may have been SKIPPED', () => {
+    const msg = alreadyExistsWarning('050_update_log.sql');
+    expect(msg).toContain('SKIPPED');
+    expect(msg).toMatch(/backfill|UPDATE|REFRESH/);
   });
 });

--- a/changes/migration-runner-observability.md
+++ b/changes/migration-runner-observability.md
@@ -1,0 +1,1 @@
+- Improved database migration logging: when a migration is recorded as applied because its objects already exist, the log now names the specific migration file and warns that any data backfill it contained may have been skipped — making a previously silent situation visible in the container startup logs.


### PR DESCRIPTION
## Changes

- Improved database migration logging: when a migration is recorded as applied because its objects already exist, the log now names the specific migration file and warns that any data backfill it contained may have been skipped.

## Why (M-arch-2 review finding)

`migrate.js` catches an `already exists` error, records the file as applied, and continues. This exists for a PGlite transaction quirk, but it's a hazard for a **mixed DDL+DML** migration: if the DDL half already exists on a re-run, the DML half (backfill / `UPDATE` / `REFRESH`) is **silently skipped forever** — and the old log line didn't even name the file.

The swallow itself is unchanged (editing existing migration files to add `IF NOT EXISTS` is disallowed by the migration-immutability rule). Instead this makes it **observable**: the warning is extracted into a pure, unit-tested `alreadyExistsWarning(filename)` that names the migration and calls out the skipped-backfill risk, so it's greppable in boot logs by filename or `SKIPPED`, and it nudges new migrations toward idempotency.

## Testing
- `migrate.test.js`: 2 new cases asserting the filename and `SKIPPED`/backfill wording. All 7 pass; complexity ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)