### PR TITLE
fix(mock): drop retired 'Owner' membership type from the demo dataset

### DIFF
--- a/app/api/src/mock/data.js
+++ b/app/api/src/mock/data.js
@@ -167,17 +167,15 @@ addAssignment(userId(5), groupId(18), 'Direct');   // Finance user with Jira
 // A Sales person with SAP Admin (over-provisioned!)
 addAssignment(userId(40), groupId(12), 'Direct');  // Sales person with SAP Admin
 
-// An HR person who is Owner of a Finance group
-addAssignment(userId(25), groupId(1), 'Owner');    // HR person owns Finance base group
+// An HR person directly in a Finance group (cross-department over-permission)
+addAssignment(userId(25), groupId(1), 'Direct');   // HR person directly in the Finance base group
 
 // Marketing person with VPN (only IT should have this)
 addAssignment(userId(55), groupId(40), 'Direct');  // Marketing with VPN
 
-// Pattern 12: Group Owners
-for (const user of users.filter(u => u.jobTitle.includes('Manager'))) {
-  const deptIndex = departments.indexOf(user.department);
-  addAssignment(user.id, groupId(deptIndex + 1), 'Owner');
-}
+// (Group ownership is modelled as a separate GroupOwnership resource in the real
+// data, not a membership type — the retired 'Owner' membershipType is gone, and
+// department managers already hold their base group as 'Direct' via Pattern 1.)
 
 // Build unmanaged permissions (mock vw_UnmanagedPermissions)
 // These are direct assignments that aren't governed by access packages

--- a/app/api/src/mock/data.test.js
+++ b/app/api/src/mock/data.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { permissionAssignments } from './data.js';
+
+// Locks the mock dataset to the current assignment model: membershipType is only
+// ever one of the three universal values. The retired types (Owner/Governed/…)
+// must never reappear here — the matrix would render a badge that no longer
+// exists in real data. Mirrors app/api/src/ingest/assignmentTypes.guard.test.js
+// for the mock source, which that guard's crawler scan does not cover.
+describe('mock dataset — assignment model', () => {
+  it('emits only the three universal membership types', () => {
+    const types = [...new Set(permissionAssignments.map((p) => p.membershipType))].sort();
+    expect(types).toEqual(['Direct', 'Eligible', 'Indirect']);
+  });
+
+  it('has no retired membership type', () => {
+    const retired = ['Owner', 'Governed', 'OAuth2Grant', 'AppRole', 'AppRoleViaGroup', 'DirectoryRole', 'DirectoryRoleEligible'];
+    const offenders = permissionAssignments.filter((p) => retired.includes(p.membershipType));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/changes/mock-data-retired-owner.md
+++ b/changes/mock-data-retired-owner.md
@@ -1,0 +1,1 @@
+- The built-in demo/mock dataset no longer uses the retired `Owner` membership type, so mock mode matches the current data model (group ownership is represented as its own resource, not a membership type).


### PR DESCRIPTION
## Why

`app/api/src/mock/data.js` still emitted `addAssignment(..., 'Owner')` in two places, so **mock mode rendered an 'Owner' matrix badge that no longer exists in real data**. `Owner` is one of the assignment types retired by the model redesign — ownership is now a `GroupOwnership` resource + a `Direct` assignment (migration 046), not a membership type. (Found by the drift audit; the static assignmentType guard doesn't scan `app/api/src`, so this slipped through.)

## What

- The HR-in-Finance row → a plain `Direct` cross-department membership (still a useful over-permission example).
- The **"Pattern 12: Group Owners"** loop is removed — department managers already hold their base group as `Direct` via Pattern 1, so it only added `Owner`-typed duplicates.

Mock now emits only `Direct`/`Indirect`/`Eligible` (verified: 355 rows, those three types only). The permissions tests mock `mock/data.js` out, so behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
