### PR TITLE
fix(api): stop leaking err.message to clients on 500 responses

### DIFF
--- a/app/api/src/routes/admin.coverage.test.js
+++ b/app/api/src/routes/admin.coverage.test.js
@@ -249,11 +249,12 @@ describe('POST /admin/clean-database', () => {
     expect(res.body.skipped.length).toBeGreaterThan(0);
   });
 
-  it('500 when the existence batch check rejects', async () => {
+  it('500 when the existence batch check rejects (generic error, no leak)', async () => {
     query.mockRejectedValueOnce(new Error('boom'));
     const res = await request(app).post('/api/admin/clean-database');
     expect(res.status).toBe(500);
-    expect(res.body.error).toMatch(/Clean database failed/);
+    expect(res.body.error).toBe('Clean database failed');
+    expect(JSON.stringify(res.body)).not.toContain('boom'); // internal detail not leaked
   });
 });
 

--- a/app/api/src/routes/admin.js
+++ b/app/api/src/routes/admin.js
@@ -577,7 +577,7 @@ router.post('/admin/clean-database', writeSystems, adminDestructiveLimiter, asyn
     res.json({ message: 'Database cleaned', wiped, skipped });
   } catch (err) {
     console.error('Clean database failed:', err.message);
-    res.status(500).json({ error: 'Clean database failed: ' + err.message });
+    res.status(500).json({ error: 'Clean database failed' });
   }
 });
 

--- a/app/api/src/routes/contexts.js
+++ b/app/api/src/routes/contexts.js
@@ -405,7 +405,7 @@ router.post('/contexts/:id/sync', writeContexts, async (req, res) => {
     res.status(202).json({ runId, instanceKey });
   } catch (err) {
     console.error('POST /contexts/:id/sync failed:', err.message);
-    res.status(500).json({ error: err.message || 'Failed to sync tree' });
+    res.status(500).json({ error: 'Failed to sync tree' });
   }
 });
 

--- a/app/api/src/routes/riskScoringRuns.js
+++ b/app/api/src/routes/riskScoringRuns.js
@@ -47,7 +47,7 @@ router.post('/risk-scoring/runs', requirePermission('admin.crawlers'), async (re
     res.status(202).json(run);
   } catch (err) {
     console.error('start scoring run failed:', err.message);
-    res.status(500).json({ error: 'Failed to start scoring run', message: err.message });
+    res.status(500).json({ error: 'Failed to start scoring run' });
   }
 });
 

--- a/changes/generic-500-errors.md
+++ b/changes/generic-500-errors.md
@@ -1,0 +1,1 @@
+- API server errors (HTTP 500) no longer echo internal error details back to the client — they return a generic message while the full detail is still logged server-side, matching the project error-handling policy.


### PR DESCRIPTION
## Changes

- API server errors (HTTP 500) no longer echo internal error details back to the client — they return a generic message while the full detail is still logged server-side, matching the project's error-handling policy.

## Why (review finding)

`app/api/CLAUDE.md` says: *"Return generic messages to clients. Log `err.message` server-side, not the full error object (avoids leaking schema info)."* Three handlers violated this on their **500** path:

- `admin.js` clean-database: `'Clean database failed: ' + err.message`
- `contexts.js` tree sync: `err.message || 'Failed to sync tree'`
- `riskScoringRuns.js` start run: `{ ..., message: err.message }`

Each already logs `err.message` via `console.error` (kept). Now the client gets a generic message.

**Deliberately left alone:** the **400** validation handlers (there the message *is* the user-facing feedback) and the crawler-facing `ingest` endpoints (authenticated, trusted, and the detail aids crawler debugging).

## Testing
- Existing 500-path tests still pass (98). Added a regression assertion that the internal detail (`boom`) no longer appears in the response body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)