### PR TITLE
ci: close all three gate-coverage gaps (#625)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -577,8 +577,12 @@ jobs:
           echo "Changed files:"; echo "${CHANGED}" | sed 's/^/  /'
 
           # Product (non-test) source that ought to be covered by a test.
+          # .sql = schema migrations (cover with a contract test); .mjs = the
+          # desktop build/launcher scripts. Both previously slipped the gate.
           CODE=$(echo "${CHANGED}" | grep -E \
             -e '^app/api/src/.*\.js$' \
+            -e '^app/api/src/.*\.sql$' \
+            -e '^app/.*\.mjs$' \
             -e '^app/ui/src/.*\.(js|jsx)$' \
             -e '^tools/.*\.ps1$' \
             -e '^setup/docker/.*\.ps1$' \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -550,14 +550,15 @@ jobs:
   # ── Stage 7: PR hygiene (tests + changelog required for code changes) ────
   # Blocks merging a code change that ships without tests or a changelog
   # fragment — the gap that let an undocumented, untested feature reach main.
-  # Escape hatch: a maintainer can apply the 'skip-hygiene' label, which
-  # skips the job entirely (job-level if, so it is never even scheduled).
+  # Escape hatch: a maintainer can apply the 'skip-hygiene' label. The label does
+  # NOT skip the job (a job-level skip left the bypass invisible and let ci-passed
+  # treat it as green). Instead the job always runs on product changes and honours
+  # the label internally — on a would-be failure it prints exactly what was waived
+  # and passes, so every bypass is recorded and provable in the job log.
   hygiene:
     name: 'PR Hygiene'
     needs: [changes]
-    if: |
-      needs.changes.outputs.has_product_changes == 'true' &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-hygiene')
+    if: needs.changes.outputs.has_product_changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -568,6 +569,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SKIP_HYGIENE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-hygiene') }}
         run: |
           set -euo pipefail
 
@@ -594,28 +596,35 @@ jobs:
           # Changelog fragment (the project mandates one per branch).
           FRAGMENT=$(echo "${CHANGED}" | grep -E '^changes/.*\.md$' || true)
 
-          FAIL=0
+          # Accumulate the human-readable reasons; severity is decided at the end
+          # so the 'skip-hygiene' bypass can downgrade them from error to warning.
+          REASONS=""
+          add_reason() { REASONS="${REASONS}${REASONS:+$'\n'}$1"; }
+
           if [ -n "${CODE}" ]; then
             if [ -z "${TESTS}" ]; then
-              echo "::error::Source code changed but no test files were added or modified."
-              echo "Add or extend a test: *.test.js (API), app/ui/e2e/*.spec.js (UI), *.Tests.ps1 (Pester unit), or Test-*.ps1 (crawler integration)."
-              FAIL=1
+              add_reason "Source code changed but no test files were added or modified. Add or extend a test: *.test.js (API), app/ui/e2e/*.spec.js (UI), *.Tests.ps1 (Pester unit), or Test-*.ps1 (crawler integration)."
             fi
             if [ -z "${FRAGMENT}" ]; then
-              echo "::error::Code changed but no changelog fragment found. Add a bullet to changes/<branch>.md (never edit CHANGES.md)."
-              FAIL=1
+              add_reason "Code changed but no changelog fragment found. Add a bullet to changes/<branch>.md (never edit CHANGES.md)."
             elif ! grep -qE '^[[:space:]]*[-*][[:space:]]+[^[:space:]]' ${FRAGMENT}; then
               # A fragment file exists but is empty / has no bullet — that silently
               # satisfied the gate before. Require at least one real bullet line.
-              echo "::error::A changelog fragment exists but has no bullet line. Add at least one '- ...' bullet describing the change to changes/<branch>.md:"
-              echo "${FRAGMENT}" | sed 's/^/  /'
-              FAIL=1
+              add_reason "A changelog fragment exists but has no bullet line. Add at least one '- ...' bullet describing the change to: ${FRAGMENT}"
             fi
           else
             echo "No product code changed — tests/changelog not required."
           fi
 
-          if [ "${FAIL}" = "1" ]; then
+          if [ -n "${REASONS}" ]; then
+            if [ "${SKIP_HYGIENE}" = "true" ]; then
+              # Observable bypass: the job runs, records what was waived, and passes.
+              echo "::warning::PR hygiene requirements NOT met, but BYPASSED via the 'skip-hygiene' label. The following would otherwise block merge:"
+              printf '%s\n' "${REASONS}" | sed 's/^/  - /'
+              echo "This bypass is intentional and is now recorded in this job's log rather than the job being silently skipped."
+              exit 0
+            fi
+            while IFS= read -r reason; do echo "::error::PR hygiene: ${reason}"; done <<< "${REASONS}"
             echo "If this change genuinely needs neither, a maintainer can add the 'skip-hygiene' label."
             exit 1
           fi

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -4,7 +4,7 @@
   "minTokens": 50,
   "reporters": ["console"],
   "ignore": [
-    "**/*.sql",
+    "**/migrations/**/*.sql",
     "**/node_modules/**",
     "**/dist/**",
     "**/build/**",

--- a/tools/node-version/ratchet.py
+++ b/tools/node-version/ratchet.py
@@ -31,6 +31,10 @@ EXCLUDE = ("node_modules/", "/dist", "bundled-scripts/", "coverage/", "docs/cove
 _WF_RE = re.compile(r"node-version:\s*['\"]?v?(\d+)")
 # `FROM node:24-slim`, `FROM node:24.1.0 AS build`, `--from=node:24 …`
 _DOCKER_RE = re.compile(r"\bnode:v?(\d+)")
+# `const NODE_VERSION = '24.16.0'` — a build/launcher .mjs pins the exact Node
+# runtime it bundles (e.g. app/desktop/scripts/build-node-launcher.mjs, which
+# also carries a matching ABI + SHA). Only the major is gated against .nvmrc.
+_MJS_RE = re.compile(r"NODE_VERSION\s*=\s*['\"]v?(\d+)")
 
 
 def parse_expected(nvmrc_text):
@@ -55,6 +59,10 @@ def scan_dockerfile(text):
     return [(m.start(), int(m.group(1))) for m in _DOCKER_RE.finditer(text)]
 
 
+def scan_mjs(text):
+    return [(m.start(), int(m.group(1))) for m in _MJS_RE.finditer(text)]
+
+
 def scan_package_json(text):
     try:
         node = json.loads(text).get("engines", {}).get("node")
@@ -77,6 +85,9 @@ def _kind(path):
         # (e.g. test/nightly/Run-NightlyLocal.ps1). Same image-ref pattern as a
         # Dockerfile, so reuse the Dockerfile scanner.
         return scan_dockerfile
+    if path.endswith(".mjs"):
+        # Build/launcher scripts pin the bundled Node via `const NODE_VERSION`.
+        return scan_mjs
     return None
 
 

--- a/tools/node-version/test_ratchet.py
+++ b/tools/node-version/test_ratchet.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ratchet import (  # noqa: E402
-    parse_expected, scan_workflow, scan_dockerfile, scan_package_json, evaluate,
+    parse_expected, scan_workflow, scan_dockerfile, scan_package_json, scan_mjs, evaluate,
 )
 
 
@@ -47,6 +47,22 @@ def test_scan_package_json_extracts_engines_major():
 def test_scan_package_json_without_engines_is_empty():
     assert scan_package_json('{"name":"x"}') == []
     assert scan_package_json('not json') == []
+
+
+def test_scan_mjs_extracts_node_version_major():
+    # A launcher .mjs pins the bundled runtime as `const NODE_VERSION = '24.16.0'`;
+    # only the major (24) is gated against .nvmrc.
+    text = "const NODE_VERSION   = '24.16.0';\nconst NODE_ABI = '137';\n"
+    assert [v for _, v in scan_mjs(text)] == [24]
+
+
+def test_scan_mjs_matches_double_quotes_and_v_prefix():
+    assert [v for _, v in scan_mjs('const NODE_VERSION = "v22.1.0"')] == [22]
+
+
+def test_scan_mjs_without_pin_is_empty():
+    # An .mjs that doesn't pin a Node version contributes no finding.
+    assert scan_mjs("import { join } from 'node:path';\nconst X = 1;\n") == []
 
 
 def test_evaluate_flags_mismatch_only():


### PR DESCRIPTION
Closes #625 — all three gate-coverage gaps from the drift audit.

## 1. node-version gate now scans `.mjs`
`app/desktop/scripts/build-node-launcher.mjs` pins the bundled Node runtime via `const NODE_VERSION = '24.16.0'` (plus a matching ABI + SHA), which floated free of `.nvmrc`. Extended `tools/node-version/ratchet.py` with `scan_mjs()` reusing the existing `evaluate()` / `collect_findings()` plumbing (same pattern as the `.ps1` support from #617). Unit-tested; gate now checks 30 references and passes (the `.mjs` already pins major 24).

## 2. `skip-hygiene` is now an observable bypass, not a silent skip
Previously the label lived in the job-level `if`, so it skipped the whole PR Hygiene job — and `ci-passed` treats a skipped job as green, leaving no trace. Now the job always runs on product changes and honours the label internally: on a would-be failure it prints exactly what was waived as a `::warning::` and exits 0. Without the label, behaviour is unchanged (errors + exit 1).

## 3. jscpd + hygiene globs closed (per maintainer decision)
- **jscpd:** replaced the blanket `**/*.sql` ignore with `**/migrations/**/*.sql`. Scanning migrations trips the 2% gate at a permanent, unfixable **7.87%** (they're immutable and append-only; matview redefinitions necessarily repeat earlier CTEs). The narrowed ignore exempts the 57 migrations while gating any editable/new SQL. Verified on a clean tracked-only tree: **SQL 0%, total 1.28% — green**.
- **hygiene:** added product `.sql` (migrations) and `app/**/*.mjs` (desktop build/launcher) to the CODE glob — both now require a test **and** a changelog like other product code. Migrations are covered by contract tests (matched by the existing `*.test.js` rule); genuinely untestable changes use the now-observable `skip-hygiene` bypass. `tools/*.e2e.mjs` harnesses stay out (not under `app/`, and they're tests themselves).

All logic verified locally: node-version unit tests (12 pass), jscpd on a clean checkout (green), and the hygiene bash across satisfied / unmet / bypassed / migration+contract-test / docs-only cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
