### PR TITLE
ci: add a PowerShell (Pester) coverage floor

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -301,8 +301,18 @@ jobs:
           $cfg.CodeCoverage.OutputPath = 'pester-coverage.xml'
           $cfg.CodeCoverage.OutputFormat = 'JaCoCo'
           $result = Invoke-Pester -Configuration $cfg
-          Write-Host "Coverage: $([Math]::Round($result.CodeCoverage.CoveragePercent, 1))%"
+          $pct = [Math]::Round($result.CodeCoverage.CoveragePercent, 1)
+          Write-Host "Coverage: $pct%"
           if ($result.FailedCount -gt 0) { exit 1 }
+          # PowerShell coverage floor — the "coverage never down" ratchet for the
+          # PS side (the JS side already has committed vitest thresholds). RAISE
+          # this when coverage rises; only ever lower it as a reviewed, justified
+          # change. Measured ~91.9%.
+          $FLOOR = 90.0
+          if ($pct -lt $FLOOR) {
+            Write-Host "::error::Pester coverage $pct% is below the floor of $FLOOR%. Add tests for the PowerShell you changed, or lower the floor in pr.yml with justification."
+            exit 1
+          }
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
The Pester job computed `CodeCoverage.CoveragePercent` and printed it, but only failed on **test failures** — so the PowerShell side had no "coverage never down" ratchet, unlike the JS side's committed vitest thresholds. A change that dropped PS coverage went unnoticed.

Adds a floor check in the job: after the run, fail if `CoveragePercent < FLOOR` with an actionable `::error::`. Floor set to **90%** (measured ~91.9%, so a small headroom against a legitimate one-off dip while still catching real regressions). Raise it when coverage rises; only lower it as a reviewed, justified change — same discipline as the complexity/filesize baselines.

CI/config only — no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
