### PR TITLE
docs: correct retired assignmentTypes across docs + document re2 Windows rebuild

### DIFF
--- a/app/api/CLAUDE.md
+++ b/app/api/CLAUDE.md
@@ -27,6 +27,16 @@ curl -s -X POST http://localhost:3001/api/ingest/contexts \
 
 Only proceed to branch/commit/push once the endpoint returns a 2xx response. The prod compose file (`docker-compose.prod.yml`) uses a pre-built image from ghcr.io — source file changes have no effect until the image is rebuilt with `docker compose build`.
 
+### Windows: rebuild `re2` before running the unit tests
+
+The `re2` dependency ships a **platform-specific native binary**, and `node_modules` is populated for Linux (the Docker/CI target). On Windows, importing the app — which several unit tests do transitively (`re2` is used by `accountlinking/classifier.js`, `contexts/plugins/manager-hierarchy.js`, and `riskscoring/engine.js`) — crashes with a native-module load error until you rebuild it for your platform:
+
+```bash
+cd app/api && npm rebuild re2
+```
+
+Run it once after `npm install` (and again after any `npm install` that repopulates `node_modules`). CI and Docker are unaffected — they install and run on Linux.
+
 ## Database Schema
 
 **Never modify the schema manually.** All schema changes go through versioned migration files in `app/api/src/db/migrations/`. The web container applies them automatically at startup.

--- a/docs/api/entities.md
+++ b/docs/api/entities.md
@@ -129,7 +129,7 @@ Business role (access package) assignments for a user. Only returns active gover
 }
 ```
 
-**Reads From:** `ResourceAssignments` (`assignmentType='Governed'`) + `Resources` (`resourceType='BusinessRole'`) + `GovernanceCatalogs`
+**Reads From:** `ResourceAssignments` (`governed=true`) + `Resources` (`resourceType='BusinessRole'`) + `GovernanceCatalogs`
 
 ---
 
@@ -189,7 +189,7 @@ Paginated resource list with optional type and system filters. Used by the Resou
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `search` | string | | Search `displayName` (SQL `LIKE`) |
-| `resourceType` | string | | Filter by `resourceType` (e.g. `Group`, `DirectoryRole`, `AppRole`, `BusinessRole`) |
+| `resourceType` | string | | Filter by `resourceType` (e.g. `Group`, `EntraDirectoryRole`, `AppRole`, `BusinessRole`) |
 | `systemId` | string | | Filter by originating system |
 | `limit` | int | 100 | Page size. Maximum: 500. |
 | `offset` | int | 0 | Pagination offset. |
@@ -237,7 +237,7 @@ Paginated list of principals assigned to this resource, with membership type bad
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `membershipType` | string | | Filter by type: `Direct`, `Indirect`, `Eligible`, `Owner` |
+| `membershipType` | string | | Filter by type: `Direct`, `Indirect`, `Eligible` |
 | `limit` | int | 100 | Page size. Maximum: 500. |
 | `offset` | int | 0 | Pagination offset. |
 
@@ -317,7 +317,7 @@ Active governed assignments for a business role. Only assignments with `state='D
 }
 ```
 
-**Reads From:** `ResourceAssignments` (`assignmentType='Governed'`) + `Principals`
+**Reads From:** `ResourceAssignments` (`governed=true`) + `Principals`
 
 ---
 
@@ -439,7 +439,7 @@ Version history for the business role resource record. Same format as [`GET /api
       "enabled": true,
       "resourceCount": 412,
       "assignmentCount": 8903,
-      "resourceTypes": ["Group", "DirectoryRole", "AppRole"]
+      "resourceTypes": ["Group", "EntraDirectoryRole", "AppRole"]
     }
   ]
 }

--- a/docs/api/matrix.md
+++ b/docs/api/matrix.md
@@ -50,7 +50,7 @@ Main matrix data. Returns all permission assignments enriched with user attribut
 | Field | Type | Description |
 |---|---|---|
 | `data` | array | Flat list of membership rows. One row per (user, resource, membershipType) combination. |
-| `data[].membershipType` | string | `Direct`, `Indirect`, `Eligible`, or `Owner` |
+| `data[].membershipType` | string | `Direct`, `Indirect`, or `Eligible` |
 | `data[].managedByAccessPackage` | boolean | Whether this resource is included in any business role (SOLL column) |
 | `totalUsers` | int | Total distinct users before the `userLimit` was applied |
 | `managedByPackages` | array | SOLL mapping — which business role IDs govern each (member, group) pair |
@@ -209,8 +209,8 @@ Tag filter dropdowns include a `(Blank)` option (internal sentinel: `BLANK_TAG`)
 
 The frontend builds the matrix from the flat `/api/permissions` response:
 
