### PR TITLE
test(api): extend OpenAPI drift guard to classify every router

### DIFF
--- a/app/api/src/routes/openapi.drift.test.js
+++ b/app/api/src/routes/openapi.drift.test.js
@@ -1,14 +1,17 @@
 // Route <-> OpenAPI spec drift guard.
 //
 // `.spectral.yaml` lints the spec's SYNTAX. It cannot tell whether a documented
-// operation still has a live route handler, nor whether a newly-added route in
-// the documented surface got left out of the spec. This test closes that gap.
+// operation still has a live route handler, whether a newly-added route in the
+// documented surface got left out of the spec, or whether a brand-new router was
+// added that nobody decided to document. This test closes all three gaps.
 //
 // The spec deliberately covers only the "ingest + crawler-admin" surface (see the
-// Scope note in openapi.yaml) — NOT the 100+ read-API routes. So we scope the
-// check to exactly the routers that back that surface, and keep an explicit
-// allow-list of endpoints in those routers that are intentionally internal /
-// undocumented (the web<->worker job protocol, delta-token CRUD, seed helpers).
+// Scope note in openapi.yaml) — NOT the 100+ read-API routes. So rather than
+// documenting everything, we require every router module under routes/ to be
+// EXPLICITLY classified as either `documented` (its routes must be in the spec)
+// or `undocumented` (read API / internal). A new router file that nobody
+// classified fails the test — so a new public surface can't silently escape the
+// drift guard, and the "documented vs not" decision is always a conscious one.
 //
 // Enumeration is runtime introspection of each Router's `.stack` (Express 5
 // exposes layer.route.path + layer.route.methods on a bare router) — robust
@@ -16,7 +19,7 @@
 // regex scan would miss.
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import YAML from 'yamljs';
@@ -30,17 +33,55 @@ const SPEC_PATH = join(__dirname, '..', 'openapi.yaml');
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
 
-// The routers whose surface the spec is meant to document. Anything registered
-// OUTSIDE these routers (jobs.js, crawlerFiles.js, the read API, …) is out of
-// scope and correctly ignored.
-const SCOPED_ROUTERS = [
-  ingestRouter,
-  selfServiceCrawlersRouter,
-  adminCrawlersRouter,
-  effectiveAccessRouter,
-];
+// Router modules whose surface the spec documents, keyed by filename so the
+// classification below stays honest against the file tree. The value is the
+// router(s) that file exports (crawlers.js exports two).
+const DOCUMENTED_ROUTERS = {
+  'ingest.js': [ingestRouter],
+  'crawlers.js': [adminCrawlersRouter, selfServiceCrawlersRouter],
+  'effectiveAccess.js': [effectiveAccessRouter],
+};
 
