### PR TITLE
test(entra): unit-test app-owner/app-permission crawler lookup helpers

### DIFF
--- a/test/unit/EntraIDCrawlerAppOwners.Tests.ps1
+++ b/test/unit/EntraIDCrawlerAppOwners.Tests.ps1
@@ -1,0 +1,56 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Pester unit tests for the app-ownership lookup index
+    (tools/crawlers/entra-id/EntraIDCrawler.AppOwners.ps1 :: Get-EntraAppOwnerIndex).
+
+.DESCRIPTION
+    Get-EntraAppOwnerIndex is pure — it turns the service-principal list into the
+    appId->spId, spId->sp, and spId->displayName maps the owner phases key off of.
+    The ConvertTo-EntraAppOwnershipGraph shaper is covered in
+    EntraIDCrawlerTransform.Tests.ps1.
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:entraDir = Join-Path $script:repoRoot 'tools' 'crawlers' 'entra-id'
+    . (Join-Path $script:entraDir 'EntraIDCrawler.Functions.ps1')
+    . (Join-Path $script:entraDir 'EntraIDCrawler.AppOwners.ps1')
+}
+
+Describe 'Get-EntraAppOwnerIndex' {
+
+    It 'maps appId->spId, spId->sp, and spId->displayName' {
+        $sps = @(
+            [pscustomobject]@{ id = 'sp1'; appId = 'app-1'; displayName = 'Payroll App' },
+            [pscustomobject]@{ id = 'sp2'; appId = 'app-2'; displayName = 'Reporting API' }
+        )
+        $idx = Get-EntraAppOwnerIndex -Sps $sps
+
+        $idx.appIdToSpId['app-1']      | Should -Be 'sp1'
+        $idx.appIdToSpId['app-2']      | Should -Be 'sp2'
+        $idx.appNameById['sp1']        | Should -Be 'Payroll App'
+        $idx.spById['sp2'].displayName | Should -Be 'Reporting API'
+    }
+
+    It 'omits the appId->spId entry for an SP with no appId (e.g. a managed identity)' {
+        $sps = @(
+            [pscustomobject]@{ id = 'sp1'; appId = 'app-1'; displayName = 'Has AppId' },
+            [pscustomobject]@{ id = 'mi1'; displayName = 'Managed Identity' }   # no appId
+        )
+        $idx = Get-EntraAppOwnerIndex -Sps $sps
+
+        $idx.appIdToSpId.Count           | Should -Be 1
+        $idx.appIdToSpId.ContainsKey('') | Should -BeFalse
+        # still indexed by spId even without an appId
+        $idx.spById['mi1'].displayName   | Should -Be 'Managed Identity'
+        $idx.appNameById['mi1']          | Should -Be 'Managed Identity'
+    }
+
+    It 'returns empty maps for no service principals' {
+        $idx = Get-EntraAppOwnerIndex -Sps @()
+        $idx.appIdToSpId.Count | Should -Be 0
+        $idx.spById.Count      | Should -Be 0
+        $idx.appNameById.Count | Should -Be 0
+    }
+}

--- a/test/unit/EntraIDCrawlerAppPermissions.Tests.ps1
+++ b/test/unit/EntraIDCrawlerAppPermissions.Tests.ps1
@@ -137,3 +137,85 @@ Describe 'Get-EntraAppRoleName' {
         Get-EntraAppRoleName -AppRole ([pscustomobject]@{ id = 'guid-1' })                                               | Should -Be 'guid-1'
     }
 }