-1. **Row deduplication** — multiple rows for the same user (e.g. `Direct` + `Owner`) are merged into a single user row with multi-type badges per cell.
-2. **Owner rows** — `membershipType='Owner'` rows are separated into synthetic rows with suffix `(Owner)` and `id: groupId__owner`.
+1. **Row deduplication** — multiple rows for the same user (e.g. `Direct` + `Eligible`) are merged into a single user row with multi-type badges per cell.
+2. **Ownership rows** — group ownership is its own resource (`resourceType='GroupOwnership'`), so an owner appears as a `Direct` membership on that ownership resource — a normal row, not a synthetic `Owner`-type split.
 3. **SOLL columns** — built from `/api/access-package-groups`. Each business role becomes a column. Resources within a role determine which cells are "managed".
 4. **AP coloring** — each business role column gets a color from a 15-color palette defined in `MatrixColumnHeaders.jsx`.
 5. **Staircase sort** — default row order groups users by their leftmost AP bucket. Custom drag order persists via versioned localStorage.

--- a/docs/concepts/data-model.md
+++ b/docs/concepts/data-model.md
@@ -18,7 +18,7 @@ All core tables are tracked by a shared `_history` audit table populated by Post
 Frequently queried attributes (`displayName`, `resourceType`, `department`) are real SQL columns with indexes. System-specific fields that vary by source live in an `extendedAttributes` TEXT (JSON) column. This gives you index performance on hot paths without a rigid, source-specific schema.
 
 **Unified business roles**
-Business roles are not stored in a separate table. They are `Resources` with `resourceType = 'BusinessRole'`. Their assignments are `ResourceAssignments` with `assignmentType = 'Governed'`. Their resource grants are `ResourceRelationships` with `relationshipType = 'Contains'`. The result is a single set of views, risk scores, and queries that apply to all resource types equally.
+Business roles are not stored in a separate table. They are `Resources` with `resourceType = 'BusinessRole'`. Their assignments are `ResourceAssignments` flagged `governed = true` (with a `Direct` `assignmentType`). Their resource grants are `ResourceRelationships` with `relationshipType = 'Contains'`. The result is a single set of views, risk scores, and queries that apply to all resource types equally.
 
 ---
 
@@ -382,7 +382,7 @@ The `resourceType` column on the Resources table is a free-form string. The valu
 | `Application` | Entra ID | Enterprise application / service principal. Parent of `AppRole` and `DelegatedPermission` — does not grant access on its own. |
 | `AppRole` | Entra ID | One synthetic resource per (Application, appRoleId). Linked to its parent via `relationshipType='HasAppRole'`. |
 | `DelegatedPermission` | Entra ID | One synthetic resource per (clientSP, targetAPI, OAuth2 scope). Linked to its parent via `relationshipType='DelegatesScope'`. |
-| `BusinessRole` | Entra ID, Omada, MidPoint | Entra ID access package; Omada business role; MidPoint role type. Contains child resources via `relationshipType='Contains'`; assigned via `assignmentType='Governed'`. |
+| `BusinessRole` | Entra ID, Omada, MidPoint | Entra ID access package; Omada business role; MidPoint role type. Contains child resources via `relationshipType='Contains'`; assigned via a `Direct` membership flagged `governed=true`. |
 | `Entitlement` | MidPoint | AD group or other entitlement synced as a MidPoint shadow (kind=entitlement). |
 | `Resource` | Omada | Omada resource. |
 | `Service` | MidPoint | MidPoint service type. |
@@ -395,18 +395,21 @@ The `resourceType` column on the Resources table is a free-form string. The valu
 
 ## assignmentType Values
 
-The `assignmentType` column on ResourceAssignments describes how the assignment was created and what it means.
+The `assignmentType` column on ResourceAssignments describes *how* a principal holds the access. **Only three values are accepted — ingest rejects anything else** (see `app/api/src/ingest/assignmentTypes.guard.test.js`):
 
 | Value | Meaning |
 |---|---|
-| `Direct` | Direct group or role membership |
-| `Owner` | Group owner relationship |
+| `Direct` | Directly held — a group/role membership, a directly-assigned app role, an OAuth2 grant, or ownership (modelled as a `Direct` membership on a `GroupOwnership` resource) |
+| `Indirect` | Inherited through a nested resource (e.g. an app role held via group membership) |
 | `Eligible` | PIM-eligible membership — granted but not yet activated |
