### PR TITLE
test(ui): lock matrix/legend badge palette to the three current membership types

### DIFF
--- a/app/ui/src/utils/colors.test.js
+++ b/app/ui/src/utils/colors.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { TYPE_COLORS } from './colors.js';
+
+// Locks the matrix/legend badge palette to the current assignment model: the
+// membership types that render as badges are exactly the three universal values.
+// The retired types (Owner/Governed/OAuth2Grant/AppRole/AppRoleViaGroup/…) must
+// never get a swatch back — they can no longer appear in the data (see
+// app/api/src/ingest/assignmentTypes.guard.test.js). A regression here would
+// reintroduce a badge for a value the matrix can never produce.
+describe('TYPE_COLORS — matrix/legend badge palette', () => {
+  it('has exactly the three universal membership types', () => {
+    expect(Object.keys(TYPE_COLORS).sort()).toEqual(['Direct', 'Eligible', 'Indirect']);
+  });
+
+  it('carries no retired assignment type', () => {
+    const retired = ['Owner', 'Governed', 'OAuth2Grant', 'AppRole', 'AppRoleViaGroup', 'DirectoryRole', 'DirectoryRoleEligible'];
+    for (const t of retired) {
+      expect(TYPE_COLORS[t], `${t} must not have a badge swatch`).toBeUndefined();
+    }
+  });
+
+  it('gives each type a letter and valid hex bg/text colours', () => {
+    for (const [type, s] of Object.entries(TYPE_COLORS)) {
+      expect(s.letter, `${type}.letter`).toBeTruthy();
+      expect(s.bg, `${type}.bg`).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(s.text, `${type}.text`).toMatch(/^#[0-9a-fA-F]{3,6}$/);
+    }
+  });
+});

--- a/app/ui/src/utils/exportToExcel.test.js
+++ b/app/ui/src/utils/exportToExcel.test.js
@@ -240,6 +240,24 @@ describe('exportToExcel', () => {
     expect(legend.getCell(2, 2).value).toBe('D');
   });
 
+  it('lists ONLY the three current membership types — no retired badge rows', async () => {
+    await exportToExcel(baseInput());
+    const wb = await loadCapturedWorkbook();
+    const legend = wb.getWorksheet('Legend');
+
+    // Membership-type rows are contiguous from row 2 to the first blank row.
+    const typeRows = [];
+    for (let r = 2; legend.getCell(r, 1).value; r++) {
+      typeRows.push(legend.getCell(r, 1).value);
+    }
+    expect([...typeRows].sort()).toEqual(['Direct', 'Eligible', 'Indirect']);
+
+    const retired = ['Owner', 'Governed', 'OAuth2Grant', 'AppRole', 'AppRoleViaGroup', 'DirectoryRole', 'DirectoryRoleEligible'];
+    for (const t of retired) {
+      expect(typeRows, `retired '${t}' must not appear in the Excel legend`).not.toContain(t);
+    }
+  });
+
   it('writes active filters and a shareable link into the Legend', async () => {
     const activeFilters = [{ field: 'dept', value: 'HR' }];
     const filterFields = [{ key: 'dept', label: 'Department' }];


### PR DESCRIPTION
## Why

The retired-`Owner`/`Governed` badge removal had **no direct UI guard**: there was no `colors.test.js` at all, and the Excel legend test only asserted the first row. A regression could reintroduce a swatch/legend row for a membership type the matrix can never produce.

## What

- **`app/ui/src/utils/colors.test.js`** (new): `TYPE_COLORS` keys are exactly `{Direct, Indirect, Eligible}`; no retired type (`Owner`/`Governed`/`OAuth2Grant`/`AppRole`/…) has a swatch; each entry has a letter + valid hex bg/text.
- **`exportToExcel.test.js`**: new assertion that the Legend sheet lists **only** those three types and no retired badge rows — iterating the whole membership-type block, not just row 1.

Both derive from the shared `TYPE_COLORS` (the Excel legend is built from it), so these lock the single source. 14 tests pass locally.

Test-only — no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
