### PR TITLE
chore(build): standardize on Node 24, add API healthcheck, commit desktop lockfile

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -763,7 +763,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: app/ui/package-lock.json
 

--- a/.github/workflows/test-coverage-review.yml
+++ b/.github/workflows/test-coverage-review.yml
@@ -83,7 +83,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install test dependencies
         if: steps.changes.outputs.has_changes == 'true'

--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -46,4 +46,12 @@ EXPOSE 3001
 # if it doesn't exist, and the node user can't write to it.
 RUN mkdir -p /data/uploads && chown -R node:node /data
 USER node
+
+# Container health: the API is up once /api/version (public, unauthenticated)
+# answers 200. Uses node directly — the slim base image ships no curl/wget — and
+# honours $PORT. Orchestrators / compose can then gate dependents on readiness
+# via `depends_on: { condition: service_healthy }`.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=40s --retries=5 \
+  CMD ["node", "-e", "require('http').get('http://127.0.0.1:'+(process.env.PORT||3001)+'/api/version',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+
 CMD ["node", "src/index.js"]

--- a/app/api/package.json
+++ b/app/api/package.json
@@ -3,6 +3,9 @@
   "version": "3.4.0",
   "description": "Identity Atlas - Ingest & Read API",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",

--- a/app/desktop/package-lock.json
+++ b/app/desktop/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "identityatlas-desktop",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "identityatlas-desktop",
+      "version": "1.0.0",
+      "dependencies": {
+        "@electric-sql/pglite": "0.2.17"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
+      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/app/desktop/package.json
+++ b/app/desktop/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "description": "Desktop dependencies for the Identity Atlas portable launcher (PGlite)",
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "@electric-sql/pglite": "0.2.17"
   }

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/changes/build-deploy-node24-hardening.md
+++ b/changes/build-deploy-node24-hardening.md
@@ -1,0 +1,1 @@
+- Hardened the Docker deployment: the web/API container now reports a health status, and the worker waits for the API to be healthy (migrations applied and responding) before it starts running crawler jobs, instead of starting as soon as the API container launches.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,11 @@ services:
       - ./setup/docker/crontab:/app/setup/docker/crontab:ro
       - job_data:/data/uploads
     depends_on:
+      # Wait for the API to pass its healthcheck (migrations applied, /api/version
+      # answering) before the worker starts firing crawler jobs at it — not merely
+      # for the container to have started.
       web:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Build/deploy hardening from the architecture audit (D2/D3/D4).

## D3 — Standardize on Node 24
The two CI jobs still pinned to **Node 22** (`pr-integration.yml`, `test-coverage-review.yml`) move to **24**, matching every other workflow and the `node:24-slim` runtime image. Added `engines: { "node": ">=24" }` to the `api`, `ui`, and `desktop` `package.json` so the required floor is explicit.

*Advisory only — no `engine-strict`*, to avoid a transitive dependency's `engines` range breaking `npm install`. The real standardization is: all CI on 24, Docker on 24, engines documents 24.

## D2 — API container healthcheck
- Added a `HEALTHCHECK` to `app/api/Dockerfile` that polls the **public, unauthenticated** `/api/version` endpoint via `node` (the slim base has no curl/wget) and honours `$PORT`.
- Switched the worker's `depends_on: web` from `service_started` → **`service_healthy`**, so it waits for migrations applied + a responding API before firing crawler jobs (previously it could start the moment the container launched).

`docker compose config` validates cleanly.

## D4 — Desktop lockfile
Committed `app/desktop/package-lock.json` for reproducible portable-launcher installs. Generated against a **clean tree** so it locks only `@electric-sql/pglite@0.2.17` (1 package) — not the local `electron-builder` tooling that had polluted `node_modules`. (`app/desktop/node_modules` is already gitignored, so the audit's "add to .gitignore" was already done.)

Deferred to a separate PR: **D1** (publish the *tested* Docker image rather than rebuilding after the smoke test) — a trickier `docker-publish.yml` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
