### PR TITLE
fix(contexts): guard ingest + plugin write paths against parent-cycles (A3)

### DIFF
--- a/app/api/src/contexts/plugins/runner.js
+++ b/app/api/src/contexts/plugins/runner.js
@@ -20,7 +20,7 @@
 import * as db from '../../db/connection.js';
 import { randomUUID } from 'crypto';
 import { getPlugin } from './registry.js';
-import { breakCycles } from '../cycleGuard.js';
+import { breakCycles, wouldCreateCycle } from '../cycleGuard.js';
 
 // Repair any parentContextId cycle a plugin's parent structure introduced, and
 // log if anything was broken. Kept as a module-level helper so the reconcile
@@ -28,6 +28,31 @@ import { breakCycles } from '../cycleGuard.js';
 async function repairPluginCycles(client, pluginName) {
   const n = await breakCycles(client);
   if (n) console.warn(`[context-plugin] ${pluginName}: broke ${n} cyclic parentContextId link(s)`);
+}
+
+// Second pass of reconcile: set parent pointers now that every target row exists.
+// Skips analyst-reparented nodes and unresolved parents, and — via wouldCreateCycle
+// — any link that would close a loop against the tree written so far this pass
+// (client sees the in-transaction rows), leaving that node a root rather than
+// writing-then-NULLing it. Extracted from reconcile to keep it under the
+// complexity ceiling; repairPluginCycles stays as the net for a batch-internal
+// cycle prevention can't see pre-persist.
+async function linkContextParents(client, contexts, newByExternalId, reparentedIds, pluginName) {
+  for (const node of contexts) {
+    if (!node.externalId || !node.parentExternalId) continue;
+    const id = newByExternalId.get(node.externalId);
+    if (reparentedIds.has(id)) continue; // analyst moved this node — keep their placement
+    const parentId = newByExternalId.get(node.parentExternalId);
+    if (!parentId) continue; // parent wasn't in the output — leave NULL
+    if (await wouldCreateCycle(client, id, parentId)) {
+      console.warn(`[context-plugin] ${pluginName}: skipped cyclic parent ${node.parentExternalId} -> ${node.externalId}`);
+      continue;
+    }
+    await client.query(
+      `UPDATE "Contexts" SET "parentContextId" = $2 WHERE id = $1`,
+      [id, parentId]
+    );
+  }
 }
 
 export async function enqueueRun(pluginName, params, triggeredBy, opts = {}) {
@@ -282,17 +307,7 @@ async function reconcile(plugin, algorithmId, runId, params, result, instanceKey
     }
 
     // 3b) Second pass: set parent pointers now that every target row exists.
-    for (const node of result.contexts) {
-      if (!node.externalId || !node.parentExternalId) continue;
-      const id = newByExternalId.get(node.externalId);
-      if (reparentedIds.has(id)) continue; // analyst moved this node — keep their placement
-      const parentId = newByExternalId.get(node.parentExternalId);
-      if (!parentId) continue; // parent wasn't in the output — leave NULL
-      await client.query(
-        `UPDATE "Contexts" SET "parentContextId" = $2 WHERE id = $1`,
-        [id, parentId]
-      );
-    }
+    await linkContextParents(client, result.contexts, newByExternalId, reparentedIds, plugin.name);
 
     // Fix-at-source: if the plugin's parentExternalId structure formed a loop,
     // repair the stored tree now — before the member-count roll-up below

--- a/app/api/src/contexts/plugins/runner.refresh.test.js
+++ b/app/api/src/contexts/plugins/runner.refresh.test.js
@@ -87,3 +87,31 @@ describe('refreshGeneratedContexts', () => {
     expect(runInsert()).toBeFalsy();
   });
 });
