### PR TITLE
perf(history): index _history so the Timeline tab stops full-scanning

### DIFF
--- a/app/api/src/db/migrations/055_history_timeline_indexes.sql
+++ b/app/api/src/db/migrations/055_history_timeline_indexes.sql
@@ -1,0 +1,51 @@
+-- ─── Timeline / recent-changes index coverage on _history ────────────
+--
+-- The entity-detail Timeline tab and the recent-changes panel query `_history`
+-- for one entity's events, filtering on JSONB-extracted foreign keys, e.g.
+--   ("tableName" = 'ResourceAssignments' AND "rowData"->>'principalId' = $id)
+--
+-- Migration 009 gave _history only ("tableName","rowId","changedAt") and
+-- ("changedAt") indexes. Those cover the attribute-change branches (Principals /
+-- Resources / Identities / Contexts, filtered by "rowId" = $id) but NOT the
+-- relationship branches, which filter on a `rowData->>'...'` expression that no
+-- index covers. Worse, the synthesized composite rowId (migration 022) puts
+-- principalId in the MIDDLE of a ResourceAssignment's rowId
+-- ("resourceId|principalId|assignmentType"), so the rowId index can't serve a
+-- user timeline even as a prefix scan.
+--
+-- Result: every timeline/recent-changes load was a full sequential scan of
+-- _history — an unbounded, ever-growing audit table (retention is deferred,
+-- see migration 009). Measured on a small tenant (~100k history rows, 161 MB):
+-- a user timeline read ~15,500 pages (the whole table). That cost grows linearly
+-- with history size, so on a busy tenant it becomes seconds per load.
+--
+-- These partial expression indexes make each relationship branch an index scan,
+-- so the planner combines them (BitmapOr) and the query becomes O(the entity's
+-- events) instead of O(the whole table). Same measurement after: ~1,200 pages,
+-- 30 ms -> 7 ms, and — crucially — flat as the table grows. They also cover the
+-- recent-changes endpoints, which filter the same way.
+--
+-- Partial (WHERE "tableName" = ...) so each index only holds the rows of its own
+-- relationship table — small, and a tight match for the query's tableName guard.
+-- Plain CREATE INDEX (not CONCURRENTLY): the migration runner wraps each file in
+-- a transaction. On a large existing _history this build briefly locks writes;
+-- that is acceptable at deploy time for an append-mostly audit table.
+
+-- User timeline: ResourceAssignments / IdentityMembers by principalId.
+CREATE INDEX IF NOT EXISTS ix_hist_ra_principal
+  ON "_history" (("rowData"->>'principalId')) WHERE "tableName" = 'ResourceAssignments';
+CREATE INDEX IF NOT EXISTS ix_hist_im_principal
+  ON "_history" (("rowData"->>'principalId')) WHERE "tableName" = 'IdentityMembers';
+
+-- Resource / access-package timeline: ResourceAssignments by resourceId,
+-- ResourceRelationships by either side.
+CREATE INDEX IF NOT EXISTS ix_hist_ra_resource
+  ON "_history" (("rowData"->>'resourceId')) WHERE "tableName" = 'ResourceAssignments';
+CREATE INDEX IF NOT EXISTS ix_hist_rr_child
+  ON "_history" (("rowData"->>'childResourceId')) WHERE "tableName" = 'ResourceRelationships';
+CREATE INDEX IF NOT EXISTS ix_hist_rr_parent
+  ON "_history" (("rowData"->>'parentResourceId')) WHERE "tableName" = 'ResourceRelationships';
+
+-- Identity timeline: IdentityMembers by identityId.
+CREATE INDEX IF NOT EXISTS ix_hist_im_identity
+  ON "_history" (("rowData"->>'identityId')) WHERE "tableName" = 'IdentityMembers';

--- a/changes/history-timeline-indexes.md
+++ b/changes/history-timeline-indexes.md
@@ -1,0 +1,1 @@
+- Made the **Timeline** tab and the recent-changes panel load much faster on user, resource, access-package and identity detail pages. They previously scanned the entire change-history table on every open, so they got slower as history grew; they now use targeted indexes and stay fast regardless of how much history has accumulated.


### PR DESCRIPTION
## Problem

The **Timeline** tab (and the recent-changes panel) on user / resource / access-package / identity detail pages was slow to load. Root cause, confirmed with `EXPLAIN ANALYZE` on real tenant data:

The endpoint (`runTimeline` in `routes/recentChanges.js`) queries `_history` for one entity's events, filtering on JSONB-extracted keys:
```sql
("tableName" = 'ResourceAssignments' AND "rowData"->>'principalId' = $id) OR ...
```
`_history` (migration 009) only has `("tableName","rowId","changedAt")` and `("changedAt")` indexes. Those cover the *attribute* branches (filtered by `"rowId" = $id`) but **not** the *relationship* branches, which filter on a `rowData->>'...'` expression no index covers. The synthesized composite rowId (migration 022) even buries `principalId` in the *middle* of an assignment's rowId, so the rowId index can't serve a user timeline as a prefix scan either.

So every load was a **full sequential scan** of `_history` — an unbounded, ever-growing audit table (retention deferred, migration 009).

### Measured on SK1 (real data: ~101k history rows, 161 MB)

| | Before | After |
|---|---|---|
| Plan | `Parallel Seq Scan` (whole table) | `BitmapOr` of index scans |
| Buffers read | 15,500 pages (~121 MB) | 1,209 pages (~10 MB) |
| Time | 30 ms | **7 ms** |

The point isn't the SK1 numbers — it's that the query becomes **O(the entity's events)** instead of **O(the whole `_history` table)**. On a production tenant with millions of history rows the seq scan is seconds and reads multi-GB every load; the index scan stays flat.

## Fix

Migration `055_history_timeline_indexes.sql` adds six **partial expression indexes** on the hot `rowData` paths (one per relationship branch, scoped by `tableName`). The planner combines them via BitmapOr. **No API code changes** — the existing query uses them as-is. They also speed up the recent-changes endpoints (same filters).

## Testing / validation

- Ran the exact `CREATE INDEX` statements + before/after `EXPLAIN (ANALYZE, BUFFERS)` on real tenant data — plan flips from Parallel Seq Scan to BitmapOr, buffer reads drop ~13x (see table).
- Index-only migration: no branches to unit-test. The migration runner applies it at startup and the contract-test global setup runs all migrations against a real Postgres 16, so a broken migration fails CI.
- `CREATE INDEX` (not CONCURRENTLY) because the runner wraps each migration in a transaction; on a large existing `_history` the build briefly locks writes, acceptable at deploy time for an append-mostly audit table.

## Follow-ups (out of scope here)
- `_history` retention/pruning — the table grows unbounded (~52k of SK1's rows are Contexts churn). Indexes make the *query* size-independent, but bounding the table would help disk/VACUUM/index maintenance.
- The recent-changes endpoints still resolve counterparty labels with a per-row `lookupResource`/`lookupPrincipal` (N+1); the Timeline endpoint already batches this via `resolveTimelineLabels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)