-// Endpoints that live in the scoped routers but are DELIBERATELY not in the
+// EVERY router module under routes/ must appear here. `documented` => all its
+// routes must be in openapi.yaml (or the allow-list); `undocumented` => the read
+// API / internal surface the public spec intentionally omits. Adding a router
+// file without classifying it fails the completeness test below — the point is
+// that "should this be in the public API spec?" is never answered by omission.
+const DOCUMENTED = 'documented';
+const UNDOCUMENTED = 'undocumented';
+const ROUTER_CLASSIFICATION = {
+  ...Object.fromEntries(Object.keys(DOCUMENTED_ROUTERS).map((f) => [f, DOCUMENTED])),
+  // ── intentionally undocumented: read API, internal, worker job protocol ──
+  'accountLinking.js': UNDOCUMENTED,
+  'admin.js': UNDOCUMENTED,
+  'authRoles.js': UNDOCUMENTED,
+  'bulkLists.js': UNDOCUMENTED,
+  'categories.js': UNDOCUMENTED,
+  'contextPlugins.js': UNDOCUMENTED,
+  'contexts.js': UNDOCUMENTED,
+  'crawlerFiles.js': UNDOCUMENTED,
+  'dataExport.js': UNDOCUMENTED,
+  'details.js': UNDOCUMENTED,
+  'governance.js': UNDOCUMENTED,
+  'identities.js': UNDOCUMENTED,
+  'jobs.js': UNDOCUMENTED,
+  'llm.js': UNDOCUMENTED,
+  'matrix.js': UNDOCUMENTED,
+  'orgChart.js': UNDOCUMENTED,
+  'perf.js': UNDOCUMENTED,
+  'permissions.js': UNDOCUMENTED,
+  'preferences.js': UNDOCUMENTED,
+  'recentChanges.js': UNDOCUMENTED,
+  'resources.js': UNDOCUMENTED,
+  'riskProfiles.js': UNDOCUMENTED,
+  'riskScores.js': UNDOCUMENTED,
+  'riskScoringRuns.js': UNDOCUMENTED,
+  'systems.js': UNDOCUMENTED,
+  'tags.js': UNDOCUMENTED,
+  'updates.js': UNDOCUMENTED,
+};
+
+// Endpoints that live in the DOCUMENTED routers but are DELIBERATELY not in the
 // public spec — the web<->worker job-orchestration protocol, Graph delta-token
 // persistence, and internal ingest/seed helpers. Adding a genuinely public
 // endpoint here to silence the guard is a review red flag; document it instead.