+
+describe('refreshGeneratedContexts — parent-cycle prevention (A3)', () => {
+  it('skips a parent link that would create a cycle, writes the acyclic one', async () => {
+    wire([tree({ ikey: 'k1' })]);
+    // P is a root; C->P is a normal link; S->S is a self-loop (a cycle). The
+    // guard skips S (wouldCreateCycle short-circuits when id === parentId),
+    // leaving it a root, while the acyclic C->P link is written.
+    PLUGIN.run.mockResolvedValue({
+      contexts: [
+        { externalId: 'P', displayName: 'Parent' },
+        { externalId: 'C', parentExternalId: 'P', displayName: 'Child' },
+        { externalId: 'S', parentExternalId: 'S', displayName: 'Self' },
+      ],
+      members: [],
+    });
+
+    await refreshGeneratedContexts('crawl-refresh', { awaitCompletion: true });
+
+    const parentUpdates = query.mock.calls.filter(([sql]) =>
+      /UPDATE\s+"Contexts"\s+SET\s+"parentContextId"\s*=\s*\$2\s+WHERE\s+id\s*=\s*\$1/.test(sql));
+    // Exactly one parent link written — the acyclic C->P.
+    expect(parentUpdates).toHaveLength(1);
+    // ...and it is not a self-loop (id !== parentId).
+    expect(parentUpdates[0][1][0]).not.toBe(parentUpdates[0][1][1]);
+    // No self-loop link slipped through the guard.
+    expect(parentUpdates.some(([, params]) => params[0] === params[1])).toBe(false);
+  });
+});

--- a/app/api/src/routes/ingest.coverage.test.js
+++ b/app/api/src/routes/ingest.coverage.test.js
@@ -247,6 +247,47 @@ describe('POST /ingest/sync-log', () => {
   });
 });
 
