### PR TITLE
fix(security): bind dev Postgres to localhost in docker-compose.yml

### DIFF
--- a/changes/dev-compose-localhost-db.md
+++ b/changes/dev-compose-localhost-db.md
@@ -1,0 +1,1 @@
+- Development Docker setup: the local PostgreSQL container is now bound to localhost only instead of all network interfaces, so the database (which uses a default local password) is no longer reachable from other machines on your network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,11 @@ services:
       POSTGRES_USER:     "${POSTGRES_USER:-identity_atlas}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-identity_atlas_local}"
     ports:
-      - "5432:5432"
+      # Bind Postgres to loopback only — the dev stack ships a known default
+      # password, so publishing 5432 on 0.0.0.0 would let anyone on the same
+      # network reach the database. Local tools (psql, a GUI) still connect via
+      # localhost:5432; nothing needs it exposed to the LAN.
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Changes

- Development Docker setup: the local PostgreSQL container is now bound to `127.0.0.1` instead of all network interfaces, so the database (which uses a default local password) is no longer reachable from other machines on the network.

## Why (review finding)

The dev `docker-compose.yml` ships a known default `POSTGRES_PASSWORD` (`identity_atlas_local`) **and** published `5432` on `0.0.0.0` — anyone on the same LAN could connect to the database with the default credentials. Binding to loopback closes that. Local tools (`psql`, a GUI) still connect via `localhost:5432`.

Dev-only — `docker-compose.prod.yml` does not publish `5432`.

Config-only change (no app code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)