### PR TITLE
fix(risk): restore ownership signals after Owner→GroupOwnership migration (#598)

### DIFF
--- a/app/api/contract-tests/riskEngineOwnership.contract.test.js
+++ b/app/api/contract-tests/riskEngineOwnership.contract.test.js
@@ -1,0 +1,117 @@
+// Contract test — the risk engine's ownership traversal against a real schema.
+//
+// Since migration 046 ownership is no longer an assignmentType='Owner' row on
+// the group's own resource; it's a Direct assignment on a synthetic
+// GroupOwnership resource linked to the owned group by a HasOwnership
+// relationship. loadScoringData()'s owner-count / principal-ownership indexes
+// (and the membership index it uses for propagation) must reflect that:
+//   - owner counts key on the OWNED group id, not the synthetic resource,
+//   - a principal's ownerships resolve to the owned groups,
+//   - GroupOwnership Direct rows must NOT leak into the membership headcount or
+//     the propagation graph (ownership is admin control, not "has access to").
+//
+// A unit test with a mocked db can't catch a wrong table/column/join here — only
+// a real PostgreSQL run can. Drives the real loadScoringData by pointing
+// db/connection.js at the contract container (DATABASE_URL is honoured first).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'crypto';
+import pg from 'pg';
+
+const noop = async () => {};
+
+let pool;
+let systemId;
+let classifierId;
+let loadScoringData;
+let closePool;
+
+// Fixture ids — a group, its synthetic ownership resource, an owner, a member.
+const groupId     = randomUUID();
+const ownershipId = randomUUID();
+const ownerPid    = randomUUID();
+const memberPid   = randomUUID();
+
+beforeAll(async () => {
+  // Must be set before db/connection.js is imported so its pool targets the
+  // contract container (buildConfig() honours DATABASE_URL first).
+  process.env.DATABASE_URL = process.env.CONTRACT_DB_URL;
+  ({ loadScoringData } = await import('../src/riskscoring/engine.js'));
+  ({ closePool } = await import('../src/db/connection.js'));
+
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'risk-ownership') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+
+  const cls = await pool.query(
+    `INSERT INTO "RiskClassifiers" ("displayName", "classifiers", "isActive")
+     VALUES ('risk-ownership-fixture', '{}'::jsonb, false) RETURNING "id"`,
+  );
+  classifierId = cls.rows[0].id;
+
+  // Group + its synthetic ownership resource.
+  await pool.query(
+    `INSERT INTO "Resources" ("id", "systemId", "displayName", "resourceType")
+     VALUES ($1, $3, 'Admins', 'Group'), ($2, $3, 'Owner @ Admins', 'GroupOwnership')`,
+    [groupId, ownershipId, systemId],
+  );
+  // Owned group ← HasOwnership → ownership resource.
+  await pool.query(
+    `INSERT INTO "ResourceRelationships" ("parentResourceId", "childResourceId", "relationshipType", "systemId")
+     VALUES ($1, $2, 'HasOwnership', $3)`,
+    [groupId, ownershipId, systemId],
+  );
+  // The owner (Direct on the GroupOwnership resource) and a plain Direct member.
+  await pool.query(
+    `INSERT INTO "ResourceAssignments"
+       ("systemId", "resourceId", "principalId", "assignmentType", "resourceType", "principalType")
+     VALUES ($1, $2, $3, 'Direct', 'GroupOwnership', 'User'),
+            ($1, $4, $5, 'Direct', 'Group',          'User')`,
+    [systemId, ownershipId, ownerPid, groupId, memberPid],
+  );
+});
+
+afterAll(async () => {
+  await pool?.query(`DELETE FROM "ResourceAssignments" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+  await pool?.query(`DELETE FROM "RiskClassifiers" WHERE "id" = $1`, [classifierId]);
+  await pool?.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool?.end();
+  await closePool?.();          // release db/connection.js's own pool
+  delete process.env.DATABASE_URL; // singleFork — env mutations leak across files
+});
+
+describe('loadScoringData — ownership traversal (post migration 046)', () => {
+  it('keys owner counts on the OWNED group and resolves principal ownerships to it', async () => {
+    const data = await loadScoringData(classifierId, noop);
+
+    // Owner count is attributed to the owned group, not the synthetic resource.
+    expect(data.ownerCountMap.get(groupId)).toBe(1);
+    expect(data.ownerCountMap.get(ownershipId)).toBeUndefined();
+
+    // The owner's ownership set resolves to the owned group id.
+    expect(data.principalOwnerships.get(ownerPid)).toBeInstanceOf(Set);
+    expect(data.principalOwnerships.get(ownerPid).has(groupId)).toBe(true);
+    expect(data.principalOwnerships.get(ownerPid).has(ownershipId)).toBe(false);
+  });
+
+  it('excludes GroupOwnership Direct rows from membership headcount and propagation', async () => {
+    const data = await loadScoringData(classifierId, noop);
+
+    // Plain member is counted; the ownership resource is not a "group with members".
+    expect(data.memberCountMap.get(groupId)).toBe(1);
+    expect(data.memberCountMap.get(ownershipId)).toBeUndefined();
+
+    // The owner is not double-counted as a member (would poison propagation).
+    expect(data.principalMemberships.get(ownerPid)).toBeUndefined();
+    expect(data.resourceMembers.get(ownershipId)).toBeUndefined();
+
+    // The real member still flows into the propagation graph.
+    expect(data.principalMemberships.get(memberPid)?.has(groupId)).toBe(true);
+    expect(data.resourceMembers.get(groupId)?.has(memberPid)).toBe(true);
+  });
+});

--- a/app/api/src/riskscoring/engine.js
+++ b/app/api/src/riskscoring/engine.js
@@ -351,32 +351,45 @@ export async function loadScoringData(classifierId, updateRun) {
 
   // Member counts per resource (Direct memberships for total headcount; the
   // governed flag is orthogonal — every row is an effective membership).
+  // GroupOwnership assignments are Direct too (the owner is a Direct member of
+  // the synthetic "Owner @ <group>" resource, migration 046), but ownership is
+  // admin control — not a membership — so it must not inflate headcount.
   const memberCountRows = await db.query(
     `SELECT "resourceId"::text AS rid, COUNT(*)::int AS cnt
        FROM "ResourceAssignments"
       WHERE "assignmentType" = 'Direct'
+        AND "resourceType" IS DISTINCT FROM 'GroupOwnership'
       GROUP BY "resourceId"`
   );
   const memberCountMap = new Map(memberCountRows.rows.map(r => [r.rid, r.cnt]));
 
-  // Owner counts per resource
+  // Owner counts per owned group. Since migration 046, ownership is a Direct
+  // assignment on a GroupOwnership resource linked to the owned group via a
+  // HasOwnership relationship (parentResourceId = owned group); the retired
+  // assignmentType='Owner' matches zero rows. Key the map by the OWNED group id
+  // so scoreResourceEntity's ownerCountMap.get(group.id) lookup resolves.
   const ownerCountRows = await db.query(
-    `SELECT "resourceId"::text AS rid, COUNT(*)::int AS cnt
-       FROM "ResourceAssignments"
-      WHERE "assignmentType" = 'Owner'
-      GROUP BY "resourceId"`
+    `SELECT rr."parentResourceId"::text AS rid, COUNT(*)::int AS cnt
+       FROM "ResourceAssignments" ra
+       JOIN "ResourceRelationships" rr
+         ON rr."childResourceId" = ra."resourceId"
+        AND rr."relationshipType" = 'HasOwnership'
+      WHERE ra."assignmentType" = 'Direct'
+        AND ra."resourceType"   = 'GroupOwnership'
+      GROUP BY rr."parentResourceId"`
   );
   const ownerCountMap = new Map(ownerCountRows.rows.map(r => [r.rid, r.cnt]));
 
   // Build bidirectional index: principal → list of resource ids (memberships)
   //                           resource  → list of principal ids (members)
-  // We only follow Direct memberships for propagation — Owner is a different
-  // relationship (admin control, not "has access to") and would double-count
-  // privileged users.
+  // We only follow Direct memberships for propagation — ownership is a different
+  // relationship (admin control, not "has access to"). Excluding GroupOwnership
+  // keeps owners from being double-counted as members of the synthetic resource.
   const assignmentRows = await db.query(
     `SELECT "principalId"::text AS pid, "resourceId"::text AS rid
        FROM "ResourceAssignments"
-      WHERE "assignmentType" = 'Direct'`
+      WHERE "assignmentType" = 'Direct'
+        AND "resourceType" IS DISTINCT FROM 'GroupOwnership'`
   );
   const principalMemberships = new Map(); // pid -> Set<rid>
   const resourceMembers      = new Map(); // rid -> Set<pid>
@@ -387,11 +400,17 @@ export async function loadScoringData(classifierId, updateRun) {
     resourceMembers.get(a.rid).add(a.pid);
   }
 
-  // Ownerships: principal → list of resource ids they own
+  // Ownerships: principal → set of owned group ids. Traverse the GroupOwnership
+  // resource back to the owned group (parentResourceId) so the "owner of N
+  // groups" signal counts distinct groups, not synthetic ownership resources.
   const ownerRows = await db.query(
-    `SELECT "principalId"::text AS pid, "resourceId"::text AS rid
-       FROM "ResourceAssignments"
-      WHERE "assignmentType" = 'Owner'`
+    `SELECT ra."principalId"::text AS pid, rr."parentResourceId"::text AS rid
+       FROM "ResourceAssignments" ra
+       JOIN "ResourceRelationships" rr
+         ON rr."childResourceId" = ra."resourceId"
+        AND rr."relationshipType" = 'HasOwnership'
+      WHERE ra."assignmentType" = 'Direct'
+        AND ra."resourceType"   = 'GroupOwnership'`
   );
   const principalOwnerships = new Map();
   for (const a of ownerRows.rows) {

--- a/app/api/src/riskscoring/engine.passes.test.js
+++ b/app/api/src/riskscoring/engine.passes.test.js
@@ -136,10 +136,10 @@ describe('loadScoringData', () => {
       if (sql.includes('FROM "Principals"')) return Promise.resolve({ rows: [{ id: 'p1', managerId: 'm1' }, { id: 'm1', managerId: null }] });
       if (sql.includes('PrincipalActivity')) return Promise.resolve({ rows: [] });
       if (sql.includes('FROM "Resources"')) return Promise.resolve({ rows: [{ id: 'r1' }] });
+      // Ownership now traverses GroupOwnership → HasOwnership (migration 046).
+      if (sql.includes('HasOwnership')) return Promise.resolve({ rows: [] });
       if (sql.includes('COUNT') && sql.includes("'Direct'")) return Promise.resolve({ rows: [{ rid: 'r1', cnt: 3 }] });
-      if (sql.includes('COUNT') && sql.includes("'Owner'")) return Promise.resolve({ rows: [] });
       if (sql.includes("'Direct'")) return Promise.resolve({ rows: [{ pid: 'p1', rid: 'r1' }] });
-      if (sql.includes("'Owner'")) return Promise.resolve({ rows: [] });
       return Promise.resolve({ rows: [] });
     });
     const data = await loadScoringData('c1', noop);

--- a/changes/risk-engine-ownership.md
+++ b/changes/risk-engine-ownership.md
@@ -1,0 +1,2 @@
+- Fixed risk scoring so group ownership counts again — owners had silently stopped contributing to risk after ownership moved to its own resource type, so the "user owns many groups" and "group has members but no owner" signals had gone dead.
+- Corrected group member counts and risk propagation to no longer treat group owners as if they were group members.


### PR DESCRIPTION
Fixes #598.

## Problem
Since migration `046_owner_as_resource.sql`, group ownership is a `Direct` assignment on a synthetic `GroupOwnership` resource (linked to the owned group via a `HasOwnership` relationship). But the risk engine still queried the **retired** `assignmentType='Owner'`, which matches **zero rows**. Ownership had silently stopped feeding risk scoring:

- "Owner of >3 groups — high administrative responsibility [+5]" never fired.
- "No owner assigned while having members — ungoverned group [+5]" fired on **every** group with members, even well-owned ones.

A second, subtler defect: the owner is now a `Direct` member of the ownership resource, so the membership/propagation index **double-counted owners as members** — contradicting the engine's own "ownership must not propagate as membership" comment.

## Fix
- Owner-count and per-principal-ownership queries now join `ResourceAssignments → ResourceRelationships (HasOwnership)` and key on the **owned group** id (so `ownerCountMap.get(group.id)` resolves).
- Membership headcount + propagation queries exclude `resourceType='GroupOwnership'`, so owners aren't counted as members of the synthetic resource.

Scoped to the live-code regression. The cosmetic matview dead-CASE-branch and `docs/architecture/matrix.md` cleanups the issue flags as high-risk/low-reward are intentionally left for a separate change.

## Tests
- New real-DB contract test (`riskEngineOwnership.contract.test.js`) seeds a GroupOwnership fixture and drives the real `loadScoringData`, asserting owner counts key on the owned group, principal ownerships resolve to it, and GroupOwnership rows stay out of the membership/propagation graph.
- Updated the mocked-db unit test for the new join SQL.
- Verified: riskscoring unit tests (65 passed) + full contract suite (24 files, 85 tests) pass against a real PostgreSQL 16 container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
