### PR TITLE
ci: node-version gate scans .ps1; fix nightly runner still on node:20

### DIFF
--- a/test/nightly/Run-NightlyLocal.ps1
+++ b/test/nightly/Run-NightlyLocal.ps1
@@ -147,7 +147,7 @@ try {
 #       -SkipIntegration -SkipE2E` to get "did I break lint?" in seconds.
 #
 # When npm is missing on the host we fall back to a one-shot
-# `node:20-slim` container (same pattern as Phase 2 / Phase 3).
+# `node:24-slim` container (same pattern as Phase 2 / Phase 3).
 if (-not $SkipStaticChecks) {
     Write-Phase "Phase 0: Static Checks"
 
@@ -199,7 +199,7 @@ if (-not $SkipStaticChecks) {
             Pop-Location
         } else {
             $uiPath = $frontendDir -replace '\\','/' -replace '^([A-Za-z]):','/$1'
-            $null = & docker run --rm -v "${uiPath}:/work" -w /work node:20-slim sh -c "npm ci >/dev/null 2>&1; npm run lint" 2>&1 |
+            $null = & docker run --rm -v "${uiPath}:/work" -w /work node:24-slim sh -c "npm ci >/dev/null 2>&1; npm run lint" 2>&1 |
                 Tee-Object -FilePath $eslintLog
             $eslintExit = $LASTEXITCODE
         }
@@ -230,7 +230,7 @@ if (-not $SkipStaticChecks) {
             # Docker fallback: mount the whole repo read-only so the spec
             # file and any $ref targets remain resolvable.
             $repoPath = $RepoRoot -replace '\\','/' -replace '^([A-Za-z]):','/$1'
-            $null = & docker run --rm -v "${repoPath}:/work:ro" -w /work node:20-slim sh -c "npx -y @stoplight/spectral-cli lint app/api/src/openapi.yaml" 2>&1 |
+            $null = & docker run --rm -v "${repoPath}:/work:ro" -w /work node:24-slim sh -c "npx -y @stoplight/spectral-cli lint app/api/src/openapi.yaml" 2>&1 |
                 Tee-Object -FilePath $spectralLog
             $spectralExit = $LASTEXITCODE
             Write-Result 'Static-Spectral' ($spectralExit -eq 0) $(if ($spectralExit -ne 0) { "exit code $spectralExit (via docker)" })
@@ -257,7 +257,7 @@ if (-not $SkipStaticChecks) {
                 Pop-Location
             } else {
                 $pkgPath = $pkg.Dir -replace '\\','/' -replace '^([A-Za-z]):','/$1'
-                $null = & docker run --rm -v "${pkgPath}:/work" -w /work node:20-slim sh -c "npm ci --omit=dev >/dev/null 2>&1; npm audit --audit-level=high" 2>&1 |
+                $null = & docker run --rm -v "${pkgPath}:/work" -w /work node:24-slim sh -c "npm ci --omit=dev >/dev/null 2>&1; npm audit --audit-level=high" 2>&1 |
                     Tee-Object -FilePath $auditLog
                 $auditExit = $LASTEXITCODE
             }
@@ -348,7 +348,7 @@ if (-not $SkipBackendUnit) {
     Write-Phase "Phase 2: Backend Unit Tests"
 
     # When npm isn't on the PATH (common on a Docker-only host) we run vitest
-    # inside a one-shot node:20-slim container that mounts the api source.
+    # inside a one-shot node:24-slim container that mounts the api source.
     $hasNpm = $null -ne (Get-Command npm -ErrorAction SilentlyContinue)
     try {
         if ($hasNpm) {
@@ -358,7 +358,7 @@ if (-not $SkipBackendUnit) {
             Pop-Location
         } else {
             $apiPath = $backendDir -replace '\\','/' -replace '^([A-Za-z]):','/$1'
-            $null = & docker run --rm -v "${apiPath}:/work" -w /work node:20-slim sh -c "npm ci >/dev/null 2>&1; npm test -- --reporter=verbose" 2>&1 |
+            $null = & docker run --rm -v "${apiPath}:/work" -w /work node:24-slim sh -c "npm ci >/dev/null 2>&1; npm test -- --reporter=verbose" 2>&1 |
                 Tee-Object -FilePath (Join-Path $LogFolder 'backend-unit.log')
             Write-Result 'Backend-Unit-Tests' ($LASTEXITCODE -eq 0) $(if ($LASTEXITCODE -ne 0) { "exit code $LASTEXITCODE (via docker)" })
         }

--- a/tools/node-version/ratchet.py
+++ b/tools/node-version/ratchet.py
@@ -72,6 +72,11 @@ def _kind(path):
         return scan_dockerfile
     if base == "package.json":
         return scan_package_json
+    if path.endswith(".ps1"):
+        # CI/helper PowerShell scripts pin Node via `docker run ... node:<v>-slim`
+        # (e.g. test/nightly/Run-NightlyLocal.ps1). Same image-ref pattern as a
+        # Dockerfile, so reuse the Dockerfile scanner.
+        return scan_dockerfile
     return None
 
 

--- a/tools/node-version/test_ratchet.py
+++ b/tools/node-version/test_ratchet.py
@@ -32,6 +32,13 @@ def test_scan_dockerfile_matches_tags_and_stages():
     assert [v for _, v in scan_dockerfile(text)] == [24, 24]
 
 
+def test_scan_dockerfile_matches_docker_run_refs_in_scripts():
+    # .ps1 CI/helper scripts pin Node via `docker run ... node:<v>-slim`; the same
+    # scanner is applied to .ps1 files so a stale pin (node:20) is caught.
+    text = '$null = & docker run --rm -w /work node:20-slim sh -c "npm ci"\n'
+    assert [v for _, v in scan_dockerfile(text)] == [20]
+
+
 def test_scan_package_json_extracts_engines_major():
     assert [v for _, v in scan_package_json('{"engines":{"node":">=24"}}')] == [24]
     assert [v for _, v in scan_package_json('{"engines":{"node":"24.x"}}')] == [24]


### PR DESCRIPTION
## Why

`test/nightly/Run-NightlyLocal.ps1` still pinned its one-shot lint / spectral / npm-audit / api-unit-test containers to **`node:20-slim`** (6 places) — a real Node drift that **#592's standardization on Node 24 missed**, because that sweep covered the standard locations (setup-node steps, `FROM node:`, `engines`) but not a PowerShell helper that spins its *own* Node containers via `docker run ... node:20-slim`. And #607's node-version gate only scanned workflows / Dockerfiles / package.json — not `.ps1` — so nothing caught it.

## What

- Bump the nightly runner's containers to `node:24-slim` (all 6).
- Extend `tools/node-version/ratchet.py` to scan `.ps1` files for `docker run ... node:<v>` image refs (same pattern as a Dockerfile), so a stale `.ps1` pin now fails the gate.

## Verification

pytest 9/9 (new docker-run scan case); the gate now checks **27** references (up from 21) and passes; reverting the nightly file to `node:20` fails the gate flagging `Run-NightlyLocal.ps1`. Confirmed no other tracked `.ps1` carries a `node:<digit>` ref.

CI/tooling only — no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