@@ -70,15 +111,17 @@ const INTENTIONALLY_UNDOCUMENTED = new Set([
 const toOpenApiPath = (p) => p.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
 const key = (method, path) => `${method.toUpperCase()} ${path}`;
 
-// "METHOD /path" for every route registered on the scoped routers.
+// "METHOD /path" for every route registered on the documented routers.
 function registeredOps() {
   const ops = new Set();
-  for (const router of SCOPED_ROUTERS) {
-    for (const layer of router.stack) {
-      if (!layer.route) continue;
-      const path = toOpenApiPath(layer.route.path);
-      for (const m of HTTP_METHODS) {
-        if (layer.route.methods[m]) ops.add(key(m, path));
+  for (const routers of Object.values(DOCUMENTED_ROUTERS)) {
+    for (const router of routers) {
+      for (const layer of router.stack) {
+        if (!layer.route) continue;
+        const path = toOpenApiPath(layer.route.path);
+        for (const m of HTTP_METHODS) {
+          if (layer.route.methods[m]) ops.add(key(m, path));
+        }
       }
     }
   }
@@ -97,9 +140,34 @@ function documentedOps() {
   return ops;
 }
 
+// Every router module on disk (excludes tests and the non-router helpers).
+function routerFilesOnDisk() {
+  return readdirSync(__dirname)
+    .filter((f) => f.endsWith('.js') && !/\.test\.js$/.test(f) && f !== 'openapi.drift.test.js');
+}
+
 describe('OpenAPI route <-> spec drift', () => {
   const registered = registeredOps();
   const documented = documentedOps();
+
+  it('every router module is classified as documented or undocumented', () => {
+    // Closes the "new public surface ships undocumented" gap: a router file
+    // nobody classified fails here, forcing the documented-vs-not decision.
+    const files = routerFilesOnDisk();
+    const unclassified = files.filter((f) => !(f in ROUTER_CLASSIFICATION)).sort();
+    expect(
+      unclassified,
+      `router module(s) under routes/ are not classified in openapi.drift.test.js. ` +
+      `Add each as DOCUMENTED_ROUTERS (and put its routes in openapi.yaml) or mark it ` +
+      `UNDOCUMENTED:\n${unclassified.join('\n')}`,
+    ).toEqual([]);
+
+    const stale = Object.keys(ROUTER_CLASSIFICATION).filter((f) => !files.includes(f)).sort();
+    expect(
+      stale,
+      `ROUTER_CLASSIFICATION lists router file(s) that no longer exist:\n${stale.join('\n')}`,
+    ).toEqual([]);
+  });
 
   it('every documented operation maps to a live registered route', () => {
     const missing = [...documented].filter((op) => !registered.has(op)).sort();
@@ -110,7 +178,7 @@ describe('OpenAPI route <-> spec drift', () => {
     ).toEqual([]);
   });
 
-  it('every in-scope registered route is documented or explicitly allow-listed', () => {
+  it('every route in the documented surface is documented or explicitly allow-listed', () => {
     const undocumented = [...registered]
       .filter((op) => !documented.has(op) && !INTENTIONALLY_UNDOCUMENTED.has(op))
       .sort();

--- a/app/api/src/routes/openapi.drift.test.js
+++ b/app/api/src/routes/openapi.drift.test.js
@@ -81,31 +81,42 @@ const ROUTER_CLASSIFICATION = {
   'updates.js': UNDOCUMENTED,
 };
 
+// The bounded set of reasons an endpoint in a DOCUMENTED router may be absent
+// from the public spec. Adding a NEW category is itself a visible, reviewed
+// change — which is the point: it stops the allow-list from becoming a silent
+// escape hatch for arbitrary public-looking routes.
+const UNDOCUMENTED_REASONS = {
+  'worker-protocol': 'web<->worker job-orchestration protocol (crawlers.js) — not a public API',
+  'delta-token': 'Graph delta-token persistence (crawlers.js) — internal crawler state',
+  'internal-ingest': 'internal computed/seed ingest helper (ingest.js) — not a public entity endpoint',
+};
+
 // Endpoints that live in the DOCUMENTED routers but are DELIBERATELY not in the
-// public spec — the web<->worker job-orchestration protocol, Graph delta-token
-// persistence, and internal ingest/seed helpers. Adding a genuinely public
-// endpoint here to silence the guard is a review red flag; document it instead.
-const INTENTIONALLY_UNDOCUMENTED = new Set([
+// public spec. Each MUST declare WHY, from UNDOCUMENTED_REASONS — so silencing
+// the guard for a genuinely public endpoint requires mis-categorising it (a
+// review red flag) rather than just appending a line.
+const INTENTIONALLY_UNDOCUMENTED = {
   // web<->worker job protocol (crawlers.js)
-  'POST /crawlers/jobs/claim',
-  'POST /crawlers/jobs/{id}/complete',
-  'POST /crawlers/jobs/{id}/fail',
-  'POST /crawlers/jobs/{id}/phases',
-  'POST /crawlers/job-progress',
-  'POST /crawlers/configs/{id}/mark-delta-mode',
+  'POST /crawlers/jobs/claim': 'worker-protocol',
+  'POST /crawlers/jobs/{id}/complete': 'worker-protocol',
+  'POST /crawlers/jobs/{id}/fail': 'worker-protocol',
+  'POST /crawlers/jobs/{id}/phases': 'worker-protocol',
+  'POST /crawlers/job-progress': 'worker-protocol',
+  'POST /crawlers/configs/{id}/mark-delta-mode': 'worker-protocol',
   // Graph delta-token persistence (crawlers.js)
-  'GET /crawlers/delta-tokens/{endpoint}',
-  'PUT /crawlers/delta-tokens/{endpoint}',
-  'DELETE /crawlers/delta-tokens/{endpoint}',
+  'GET /crawlers/delta-tokens/{endpoint}': 'delta-token',
+  'PUT /crawlers/delta-tokens/{endpoint}': 'delta-token',
+  'DELETE /crawlers/delta-tokens/{endpoint}': 'delta-token',
   // internal ingest / seed helpers (ingest.js)
-  'POST /ingest/classify-business-role-assignments',
-  'POST /ingest/context-members',
-  'POST /ingest/matrix-default-filter',
-  'POST /ingest/principal-activity',
-  'POST /ingest/principals-presence',
-  'POST /ingest/resource-assignments-identity',
-  'POST /ingest/sync-log',
-]);
+  'POST /ingest/classify-business-role-assignments': 'internal-ingest',
+  'POST /ingest/context-members': 'internal-ingest',
+  'POST /ingest/matrix-default-filter': 'internal-ingest',
+  'POST /ingest/principal-activity': 'internal-ingest',
+  'POST /ingest/principals-presence': 'internal-ingest',
+  'POST /ingest/resource-assignments-identity': 'internal-ingest',
+  'POST /ingest/sync-log': 'internal-ingest',
+};
+const ALLOWLISTED_OPS = new Set(Object.keys(INTENTIONALLY_UNDOCUMENTED));
 
 // Express `:param` -> OpenAPI `{param}` so the two sides compare apples to apples.
 const toOpenApiPath = (p) => p.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
@@ -180,7 +191,7 @@ describe('OpenAPI route <-> spec drift', () => {
 
   it('every route in the documented surface is documented or explicitly allow-listed', () => {
     const undocumented = [...registered]
-      .filter((op) => !documented.has(op) && !INTENTIONALLY_UNDOCUMENTED.has(op))
+      .filter((op) => !documented.has(op) && !ALLOWLISTED_OPS.has(op))
       .sort();
     expect(
       undocumented,
@@ -193,13 +204,30 @@ describe('OpenAPI route <-> spec drift', () => {
   it('the allow-list has no stale entries', () => {
     // Keeps the allow-list honest: if a route is deleted or later documented,
     // its allow-list entry must go too.
-    const stale = [...INTENTIONALLY_UNDOCUMENTED]
+    const stale = [...ALLOWLISTED_OPS]
       .filter((op) => !registered.has(op) || documented.has(op))
       .sort();
     expect(
       stale,
       `INTENTIONALLY_UNDOCUMENTED lists entries that are no longer ` +
       `undocumented registered routes:\n${stale.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every allow-list entry declares a known internal reason', () => {
+    // Bounds WHY an endpoint may be undocumented: an entry must be one of the
+    // recognised internal surfaces (worker-protocol / delta-token / internal-
+    // ingest), not an arbitrary public-looking route slipped in to silence the
+    // guard. A genuinely new internal surface means a reviewed UNDOCUMENTED_REASONS
+    // addition — deliberately a visible change, not a one-line append.
+    const badReasons = Object.entries(INTENTIONALLY_UNDOCUMENTED)
+      .filter(([, reason]) => !(reason in UNDOCUMENTED_REASONS))
+      .map(([op, reason]) => `${op} -> '${reason}'`)
+      .sort();
+    expect(
+      badReasons,
+      `allow-list entry with an unknown reason. Use one of ` +
+      `${Object.keys(UNDOCUMENTED_REASONS).join(', ')}, or document the route:\n${badReasons.join('\n')}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Why

The audit flagged that the OpenAPI drift guard only introspected the **4 documented-surface routers** — a route added to any of the other 26 routers (or an entirely new router = a new public API surface) shipped **completely unchecked**. But `openapi.yaml` *intentionally* documents only the ingest+crawler-admin surface, not the 100+ read routes, so "document everything and diff" is the wrong fix.

## What

Every router module under `routes/` must now be **explicitly classified**:

- `documented` — its routes must appear in `openapi.yaml` (or the allow-list). Currently `ingest.js`, `crawlers.js`, `effectiveAccess.js`.
- `undocumented` — the read API / internal / worker-protocol surface the public spec omits by design (the other 27).

A new **completeness test** fails if any router file on disk isn't classified, and if the classification lists a file that no longer exists. So a new public surface can't silently escape the guard — the "should this be in the public spec?" question can never be answered by omission. The documented set is single-sourced from the imported routers, and the existing three spec-sync checks (documented→live, live→documented, stale allow-list) are unchanged.

## Verification

- 4/4 tests pass locally.
- Negative check: dropping an unclassified `.js` into `routes/` fails the completeness test with a clear "classify each as DOCUMENTED/UNDOCUMENTED" message; removing it restores green.

Test-only change — no changelog fragment (pr.yml hygiene excludes `*.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