+// ── POST /ingest/contexts — parent-cycle repair (A3) ─────────────────────────
+const CYCLE_REPAIR_RE = /UPDATE\s+"Contexts"[\s\S]*"parentContextId"\s*=\s*NULL/i;
+const goodContext = {
+  records: [{ displayName: 'Dept', variant: 'synced', targetType: 'Identity', contextType: 'Department' }],
+  systemId: 1,
+  syncMode: 'full',
+};
+
+describe('POST /ingest/contexts — parent-cycle repair', () => {
+  it('runs breakCycles after a contexts batch that wrote rows', async () => {
+    mockIngest.mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0 });
+    const res = await request(app).post('/ingest/contexts').send(goodContext);
+    expect(res.status).toBe(201);
+    expect(mockQuery.mock.calls.some(([sql]) => CYCLE_REPAIR_RE.test(sql))).toBe(true);
+  });
+
+  it('does NOT run the cycle repair for a non-contexts entity', async () => {
+    mockIngest.mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0 });
+    const res = await request(app).post('/ingest/principals').send(goodPrincipal);
+    expect(res.status).toBe(201);
+    expect(mockQuery.mock.calls.some(([sql]) => CYCLE_REPAIR_RE.test(sql))).toBe(false);
+  });
+
+  it('skips the repair when the batch wrote no rows', async () => {
+    mockIngest.mockResolvedValueOnce({ inserted: 0, updated: 0, deleted: 0 });
+    const res = await request(app).post('/ingest/contexts').send(goodContext);
+    expect(res.status).toBe(201);
+    expect(mockQuery.mock.calls.some(([sql]) => CYCLE_REPAIR_RE.test(sql))).toBe(false);
+  });
+
+  it('a breakCycles failure is non-fatal (still 201)', async () => {
+    mockIngest.mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0 });
+    mockQuery.mockImplementation((sql) =>
+      CYCLE_REPAIR_RE.test(sql)
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve({ rows: [], rowCount: 0 }));
+    const res = await request(app).post('/ingest/contexts').send(goodContext);
+    expect(res.status).toBe(201);
+  });
+});
+
 // ── POST /ingest/principals-presence ─────────────────────────────────────────
 
 describe('POST /ingest/principals-presence', () => {

--- a/app/api/src/routes/ingest.js
+++ b/app/api/src/routes/ingest.js
@@ -175,6 +175,22 @@ export function writeAuditLog(req, body) {
   ).catch(() => {});
 }
 
+// Contexts self-reference via parentContextId; a mis-parented synced tree can
+// persist a cycle. True prevention isn't feasible for a set-based bulk upsert (a
+// batch-internal A->B->A loop is invisible pre-persist), so repair reactively per
+// contexts batch — don't wait for the end-of-sync refresh-views call, which a
+// delta/partial crawl may never make. No-op on a clean tree. Extracted from the
+// handler so the generic ingest path stays under the complexity ceiling.
+async function repairContextCyclesAfterIngest(entityType, result) {
+  if (entityType !== 'contexts' || (result.inserted + result.updated) <= 0) return;
+  try {
+    const broken = await breakCycles(db);
+    if (broken) console.warn(`Ingest contexts: broke ${broken} cyclic parentContextId link(s)`);
+  } catch (cycErr) {
+    console.warn('Ingest contexts cycle repair failed (non-fatal):', cycErr.message);
+  }
+}
+
 function createIngestHandler(entityType) {
   const tableName = ENTITY_TABLE_MAP[entityType];   // snake_case in v5
   const keyColumns = ENTITY_KEY_MAP[entityType];     // camelCase from caller; engine converts
@@ -229,6 +245,8 @@ function createIngestHandler(entityType) {
 
       const delErr = await applyDeleteByIds(body, tableName, result);
       if (delErr) return res.status(delErr.status).json(delErr.body);
+
+      await repairContextCyclesAfterIngest(entityType, result);
 
       await writeSyncLog(null, `API-${entityType}`, tableName, startTime,
                          body.records.length, result.inserted, result.updated, result.deleted, null);

--- a/changes/context-cycle-guard-writepath.md
+++ b/changes/context-cycle-guard-writepath.md
@@ -1,0 +1,1 @@
+- Made context hierarchies more resilient to parent-loops. Generated (plugin) context trees now skip any parent link that would create a cycle, and imported context batches self-repair a cyclic parent link immediately after the batch rather than waiting for the end-of-sync refresh — so a mis-parented tree can no longer leave a stored loop behind.


### PR DESCRIPTION
Audit finding **A3**. `wouldCreateCycle` was only wired into the UI reparent (`PATCH /contexts/:id`). The other two write paths that persist `parentContextId` — the **plugin runner** and the **ingest upsert** — relied solely on `breakCycles` running at end-of-sync (`refresh-views`), which a delta/partial crawl **may never call**, so a mis-parented tree could leave a stored loop behind (matches the deferred-source-fix note from earlier work).

## Two coordinated guards
**Plugin runner — true prevention.** The runner writes parent links one at a time against already-persisted (in-transaction) rows, so prevention is feasible: the parent-linking pass now calls `wouldCreateCycle(client, id, parentId)` and **skips** a link that would close a loop against the tree written so far this pass (leaving that node a root) instead of writing-then-NULLing it. `repairPluginCycles` stays as the net for a batch-internal cycle prevention can't see. Extracted into `linkContextParents` so `reconcile` stays under the complexity ceiling.

**Ingest — per-batch repair.** A set-based bulk upsert *can't* prevent a batch-internal `A→B→A` loop pre-persist (invisible until written), so it repairs reactively **per contexts batch** (`repairContextCyclesAfterIngest`) rather than only at `refresh-views`. No-op on a clean tree.

## Tests
- Runner: skips a cyclic (self-loop) parent link while writing the acyclic one (self-loop exercises the guard's short-circuit — no stateful cycle-query mock needed).
- Ingest: fires the repair only for `contexts` that wrote rows, **not** for other entities or empty batches, and treats a `breakCycles` failure as non-fatal (still 201).
- **185 contexts+ingest tests green; both complexity ratchets pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
