### PR TITLE
fix(ingest): resolve context parentExternalId to parentContextId, not parentResourceId

### DIFF
--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -94,7 +94,19 @@ export function normalizeRecords(records, coreColumns, options = {}) {
       // ContextMembers_contextId_fkey on the context-members upsert).
       const sysPrefix = systemPrefix || idPrefix.split('-')[0];
 
-      if (rec.parentExternalId && !normalized.parentResourceId) {
+      // A parentExternalId names the record's parent in the SAME entity family,
+      // so it must resolve into that family's namespace and land on that table's
+      // parent FK column — not always Resources. A Context's parent is another
+      // Context ("<sys>-contexts" → parentContextId); a resource-relationship's
+      // parent is another Resource ("<sys>-resources" → parentResourceId). Key
+      // off whichever parent column the target table actually has (coreSet) so a
+      // context tree's parentExternalId no longer mis-resolves to a Resources id
+      // (which left the hierarchy unset — the parent link only survived as raw
+      // text in extendedAttributes).
+      if (rec.parentExternalId && coreSet.has('parentContextId') && !normalized.parentContextId) {
+        normalized.parentContextId = deterministicGuid(`${sysPrefix}-contexts`, String(rec.parentExternalId));
+      }
+      if (rec.parentExternalId && coreSet.has('parentResourceId') && !normalized.parentResourceId) {
         normalized.parentResourceId = deterministicGuid(`${sysPrefix}-resources`, String(rec.parentExternalId));
       }
       if (rec.childExternalId && !normalized.childResourceId) {

--- a/app/api/src/ingest/normalization.js
+++ b/app/api/src/ingest/normalization.js
@@ -26,6 +26,60 @@ export function deterministicGuid(prefix, externalId) {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// External-ID → target-column mappings that resolve 1:1 into a fixed entity
+// namespace. Each entry: the caller-supplied field, the normalized column it
+// fills, and the entity suffix whose "<sys>-<suffix>" namespace generated that
+// entity's deterministic id. Resolved only when the field is present and the
+// target isn't already set. parentExternalId and memberExternalId are handled
+// separately in resolveExternalRefs (their target/namespace is dynamic).
+const SIMPLE_EXTERNAL_REFS = [
+  { field: 'childExternalId',     target: 'childResourceId', ns: 'resources' },
+  { field: 'identityExternalId',  target: 'identityId',      ns: 'identities' },
+  { field: 'userExternalId',      target: 'principalId',     ns: 'principals' },
+  { field: 'resourceExternalId',  target: 'resourceId',      ns: 'resources' },
+  { field: 'principalExternalId', target: 'principalId',     ns: 'principals' },
+  { field: 'contextExternalId',   target: 'contextId',       ns: 'contexts' },
+];
+
+/**
+ * Resolve a record's external-ID references to deterministic UUIDs in the same
+ * "<sys>-<entity>" namespace the target entity used, so the generated FKs line
+ * up with the rows the other endpoints created. Mutates `normalized`.
+ *
+ * All target column names come from trusted constants (never the record), so the
+ * dynamic `normalized[target]` writes can't be remote-property-injected.
+ */
+function resolveExternalRefs(rec, normalized, coreSet, sysPrefix) {
+  // A parentExternalId names the record's parent in the SAME entity family, so it
+  // must land on whichever parent FK the target table has: a Context's parent is
+  // another Context ("<sys>-contexts" → parentContextId); a resource
+  // relationship's parent is another Resource ("<sys>-resources" →
+  // parentResourceId). Keying off coreSet stops a context tree's parentExternalId
+  // mis-resolving to a Resources id (which left the hierarchy unset, surviving
+  // only as raw text in extendedAttributes).
+  if (rec.parentExternalId) {
+    if (coreSet.has('parentContextId') && !normalized.parentContextId) {
+      normalized.parentContextId = deterministicGuid(`${sysPrefix}-contexts`, String(rec.parentExternalId));
+    } else if (coreSet.has('parentResourceId') && !normalized.parentResourceId) {
+      normalized.parentResourceId = deterministicGuid(`${sysPrefix}-resources`, String(rec.parentExternalId));
+    }
+  }
+
+  for (const { field, target, ns } of SIMPLE_EXTERNAL_REFS) {
+    if (rec[field] && !normalized[target]) {
+      normalized[target] = deterministicGuid(`${sysPrefix}-${ns}`, String(rec[field]));
+    }
+  }
+
+  // A context-member's memberId namespace depends on what kind of entity it is.
+  if (rec.memberExternalId && !normalized.memberId) {
+    const memberNs = { Identity: 'identities', Principal: 'principals', Resource: 'resources' }[rec.memberType];
+    if (memberNs) {
+      normalized.memberId = deterministicGuid(`${sysPrefix}-${memberNs}`, String(rec.memberExternalId));
+    }
+  }
+}
+
 /**
  * Normalize a batch of records for a given entity type.
  *
@@ -72,74 +126,16 @@ export function normalizeRecords(records, coreColumns, options = {}) {
       normalized.externalId = String(rec.externalId);
     }
 
-    // Handle external-ID-based references for resource-relationships and
-    // resource-assignments. When the caller sends parentExternalId /
-    // childExternalId / resourceExternalId / principalExternalId, convert
-    // them to deterministic UUIDs using the same prefix namespace so the FKs
-    // match the IDs generated for the parent/child entities.
+    // Resolve external-ID references (parent/child/resource/principal/identity/
+    // context/member) to deterministic UUIDs so the generated FKs match the ids
+    // the other endpoints created for the same externalId — see resolveExternalRefs.
     if (idGeneration === 'deterministic') {
-      // Cross-entity ID resolution: derive the prefix used to generate the
-      // target entity's deterministic GUID. The convention is that the ingest
-      // caller sets idPrefix = "<systemPrefix>-<endpointSuffix>", e.g.
-      // "<sys>-resources", "<sys>-principals", "<sys>-resource-assignments".
-      //
-      // To resolve a resourceExternalId we need "<sys>-resources" — i.e. keep
-      // the system prefix and swap the entity suffix. Same for principals.
-      //
       // Prefer the explicit systemPrefix the route recovers by stripping the
-      // known entity suffix off idPrefix — that survives a system prefix that
-      // itself contains hyphens. Splitting on the first hyphen only works when
-      // the system prefix is hyphen-free, and otherwise resolves references to
-      // the wrong namespace, causing FK violations (e.g.
-      // ContextMembers_contextId_fkey on the context-members upsert).
+      // known entity suffix off idPrefix — it survives a system prefix that
+      // itself contains hyphens (splitting on the first hyphen would resolve to
+      // the wrong namespace, e.g. a ContextMembers_contextId_fkey violation).
       const sysPrefix = systemPrefix || idPrefix.split('-')[0];
-
-      // A parentExternalId names the record's parent in the SAME entity family,
-      // so it must resolve into that family's namespace and land on that table's
-      // parent FK column — not always Resources. A Context's parent is another
-      // Context ("<sys>-contexts" → parentContextId); a resource-relationship's
-      // parent is another Resource ("<sys>-resources" → parentResourceId). Key
-      // off whichever parent column the target table actually has (coreSet) so a
-      // context tree's parentExternalId no longer mis-resolves to a Resources id
-      // (which left the hierarchy unset — the parent link only survived as raw
-      // text in extendedAttributes).
-      if (rec.parentExternalId && coreSet.has('parentContextId') && !normalized.parentContextId) {
-        normalized.parentContextId = deterministicGuid(`${sysPrefix}-contexts`, String(rec.parentExternalId));
-      }
-      if (rec.parentExternalId && coreSet.has('parentResourceId') && !normalized.parentResourceId) {
-        normalized.parentResourceId = deterministicGuid(`${sysPrefix}-resources`, String(rec.parentExternalId));
-      }
-      if (rec.childExternalId && !normalized.childResourceId) {
-        normalized.childResourceId = deterministicGuid(`${sysPrefix}-resources`, String(rec.childExternalId));
-      }
-      // Identity-member external IDs
-      if (rec.identityExternalId && !normalized.identityId) {
-        normalized.identityId = deterministicGuid(`${sysPrefix}-identities`, String(rec.identityExternalId));
-      }
-      if (rec.userExternalId && !normalized.principalId) {
-        normalized.principalId = deterministicGuid(`${sysPrefix}-principals`, String(rec.userExternalId));
-      }
-      if (rec.resourceExternalId && !normalized.resourceId) {
-        normalized.resourceId = deterministicGuid(`${sysPrefix}-resources`, String(rec.resourceExternalId));
-      }
-      if (rec.principalExternalId && !normalized.principalId) {
-        normalized.principalId = deterministicGuid(`${sysPrefix}-principals`, String(rec.principalExternalId));
-      }
-      // Context-member references (ingest/context-members). The context endpoint
-      // generates context IDs under "<sys>-contexts" and each member entity under
-      // "<sys>-<entity>", so re-derive the same namespaces here to make the FKs
-      // line up. The CSV crawler sends these externalIds expecting resolution
-      // here — see tools/crawlers/csv/Start-CSVCrawler.ps1 → ContextMembers.csv.
-      if (rec.contextExternalId && !normalized.contextId) {
-        normalized.contextId = deterministicGuid(`${sysPrefix}-contexts`, String(rec.contextExternalId));
-      }
-      if (rec.memberExternalId && !normalized.memberId) {
-        // memberId's namespace depends on what kind of entity the member is.
-        const memberNs = { Identity: 'identities', Principal: 'principals', Resource: 'resources' }[rec.memberType];
-        if (memberNs) {
-          normalized.memberId = deterministicGuid(`${sysPrefix}-${memberNs}`, String(rec.memberExternalId));
-        }
-      }
+      resolveExternalRefs(rec, normalized, coreSet, sysPrefix);
     }
 
     // Set systemId if provided, the record doesn't override it, AND the table has the column

--- a/app/api/src/ingest/normalization.test.js
+++ b/app/api/src/ingest/normalization.test.js
@@ -189,3 +189,75 @@ describe('normalizeRecords — context-member externalId resolution', () => {
     expect(oldBehaviour[0].contextId).not.toBe(ctx[0].id);
   });
 });
+
+describe('normalizeRecords — context parentExternalId resolution', () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  // Contexts are ingested with idPrefix "<sys>-contexts".
+  const contextOpts = { idGeneration: 'deterministic', idPrefix: 'Omada-contexts', systemId: 1 };
+  const contextCols = ['id', 'externalId', 'displayName', 'variant', 'targetType', 'contextType', 'parentContextId', 'systemId'];
+
+  it('resolves a context parentExternalId to a deterministic UUID in parentContextId', () => {
+    const r = normalizeRecords(
+      [{ externalId: 'child', displayName: 'Child', contextType: 'OrgUnit', parentExternalId: 'root' }],
+      contextCols, contextOpts
+    );
+    expect(r[0].parentContextId).toMatch(UUID_RE);
+  });
+
+  it('child parentContextId matches the id the Contexts endpoint generates for the parent (the FK that was broken)', () => {
+    // A parented context tree must link child→parent by the exact UUID the parent
+    // context row got. Both are sent with idPrefix "<sys>-contexts", so the child's
+    // resolved parentContextId has to equal the parent's generated id.
+    const parentKey = 'root';
+    const parent = normalizeRecords(
+      [{ externalId: parentKey, displayName: 'Root', contextType: 'OrgUnit' }],
+      contextCols, contextOpts
+    );
+    const child = normalizeRecords(
+      [{ externalId: 'child', displayName: 'Child', contextType: 'OrgUnit', parentExternalId: parentKey }],
+      contextCols, contextOpts
+    );
+    expect(child[0].parentContextId).toBe(parent[0].id);
+  });
+
+  it('does NOT mis-resolve a context parent into parentResourceId (the bug)', () => {
+    // Before the fix, every deterministic parentExternalId became a parentResourceId
+    // under "<sys>-resources" — wrong table, wrong namespace — so the context
+    // hierarchy silently never persisted (the parent survived only as raw text in
+    // extendedAttributes).
+    const r = normalizeRecords(
+      [{ externalId: 'child', displayName: 'Child', contextType: 'OrgUnit', parentExternalId: 'root' }],
+      contextCols, contextOpts
+    );
+    expect(r[0].parentResourceId).toBeUndefined();
+  });
+
+  it('does not overwrite an explicit parentContextId', () => {
+    const explicit = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    const r = normalizeRecords(
+      [{ externalId: 'child', parentContextId: explicit, parentExternalId: 'root', contextType: 'OrgUnit' }],
+      contextCols, contextOpts
+    );
+    expect(r[0].parentContextId).toBe(explicit);
+  });
+
+  it('still resolves a resource-relationship parentExternalId to parentResourceId (table has no parentContextId column)', () => {
+    // Regression guard: the resource-relationships table carries parentResourceId,
+    // not parentContextId, so parentExternalId must keep resolving into
+    // "<sys>-resources" and match the id the Resources endpoint generates.
+    const relOpts = { idGeneration: 'deterministic', idPrefix: 'Omada-resource-relationships', systemPrefix: 'Omada', systemId: 1 };
+    const relCols = ['parentResourceId', 'childResourceId', 'relationshipType', 'systemId'];
+    const r = normalizeRecords(
+      [{ parentExternalId: 'grp', childExternalId: 'sub', relationshipType: 'Contains' }],
+      relCols, relOpts
+    );
+    expect(r[0].parentResourceId).toMatch(UUID_RE);
+    expect(r[0].parentContextId).toBeUndefined();
+    const resource = normalizeRecords(
+      [{ externalId: 'grp', displayName: 'Grp' }],
+      ['id', 'externalId', 'displayName'],
+      { idGeneration: 'deterministic', idPrefix: 'Omada-resources', systemId: 1 }
+    );
+    expect(r[0].parentResourceId).toBe(resource[0].id);
+  });
+});

--- a/changes/ingest-context-parent-resolution.md
+++ b/changes/ingest-context-parent-resolution.md
@@ -1,0 +1,1 @@
+- Fixed imported context hierarchies (such as org-unit or department trees) not linking to their parent. A context's parent reference is now resolved into the correct context, so parent/child relationships persist on import instead of being silently dropped.


### PR DESCRIPTION
## Problem
The deterministic-ID resolver in `ingest/normalization.js` hardcoded `parentExternalId → parentResourceId` for **every** ingest endpoint. So when a crawler sends a **Context** with a `parentExternalId` (org-unit / department trees, IGA business-role hierarchies), the parent was resolved into the *Resources* namespace — the wrong table and the wrong id. The `Contexts` table has no `parentResourceId` column, so the FK was dropped: **the hierarchy never persisted**, and the parent key survived only as raw text inside `extendedAttributes`.

This is a "fix at the source" data-model bug (architecture audit finding A1).

## Fix
Resolve `parentExternalId` against whichever parent FK the **target table actually has** (keyed on the discovered core columns), instead of assuming Resources:
- a **Context**'s parent resolves under `"<sys>-contexts"` → `parentContextId`
- a **resource-relationship**'s parent keeps resolving under `"<sys>-resources"` → `parentResourceId`

Because contexts are ingested under the same `"<sys>-contexts"` namespace, a child's resolved `parentContextId` now equals the parent context row's own generated id — the FK lines up exactly.

## Tests (`normalization.test.js`, +5)
- `parentContextId` resolves to a deterministic UUID
- child `parentContextId` **matches the id the Contexts endpoint generates for the parent** (the broken FK)
- a context parent is **not** mis-resolved into `parentResourceId`
- an explicit `parentContextId` is not overwritten
- **regression:** resource-relationships still resolve `parentExternalId → parentResourceId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
