### PR TITLE
ci+test: enforce PSMutant floor + fixture-based transform output-shape contract (#628)

### DIFF
--- a/.ci/psmutant.config.json
+++ b/.ci/psmutant.config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "PSMutant mutation-testing config for IdentityAtlas's decomposed PowerShell crawler transforms (the pure ConvertTo-* record-shapers). Report-only to start (break=null) — set a floor once the scores are understood. Run: Install-Module PSMutant; Invoke-PSMutation -ConfigFile .ci/psmutant.config.json -SourceRoot .",
+  "_comment": "PSMutant mutation-testing config for IdentityAtlas's decomposed PowerShell crawler transforms (the pure ConvertTo-* record-shapers). Enforced: the build fails when the mutation score drops below break (80% — the transforms sit around 85%, so this locks in the current bar and forces new transform logic to be mutation-tested, not just line-covered). Run: Install-Module PSMutant; Invoke-PSMutation -ConfigFile .ci/psmutant.config.json -SourceRoot .",
   "sandboxSubtrees": ["tools", "test", "setup"],
   "mutate": [
     "tools/crawlers/entra-id/EntraIDCrawler.Transform.ps1",
@@ -17,6 +17,6 @@
   },
   "coveredLinesOnly": true,
   "operators": ["BinaryOperator", "BooleanLiteral", "NumberLiteral", "NegationRemoval"],
-  "thresholds": { "high": 80, "low": 60, "break": null },
+  "thresholds": { "high": 80, "low": 60, "break": 80 },
   "reportPath": "reports/ps-mutation.json"
 }

--- a/.github/workflows/ps-mutation.yml
+++ b/.github/workflows/ps-mutation.yml
@@ -3,17 +3,18 @@
 # transforms (the pure ConvertTo-* record-shapers) against their Pester suites --
 # the metric that proves the tests would CATCH a bug, not just execute the line.
 #
-# REPORT-ONLY for now (.ci/psmutant.config.json has thresholds.break = null): it
-# prints the score and uploads the report, but does not fail the build. Set a floor
-# once the scores are understood. Mutation is heavier than unit tests, so it runs
-# weekly, on demand, and on PRs that touch the mutated transforms (not every PR).
+# ENFORCED (.ci/psmutant.config.json has thresholds.break = 80): the run FAILS when
+# the mutation score drops below the floor — PSMutant returns a non-zero exit code,
+# which the step below rethrows. PR runs gate but never commit; weekly/on-demand runs
+# gate AND publish the score. Mutation is heavier than unit tests, so it runs weekly,
+# on demand, and on PRs that touch the mutated transforms (not every PR).
 #
 # Because it's the ONLY place mutation runs, the weekly/on-demand run also owns the
 # mutation figure on the Test Coverage docs page: it writes the score to
 # docs/coverage/powershell/mutation.json, re-renders docs/reference/coverage.md from
 # the already-committed coverage summaries (tools/generate-coverage-doc.py), and
 # commits both back to main. coverage.yml (every merge) just reads that file back —
-# it never runs mutation itself. PR runs stay report-only (no commit). Same
+# it never runs mutation itself. PR runs gate but do not commit. Same
 # protected-main push mechanics as coverage.yml / sbom-update.yml: the GitHub App
 # token is required (GITHUB_TOKEN can't bypass branch protection) and the push
 # rebases-and-retries to absorb a concurrent commit.
@@ -44,8 +45,8 @@ jobs:
     name: Mutation testing (PSMutant)
     runs-on: ubuntu-latest
     steps:
-      # Bot token only for the publishing (non-PR) runs — PR runs are report-only
-      # and never push, so they don't need it.
+      # Bot token only for the publishing (non-PR) runs — PR runs gate on the
+      # score but never push, so they do not need it.
       - name: Generate bot token
         id: bot-token
         if: github.event_name != 'pull_request'
@@ -67,7 +68,7 @@ jobs:
           Install-Module Pester -RequiredVersion 5.8.0 -Force -Scope CurrentUser
           Install-Module PSMutant -RequiredVersion 0.1.0 -Force -Scope CurrentUser
 
-      - name: Run mutation testing (report-only)
+      - name: Run mutation testing (enforced — fails below the break floor)
         shell: pwsh
         run: |
           Import-Module PSMutant -Force