+
+Describe 'Get-EntraAppPermissionIndex' {
+
+    It 'builds spInfo, spById, and appRoleNameById (target APIs are just SPs with an appRoles catalog)' {
+        $sps = @(
+            [pscustomobject]@{ id = 'sp1'; displayName = 'Payroll App' },
+            [pscustomobject]@{ id = 'graphSp'; displayName = 'Microsoft Graph';
+                appRoles = @(
+                    [pscustomobject]@{ id = 'role-mailread'; value = 'Mail.Read' },
+                    [pscustomobject]@{ id = 'role-dirread';  displayName = 'Read directory data' }  # no value -> displayName
+                ) }
+        )
+        $idx = Get-EntraAppPermissionIndex -Sps $sps
+
+        $idx.spInfo['sp1'].displayName                | Should -Be 'Payroll App'
+        $idx.spInfo['sp1'].principalType              | Should -Not -BeNullOrEmpty  # classifier or fallback
+        $idx.spById['graphSp'].displayName            | Should -Be 'Microsoft Graph'
+        $idx.appRoleNameById['graphSp|role-mailread'] | Should -Be 'Mail.Read'
+        $idx.appRoleNameById['graphSp|role-dirread']  | Should -Be 'Read directory data'
+    }
+
+    It 'skips appRoles that have no id' {
+        $sps = @(
+            [pscustomobject]@{ id = 'api1'; displayName = 'API';
+                appRoles = @([pscustomobject]@{ value = 'NoId.Scope' }) }   # missing id
+        )
+        $idx = Get-EntraAppPermissionIndex -Sps $sps
+        $idx.appRoleNameById.Count | Should -Be 0
+    }
+
+    It 'returns empty maps for no service principals' {
+        $idx = Get-EntraAppPermissionIndex -Sps @()
+        $idx.spInfo.Count          | Should -Be 0
+        $idx.appRoleNameById.Count | Should -Be 0
+        $idx.spById.Count          | Should -Be 0
+    }
+}
+
+Describe 'Resolve-EntraAppPermissionFields' {
+
+    It 'resolves the permission name, client name/type, and target name from the maps' {
+        $a = [pscustomobject]@{ principalId = 'sp1'; resourceId = 'graphSp'; appRoleId = 'role-x'; resourceDisplayName = 'Microsoft Graph' }
+        $f = Resolve-EntraAppPermissionFields -Assignment $a `
+            -AppRoleNameById @{ 'graphSp|role-x' = 'Mail.Read' } `
+            -SpInfo @{ sp1 = @{ displayName = 'Payroll App'; principalType = 'AIAgent' } }
+
+        $f.permName   | Should -Be 'Mail.Read'
+        $f.clientName | Should -Be 'Payroll App'
+        $f.clientType | Should -Be 'AIAgent'      # carried from SpInfo, not flattened
+        $f.targetName | Should -Be 'Microsoft Graph'
+    }
+
+    It 'falls back to the appRole guid, the client SP id, ServicePrincipal, and the target id when the maps are empty' {
+        $a = [pscustomobject]@{ principalId = 'spX'; resourceId = 'apiX'; appRoleId = 'guid-9' }
+        $f = Resolve-EntraAppPermissionFields -Assignment $a
+
+        $f.permName   | Should -Be 'guid-9'
+        $f.clientName | Should -Be 'spX'
+        $f.clientType | Should -Be 'ServicePrincipal'
+        $f.targetName | Should -Be 'apiX'
+    }
+
+    It 'falls back to the target SP''s SpInfo displayName when the assignment has no resourceDisplayName' {
+        $a = [pscustomobject]@{ principalId = 'sp1'; resourceId = 'graphSp'; appRoleId = 'r1' }
+        $f = Resolve-EntraAppPermissionFields -Assignment $a `
+            -SpInfo @{ graphSp = @{ displayName = 'Microsoft Graph' } }
+        $f.targetName | Should -Be 'Microsoft Graph'
+    }
+}
+
+Describe 'Format-FGApplicationPermissionName' {
+
+    It 'includes the holder SP when a client name is supplied' {
+        Format-FGApplicationPermissionName -Permission 'Mail.Read' -TargetName 'Microsoft Graph' -ClientName 'Payroll App' |
+            Should -Be 'Mail.Read on Microsoft Graph (via Payroll App)'
+    }
+
+    It 'omits the "(via ...)" suffix when there is no client name' {
+        Format-FGApplicationPermissionName -Permission 'Mail.Read' -TargetName 'Microsoft Graph' |
+            Should -Be 'Mail.Read on Microsoft Graph'
+    }
+}


### PR DESCRIPTION
## Why

Continuing the drift-audit hardening (the crawler layer is the least-tested). The newly-merged app-owners and app-permissions crawlers had their `ConvertTo-*Graph` shapers tested, but their **pure lookup/resolve helpers were uncovered** — exactly the small, cheap-to-test functions the "extract testable logic" crawler convention exists for.

## What

Adds Pester unit tests for the untested pure functions:

- **`Get-EntraAppOwnerIndex`** — new `test/unit/EntraIDCrawlerAppOwners.Tests.ps1`: the `appId→spId` / `spId→sp` / `spId→displayName` maps, including the no-`appId` (managed-identity) case and empty input.
- **`Get-EntraAppPermissionIndex`, `Resolve-EntraAppPermissionFields`, `Format-FGApplicationPermissionName`** — extend `test/unit/EntraIDCrawlerAppPermissions.Tests.ps1`: the `appRoleNameById` catalog build (value→displayName→guid), the permission/client/target field resolution with its id/name/`ServicePrincipal` fallbacks, and the `"<perm> on <target> (via <client>)"` name formatting.

Kept `Get-EntraAppOwnerIndex` in its own file rather than growing the already-971-line `EntraIDCrawlerTransform.Tests.ps1`.

## Verification

22 tests pass locally under Pester 5.8 (11 new). Test-only change — no changelog fragment (pr.yml hygiene excludes `*.Tests.ps1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
