### PR TITLE
ci(coverage): add an enforced coverage floor (ratchet) for the JS suites (finding #6)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -402,9 +402,11 @@ jobs:
         working-directory: app/ui
         run: npm ci
 
-      - name: Run Vitest
+      - name: Run Vitest (with coverage ratchet)
         working-directory: app/ui
-        run: npm test
+        # Coverage-enabled so the committed thresholds floor in vite.config.js is
+        # enforced — a change that drops UI coverage below the floor fails here.
+        run: npm run test:coverage
 
   # ── Stage 4c: Node-launcher UI build (crawler wizard bundling) ──────────
   # The portable/desktop build (app/desktop/scripts/build-node-launcher.mjs)

--- a/app/api/vitest.config.js
+++ b/app/api/vitest.config.js
@@ -30,6 +30,18 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       include: ['src/**/*.js'],
       exclude: ['src/**/*.test.js', 'src/index.js'],
+      // Coverage ratchet: a committed FLOOR that `npm run test:coverage` (run in
+      // the PR Checks job) enforces — a change that drops unit coverage below
+      // these fails CI. Set just under the current numbers so normal variance
+      // doesn't flake. When you raise coverage, RAISE these too (the same
+      // manual-ratchet discipline as the complexity baseline; never lower them).
+      // Measured on this suite (unit only; contract tests add more): S67.8 B59.9 F67.9 L71.2.
+      thresholds: {
+        statements: 67,
+        branches: 59,
+        functions: 67,
+        lines: 71,
+      },
     },
   },
 });

--- a/app/ui/vite.config.js
+++ b/app/ui/vite.config.js
@@ -30,6 +30,17 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       include: ['src/**/*.{js,jsx}'],
       exclude: ['src/**/*.test.{js,jsx}', 'src/main.jsx', 'src/test-utils/**'],
+      // Coverage ratchet: a committed FLOOR enforced by the PR Checks job (which
+      // runs `npm run test:coverage`). A change that drops UI coverage below
+      // these fails CI. Set just under current so normal variance doesn't flake;
+      // RAISE these when you raise coverage (never lower them — same discipline
+      // as the complexity baseline). Measured: S63.7 B55.1 F56.8 L66.9.
+      thresholds: {
+        statements: 63,
+        branches: 55,
+        functions: 56,
+        lines: 66,
+      },
     },
   },
   server: {


### PR DESCRIPTION
## Changes

The **"coverage never down"** principle in CLAUDE.md had **no enforcing gate** — a PR could delete assertions and stay green. This adds one, modeled on the existing complexity ratchet's manual-baseline discipline.

- Committed **vitest `coverage.thresholds`** (a floor) to `app/api/vitest.config.js` and `app/ui/vite.config.js`.
- Switched the **UI PR job** to `npm run test:coverage` (the API job already ran it), so both floors are enforced in `PR Checks`.

A change that drops unit coverage below the floor now **fails CI**.

Floors are set just under the current numbers to avoid run-to-run variance flake:
| suite | statements | branches | functions | lines |
|-------|-----------|----------|-----------|-------|
| API | 67 | 59 | 67 | 71 |
| UI | 63 | 55 | 56 | 66 |

**Discipline:** RAISE these when coverage improves; never lower them (same rule as the complexity baseline's `--update`).

## Out of scope
Pester (PowerShell) coverage is produced by a separate weekly job, not on PRs — gating it would need its own mechanism. This PR gates the two JS suites, where the god-component/coverage-theater risks live.

## Verified locally
Both suites pass their new floors: API 145 files (S67.8/B59.9/F67.9/L71.2), UI 99 files (S63.8/B55.4/F57.0/L66.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)