### PR TITLE
ci(publish): push the smoke-tested image, not a post-test rebuild (D1)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -194,83 +194,44 @@ jobs:
         run: docker compose -f docker-compose.qa.yml down -v 2>/dev/null || true
 
       # ── Push images (only reached if smoke test passed) ─────────────
-      - name: Push web image (release tag → latest)
-        if: steps.config.outputs.channel == 'release'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./app/api/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/fortigi/identity-atlas:latest
-            ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
-          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web,ignore-error=true
+      # Push the EXACT images that were built, loaded and smoke-tested above by
+      # retagging the local :qa images — NOT by rebuilding. A rebuild (even a
+      # cached one) can diverge from the tested bits on a cache miss, a
+      # best-effort cache-export failure, or base-image drift between the two
+      # builds, so "published" would no longer equal "tested".
+      #
+      # Safe because the build steps above use buildx `load: true`, which only
+      # works for a single-platform image (this workflow sets no `platforms:`), so
+      # the loaded :qa image IS the artifact. `Tear down` runs `compose down -v`
+      # (containers/volumes only), so the images survive. If this workflow ever
+      # goes multi-arch, `load` can't hold a manifest list — switch to a
+      # build-once, smoke-test-by-digest, push-by-digest flow instead.
+      - name: Resolve channel's floating tag
+        id: tags
+        run: |
+          case "${{ steps.config.outputs.channel }}" in
+            release) FLOAT=latest ;;
+            beta)    FLOAT=beta   ;;
+            *)       FLOAT=edge   ;;
+          esac
+          echo "float=$FLOAT" >> "$GITHUB_OUTPUT"
 
-      - name: Push worker image (release tag → latest)
-        if: steps.config.outputs.channel == 'release'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./setup/docker/Dockerfile.powershell
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:latest
-            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
+      - name: Push web image (tested artifact)
+        run: |
+          FLOAT="${{ steps.tags.outputs.float }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          REPO="${{ env.REGISTRY }}/fortigi/identity-atlas"
+          docker tag identity-atlas-web:qa "$REPO:$FLOAT"
+          docker tag identity-atlas-web:qa "$REPO:$VERSION"
+          docker push "$REPO:$FLOAT"
+          docker push "$REPO:$VERSION"
 
-      - name: Push web image (pre-release tag → beta)
-        if: steps.config.outputs.channel == 'beta'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./app/api/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/fortigi/identity-atlas:beta
-            ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
-          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web,ignore-error=true
-
-      - name: Push worker image (pre-release tag → beta)
-        if: steps.config.outputs.channel == 'beta'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./setup/docker/Dockerfile.powershell
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:beta
-            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
-
-      - name: Push web image (main → edge)
-        if: steps.config.outputs.channel == 'main'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./app/api/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/fortigi/identity-atlas:edge
-            ${{ env.REGISTRY }}/fortigi/identity-atlas:${{ steps.version.outputs.version }}
-          build-args: MODULE_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=web
-          cache-to: type=gha,mode=min,scope=web,ignore-error=true
-
-      - name: Push worker image (main → edge)
-        if: steps.config.outputs.channel == 'main'
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ./setup/docker/Dockerfile.powershell
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:edge
-            ${{ env.REGISTRY }}/fortigi/identity-atlas-worker:${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=worker
-          cache-to: type=gha,mode=min,scope=worker,ignore-error=true
+      - name: Push worker image (tested artifact)
+        run: |
+          FLOAT="${{ steps.tags.outputs.float }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          REPO="${{ env.REGISTRY }}/fortigi/identity-atlas-worker"
+          docker tag identity-atlas-worker:qa "$REPO:$FLOAT"
+          docker tag identity-atlas-worker:qa "$REPO:$VERSION"
+          docker push "$REPO:$FLOAT"
+          docker push "$REPO:$VERSION"

--- a/changes/publish-tested-image.md
+++ b/changes/publish-tested-image.md
@@ -1,0 +1,1 @@
+- The published Docker images (`:edge`, `:latest`, `:beta`, and the versioned tags) are now the exact images that passed the release smoke test, rather than a fresh rebuild made after testing. What you pull is now guaranteed to be what was verified.


### PR DESCRIPTION
Audit finding **D1**. `docker-publish.yml` built each image **twice**: once with `load: true` for the smoke test, then again (six conditional `docker/build-push-action` steps) with `push: true`. The pushed bits were a **fresh rebuild** that could diverge from the tested ones on a cache miss, a best-effort cache-export failure, or base-image drift — so *"published" wasn't guaranteed to equal "tested"*.

## Fix
Build + smoke-test + push are all **one job on one runner**, so the loaded `:qa` images are still present at push time. Replaced the six rebuild-push steps with:
- a **channel tag resolver** (`release→latest`, `beta→beta`, `main→edge`), and
- two steps that `docker tag` the tested `identity-atlas-web:qa` / `identity-atlas-worker:qa` images and `docker push` them (floating tag + version).

No second build — the exact image that answered the smoke-test endpoints is what ships. Also removes ~80 lines and one full rebuild per publish.

## Why it's safe
- **Single-arch**: the workflow sets no `platforms:`, so buildx `load` holds a real (not manifest-list) image and `docker tag`/`push` is byte-for-byte identical. A comment flags that a future **multi-arch** change must switch to build-once / push-by-digest instead.
- `Tear down` runs `compose down -v` (containers/volumes only) — the images survive.
- `docker login` already ran before the push; `MODULE_VERSION` is baked into the `:qa` web image at build time, so it carries through.

**Pre-existing, out of scope:** the smoke stack (`docker-compose.qa.yml`) starts only postgres + web, so the worker image's guarantee stays "it builds" — same as before this change.

_CI-only change; validated with `yaml.safe_load`. Can't be unit-tested (no live publish)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
