### PR TITLE
test(data-model): guard assignmentType schema enum + matrix matview column set

### DIFF
--- a/app/api/contract-tests/matviewColumnSet.contract.test.js
+++ b/app/api/contract-tests/matviewColumnSet.contract.test.js
@@ -1,0 +1,52 @@
+// Contract test — the live matrix materialized view exposes a stable column set.
+//
+// vw_ResourceUserPermissionAssignments has been redefined ~10 times (043/046/049/…).
+// The matrix UI and several read routes select fixed columns off it; a future
+// redefinition that silently drops or renames one would break the matrix at read
+// time with no unit test failing (unit tests mock the DB). This pins the column
+// contract structurally — a redefinition that removes a required column fails here.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+
+let pool;
+
+// Columns the matrix / read layer depends on. Presence-checked (extra columns are
+// fine); dropping or renaming any of these must fail. This is the collapsed
+// per-(resource, principal, how-held) grid — its unique key is
+// (resourceId, principalId, membershipType).
+const REQUIRED_COLUMNS = [
+  'resourceId',
+  'principalId',
+  'principalType',
+  'membershipType',
+  'managedByAccessPackage',
+];
+
+beforeAll(async () => {
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+});
+
+afterAll(async () => {
+  await pool?.end();
+});
+
+describe('vw_ResourceUserPermissionAssignments — column contract', () => {
+  it('exposes every column the matrix/read layer depends on', async () => {
+    // `SELECT * LIMIT 0` returns the field metadata even for a matview (which is
+    // absent from information_schema.columns), and needs no REFRESH.
+    const res = await pool.query('SELECT * FROM "vw_ResourceUserPermissionAssignments" LIMIT 0');
+    const cols = new Set(res.fields.map((f) => f.name));
+    const missing = REQUIRED_COLUMNS.filter((c) => !cols.has(c));
+    expect(missing, `matview is missing required column(s): ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('keeps membershipType as the collapsed how-held value (no legacy source types leak as columns)', async () => {
+    // A sanity assertion that the view still models "how held" via membershipType
+    // rather than exposing a raw assignmentType column consumers would misread.
+    const res = await pool.query('SELECT * FROM "vw_ResourceUserPermissionAssignments" LIMIT 0');
+    const cols = new Set(res.fields.map((f) => f.name));
+    expect(cols.has('membershipType')).toBe(true);
+    expect(cols.has('assignmentType')).toBe(false);
+  });
+});

--- a/app/api/src/ingest/assignmentTypeSchema.guard.test.js
+++ b/app/api/src/ingest/assignmentTypeSchema.guard.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// Static guard: every `assignmentType` schema field in validation.js must be
+// constrained to `enum: ASSIGNMENT_TYPES` (the three universal values). A NEW
+// ingest schema — or a future edit — that declared assignmentType as free text
+// (or with a drifted enum) would let a retired type (Owner/Governed/…) back in
+// via that endpoint. Scanning the source keeps the internal SCHEMAS object
+// un-exported. Complements assignmentTypes.guard.test.js (runtime rejection +
+// crawler emission scan).
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'validation.js'), 'utf8');
+
+// Each field definition looks like:
+//   assignmentType: { type: 'string', enum: ASSIGNMENT_TYPES },
+const defs = [...src.matchAll(/assignmentType\s*:\s*\{([^}]*)\}/g)].map((m) => m[1]);
+
+describe('assignmentType schema fields are enum-constrained', () => {
+  it('validation.js declares assignmentType on at least the two assignment schemas', () => {
+    expect(defs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every assignmentType schema field constrains it to enum: ASSIGNMENT_TYPES', () => {
+    const offenders = defs.filter((body) => !/enum\s*:\s*ASSIGNMENT_TYPES\b/.test(body));
+    expect(
+      offenders,
+      `an assignmentType schema field is not constrained to ASSIGNMENT_TYPES ` +
+      `(free text or a drifted enum would let a retired type in):\n${offenders.join('\n---\n')}`,
+    ).toEqual([]);
+  });
+
+  it('ASSIGNMENT_TYPES is exactly the three universal values', () => {
+    expect(src).toMatch(/const ASSIGNMENT_TYPES\s*=\s*\[\s*'Direct',\s*'Indirect',\s*'Eligible'\s*\]/);
+  });
+});


### PR DESCRIPTION
Bundles the data-model / retired-type items from the audit into one PR — **all new test files, no production change, no overlap with the open stack (#610–#618)**, so nothing clashes.

## What

- **`assignmentTypeSchema.guard.test.js`** — statically scans `validation.js` so **every** `assignmentType` schema field stays constrained to `enum: ASSIGNMENT_TYPES`. A new ingest schema (or a future edit) that declared `assignmentType` as free text — or with a drifted enum — would let a retired type (`Owner`/`Governed`/…) back in through that endpoint. The existing `assignmentTypes.guard.test.js` guards the runtime + crawler emissions; this guards the **schema shape**. Scanning the source keeps the internal `SCHEMAS` object un-exported (so this needs no production change / changelog).
- **`matviewColumnSet.contract.test.js`** — pins the live `vw_ResourceUserPermissionAssignments` **column contract** (`resourceId, principalId, principalType, membershipType, managedByAccessPackage`) so a future redefinition (it's been redefined ~10×) can't silently drop/rename a column the matrix reads. Also asserts the view exposes collapsed `membershipType`, not a raw `assignmentType`.

## Not included, on purpose

Migration 046's `Owner → GroupOwnership` rewrite is now **frozen by the migration-immutability gate (#611)** — its SQL can't drift — so a behavioural contract test for it adds little. Noted in the outstanding backlog.

## Verification

`assignmentTypeSchema` 3/3; `matviewColumnSet` 2/2 (run in isolation). `validation.js` is byte-identical to `main`. Test-only — no changelog fragment.

> The matview test runs in the contract suite, whose full-run flakiness is fixed by #614 (not yet merged) — its CI here may need a re-run until #614 lands; it's deterministic in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
