### PR TITLE
fix(matrix): remove dead retired-assignmentType badges from the legend

### DIFF
--- a/app/ui/src/components/matrix/MatrixLegend.jsx
+++ b/app/ui/src/components/matrix/MatrixLegend.jsx
@@ -9,13 +9,14 @@ import { TYPE_COLORS } from '@ui/utils/colors';
 
 // The matrix shows only HOW access is held. Source-attribute types collapse
 // onto these in MatrixView (business role / OAuth2 grant / direct app role →
-// Direct; app role via group → Indirect), so the legend only lists the four
-// real badges. Whether access is governed is shown by the cell colour below.
+// Direct; app role via group → Indirect), so the legend only lists the three
+// real badges. Ownership is no longer a badge — it is its own resource
+// (resourceType='GroupOwnership') shown as a normal row. Whether access is
+// governed is shown by the cell colour below.
 const TYPE_LABELS = [
   ['Direct', 'Direct membership'],
   ['Indirect', 'Indirect (via a nested resource)'],
   ['Eligible', 'Eligible — just-in-time access'],
-  ['Owner', 'Owner of the resource'],
 ];
 
 function Badge({ type }) {

--- a/app/ui/src/components/matrix/MatrixLegend.test.js
+++ b/app/ui/src/components/matrix/MatrixLegend.test.js
@@ -3,22 +3,23 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement as h } from 'react';
 import MatrixLegend from './MatrixLegend';
 
-// The matrix view (vw_ResourceUserPermissionAssignments, migration 025) collapses
-// the source-attribute assignment types onto how access is HELD: business role /
+// The matrix view (vw_ResourceUserPermissionAssignments) collapses the
+// source-attribute assignment types onto how access is HELD: business role /
 // OAuth2 grant / direct app role -> Direct, app role via group -> Indirect. So the
-// legend must only show the four real badges (D/I/E/O) — not Governed/OAuth2/AppRole,
-// which never render as badges (governance is shown by the cell colour instead).
+// legend must only show the three real badges (D/I/E) — not Owner/Governed/OAuth2/
+// AppRole, which never render as badges (ownership is its own GroupOwnership
+// resource row; governance is shown by the cell colour instead).
 describe('MatrixLegend', () => {
   const html = renderToStaticMarkup(h(MatrixLegend));
 
-  it('lists the four held-access badges with corrected wording', () => {
+  it('lists the three held-access badges with corrected wording', () => {
     expect(html).toContain('Direct membership');
     expect(html).toContain('Indirect (via a nested resource)');
     expect(html).toContain('Eligible — just-in-time access');
-    expect(html).toContain('Owner of the resource');
   });
 
-  it('does not list the collapsed source-attribute types as badges', () => {
+  it('does not list retired assignment types (incl. Owner) as badges', () => {
+    expect(html).not.toContain('Owner of the resource');
     expect(html).not.toContain('Governed (granted');
     expect(html).not.toContain('App role');
     expect(html).not.toContain('OAuth2 delegated');

--- a/app/ui/src/utils/colors.js
+++ b/app/ui/src/utils/colors.js
@@ -23,14 +23,14 @@ export function getAccessPackageColor(index, isDark) {
   return palette[index % palette.length];
 }
 
+// Matrix cell / legend badge colours, keyed by membershipType. The matrix view
+// (vw_ResourceUserPermissionAssignments) collapses every source assignment type
+// onto how the access is HELD, so only these three ever render as badges — on
+// screen and in the Excel export legend alike. The retired types that used to
+// have swatches here (Owner/Governed/OAuth2Grant/AppRole/AppRoleViaGroup) can no
+// longer appear in the data; see app/api/src/ingest/assignmentTypes.guard.test.js.
 export const TYPE_COLORS = {
-  Direct:          { letter: 'D', bg: '#166534', text: '#fff' },
-  Indirect:        { letter: 'I', bg: '#1e40af', text: '#fff' },
-  Eligible:        { letter: 'E', bg: '#854d0e', text: '#fff' },
-  Owner:           { letter: 'O', bg: '#9d174d', text: '#fff' },
-  Governed:        { letter: 'G', bg: '#5b21b6', text: '#fff' },
-  OAuth2Grant:     { letter: 'A', bg: '#0e7490', text: '#fff' },
-  // App role assignments: direct (R) and via group membership (R*).
-  AppRole:         { letter: 'R', bg: '#a16207', text: '#fff' },
-  AppRoleViaGroup: { letter: 'R', bg: '#ca8a04', text: '#fff' },
+  Direct:   { letter: 'D', bg: '#166534', text: '#fff' },
+  Indirect: { letter: 'I', bg: '#1e40af', text: '#fff' },
+  Eligible: { letter: 'E', bg: '#854d0e', text: '#fff' },
 };

--- a/changes/matrix-retire-owner-badge.md
+++ b/changes/matrix-retire-owner-badge.md
@@ -1,0 +1,1 @@
+- Cleaned up the access matrix legend: it now shows only the badges that can actually appear (Direct, Indirect, Eligible). The obsolete "Owner" badge and other retired assignment-type badges (Governed, OAuth2 grant, App role) were removed from both the on-screen legend and the Excel export legend. Ownership continues to appear as its own resource row.


### PR DESCRIPTION
## Problem
`utils/colors.js` `TYPE_COLORS` still carried badge swatches for five **retired** assignment types — `Owner`, `Governed`, `OAuth2Grant`, `AppRole`, `AppRoleViaGroup` — and the matrix legend listed `Owner` as one of "the four real badges" (audit finding B1).

None of these can render anymore:
- the matrix view `vw_ResourceUserPermissionAssignments` collapses every source type onto **Direct / Indirect / Eligible**,
- migration `046_owner_as_resource.sql` moved ownership to its own `GroupOwnership` **resource row** and deleted the `assignmentType='Owner'` rows,
- ingest rejects all five (`assignmentTypes.guard.test.js`).

Because `TYPE_COLORS` drives **both** the on-screen legend **and** the Excel-export legend (which iterates every entry), the dead types even showed up as phantom legend rows in exported workbooks.

## Fix
Keep only `Direct/Indirect/Eligible` — a single source of truth matching the matrix view and the assignmentTypes guard. Removed `Owner` from the legend's `TYPE_LABELS` and corrected the stale comment (ownership is now a normal `GroupOwnership` row). `MatrixCell`/`exportToExcel` read `TYPE_COLORS` dynamically and the badge renderer returns nothing for an unknown type, so **no cell rendering changes**.

Deliberately **not** touched: the Azure-RM "Owner role on a subscription" copy in `MatrixFilterWizard.jsx` (a different concept), and the broader dead `realGroupId`/`isOwnerRow` machinery in `MatrixView.jsx` (a separate, larger cleanup).

## Tests
- `MatrixLegend.test.js`: asserts the **three** badges and that Owner/Governed/OAuth2/AppRole are absent.
- `exportToExcel.test.js`: legend test still green (first row `Direct`/`D`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
