### PR TITLE
refactor(crawlers): consolidate the 5 drifted Send-IngestBatch copies (M-arch-4)

### DIFF
--- a/changes/consolidate-crawler-ingest.md
+++ b/changes/consolidate-crawler-ingest.md
@@ -1,0 +1,1 @@
+- Internal refactor: unified how all crawlers send data to the ingest API into one shared, tested implementation, removing duplicated batching logic that had drifted between crawlers. No change to what data is synced or how.

--- a/test/unit/CrawlerIngestBatch.Tests.ps1
+++ b/test/unit/CrawlerIngestBatch.Tests.ps1
@@ -1,0 +1,105 @@
+# Pester tests for the shared Invoke-CrawlerIngestBatch — the one canonical
+# crawler ingest-batch protocol that replaced five drifted per-crawler copies.
+# Invoke-IngestAPI is mocked so we can assert the exact request bodies for every
+# opt-in behaviour (chunking, deletes, empty-skip, id-generation, sync-mode
+# resolver, stats). No network.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' '..' 'tools' 'crawlers' 'shared' 'Invoke-CrawlerIngest.ps1')
+    function New-Recs { param([int]$n) 1..$n | ForEach-Object { @{ id = "id-$_" } } }
+}
+
+Describe 'Invoke-CrawlerIngestBatch' {
+    BeforeEach {
+        $script:sent = [System.Collections.Generic.List[object]]::new()
+        Mock Invoke-IngestAPI {
+            $script:sent.Add($Body)
+            return @{ inserted = $Body.records.Count; updated = 0; deleted = 0; syncId = 'sync-1' }
+        } -ModuleName $null
+    }
+
+    Context 'single batch' {
+        It 'sends one full-sync batch with the records as a JSON array' {
+            $r = Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -SystemId 7 -Records (New-Recs 3)
+            $script:sent.Count | Should -Be 1
+            $b = $script:sent[0]
+            $b.systemId | Should -Be 7
+            $b.syncMode | Should -Be 'full'
+            $b.records.Count | Should -Be 3
+            $b.ContainsKey('syncSession') | Should -BeFalse
+            $r.inserted | Should -Be 3
+        }
+
+        It 'wraps a single record as an array (the delta single-record fix)' {
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -Records (New-Recs 1) | Out-Null
+            ,$script:sent[0].records | Should -BeOfType [System.Collections.IEnumerable]
+            $script:sent[0].records.Count | Should -Be 1
+        }
+    }
+
+    Context 'chunked session' {
+        It 'splits into start/continue/end sessions above BatchSize' {
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resource-assignments' -Records (New-Recs 5) -BatchSize 2 | Out-Null
+            $script:sent.Count | Should -Be 3
+            $script:sent[0].syncSession | Should -Be 'start'
+            $script:sent[1].syncSession | Should -Be 'continue'
+            $script:sent[2].syncSession | Should -Be 'end'
+            $script:sent[1].syncId | Should -Be 'sync-1'   # carried from the start batch
+        }
+    }
+
+    Context 'deletes' {
+        It 'includes deletedIds in the single batch' {
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -Records (New-Recs 2) -DeletedIds @('a', 'b') | Out-Null
+            $script:sent.Count | Should -Be 1
+            $script:sent[0].deletedIds.Count | Should -Be 2
+        }
+
+        It 'sends a separate delete batch first in the chunked path' {
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -Records (New-Recs 4) -DeletedIds @('x') -BatchSize 2 | Out-Null
+            $script:sent[0].deletedIds.Count | Should -Be 1
+            $script:sent[0].records.Count | Should -Be 0        # delete-only leading batch
+            $script:sent[1].syncSession | Should -Be 'start'
+        }
+    }
+
+    Context 'empty records' {
+        It 'sends an empty full-sync batch by default (server scoped-delete)' {
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -SystemId 3 -Records @() | Out-Null
+            $script:sent.Count | Should -Be 1
+            $script:sent[0].records.Count | Should -Be 0
+        }
+
+        It 'skips the call entirely with -SkipWhenEmpty' {
+            $r = Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -Records @() -SkipWhenEmpty
+            $script:sent.Count | Should -Be 0
+            $r.inserted | Should -Be 0
+        }
+    }
+
+    Context 'deterministic id generation (CSV)' {
+        It 'adds idGeneration and a per-endpoint idPrefix' {
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resource-assignments' -Records (New-Recs 1) -IdGeneration 'deterministic' -IdPrefix 'acme' | Out-Null
+            $script:sent[0].idGeneration | Should -Be 'deterministic'
+            $script:sent[0].idPrefix | Should -Be 'acme-resource-assignments'
+        }
+    }
+
+    Context 'sync-mode resolver (midPoint)' {
+        It 'resolves the sync mode per entity' {
+            $resolver = { param($e) if ($e -eq 'identities') { 'delta' } else { 'full' } }
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/identities' -Records (New-Recs 1) -SyncModeResolver $resolver | Out-Null
+            $script:sent[0].syncMode | Should -Be 'delta'
+        }
+    }
+
+    Context 'stats callback (midPoint)' {
+        It 'invokes -OnStat with entity and record count' {
+            $script:stat = $null
+            $onStat = { param($e, $s, $c) $script:stat = @{ entity = $e; count = $c } }
+            Invoke-CrawlerIngestBatch -Endpoint 'ingest/resources' -Records (New-Recs 4) -OnStat $onStat | Out-Null
+            $script:stat.entity | Should -Be 'resources'
+            $script:stat.count | Should -Be 4
+        }
+    }
+}

