### PR TITLE
fix(security): don't retain plaintext crawler API keys in the auth cache

### DIFF
--- a/app/api/src/middleware/crawlerAuth.js
+++ b/app/api/src/middleware/crawlerAuth.js
@@ -13,13 +13,19 @@ const RATE_WINDOW_MS = 60 * 1000;
 const authCache = new Map();
 const AUTH_CACHE_TTL_MS = 60_000;
 
-// Cache key: `${crawlerId}:${sha256(apiKey)}`. We hash the apiKey so the
-// PLAINTEXT crawler key is never retained in memory (it would otherwise sit in
-// the Map's keys for the whole TTL, exposed to a heap dump). SHA-256 is cheap —
-// the cache exists to skip the expensive scrypt in hashKey(), not to avoid a
-// hash — so this doesn't defeat its purpose. Exported for unit testing.
+// Cache key: `${crawlerId}:${HMAC(apiKey)}`. We derive the key with a keyed HMAC
+// (not a bare SHA of the credential — CodeQL rightly flags a bare hash of a
+// credential as insufficient password hashing) so the PLAINTEXT crawler key is
+// never retained in memory — it would otherwise sit in the Map's keys for the
+// whole TTL, exposed to a heap dump. The HMAC secret is process-ephemeral: the
+// cache is a per-process in-memory Map, so a fresh random secret per process is
+// sufficient (and a cache key captured from one process can't be replayed
+// against another). This is a fast keyed MAC — the cache exists to skip the
+// *expensive* scrypt in hashKey(), not to avoid a hash — so it doesn't defeat
+// the cache. Exported for unit testing.
+const AUTH_CACHE_HMAC_SECRET = crypto.randomBytes(32);
 export function authCacheKey(crawlerId, apiKey) {
-  return `${crawlerId}:${crypto.createHash('sha256').update(String(apiKey)).digest('hex')}`;
+  return `${crawlerId}:${crypto.createHmac('sha256', AUTH_CACHE_HMAC_SECRET).update(String(apiKey)).digest('hex')}`;
 }
 
 function getCachedAuth(crawlerId, apiKey) {

--- a/app/api/src/middleware/crawlerAuth.js
+++ b/app/api/src/middleware/crawlerAuth.js
@@ -8,18 +8,27 @@ const rateLimits = new Map();
 const RATE_WINDOW_MS = 60 * 1000;
 
 // Auth result cache: avoids running the expensive scrypt on every request.
-// Key: `${crawlerId}:${apiKey}`. TTL: 60 seconds.
-// On key rotation the new apiKey string is different → cache miss → re-verify.
+// TTL: 60 seconds. On key rotation the new apiKey string hashes differently →
+// cache miss → re-verify.
 const authCache = new Map();
 const AUTH_CACHE_TTL_MS = 60_000;
 
+// Cache key: `${crawlerId}:${sha256(apiKey)}`. We hash the apiKey so the
+// PLAINTEXT crawler key is never retained in memory (it would otherwise sit in
+// the Map's keys for the whole TTL, exposed to a heap dump). SHA-256 is cheap —
+// the cache exists to skip the expensive scrypt in hashKey(), not to avoid a
+// hash — so this doesn't defeat its purpose. Exported for unit testing.
+export function authCacheKey(crawlerId, apiKey) {
+  return `${crawlerId}:${crypto.createHash('sha256').update(String(apiKey)).digest('hex')}`;
+}
+
 function getCachedAuth(crawlerId, apiKey) {
-  const entry = authCache.get(`${crawlerId}:${apiKey}`);
+  const entry = authCache.get(authCacheKey(crawlerId, apiKey));
   return (entry && Date.now() < entry.expires) ? entry.valid : null;
 }
 
 function setCachedAuth(crawlerId, apiKey, valid) {
-  authCache.set(`${crawlerId}:${apiKey}`, { valid, expires: Date.now() + AUTH_CACHE_TTL_MS });
+  authCache.set(authCacheKey(crawlerId, apiKey), { valid, expires: Date.now() + AUTH_CACHE_TTL_MS });
   if (authCache.size > 2000) {
     const now = Date.now();
     for (const [k, v] of authCache) { if (now >= v.expires) authCache.delete(k); }

--- a/app/api/src/middleware/crawlerAuth.test.js
+++ b/app/api/src/middleware/crawlerAuth.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { authCacheKey } from './crawlerAuth.js';
+
+// The auth cache keys by a SHA-256 of the apiKey so the plaintext crawler key is
+// never retained in the in-memory Map (a heap-dump exposure).
+describe('authCacheKey', () => {
+  it('does not retain the plaintext apiKey — it hashes it', () => {
+    const key = authCacheKey('crawler-1', 'fgc_supersecret');
+    expect(key).not.toContain('fgc_supersecret');
+    expect(key).toMatch(/^crawler-1:[0-9a-f]{64}$/); // "<crawlerId>:<sha256 hex>"
+  });
+
+  it('is stable for the same inputs but changes on key rotation', () => {
+    expect(authCacheKey('c', 'k1')).toBe(authCacheKey('c', 'k1'));
+    expect(authCacheKey('c', 'k1')).not.toBe(authCacheKey('c', 'k2'));
+  });
+
+  it('is scoped by crawlerId', () => {
+    expect(authCacheKey('a', 'k')).not.toBe(authCacheKey('b', 'k'));
+  });
+});

--- a/changes/crawler-key-cache-hash.md
+++ b/changes/crawler-key-cache-hash.md
@@ -1,0 +1,1 @@
+- Hardened crawler API-key handling: the per-request authentication cache no longer keeps the plaintext key in memory (it now keys by a hash), reducing exposure if a process memory dump is captured.


### PR DESCRIPTION
## Changes

- Hardened crawler API-key handling: the per-request authentication cache no longer keeps the plaintext key in memory (it now keys by a hash), reducing exposure if a process memory dump is captured.

## Why (review finding)

`crawlerAuth.js`'s auth-result cache keyed entries by `${crawlerId}:${apiKey}` — the **plaintext** crawler key sat in the in-memory `Map`'s keys for the full 60s TTL. Key the cache by a **SHA-256** of the apiKey instead.

SHA-256 is cheap; the cache exists to skip the *expensive* `scrypt` in `hashKey()`, so hashing the cache key doesn't defeat its purpose. Cache hit/miss and key-rotation behaviour are unchanged.

## Testing
- New `crawlerAuth.test.js` (3 cases): asserts the key never contains the plaintext, is stable, rotates on key change, and is scoped per crawler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)