### PR TITLE
ci(filesize): add a file-length ratchet enforcing the >1000-line split rule (finding #17)

### DIFF
--- a/.ci/filesize-baseline.json
+++ b/.ci/filesize-baseline.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "File-length ratchet baseline. Files currently over the ceiling; each may only shrink. Only ever lowered (python tools/filesize/ratchet.py --update). See the tool header.",
+  "ceiling": 1000,
+  "files": {
+    "app/ui/src/components/AdminPage.jsx": 1726,
+    "app/ui/src/components/MatrixView.jsx": 1170,
+    "app/ui/src/components/matrix/MatrixFilterWizard.jsx": 1239,
+    "tools/crawlers/entra-id/EntraIDCrawler.Phases.ps1": 1873,
+    "tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1": 1011,
+    "tools/crawlers/omada/OmadaCrawler.Phases.ps1": 1081
+  }
+}

--- a/.github/workflows/filesize.yml
+++ b/.github/workflows/filesize.yml
@@ -1,0 +1,42 @@
+# ─── File-length ratchet ─────────────────────────────────────────────────────
+# Enforces the CLAUDE.md rule: a source file past ~1000 lines "must be broken
+# into focused files/functions before more is added to it." Every source file
+# currently over the ceiling is grandfathered in .ci/filesize-baseline.json and
+# may only SHRINK; a new file (or one that crosses the ceiling) over the limit
+# fails. The baseline only ever ratchets down. See tools/filesize/ratchet.py.
+# ─────────────────────────────────────────────────────────────────────────────
+name: File-length ratchet
+
+on:
+  pull_request:
+    branches: [main]
+    # A PR that changes ONLY docs / a version bump / the baseline itself has no
+    # source to re-measure. `.ci/**` covers a pure re-baseline (self-consistent
+    # by construction); a real change that also re-baselines still runs, since
+    # paths-ignore only skips when EVERY changed file matches.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'setup/IdentityAtlas.psd1'
+      - '.ci/**'
+  workflow_dispatch:
+
+concurrency:
+  group: filesize-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ratchet:
+    name: File-length ratchet
+    runs-on: ubuntu-latest   # git + python3 are preinstalled on the GitHub runner
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Validate the ratchet gate logic (Python) before it gates anything.
+      - name: Test the ratchet gate logic
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest tools/filesize/test_ratchet.py -q
+
+      - name: Run file-length ratchet
+        run: python3 tools/filesize/ratchet.py