--- a/test/unit/OmadaCrawlerFunctions.Tests.ps1
+++ b/test/unit/OmadaCrawlerFunctions.Tests.ps1
@@ -233,15 +233,17 @@ Describe 'Send-IngestBatch' {
         }
     }
 
-    It 'sends a separate delta delete batch when DeletedIds are supplied' {
-        Mock Invoke-IngestAPI { return @{ inserted = 1; updated = 0; deleted = 0 } }
+    It 'sends deletes in-band with the records batch (unified protocol)' {
+        # The shared Send-IngestBatch carries the tombstones alongside the upserts
+        # in a single batch (the ingest API applies records first, then deletes),
+        # rather than a separate delta call — one round trip, identical end state.
+        Mock Invoke-IngestAPI { return @{ inserted = 1; updated = 0; deleted = 2 } }
         $recs = @([PSCustomObject]@{ id = 'keep' })
         Send-IngestBatch -Endpoint 'ingest/principals' -SystemId 1 `
             -Records $recs -DeletedIds @('gone1', 'gone2') | Out-Null
-        # One delete (delta) call + one upsert (full) call
-        Should -Invoke Invoke-IngestAPI -Times 2 -Exactly
+        Should -Invoke Invoke-IngestAPI -Times 1 -Exactly
         Should -Invoke Invoke-IngestAPI -Times 1 -Exactly -ParameterFilter {
-            $Body.syncMode -eq 'delta' -and $Body.deletedIds.Count -eq 2
+            $Body.records.Count -eq 1 -and $Body.deletedIds.Count -eq 2
         }
     }
 

--- a/tools/crawlers/azure-rm/AzureRMCrawler.Functions.ps1
+++ b/tools/crawlers/azure-rm/AzureRMCrawler.Functions.ps1
@@ -38,6 +38,9 @@ function Get-ScopeNodeId {
     Get-CapabilityId -TargetNodeId $safe -CapabilityId 'azure-scope'
 }
 
+# Thin adapter over the shared Invoke-CrawlerIngestBatch (tools/crawlers/shared/
+# Invoke-CrawlerIngest.ps1). Azure RM sends small batches, so the shared chunking
+# never triggers; an empty batch is still sent as a full sync (no -SkipWhenEmpty).
 function Send-IngestBatch {
     [CmdletBinding()]
     param(
@@ -47,11 +50,7 @@ function Send-IngestBatch {
         [hashtable]$Scope = @{},
         [array]$Records = @()
     )
-    if (-not $Records -or $Records.Count -eq 0) {
-        return Invoke-IngestAPI -Endpoint $Endpoint -Body @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = @() }
-    }
-    $body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Records }
-    Invoke-IngestAPI -Endpoint $Endpoint -Body $body
+    Invoke-CrawlerIngestBatch -Endpoint $Endpoint -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope -Records $Records
 }
 
 # Per-phase wall-clock + round-trip report — the call counts make the cross-subscription savings of

--- a/tools/crawlers/csv/CSVCrawler.Functions.ps1
+++ b/tools/crawlers/csv/CSVCrawler.Functions.ps1
@@ -18,34 +18,16 @@
 
 # ─── Helpers ─────────────────────────────────────────────────────
 
+# Thin adapter over the shared Invoke-CrawlerIngestBatch (tools/crawlers/shared/
+# Invoke-CrawlerIngest.ps1). CSV uses deterministic ids (idPrefix becomes
+# "<SystemType>-<entity>", matching normalization.js's idGeneration contract), a
+# 10000 batch size, and skips empty batches. The original returned nothing, so
+# the shared result is swallowed here.
 function Send-IngestBatch {
     [CmdletBinding()]
     param([string]$Endpoint, [int]$SystemId, [string]$SyncMode = 'full', [hashtable]$Scope = @{}, $Records, [int]$BatchSize = 10000)
-    $count = if ($null -eq $Records) { 0 } else { $Records.Count }
-    if ($count -eq 0) { Write-Host "  No records to send" -ForegroundColor Yellow; return }
-    Write-Host "  Sending $count records to $Endpoint..." -ForegroundColor Cyan
-    if ($count -le $BatchSize) {
-        $body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = $Records; idGeneration = 'deterministic'; idPrefix = "$SystemType-$($Endpoint.Split('/')[-1])" }
-        $result = Invoke-IngestAPI -Endpoint $Endpoint -Body $body
-        Write-Host "  → $($result.inserted) inserted, $($result.updated) updated, $($result.deleted) deleted" -ForegroundColor Green
-        return
-    }
-    $syncId = $null
-    $totalIns = 0; $totalUpd = 0; $totalDel = 0
-    $batch = [System.Collections.Generic.List[object]]::new($BatchSize)
-    for ($i = 0; $i -lt $count; $i += $BatchSize) {
-        $end = [Math]::Min($i + $BatchSize - 1, $count - 1)
-        $batch.Clear()
-        for ($j = $i; $j -le $end; $j++) { [void]$batch.Add($Records[$j]) }
-        $isFirst = ($i -eq 0); $isLast = ($i + $BatchSize -ge $count)
-        $body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = $batch; idGeneration = 'deterministic'; idPrefix = "$SystemType-$($Endpoint.Split('/')[-1])"; syncSession = if ($isFirst) { 'start' } elseif ($isLast) { 'end' } else { 'continue' } }
-        if ($syncId) { $body.syncId = $syncId }
-        $result = Invoke-IngestAPI -Endpoint $Endpoint -Body $body
-        if ($isFirst) { $syncId = $result.syncId }
-        $totalIns += [int]$result.inserted; $totalUpd += [int]$result.updated; $totalDel += [int]$result.deleted
-        Write-Host "    batch $([int]($i / $BatchSize) + 1): +$($result.inserted) ins, $($result.updated) upd ($([int]($end + 1))/$count)" -ForegroundColor DarkGray
-    }
-    Write-Host "  → $totalIns inserted, $totalUpd updated, $totalDel deleted (chunked)" -ForegroundColor Green
+    Invoke-CrawlerIngestBatch -Endpoint $Endpoint -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope `
+        -Records $Records -BatchSize $BatchSize -IdGeneration 'deterministic' -IdPrefix $SystemType -SkipWhenEmpty | Out-Null
 }
 
 function Read-CsvFile {

--- a/tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1
+++ b/tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1
@@ -16,6 +16,11 @@
     tools/crawlers/shared/Invoke-CrawlerIngest.ps1 — dot-source that file too.
 #>
 
+# Thin adapter over the shared Invoke-CrawlerIngestBatch (tools/crawlers/shared/
+# Invoke-CrawlerIngest.ps1), which now owns the one canonical ingest protocol
+# (single batch, chunked start/continue/end sessions, in-band delta tombstones).
+# Entra keeps the same call surface; -SkipWhenEmpty preserves the crawler's
+# original "no records and no deletes → no call" behaviour.
 function Send-IngestBatch {
     [CmdletBinding()]
     param(
@@ -24,95 +29,11 @@ function Send-IngestBatch {
         [string]$SyncMode = 'full',
         [hashtable]$Scope = @{},
         [array]$Records,
-        # Optional: a list of ids to DELETE at the target, alongside the
-        # upserts in $Records. The ingest API applies `records` first, then
-        # deletes any row matching `id IN (...)`. Used by delta flows where
-        # Graph `@removed` events give us tombstones that aren't deletable
-        # through the upsert path.
         [string[]]$DeletedIds = @(),
-        # 5000 strikes a balance between MERGE round-trip overhead and lock
-        # duration. With RCSI enabled on the database, readers don't block on
-        # writers, but smaller batches still make the crawler give back the
-        # CPU more often and reduce tempdb version-store pressure.
         [int]$BatchSize = 5000
     )
-
-    $haveRecords = $Records -and $Records.Count -gt 0
-    $haveDeletes = $DeletedIds -and $DeletedIds.Count -gt 0
-    if (-not $haveRecords -and -not $haveDeletes) {
-        Write-Host "  No records to send" -ForegroundColor Yellow
-        return @{ inserted = 0; updated = 0; deleted = 0 }
-    }
-
-    Write-FGIngestBatchHeader -Endpoint $Endpoint -Records $Records -DeletedIds $DeletedIds -HaveRecords $haveRecords -HaveDeletes $haveDeletes
-
-    # Single batch (includes the deletes-only case where $Records may be empty).
-    if (-not $haveRecords -or $Records.Count -le $BatchSize) {
-        return Send-FGSingleIngestBatch -Endpoint $Endpoint -SystemId $SystemId -SyncMode $SyncMode `
-            -Scope $Scope -Records $Records -DeletedIds $DeletedIds -HaveRecords $haveRecords -HaveDeletes $haveDeletes
-    }
-    return Send-FGChunkedIngestBatches -Endpoint $Endpoint -SystemId $SystemId -SyncMode $SyncMode `
-        -Scope $Scope -Records $Records -DeletedIds $DeletedIds -HaveDeletes $haveDeletes -BatchSize $BatchSize
-}
-
-# Print the "Sending N records/deletes to <endpoint>" header line for Send-IngestBatch.
-function Write-FGIngestBatchHeader {
-    [CmdletBinding()]
-    param($Endpoint, $Records, $DeletedIds, [bool]$HaveRecords, [bool]$HaveDeletes)
-    $count = if ($HaveRecords) { $Records.Count } else { $DeletedIds.Count }
-    $what  = if ($HaveRecords) { 'records' } else { 'deletes' }
-    Write-Host "  Sending $count $what to $Endpoint..." -NoNewline -ForegroundColor Cyan
-    if ($HaveRecords -and $HaveDeletes) { Write-Host " (+$($DeletedIds.Count) deletes)" -ForegroundColor Cyan }
-    else { Write-Host '' -ForegroundColor Cyan }
-}
-
-# One ingest call: all records (<= BatchSize) plus any deletes in the same body.
-function Send-FGSingleIngestBatch {
-    [CmdletBinding()]
-    param($Endpoint, [int]$SystemId, [string]$SyncMode, [hashtable]$Scope, $Records, [string[]]$DeletedIds, [bool]$HaveRecords, [bool]$HaveDeletes)
-    $body = @{
-        systemId = $SystemId
-        syncMode = $SyncMode
-        scope    = $Scope
-        records  = if ($HaveRecords) { ConvertTo-JsonArray $Records } else { ConvertTo-JsonArray $null }
-    }
-    if ($HaveDeletes) { $body['deletedIds'] = ConvertTo-JsonArray $DeletedIds }
-    $result = Invoke-IngestAPI -Endpoint $Endpoint -Body $body
-    Write-Host "  Result: $($result.inserted) inserted, $($result.updated) updated, $($result.deleted) deleted" -ForegroundColor Green
-    return $result
-}
-
-# Chunked start/continue/end session for records exceeding BatchSize. Any deletes go
-# as a SEPARATE call first — chunked sessions don't mesh with in-band deletes.
-function Send-FGChunkedIngestBatches {
-    [CmdletBinding()]
-    param($Endpoint, [int]$SystemId, [string]$SyncMode, [hashtable]$Scope, [array]$Records, [string[]]$DeletedIds, [bool]$HaveDeletes, [int]$BatchSize)
-    $totalDeleted = 0
-    if ($HaveDeletes) {
-        $delBody = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $null; deletedIds = ConvertTo-JsonArray $DeletedIds }
-        $totalDeleted = ((Invoke-IngestAPI -Endpoint $Endpoint -Body $delBody).deleted ?? 0)
-    }
-    $totalInserted = 0; $totalUpdated = 0; $syncId = $null; $result = $null
-    for ($i = 0; $i -lt $Records.Count; $i += $BatchSize) {
-        $batch = $Records[$i..([Math]::Min($i + $BatchSize - 1, $Records.Count - 1))]
-        $isFirst = ($i -eq 0)
-        $body = @{
-            systemId    = $SystemId
-            syncMode    = $SyncMode
-            scope       = $Scope
-            records     = ConvertTo-JsonArray $batch
-            syncSession = if ($isFirst) { 'start' } elseif ($i + $BatchSize -ge $Records.Count) { 'end' } else { 'continue' }
-        }
-        if ($syncId) { $body.syncId = $syncId }
-        $result = Invoke-IngestAPI -Endpoint $Endpoint -Body $body
-        if ($isFirst) { $syncId = $result.syncId }
-        $totalInserted += ($result.inserted ?? 0)
-        $totalUpdated += ($result.updated ?? 0)
-        Write-Host "  Batch $([Math]::Floor($i / $BatchSize) + 1)/$([Math]::Ceiling($Records.Count / $BatchSize)) done" -ForegroundColor Gray
-    }
-    $deleted = ($result.deleted ?? 0) + $totalDeleted
-    Write-Host "  Total: $totalInserted inserted, $totalUpdated updated, $deleted deleted" -ForegroundColor Green
-    return @{ inserted = $totalInserted; updated = $totalUpdated; deleted = $deleted }
+    Invoke-CrawlerIngestBatch -Endpoint $Endpoint -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope `
+        -Records $Records -DeletedIds $DeletedIds -BatchSize $BatchSize -SkipWhenEmpty
 }
 
 # HTTP status code off a caught error's response, or $null if unavailable.

--- a/tools/crawlers/midpoint/MidpointCrawler.Functions.ps1
+++ b/tools/crawlers/midpoint/MidpointCrawler.Functions.ps1
@@ -20,6 +20,13 @@ function Get-EntitySyncMode {
     return $SyncMode
 }
 
+# Thin adapter over the shared Invoke-CrawlerIngestBatch (tools/crawlers/shared/
+# Invoke-CrawlerIngest.ps1), wiring midPoint's crawler-specific bits:
+#   • per-endpoint sync mode via Get-EntitySyncMode (unless -SyncModeOverride)
+#     — cross-system tables are forced to delta so a full sync never wipes
+#     another source's data;
+#   • -SkipWhenEmpty (a phase with no records must NOT scoped-delete);
+#   • Add-IngestStat timing via -OnStat.
 function Send-IngestBatch {
     [CmdletBinding()]
     param(
@@ -30,39 +37,18 @@ function Send-IngestBatch {
         [array]$Records     = @(),
         [int]$BatchSize     = 5000
     )
-    $entity = ($Endpoint -replace '^ingest/', '')
-    $mode   = if ($SyncModeOverride) { $SyncModeOverride } else { Get-EntitySyncMode -Entity $entity }
-
-    if (-not $Records -or $Records.Count -eq 0) {
-        # The ingest API rejects an empty records array (no scoped-delete-only mode),
-        # so skip the call entirely when a phase produced no records.
-        Write-Host "  (no records for $Endpoint — skipping)" -ForegroundColor DarkGray
-        return @{ inserted = 0; updated = 0; deleted = 0 }
+    $params = @{
+        Endpoint      = $Endpoint
+        SystemId      = $SystemId
+        Scope         = $Scope
+        Records       = $Records
+        BatchSize     = $BatchSize
+        SkipWhenEmpty = $true
+        OnStat        = { param($e, $s, $c) Add-IngestStat -Endpoint $e -Seconds $s -Records $c }
     }
-    $swIngest = [System.Diagnostics.Stopwatch]::StartNew()
-    if ($Records.Count -le $BatchSize) {
-        $Body   = @{ systemId = $SystemId; syncMode = $mode; scope = $Scope; records = ConvertTo-JsonArray $Records }
-        $Result = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-    }
-    else {
-        # Chunked session for large batches
-        $SyncId = $null; $TotIns = 0; $TotUpd = 0; $TotDel = 0
-        for ($i = 0; $i -lt $Records.Count; $i += $BatchSize) {
-            $Chunk   = $Records[$i..([Math]::Min($i + $BatchSize - 1, $Records.Count - 1))]
-            $IsFirst = ($i -eq 0)
-            $IsLast  = ($i + $BatchSize -ge $Records.Count)
-            $Body    = @{ systemId = $SystemId; syncMode = $mode; scope = $Scope; records = ConvertTo-JsonArray $Chunk
-                          syncSession = if ($IsFirst) { 'start' } elseif ($IsLast) { 'end' } else { 'continue' } }
-            if ($SyncId) { $Body.syncId = $SyncId }
-            $R = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-            if ($IsFirst -and $R.syncId) { $SyncId = $R.syncId }
-            $TotIns += ($R.inserted ?? 0); $TotUpd += ($R.updated ?? 0); $TotDel += ($R.deleted ?? 0)
-        }
-        $Result = @{ inserted = $TotIns; updated = $TotUpd; deleted = $TotDel }
-    }
-    $swIngest.Stop()
-    Add-IngestStat -Endpoint $entity -Seconds $swIngest.Elapsed.TotalSeconds -Records $Records.Count
-    return $Result
+    if ($SyncModeOverride) { $params['SyncMode'] = $SyncModeOverride }
+    else { $params['SyncModeResolver'] = { param($e) Get-EntitySyncMode -Entity $e } }
+    Invoke-CrawlerIngestBatch @params
 }
 
 # ── Streaming ingest ──────────────────────────────────────────────────────────

--- a/tools/crawlers/omada/OmadaCrawler.Functions.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Functions.ps1
@@ -97,6 +97,10 @@ function Write-Phase {
     $Script:phases.Add($Phase)
 }
 
+# Thin adapter over the shared Invoke-CrawlerIngestBatch (tools/crawlers/shared/
+# Invoke-CrawlerIngest.ps1). Omada's original behaviour is the shared default —
+# no -SkipWhenEmpty, so an empty batch is still sent as a full sync and the
+# server scoped-deletes stale rows.
 function Send-IngestBatch {
     [CmdletBinding()]
     param(
@@ -108,36 +112,8 @@ function Send-IngestBatch {
         [string[]]$DeletedIds = @(),
         [int]$BatchSize     = 5000
     )
-    if (-not $Records -or $Records.Count -eq 0) {
-        # Still send an empty full-sync batch so the server can scoped-delete stale data
-        $Body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = @() }
-        return Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-    }
-
-    if ($DeletedIds.Count -gt 0) {
-        $DelBody = @{ systemId = $SystemId; syncMode = 'delta'; scope = $Scope; records = @(); deletedIds = ConvertTo-JsonArray $DeletedIds }
-        Invoke-IngestAPI -Endpoint $Endpoint -Body $DelBody | Out-Null
-    }
-
-    if ($Records.Count -le $BatchSize) {
-        $Body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Records }
-        return Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-    }
-
-    # Chunked session for large batches
-    $SyncId = $Null; $TotalInserted = 0; $TotalUpdated = 0; $TotalDeleted = 0
-    for ($I = 0; $I -lt $Records.Count; $I += $BatchSize) {
-        $Chunk   = $Records[$I..([Math]::Min($I + $BatchSize - 1, $Records.Count - 1))]
-        $IsFirst = ($I -eq 0)
-        $IsLast  = ($I + $BatchSize -ge $Records.Count)
-        $Body    = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Chunk
-                      syncSession = if ($IsFirst) { 'start' } elseif ($IsLast) { 'end' } else { 'continue' } }
-        if ($SyncId) { $Body.syncId = $SyncId }
-        $Result = Invoke-IngestAPI -Endpoint $Endpoint -Body $Body
-        if ($IsFirst -and $Result.syncId) { $SyncId = $Result.syncId }
-        $TotalInserted += ($Result.inserted ?? 0); $TotalUpdated += ($Result.updated ?? 0); $TotalDeleted += ($Result.deleted ?? 0)
-    }
-    return @{ inserted = $TotalInserted; updated = $TotalUpdated; deleted = $TotalDeleted }
+    Invoke-CrawlerIngestBatch -Endpoint $Endpoint -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope `
+        -Records $Records -DeletedIds $DeletedIds -BatchSize $BatchSize
 }
 
 #endregion Functions

--- a/tools/crawlers/shared/Invoke-CrawlerIngest.ps1
+++ b/tools/crawlers/shared/Invoke-CrawlerIngest.ps1
@@ -115,4 +115,133 @@ function ConvertTo-JsonArray {
     return ,$list
 }
 
+# ─── Shared ingest-batch protocol ────────────────────────────────────────────
+# The one canonical implementation of the crawler ingest protocol. Every crawler
+# used to carry its own near-identical Send-IngestBatch (single batch, chunked
+# start/continue/end sessions, empty handling) and they had DRIFTED — different
+# batch sizes, delete handling, id-generation, empty-batch behaviour. This
+# consolidates them: each crawler keeps only a thin Send-IngestBatch adapter that
+# forwards to this function, wiring its crawler-specific bits as opt-in params:
+#   -DeletedIds        delta tombstones sent alongside the upserts (Entra, Omada)
+#   -BatchSize         chunk threshold (default 5000; CSV uses 10000)
+#   -IdGeneration / -IdPrefix   deterministic-id contract (CSV: idPrefix becomes
+#                      "<IdPrefix>-<entity>", matching normalization.js)
+#   -SyncModeResolver  scriptblock ($entity) -> mode, for a per-endpoint sync
+#                      mode (midPoint forces cross-system tables to delta)
+#   -SkipWhenEmpty     on no records, skip the call entirely instead of sending
+#                      an empty full-sync batch (midPoint/CSV: never scoped-wipe)
+#   -OnStat            scriptblock ($entity,$seconds,$recordCount) for timing stats
+# ConvertTo-JsonArray is applied to every records payload so single-record delta
+# batches always serialise as an array (previously only some crawlers did this).
+
+function Get-FGIngestBodyBase {
+    [CmdletBinding()]
+    param([int]$SystemId, [string]$SyncMode, [hashtable]$Scope, $Records, [string]$IdGeneration, [string]$IdPrefix)
+    $body = @{ systemId = $SystemId; syncMode = $SyncMode; scope = $Scope; records = ConvertTo-JsonArray $Records }
+    if ($IdGeneration) { $body['idGeneration'] = $IdGeneration }
+    if ($IdPrefix)     { $body['idPrefix']     = $IdPrefix }
+    return $body
+}
+
+function Write-FGIngestBatchHeader {
+    [CmdletBinding()]
+    param($Endpoint, $Records, $DeletedIds, [bool]$HaveRecords, [bool]$HaveDeletes)
+    $count = if ($HaveRecords) { $Records.Count } else { $DeletedIds.Count }
+    $what  = if ($HaveRecords) { 'records' } else { 'deletes' }
+    Write-Host "  Sending $count $what to $Endpoint..." -NoNewline -ForegroundColor Cyan
+    if ($HaveRecords -and $HaveDeletes) { Write-Host " (+$($DeletedIds.Count) deletes)" -ForegroundColor Cyan }
+    else { Write-Host '' -ForegroundColor Cyan }
+}
+
+function Send-FGSingleIngestBatch {
+    [CmdletBinding()]
+    param($Endpoint, [int]$SystemId, [string]$SyncMode, [hashtable]$Scope, $Records, [string[]]$DeletedIds, [bool]$HaveRecords, [bool]$HaveDeletes, [string]$IdGeneration, [string]$IdPrefix)
+    $recs = if ($HaveRecords) { $Records } else { $null }
+    $body = Get-FGIngestBodyBase -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope -Records $recs -IdGeneration $IdGeneration -IdPrefix $IdPrefix
+    if ($HaveDeletes) { $body['deletedIds'] = ConvertTo-JsonArray $DeletedIds }
+    $result = Invoke-IngestAPI -Endpoint $Endpoint -Body $body
+    Write-Host "  Result: $($result.inserted) inserted, $($result.updated) updated, $($result.deleted) deleted" -ForegroundColor Green
+    return $result
+}
+
+function Send-FGChunkedIngestBatches {
+    [CmdletBinding()]
+    param($Endpoint, [int]$SystemId, [string]$SyncMode, [hashtable]$Scope, [array]$Records, [string[]]$DeletedIds, [bool]$HaveDeletes, [int]$BatchSize, [string]$IdGeneration, [string]$IdPrefix)
+    $totalDeleted = 0
+    if ($HaveDeletes) {
+        $delBody = Get-FGIngestBodyBase -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope -Records $null -IdGeneration $IdGeneration -IdPrefix $IdPrefix
+        $delBody['deletedIds'] = ConvertTo-JsonArray $DeletedIds
+        $totalDeleted = ((Invoke-IngestAPI -Endpoint $Endpoint -Body $delBody).deleted ?? 0)
+    }
+    $totalInserted = 0; $totalUpdated = 0; $syncId = $null; $result = $null
+    for ($i = 0; $i -lt $Records.Count; $i += $BatchSize) {
+        $batch   = $Records[$i..([Math]::Min($i + $BatchSize - 1, $Records.Count - 1))]
+        $isFirst = ($i -eq 0)
+        $body = Get-FGIngestBodyBase -SystemId $SystemId -SyncMode $SyncMode -Scope $Scope -Records $batch -IdGeneration $IdGeneration -IdPrefix $IdPrefix
+        $body['syncSession'] = if ($isFirst) { 'start' } elseif ($i + $BatchSize -ge $Records.Count) { 'end' } else { 'continue' }
+        if ($syncId) { $body['syncId'] = $syncId }
+        $result = Invoke-IngestAPI -Endpoint $Endpoint -Body $body
+        if ($isFirst) { $syncId = $result.syncId }
+        $totalInserted += ($result.inserted ?? 0)
+        $totalUpdated  += ($result.updated ?? 0)
+        Write-Host "  Batch $([Math]::Floor($i / $BatchSize) + 1)/$([Math]::Ceiling($Records.Count / $BatchSize)) done" -ForegroundColor Gray
+    }
+    $deleted = ($result.deleted ?? 0) + $totalDeleted
+    Write-Host "  Total: $totalInserted inserted, $totalUpdated updated, $deleted deleted" -ForegroundColor Green
+    return @{ inserted = $totalInserted; updated = $totalUpdated; deleted = $deleted }
+}
+
+function Invoke-CrawlerIngestBatch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [int]$SystemId = 0,
+        [string]$SyncMode = 'full',
+        [hashtable]$Scope = @{},
+        [array]$Records = @(),
+        [string[]]$DeletedIds = @(),
+        [int]$BatchSize = 5000,
+        [string]$IdGeneration,
+        [string]$IdPrefix,
+        [scriptblock]$SyncModeResolver,
+        [switch]$SkipWhenEmpty,
+        [scriptblock]$OnStat
+    )
+    $entity = ($Endpoint -replace '^ingest/', '')
+    $mode   = if ($SyncModeResolver) { & $SyncModeResolver $entity } else { $SyncMode }
+    # CSV's deterministic idPrefix is per-endpoint: "<prefix>-<entity>".
+    $fullIdPrefix = if ($IdPrefix) { "$IdPrefix-$entity" } else { $null }
+
+    $haveRecords = $Records -and $Records.Count -gt 0
+    $haveDeletes = $DeletedIds -and $DeletedIds.Count -gt 0
+
+    if (-not $haveRecords -and -not $haveDeletes) {
+        if ($SkipWhenEmpty) {
+            Write-Host "  (no records for $Endpoint - skipping)" -ForegroundColor DarkGray
+            return @{ inserted = 0; updated = 0; deleted = 0 }
+        }
+        # Empty full-sync batch so the server scoped-deletes stale rows.
+        $body = Get-FGIngestBodyBase -SystemId $SystemId -SyncMode $mode -Scope $Scope -Records @() -IdGeneration $IdGeneration -IdPrefix $fullIdPrefix
+        return (Invoke-IngestAPI -Endpoint $Endpoint -Body $body)
+    }
+
+    Write-FGIngestBatchHeader -Endpoint $Endpoint -Records $Records -DeletedIds $DeletedIds -HaveRecords $haveRecords -HaveDeletes $haveDeletes
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+    $result =
+        if (-not $haveRecords -or $Records.Count -le $BatchSize) {
+            Send-FGSingleIngestBatch -Endpoint $Endpoint -SystemId $SystemId -SyncMode $mode -Scope $Scope `
+                -Records $Records -DeletedIds $DeletedIds -HaveRecords $haveRecords -HaveDeletes $haveDeletes `
+                -IdGeneration $IdGeneration -IdPrefix $fullIdPrefix
+        }
+        else {
+            Send-FGChunkedIngestBatches -Endpoint $Endpoint -SystemId $SystemId -SyncMode $mode -Scope $Scope `
+                -Records $Records -DeletedIds $DeletedIds -HaveDeletes $haveDeletes -BatchSize $BatchSize `
+                -IdGeneration $IdGeneration -IdPrefix $fullIdPrefix
+        }
+    $sw.Stop()
+    if ($OnStat) { & $OnStat $entity $sw.Elapsed.TotalSeconds $Records.Count }
+    return $result
+}
+
 #endregion Functions


### PR DESCRIPTION
## Changes

All five crawlers carried their own near-identical `Send-IngestBatch` (single batch, chunked start/continue/end sessions, empty handling) and they had **drifted** — different batch sizes, delete handling, id-generation, empty-batch behaviour, and some lacked the single-record `ConvertTo-JsonArray` array-wrap fix.

This hoists the one canonical protocol into `tools/crawlers/shared/Invoke-CrawlerIngest.ps1` as **`Invoke-CrawlerIngestBatch`** (built on Entra's already-decomposed FG helpers, now shared), exposing the genuinely crawler-specific bits as opt-in params: `-DeletedIds`, `-BatchSize`, `-IdGeneration`/`-IdPrefix`, `-SyncModeResolver`, `-SkipWhenEmpty`, `-OnStat`.

Each crawler keeps only a **thin `Send-IngestBatch` adapter** forwarding its specifics — **zero call-site changes** across ~71 call sites, each crawler's exact behaviour preserved:

| Crawler | Behaviour preserved |
|---------|---------------------|
| entra | skip-empty, in-band delta tombstones |
| omada | send-empty (scoped delete); deletes now **in-band** (identical end state) |
| azure | send-empty; small batches so chunking never triggers |
| csv | deterministic idPrefix `<SystemType>-<entity>`, 10000 batch, skip-empty |
| midpoint | per-endpoint sync mode (`Get-EntitySyncMode`), skip-empty, `Add-IngestStat` |

## Testing (validated locally with Pester 5.8)

- New `test/unit/CrawlerIngestBatch.Tests.ps1` — **10 cases** pinning the shared protocol across every axis (single/chunked, deletes, empty send-vs-skip, id-generation, sync-mode resolver, stats callback).
- **All 479** crawler Functions/Phases/Dispatcher tests pass. The one omada test asserting the old *separate*-delete-batch shape is updated to the unified *in-band* shape (belt-and-suspenders with the full-sync reconcile — identical end state).
- PSScriptAnalyzer (CI's exclusion set): 0 issues on changed files.

## Out of scope
midPoint's separate streaming path (`Send-IngestStreamChunk`) is left as-is — it's a distinct function, not part of the `Send-IngestBatch` dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)