### PR TITLE
ci: drop pr-integration paths-ignore so its gate can be a required check (finding #10, step 1)

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -33,15 +33,16 @@ on:
     branches:
       - main
       - 'release/**'
-    paths-ignore:
-      - '.github/workflows/**'
-      - 'app/desktop/scripts/**'
-      - 'changes/**'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'setup/IdentityAtlas.psd1'
-      - '**.md'
-      - '.ci/**'
+    # NO top-level paths-ignore. The workflow must run on EVERY PR so its
+    # `if: always()` gate job (Integration CI Passed) always posts a status —
+    # a required status check whose job is skipped stays "pending" forever and
+    # deadlocks the merge, so a paths-ignore here (which skips the whole workflow
+    # for docs-only PRs) is incompatible with making the gate required.
+    # The EXPENSIVE suites are still scoped: the `changes` (commit-range) and
+    # `filter` (dorny path-scope) jobs gate integration / e2e / load-soak, so a
+    # docs-only or PowerShell-only PR skips whichever aren't relevant. Skipped
+    # jobs pass the gate (it only fails on `failure`/`cancelled`), so the gate
+    # goes green without running them. See docs/architecture/ci-scope-testing.md.
 
 # Cancel superseded runs when a PR branch is pushed again — these Docker/load
 # suites are expensive, so don't let a stale run keep burning a runner (F4).


### PR DESCRIPTION
## What & why

Step 1 of making the integration suite a **required** check on `main` (finding #10 — the documented Phase-3 migration was never completed, so a PR whose integration suite fails can currently still merge).

The gate job `Integration CI Passed` (`if: always()`) can only be a **required** status check if the workflow always **runs** — a required check whose job is skipped stays `pending` forever and **deadlocks** the merge. The top-level `paths-ignore` skipped the *entire* workflow for docs-/workflow-only PRs, so the gate never posted for them. This removes it.

## The scope-aware design is preserved

The **expensive** suites stay scoped — the `changes` (commit-range) and `filter` (dorny path-scope) jobs still gate `integration` / `e2e` / `load-soak` (`:208`, `:698`, `:806`), and skipped jobs **pass** the gate (it fails only on `failure`/`cancelled`). So a docs-only or scope-limited PR still **skips** the heavy jobs — the gate just goes green without running them. e2e/load-soak still only run when their files change.

## This PR self-verifies

It changes only a workflow file, so with `paths-ignore` gone, `pr-integration` now runs on it, `filter` finds no api/ui/ps changes → **integration / e2e / load-soak skip**, and **`Integration CI Passed` posts green**. That's exactly the docs-only behaviour a repo admin needs before flipping the ruleset switch.

## Step 2 (needs a repo admin — I can't edit rulesets)
Add `Integration CI Passed` to the `main` ruleset (`15779470`) required status checks (alongside the existing `PR Summary` / `CI Passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)