--- a/tools/filesize/ratchet.py
+++ b/tools/filesize/ratchet.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""File-length ratchet — enforces the CLAUDE.md rule that a source file past
+~1000 lines "must be broken into focused files/functions before more is added
+to it."
+
+Mirrors the cyclomatic/cognitive complexity ratchet (tools/complexity/ratchet.py):
+every source file currently over the ceiling is grandfathered into a committed
+baseline (.ci/filesize-baseline.json). CI then enforces, per file:
+  - a grandfathered file may only SHRINK (its line count must not exceed the
+    baselined value);
+  - a new file, or a file that crosses the ceiling for the first time, must be
+    at or under the ceiling.
+The baseline only ever ratchets DOWN (via --update).
+
+Usage:
+  python tools/filesize/ratchet.py            # check (CI)
+  python tools/filesize/ratchet.py --update   # re-baseline from current sources
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BASELINE = os.path.join(REPO, ".ci", "filesize-baseline.json")
+CEILING = 1000
+EXTS = (".ps1", ".js", ".jsx", ".sql")
+# Substrings marking a path as out of scope: vendored, build output, generated,
+# and test files (tests legitimately grow as cases are added; the rule is about
+# source maintainability). test/ (harness scripts) is excluded by prefix below.
+EXCLUDE = (
+    "node_modules/", "/dist", "dist-frontend", "dist-node-launcher",
+    "bundled-scripts/", "coverage/", "docs/coverage", "/site/",
+    "app-bundle.mjs", ".test.", ".Tests.", "/e2e/",
+)
+
+
+def tracked_source():
+    out = subprocess.run(["git", "ls-files", "-z"], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout
+    for p in out.split("\0"):
+        if not p or not p.endswith(EXTS):
+            continue
+        if p.startswith("test/"):          # PowerShell test-harness scripts, not source
+            continue
+        if any(x in p for x in EXCLUDE):
+            continue
+        yield p
+
+
+def line_count(path):
+    with open(os.path.join(REPO, path), "rb") as f:
+        return sum(1 for _ in f)
+
+
+def measure():
+    return {p: line_count(p) for p in tracked_source()}
+
+
+def over_ceiling(sizes):
+    return {p: n for p, n in sizes.items() if n > CEILING}
+
+
+def load_baseline():
+    if not os.path.exists(BASELINE):
+        return {}
+    with open(BASELINE, encoding="utf-8") as f:
+        return json.load(f).get("files", {})
+
+
+def evaluate(over, baseline):
+    """Return the list of violation messages (empty == pass)."""
+    fails = []
+    for p, n in sorted(over.items()):
+        if p in baseline:
+            if n > baseline[p]:
+                fails.append(f"{p}: {n} lines - grew past its grandfathered ceiling "
+                             f"({baseline[p]}). Split it into focused files; do not add to it.")
+        else:
+            fails.append(f"{p}: {n} lines - new file over the {CEILING}-line ceiling. "
+                         f"Split it into focused files/functions.")
+    return fails
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--update", action="store_true",
+                    help="re-baseline: record current over-ceiling files (ratchets down only)")
+    args = ap.parse_args()
+
+    over = over_ceiling(measure())
+
+    if args.update:
+        os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
+        with open(BASELINE, "w", encoding="utf-8") as f:
+            json.dump({
+                "_comment": ("File-length ratchet baseline. Files currently over the "
+                             "ceiling; each may only shrink. Only ever lowered "
+                             "(python tools/filesize/ratchet.py --update). See the tool header."),
+                "ceiling": CEILING,
+                "files": dict(sorted(over.items())),
+            }, f, indent=2)
+            f.write("\n")
+        print(f"Wrote baseline: {len(over)} file(s) over {CEILING} lines.")
+        return 0
+
+    baseline = load_baseline()
+    fails = evaluate(over, baseline)
+    print(f"[filesize] {len(over)} file(s) over {CEILING} lines "
+          f"({len(baseline)} grandfathered).")
+    if fails:
+        print(f"File-length ratchet FAILED: {len(fails)} violation(s). Split the file(s), "
+              f"or - only for an intentional, reviewed increase - re-baseline with: "
+              f"python tools/filesize/ratchet.py --update")
+        for msg in fails:
+            print(f"::error::File-length ratchet: {msg}")
+        return 1
+    print("File-length ratchet OK - no file exceeds its ceiling.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/filesize/test_ratchet.py
+++ b/tools/filesize/test_ratchet.py
@@ -1,0 +1,45 @@
+"""Unit tests for the file-length ratchet's pure evaluation logic.
+
+Run: python -m pytest tools/filesize/test_ratchet.py   (or: python tools/filesize/test_ratchet.py)
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from ratchet import evaluate, CEILING  # noqa: E402
+
+
+def test_new_file_over_ceiling_fails():
+    over = {"src/big.js": CEILING + 50}
+    fails = evaluate(over, baseline={})
+    assert len(fails) == 1
+    assert "new file over" in fails[0]
+
+
+def test_grandfathered_file_that_grew_fails():
+    over = {"src/legacy.jsx": 1300}
+    fails = evaluate(over, baseline={"src/legacy.jsx": 1200})
+    assert len(fails) == 1
+    assert "grew past its grandfathered ceiling" in fails[0]
+
+
+def test_grandfathered_file_that_shrank_passes():
+    over = {"src/legacy.jsx": 1100}          # still over ceiling, but below its baseline
+    assert evaluate(over, baseline={"src/legacy.jsx": 1200}) == []
+
+
+def test_grandfathered_file_at_exactly_baseline_passes():
+    over = {"src/legacy.jsx": 1200}
+    assert evaluate(over, baseline={"src/legacy.jsx": 1200}) == []
+
+
+def test_no_files_over_ceiling_passes():
+    assert evaluate({}, baseline={"src/legacy.jsx": 1200}) == []
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")


### PR DESCRIPTION
## Changes

The CLAUDE.md rule — *"a source file past ~1000 lines must be broken into focused files/functions before more is added to it"* — had **no automated enforcement**. The complexity ratchet gates per-**function** complexity, not file **length**, so a monolith of simple functions sails through (exactly how AdminPage.jsx reached 1726 lines).

Adds a **file-length ratchet** modeled on the complexity one:
- `tools/filesize/ratchet.py` measures tracked source files (`.ps1/.js/.jsx/.sql`, excluding tests/vendored/generated) and gates them against `.ci/filesize-baseline.json`.
- The **6 files currently over 1000 lines are grandfathered** and may only **shrink**; a new file (or one that crosses 1000) fails.
- The baseline only ratchets **down** (via `--update`).
- Runs as its own lightweight PR workflow (`git` + `python3` only).

Grandfathered baseline:
```
EntraIDCrawler.Phases.ps1        1873
AdminPage.jsx                    1726   (dropping to 167 once #579 merges)
MatrixFilterWizard.jsx           1239
MatrixView.jsx                   1170
OmadaCrawler.Phases.ps1          1081
EntraIDCrawler.Transform.ps1     1011
```

## Testing
- `tools/filesize/test_ratchet.py` (5 cases) covers the pure `evaluate()` logic: new-over-ceiling fails, grandfathered-grew fails, grandfathered-shrank/at-baseline pass, none-over passes. CI runs it before the gate.
- Verified locally: the check passes on the current tree (6 grandfathered, 0 violations).

## Note
Like the complexity ratchet, this should be added to the `main` branch ruleset's required checks to be blocking (currently it will run and report, but a required-check entry makes it enforce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)