--- a/test/unit/CrawlerTransformOutputShape.Tests.ps1
+++ b/test/unit/CrawlerTransformOutputShape.Tests.ps1
@@ -1,0 +1,113 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Cross-crawler output-shape contract for the pure transform record-shapers.
+
+.DESCRIPTION
+    A fixture-based, credential-free stand-in for the deep tenant test: instead of
+    running a crawler against a live tenant, it dot-sources every crawler's
+    *.Transform.ps1 and EXECUTES the assignment-/resource-emitting shapers on canned
+    input, then asserts the emitted records carry only legal shapes.
+
+    This complements the existing guards rather than duplicating them:
+      • the JS guards (assignmentTypes/assignmentTypeSchema/resourceTypes.guard.test.js)
+        STATICALLY scan the crawler source for retired literals;
+      • migration 054's CHECK rejects them at the DB write path;
+      • this test proves the transforms, when actually run, EMIT only the legal set —
+        catching a computed/conditional path a source scan can miss, and a new shaper
+        whose own unit test forgot to assert its assignmentType.
+
+    assignmentType is a CLOSED vocabulary — {Direct, Indirect, Eligible}; ownership,
+    governance and the old source-detail types collapse to these (data model v3.1).
+    resourceType is OPEN, but the two renamed Entra literals (EntraGroup -> Group,
+    EntraRole -> EntraDirectoryRole, migration 052) must never reappear.
+
+.USAGE
+    Invoke-Pester -Path test/unit/CrawlerTransformOutputShape.Tests.ps1 -Output Detailed
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $crawlers = Join-Path $script:repoRoot 'tools' 'crawlers'
+    # Entra's transform is split across files (file-length ratchet) — ConvertTo-*
+    # shapers call helpers in Functions.ps1 / AppOwners.ps1, so dot-source the full
+    # set exactly as EntraIDCrawlerTransform.Tests.ps1 does.
+    . (Join-Path $crawlers 'entra-id' 'EntraIDCrawler.Functions.ps1')
+    . (Join-Path $crawlers 'entra-id' 'EntraIDCrawler.Transform.ps1')
+    . (Join-Path $crawlers 'entra-id' 'EntraIDCrawler.AppOwners.ps1')
+    . (Join-Path $script:repoRoot 'tools' 'powershell-sdk' 'helpers' 'Get-FGServicePrincipalType.ps1')
+    . (Join-Path $crawlers 'midpoint' 'MidpointCrawler.Transform.ps1')
+    . (Join-Path $crawlers 'omada'    'OmadaCrawler.Transform.ps1')
+    . (Join-Path $crawlers 'csv'      'CSVCrawler.Transform.ps1')
+    . (Join-Path $crawlers 'azure-rm' 'AzureRMCrawler.Transform.ps1')
+
+    $script:LEGAL_ASSIGNMENT   = @('Direct', 'Indirect', 'Eligible')
+    $script:RETIRED_RESOURCE   = @('EntraGroup', 'EntraRole')
+
+    # Collect the assignmentType values a shaper emits, tolerating a single record,
+    # an array, or a { resources; assignments; relationships } bag.
+    function Get-AssignmentTypes {
+        param($Output)
+        $recs = @()
+        foreach ($o in @($Output)) {
+            if ($null -eq $o) { continue }
+            if ($o.assignments -or $o.resources) { $recs += @($o.assignments) }
+            else { $recs += $o }
+        }
+        @($recs | Where-Object { $_ -and $null -ne $_.assignmentType } | ForEach-Object { $_.assignmentType })
+    }
+}
+
+Describe 'Crawler transform output contract — assignmentType is always legal' {
+    It 'CSV — ConvertTo-CsvAssignmentRecord emits only the legal set' {
+        $idx = @{ Res = 0; User = 1; Type = 2 }
+        foreach ($t in @('Direct', 'Indirect', 'Eligible', '')) {
+            $rec = ConvertTo-CsvAssignmentRecord -Row @('r1', 'u1', $t) -Idx $idx -SystemId 2
+            $rec.assignmentType | Should -BeIn $script:LEGAL_ASSIGNMENT
+        }
+    }
+
+    It 'Entra — ConvertTo-EntraGroupOwnership emits legal assignments + non-retired resources' {
+        $out = ConvertTo-EntraGroupOwnership -RawOwners @(
+            @{ groupId = 'g1'; principalId = 'u1' }
+            @{ groupId = 'g2'; principalId = 'u1' }
+        ) -GroupNameById @{ g1 = 'Sales'; g2 = 'Eng' }
+        (Get-AssignmentTypes $out) | Should -Not -BeNullOrEmpty
+        foreach ($a in Get-AssignmentTypes $out) { $a | Should -BeIn $script:LEGAL_ASSIGNMENT }
+        $out.resources | ForEach-Object { $_.resourceType | Should -Not -BeIn $script:RETIRED_RESOURCE }
+    }
+
+    It 'Midpoint — entitlement + governance assignments are legal' {
+        (New-MidpointEntitlementAssignmentRecord -EntitlementOid 'e1' -OwnerOid 'u1' -ViaAccount 's9').assignmentType `
+            | Should -BeIn $script:LEGAL_ASSIGNMENT
+        (New-MidpointGovernanceAssignmentRecord -ResourceId 'r1' -PrincipalId 'u1' -ResourceType 'BusinessRole' -Grant 'direct').assignmentType `
+            | Should -BeIn $script:LEGAL_ASSIGNMENT
+    }
+
+    It 'Omada — role assignment is legal' {
+        $item = [pscustomobject]@{ VALIDFROM = '2026-01-01'; VALIDTO = '2026-12-31' }
+        (New-OmadaRoleAssignmentRecord -ResourceUid 'res-1' -PrincipalId 'usr-1' -RoleAssignment $item).assignmentType `
+            | Should -BeIn $script:LEGAL_ASSIGNMENT
+    }
+
+    It 'Azure RM — role grant is legal' {
+        $a = [pscustomobject]@{ name = 'ra1'; properties = [pscustomobject]@{ principalId = 'p1' } }
+        (New-AzureGrantRecord -CapResId 'cap1' -Assignment $a -PrincipalType 'User').assignmentType `
+            | Should -BeIn $script:LEGAL_ASSIGNMENT
+    }
+
+    It 'the union of every emitted assignmentType is a subset of the legal set (never a retired type)' {
+        $idx  = @{ Res = 0; User = 1; Type = 2 }
+        $azA  = [pscustomobject]@{ name = 'ra1'; properties = [pscustomobject]@{ principalId = 'p1' } }
+        $emitted = @()
+        $emitted += (ConvertTo-CsvAssignmentRecord -Row @('r1', 'u1', 'Eligible') -Idx $idx -SystemId 2).assignmentType
+        $emitted += Get-AssignmentTypes (ConvertTo-EntraGroupOwnership -RawOwners @(@{ groupId = 'g1'; principalId = 'u1' }) -GroupNameById @{ g1 = 'Sales' })
+        $emitted += (New-MidpointEntitlementAssignmentRecord -EntitlementOid 'e1' -OwnerOid 'u1' -ViaAccount 's9').assignmentType
+        $emitted += (New-MidpointGovernanceAssignmentRecord -ResourceId 'r1' -PrincipalId 'u1' -ResourceType 'BusinessRole' -Grant 'direct').assignmentType
+        $emitted += (New-OmadaRoleAssignmentRecord -ResourceUid 'res-1' -PrincipalId 'usr-1' -RoleAssignment ([pscustomobject]@{ VALIDFROM = '2026-01-01' })).assignmentType
+        $emitted += (New-AzureGrantRecord -CapResId 'cap1' -Assignment $azA -PrincipalType 'User').assignmentType
+
+        $illegal = @($emitted | Where-Object { $_ -and $_ -notin $script:LEGAL_ASSIGNMENT }) | Sort-Object -Unique
+        $illegal | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
Addresses two of the four remaining drift-audit depth items in **#628**.

## 1. Enforce the PowerShell mutation-score floor (PSMutant item)
The crawler-transform mutation score has settled around **85%** (182/215 mutants killed), comfortably above the report band's `high=80`. Flip `.ci/psmutant.config.json` `thresholds.break` from `null` to **80**, so the run now **fails** when the score drops below the floor — PSMutant returns a non-zero exit code and `ps-mutation.yml` already rethrows it. No workflow logic change; only the stale "report-only" wording is updated to "enforced". This locks in the current bar and forces new transform logic to be mutation-tested (tests must *kill* mutants), not just line-covered.

> The `ps-mutation.yml` run on **this PR** exercises the new floor (it triggers on the config change) — a live check that 85% clears the 80% gate.

## 2. Fixture-based crawler-output shape contract (secret-free crawler test item)
New `test/unit/CrawlerTransformOutputShape.Tests.ps1` — a credential-free stand-in for the deep-tenant test. It dot-sources every crawler's `*.Transform.ps1` and **executes** the assignment-emitting shapers on canned input, asserting each emitted record carries a legal `assignmentType` (`{Direct, Indirect, Eligible}`) and no retired `resourceType` rename (`EntraGroup`/`EntraRole`).

Complements the existing guards rather than duplicating them:
- the JS `assignmentTypes`/`resourceTypes` guards scan the source **statically**;
- migration 054's `CHECK` rejects bad **writes**;
- this proves the transforms, when **run**, emit only the legal set — catching a computed/conditional path a source scan can miss, and a new shaper whose own unit test forgot to assert its `assignmentType`.

Covers all five crawlers (Entra, midPoint, Omada, CSV, Azure RM); 6 tests, green under Pester 5.8.

## Still open in #628 (not in this PR)
- **Per-file coverage baseline** — a committed per-*file* coverage ratchet (greenfield).
- **Derive the OpenAPI documented-router set** — `openapi.drift.test.js` still hand-maintains `DOCUMENTED_ROUTERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
