### PR TITLE
chore: re-sync complexity ratchet baselines to current values

### DIFF
--- a/.ci/cognitive-baseline.json
+++ b/.ci/cognitive-baseline.json
@@ -217,24 +217,12 @@
     "tools/crawlers/azure-rm/Get-AzureRMHelpers.ps1": [
       21
     ],
-    "tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1": [
-      34,
-      26,
-      18,
-      17
-    ],
     "tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1": [
-      22
-    ],
-    "tools/crawlers/entra-id/Start-EntraIDCrawler.ps1": [
-      618
+      17
     ],
     "tools/crawlers/midpoint/Invoke-MidpointApi.ps1": [
       22,
       22
-    ],
-    "tools/crawlers/midpoint/MidpointCrawler.Functions.ps1": [
-      20
     ],
     "tools/crawlers/odata/Invoke-ODataGetRequest.ps1": [
       70

--- a/.ci/complexity-baseline.json
+++ b/.ci/complexity-baseline.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Cyclomatic-complexity ratchet baseline. Per file: the sorted list of unit CCs over the language threshold. Only ever lowered (python tools/complexity/ratchet.py --update). See the tool header.",
+  "_comment": "Cyclomatic complexity ratchet baseline. Per file: the sorted list of unit values over the language threshold. Only ever lowered (--update). See tools/complexity/ratchet.py header.",
+  "metric": "cc",
   "thresholds": {
     "ps": 15,
     "py": 15,
@@ -13,13 +14,10 @@
       32
     ],
     "app/api/src/contexts/plugins/runner.js": [
-      27
+      22
     ],
     "app/api/src/effectiveAccess/engine.js": [
       25
-    ],
-    "app/api/src/ingest/normalization.js": [
-      35
     ],
     "app/api/src/ingest/validation.js": [
       42,
@@ -34,10 +32,10 @@
       22
     ],
     "app/api/src/routes/admin.js": [
-      39
+      30
     ],
     "app/api/src/routes/contexts.js": [
-      33,
+      30,
       22,
       21
     ],
@@ -129,9 +127,6 @@
     "app/ui/src/components/TimeSeriesChart.jsx": [
       25
     ],
-    "app/ui/src/components/UpdatesSettings.jsx": [
-      21
-    ],
     "app/ui/src/components/admin/LLMSettingsSection.jsx": [
       36
     ],
@@ -184,9 +179,6 @@
     ],
     "test/nightly/Test-RiskScoringLLM.ps1": [
       50
-    ],
-    "tools/crawlers/entra-id/EntraIDCrawler.Functions.ps1": [
-      18
     ],
     "tools/crawlers/odata/Invoke-ODataGetRequest.ps1": [
       31


### PR DESCRIPTION
Re-syncs the cyclomatic and cognitive complexity ratchet baselines so each per-file grandfathered ceiling reflects current measured complexity.

**Gate values are unchanged** — cyclomatic `ps 15 / py 15 / js 20`, cognitive `ps 15 / py 15 / js 15`. Every baseline entry is only **lowered or removed**, never raised.

### Cyclomatic (`.ci/complexity-baseline.json`)
- `contexts/plugins/runner.js` 27 → 22
- `routes/admin.js` 39 → 30
- `routes/contexts.js` 33 → 30
- `ingest/normalization.js` (35), `components/UpdatesSettings.jsx` (21), `crawlers/entra-id/EntraIDCrawler.Functions.ps1` (18) — dropped out (now under threshold)

### Cognitive (`.ci/cognitive-baseline.json`)
- `crawlers/entra-id/EntraIDCrawler.Transform.ps1` 22 → 17
- `crawlers/entra-id/Start-EntraIDCrawler.ps1` (stale 618 → now 11), `EntraIDCrawler.Functions.ps1`, `crawlers/midpoint/MidpointCrawler.Functions.ps1` — dropped out. These were stale entries left over from the Entra crawler split; the files are now small (`Start-EntraIDCrawler.ps1` is 353 lines / cc 12 / cog 11).

Both gates pass green after the re-sync. CI-baseline artifact only — no functional code change, so no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)