-| `Governed` | Assigned through a business role or access package |
-| `AppRole` | Direct app role assignment to a principal |
-| `AppRoleViaGroup` | App role inherited through group membership |
-| `OAuth2Grant` | Delegated OAuth2 permission grant |
-| Custom | Any string for CSV-imported assignments |
+
+Everything that used to be its own `assignmentType` is now modelled differently — the source detail is carried elsewhere, not in `assignmentType`:
+
+- **Ownership** → a `Direct` membership on a `GroupOwnership` resource (not an `Owner` type).
+- **Governance** → the `governed` boolean flag on the assignment, with the business role / access package flagged `governanceResource` (not a `Governed` type).
+- **Source-attribute detail** (former `OAuth2Grant`, `AppRole`, `AppRoleViaGroup`, `DirectoryRole`, `DirectoryRoleEligible`) → collapses to `Direct` / `Indirect` / `Eligible`, with `resourceType` carrying the source detail.
+
+CSV and custom crawlers follow the same rule — map onto one of the three accepted values (they can't invent their own `assignmentType`).
 
 ---
 
@@ -416,17 +419,18 @@ The same tables (Resources, Principals, ResourceAssignments) absorb data from an
 
 | Source System | Crawler | resourceType | principalType | assignmentType |
 |---|---|---|---|---|
-| Entra ID groups | Entra ID | `Group` | `User` | `Direct` / `Owner` / `Eligible` |
+| Entra ID groups | Entra ID | `Group` | `User` | `Direct` / `Eligible` |
+| Entra ID group ownership | Entra ID | `GroupOwnership` | `User` | `Direct` |
 | Entra ID enterprise apps | Entra ID | `Application` | — | — (parent only) |
-| Entra ID app roles | Entra ID | `AppRole` | `User` / `ServicePrincipal` | `AppRole` / `AppRoleViaGroup` |
-| Entra ID OAuth2 grants | Entra ID | `DelegatedPermission` | `User` | `OAuth2Grant` |
-| Entra ID access packages | Entra ID | `BusinessRole` | `User` | `Governed` |
-| Omada business roles | Omada | `BusinessRole` | `User` | `Governed` |
-| Omada resources | Omada | `Resource` | `User` | `Governed` |
-| MidPoint roles | MidPoint | `BusinessRole` | `User` | `Governed` |
+| Entra ID app roles | Entra ID | `AppRole` | `User` / `ServicePrincipal` | `Direct` / `Indirect` |
+| Entra ID OAuth2 grants | Entra ID | `DelegatedPermission` | `User` | `Direct` |
+| Entra ID access packages | Entra ID | `BusinessRole` | `User` | `Direct` (`governed`) |
+| Omada business roles | Omada | `BusinessRole` | `User` | `Direct` (`governed`) |
+| Omada resources | Omada | `Resource` | `User` | `Direct` (`governed`) |
+| MidPoint roles | MidPoint | `BusinessRole` | `User` | `Direct` (`governed`) |
 | MidPoint entitlements (AD groups etc.) | MidPoint | `Entitlement` | `User` | `Direct` |
-| MidPoint service types | MidPoint | `Service` | `User` | `Governed` |
-| Any system | CSV / custom crawler | Any string | Any | Any |
+| MidPoint service types | MidPoint | `Service` | `User` | `Direct` (`governed`) |
+| Any system | CSV / custom crawler | Any string | Any | `Direct` / `Indirect` / `Eligible` |
 
 ---
 

--- a/docs/ui/overview.md
+++ b/docs/ui/overview.md
@@ -37,9 +37,8 @@ Each cell shows all membership types that apply, side by side:
 | `D` | Direct member |
 | `I` | Indirect (transitive) member |
 | `E` | Eligible (PIM) member |
-| `O` | Owner |
 
-Cells with multiple types show all badges. Owner (`O`) memberships appear in separate rows suffixed with `(Owner)` — ownership is a fundamentally different relationship from membership.
+Cells with multiple types show all badges. Ownership is its own resource (`resourceType='GroupOwnership'`) shown as a normal row, so an owner appears as a `Direct` membership on that ownership resource rather than a separate badge.
 
 #### Business Role Columns (SOLL View)
 


### PR DESCRIPTION
Documentation-only. The docs still presented **retired assignment types as live** (audit findings F2a/F2b). The model now accepts only `Direct`/`Indirect`/`Eligible`, with ownership modelled as a `GroupOwnership` resource, governance as a `governed` flag, and former source-attribute detail carried by `resourceType`.

## Changes
- **`data-model.md`** — rewrote the "assignmentType Values" table to the three accepted values plus a note on how `Owner`/`Governed`/`OAuth2Grant`/`AppRole`/`AppRoleViaGroup`/`DirectoryRole` are now modelled; fixed the Source System Mapping `assignmentType` column and added a `GroupOwnership` row; corrected two `assignmentType='Governed'` business-role references to the `governed=true` flag.
- **`api/entities.md`** — `assignmentType='Governed'` → `governed=true` (×2), dropped `Owner` from the `membershipType` filter, `DirectoryRole` → `EntraDirectoryRole`.
- **`api/matrix.md`** — `membershipType` is `Direct/Indirect/Eligible`; rewrote the "Owner rows" rendering note to the GroupOwnership-resource model.
- **`ui/overview.md`** — removed the dead `O`/Owner badge row and its note.
- **`app/api/CLAUDE.md` (D5)** — documented that `re2` needs `npm rebuild re2` on Windows before the unit tests can import the app (it ships a Linux native binary).

## Deliberately deferred
`docs/architecture/matrix.md`'s badge-collapse table and "Owner rows are split" section describe the **matview CASE internals** (migration 025's collapse logic, superseded by 045/046/049). Those will be rewritten together with the **A2 matview-cleanup PR** so the doc and the SQL move in lockstep (fix at the source).

Left intact (not the retired type): `ui/overview.md`'s "Owner management per system" (the separate team/system-owner feature) and "Member / Owner role badges" (ownership still exists as a concept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
