### PR TITLE
refactor(ps): rename functions to approved verbs + re-enable PSUseApprovedVerbs (#601)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,8 +183,7 @@ jobs:
           # Scan all production PowerShell roots.
           #
           # Excluded paths:
-          #   test/               — test-harness scripts use non-approved verbs
-          #                         (Report-Result) intentionally; not production code
+          #   test/               — test-harness scripts, not production code
           #   setup/CreatePSD.ps1 — developer-only manifest regeneration tool with
           #                         hardcoded local paths; not shipped in the container
           #
@@ -207,7 +206,6 @@ jobs:
             'PSUseSingularNouns'                       # internal naming convention; not module exports
             'PSAvoidDefaultValueSwitchParameter'       # crawler phase switches default to $true intentionally
             'PSUseProcessBlockForPipelineCommand'      # these functions are not designed for pipeline use
-            'PSUseApprovedVerbs'                       # Map- prefix used for private script-level helpers
             'PSAvoidUsingEmptyCatchBlock'              # empty catches are intentional for non-critical operations
             'PSUseDeclaredVarsMoreThanAssignments'     # investigate separately; too noisy for CI gate
             'PSAvoidUsingInvokeExpression'             # scheduler crontab is image-baked, not dynamic user input

--- a/changes/approved-verbs-601.md
+++ b/changes/approved-verbs-601.md
@@ -1,0 +1,2 @@
+- Standardized PowerShell function names across the crawlers and test harnesses to use PowerShell approved verbs (no behaviour change).
+- Re-enabled the `PSUseApprovedVerbs` PowerShell lint gate in CI so unapproved-verb function names are flagged going forward.

--- a/test/nightly/Configure-LLM.ps1
+++ b/test/nightly/Configure-LLM.ps1
@@ -41,7 +41,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -66,7 +66,7 @@ if (Test-Path $SecretsPath) {
     try {
         $secrets = Get-Content $SecretsPath -Raw | ConvertFrom-Json
     } catch {
-        Report-Result 'LLM-Config/LoadSecrets' $false "failed to parse: $($_.Exception.Message)"
+        Write-Result 'LLM-Config/LoadSecrets' $false "failed to parse: $($_.Exception.Message)"
         if (-not $WriteResult) { exit 1 } else { return }
     }
 }
@@ -84,11 +84,11 @@ $apiVersion  = if ($secrets.llm.apiVersion) { $secrets.llm.apiVersion } else { $
 
 # Treat placeholder values as "not configured"
 if ($apiKey -eq 'sk-ant-...' -or $apiKey -eq '' -or -not $apiKey) {
-    Report-Result 'LLM-Config/Available' $true 'skipped (no API key in secrets or env)'
+    Write-Result 'LLM-Config/Available' $true 'skipped (no API key in secrets or env)'
     if (-not $WriteResult) { exit 0 } else { return }
 }
 
-Report-Result 'LLM-Config/Available' $true "provider=$provider model=$model"
+Write-Result 'LLM-Config/Available' $true "provider=$provider model=$model"
 
 # ─── Save config via API ─────────────────────────────────────────
 $body = @{
@@ -98,7 +98,7 @@ $body = @{
 }
 if ($provider -eq 'azure-openai') {
     if (-not $endpoint -or -not $deployment) {
-        Report-Result 'LLM-Config/AzureFields' $false 'azure-openai requires endpoint + deployment'
+        Write-Result 'LLM-Config/AzureFields' $false 'azure-openai requires endpoint + deployment'
         if (-not $WriteResult) { exit 1 } else { return }
     }
     $body.endpoint   = $endpoint
@@ -118,7 +118,7 @@ for ($attempt = 1; $attempt -le 2; $attempt++) {
             -Body ($body | ConvertTo-Json -Compress) -TimeoutSec 30
         if ($resp.ok) {
             $suffix = if ($attempt -gt 1) { " (retry $attempt)" } else { '' }
-            Report-Result 'LLM-Config/Save' $true "provider=$($resp.config.provider) model=$($resp.config.model)$suffix"
+            Write-Result 'LLM-Config/Save' $true "provider=$($resp.config.provider) model=$($resp.config.model)$suffix"
             $saved = $true
             break
         } else {
@@ -131,7 +131,7 @@ for ($attempt = 1; $attempt -le 2; $attempt++) {
         } else {
             $detail = $_.Exception.Message
             if ($_.ErrorDetails.Message) { $detail += " — $($_.ErrorDetails.Message)" }
-            Report-Result 'LLM-Config/Save' $false $detail
+            Write-Result 'LLM-Config/Save' $false $detail
             if (-not $WriteResult) { exit 1 } else { return }
         }
     }
@@ -146,12 +146,12 @@ try {
         -Method Post -ContentType 'application/json' `
         -Body '{}' -TimeoutSec 30
     if ($testResp.ok) {
-        Report-Result 'LLM-Config/TestConnection' $true "model=$($testResp.model) latency=$($testResp.latencyMs)ms"
+        Write-Result 'LLM-Config/TestConnection' $true "model=$($testResp.model) latency=$($testResp.latencyMs)ms"
     } else {
-        Report-Result 'LLM-Config/TestConnection' $false $testResp.error
+        Write-Result 'LLM-Config/TestConnection' $false $testResp.error
     }
 } catch {
-    Report-Result 'LLM-Config/TestConnection' $false $_.Exception.Message
+    Write-Result 'LLM-Config/TestConnection' $false $_.Exception.Message
 }
 
 if (-not $WriteResult) { exit $standaloneFailures }

--- a/test/nightly/Test-AccountCorrelation.ps1
+++ b/test/nightly/Test-AccountCorrelation.ps1
@@ -38,7 +38,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -104,12 +104,12 @@ try {
     }
 
     if ($systemAId -and $systemBId) {
-        Report-Result 'Correlation/SystemsCreated' $true "A=$systemAId B=$systemBId"
+        Write-Result 'Correlation/SystemsCreated' $true "A=$systemAId B=$systemBId"
     } else {
-        Report-Result 'Correlation/SystemsCreated' $false "could not resolve system IDs (A=$systemAId B=$systemBId)"
+        Write-Result 'Correlation/SystemsCreated' $false "could not resolve system IDs (A=$systemAId B=$systemBId)"
     }
 } catch {
-    Report-Result 'Correlation/SystemsCreated' $false $_.Exception.Message
+    Write-Result 'Correlation/SystemsCreated' $false $_.Exception.Message
 }
 
 # --- 2. Create 1 principal in each system via /ingest/principals ------
@@ -142,9 +142,9 @@ try {
             }
         )
     }
-    Report-Result 'Correlation/PrincipalsCreated' $true "SystemA + SystemB principals ingested"
+    Write-Result 'Correlation/PrincipalsCreated' $true "SystemA + SystemB principals ingested"
 } catch {
-    Report-Result 'Correlation/PrincipalsCreated' $false $_.Exception.Message
+    Write-Result 'Correlation/PrincipalsCreated' $false $_.Exception.Message
 }
 
 # --- 3. Create 1 identity via /ingest/identities ---------------------
@@ -161,9 +161,9 @@ try {
             }
         )
     }
-    Report-Result 'Correlation/IdentityCreated' $true 'identity ingested'
+    Write-Result 'Correlation/IdentityCreated' $true 'identity ingested'
 } catch {
-    Report-Result 'Correlation/IdentityCreated' $false $_.Exception.Message
+    Write-Result 'Correlation/IdentityCreated' $false $_.Exception.Message
 }
 
 # --- 4. Link both principals to the identity via /ingest/identity-members
@@ -184,9 +184,9 @@ try {
             }
         )
     }
-    Report-Result 'Correlation/MembersLinked' $true '2 identity-members ingested'
+    Write-Result 'Correlation/MembersLinked' $true '2 identity-members ingested'
 } catch {
-    Report-Result 'Correlation/MembersLinked' $false $_.Exception.Message
+    Write-Result 'Correlation/MembersLinked' $false $_.Exception.Message
 }
 
 # --- 5. GET /identities and verify at least 1 identity exists --------
@@ -194,12 +194,12 @@ try {
     $rList = Invoke-LocalApi -Path '/identities?limit=100'
     $identities = if ($rList.data) { @($rList.data) } else { @($rList) }
     if ($identities.Count -ge 1) {
-        Report-Result 'Correlation/IdentityExists' $true "count=$($identities.Count)"
+        Write-Result 'Correlation/IdentityExists' $true "count=$($identities.Count)"
     } else {
-        Report-Result 'Correlation/IdentityExists' $false 'no identities returned'
+        Write-Result 'Correlation/IdentityExists' $false 'no identities returned'
     }
 } catch {
-    Report-Result 'Correlation/IdentityExists' $false $_.Exception.Message
+    Write-Result 'Correlation/IdentityExists' $false $_.Exception.Message
 }
 
 # --- 6. Verify the identity is queryable -----------------------------
@@ -210,12 +210,12 @@ try {
         $_.displayName -eq 'Alice Correlation' -or $_.externalId -eq 'corr-identity-1'
     }
     if ($match) {
-        Report-Result 'Correlation/IdentityQueryable' $true "found identity displayName=$($match.displayName)"
+        Write-Result 'Correlation/IdentityQueryable' $true "found identity displayName=$($match.displayName)"
     } else {
-        Report-Result 'Correlation/IdentityQueryable' $false 'corr-identity-1 not found in identity list'
+        Write-Result 'Correlation/IdentityQueryable' $false 'corr-identity-1 not found in identity list'
     }
 } catch {
-    Report-Result 'Correlation/IdentityQueryable' $false $_.Exception.Message
+    Write-Result 'Correlation/IdentityQueryable' $false $_.Exception.Message
 }
 
 if (-not $WriteResult) { exit $standaloneFailures }

--- a/test/nightly/Test-DetailPageCounts.ps1
+++ b/test/nightly/Test-DetailPageCounts.ps1
@@ -50,7 +50,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color  = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS'  } else { 'FAIL' }
@@ -123,9 +123,9 @@ try {
         records      = @(@{ displayName = "DPC-Test-$ts"; systemType = 'Test'; enabled = $true; syncEnabled = $true })
     }
     $systemId = @($r.systemIds)[0]
-    Report-Result 'Setup/System' ($null -ne $systemId) "id=$systemId"
+    Write-Result 'Setup/System' ($null -ne $systemId) "id=$systemId"
 } catch {
-    Report-Result 'Setup/System' $false $_.Exception.Message
+    Write-Result 'Setup/System' $false $_.Exception.Message
 }
 
 if (-not $systemId) {
@@ -147,9 +147,9 @@ try {
             @{ externalId = $charlieExtId; displayName = 'DPC Charlie'; principalType = 'User'; accountEnabled = $true }
         )
     }
-    Report-Result 'Setup/Principals' ($r.inserted -ge 3 -or $r.upserted -ge 3) "inserted=$($r.inserted)"
+    Write-Result 'Setup/Principals' ($r.inserted -ge 3 -or $r.upserted -ge 3) "inserted=$($r.inserted)"
 } catch {
-    Report-Result 'Setup/Principals' $false $_.Exception.Message
+    Write-Result 'Setup/Principals' $false $_.Exception.Message
 }
 
 # 3. Create resources (GroupA, BusinessRoleA, OtherParent)
@@ -165,9 +165,9 @@ try {
             @{ externalId = $otherExtId;  displayName = 'DPC OtherParent';   resourceType = 'Group' }
         )
     }
-    Report-Result 'Setup/Resources' ($r.inserted -ge 3 -or $r.upserted -ge 3) "inserted=$($r.inserted)"
+    Write-Result 'Setup/Resources' ($r.inserted -ge 3 -or $r.upserted -ge 3) "inserted=$($r.inserted)"
 } catch {
-    Report-Result 'Setup/Resources' $false $_.Exception.Message
+    Write-Result 'Setup/Resources' $false $_.Exception.Message
 }
 
 # 4. Look up database IDs for Alice, GroupA, BusinessRoleA
@@ -177,9 +177,9 @@ try {
     $rows  = if ($users -is [array]) { $users } else { $users.data }
     $alice = $rows | Where-Object { $_.displayName -like '*DPC Alice*' } | Select-Object -First 1
     $aliceId = $alice.id
-    Report-Result 'Setup/LookupAlice' ($null -ne $aliceId) "id=$aliceId"
+    Write-Result 'Setup/LookupAlice' ($null -ne $aliceId) "id=$aliceId"
 } catch {
-    Report-Result 'Setup/LookupAlice' $false $_.Exception.Message
+    Write-Result 'Setup/LookupAlice' $false $_.Exception.Message
 }
 
 try {
@@ -198,10 +198,10 @@ try {
     $other  = $rows3 | Where-Object { $_.displayName -like '*DPC OtherParent*' } | Select-Object -First 1
     $otherId = $other.id
 
-    Report-Result 'Setup/LookupResources' ($null -ne $groupAId -and $null -ne $brId -and $null -ne $otherId) `
+    Write-Result 'Setup/LookupResources' ($null -ne $groupAId -and $null -ne $brId -and $null -ne $otherId) `
         "groupA=$groupAId br=$brId other=$otherId"
 } catch {
-    Report-Result 'Setup/LookupResources' $false $_.Exception.Message
+    Write-Result 'Setup/LookupResources' $false $_.Exception.Message
 }
 
 # 5. Assign Alice + Bob to GroupA (Charlie intentionally gets no assignment)
@@ -217,9 +217,9 @@ if ($groupAId -and $aliceId) {
                 @{ resourceExternalId = $groupAExtId; principalExternalId = $bobExtId;   assignmentType = 'Direct' }
             )
         }
-        Report-Result 'Setup/Assignments' $true "ok"
+        Write-Result 'Setup/Assignments' $true "ok"
     } catch {
-        Report-Result 'Setup/Assignments' $false $_.Exception.Message
+        Write-Result 'Setup/Assignments' $false $_.Exception.Message
     }
 }
 
@@ -238,9 +238,9 @@ if ($groupAId -and $brId -and $otherId) {
                 @{ parentExternalId = $otherExtId; childExternalId = $groupAExtId; relationshipType = 'Contains' }
             )
         }
-        Report-Result 'Setup/Relationships' $true "ok"
+        Write-Result 'Setup/Relationships' $true "ok"
     } catch {
-        Report-Result 'Setup/Relationships' $false $_.Exception.Message
+        Write-Result 'Setup/Relationships' $false $_.Exception.Message
     }
 }
 
@@ -266,7 +266,7 @@ try {
     $dataCount  = @($r.data).Count
 
     # totalUsers must be a positive integer
-    Report-Result 'Permissions/NoLimit/TotalUsersIsInt' `
+    Write-Result 'Permissions/NoLimit/TotalUsersIsInt' `
         ($totalUsers -is [int] -or $totalUsers -is [long] -or ($totalUsers -match '^\d+$')) `
         "totalUsers=$totalUsers"
 
@@ -274,18 +274,18 @@ try {
     # dataRows is the number of assignment rows (one user can appear many times).
     # In a real dataset users have multiple assignments, so dataRows > totalUsers
     # is normal. We just verify totalUsers is a positive number.
-    Report-Result 'Permissions/NoLimit/TotalUsersGtDataRows' `
+    Write-Result 'Permissions/NoLimit/TotalUsersGtDataRows' `
         ([int]$totalUsers -gt 0) `
         "totalUsers=$totalUsers dataRows=$dataCount"
 
     # If we got a ground-truth count, verify totalUsers >= it
     if ($null -ne $principalTotal) {
-        Report-Result 'Permissions/NoLimit/TotalUsersMatchesPrincipalCount' `
+        Write-Result 'Permissions/NoLimit/TotalUsersMatchesPrincipalCount' `
             ([int]$totalUsers -ge [int]$principalTotal) `
             "totalUsers=$totalUsers principalTotal=$principalTotal"
     }
 } catch {
-    Report-Result 'Permissions/NoLimit/TotalUsersIsInt' $false $_.Exception.Message
+    Write-Result 'Permissions/NoLimit/TotalUsersIsInt' $false $_.Exception.Message
 }
 
 # 1b. Binding limit (userLimit=1): totalUsers must be the same full count as above
@@ -298,18 +298,18 @@ try {
     # userLimit=1 means "show data for up to 1 user" — but that user
     # can have multiple assignment rows. Count distinct users instead.
     $distinctUsers = @($limited.data | ForEach-Object { $_.memberId ?? $_.userId ?? $_.principalId } | Sort-Object -Unique).Count
-    Report-Result 'Permissions/Limit1/DataRespectsCap' `
+    Write-Result 'Permissions/Limit1/DataRespectsCap' `
         ($distinctUsers -le 1) `
         "distinctUsers=$distinctUsers dataRows=$dataLtd (expected <= 1 distinct user)"
 
     # totalUsers is NOT capped — must equal the no-limit totalUsers
     if ($null -ne $totalUsers) {
-        Report-Result 'Permissions/Limit1/TotalUsersUnchanged' `
+        Write-Result 'Permissions/Limit1/TotalUsersUnchanged' `
             ([int]$totalLtd -eq [int]$totalUsers) `
             "limited=$totalLtd noLimit=$totalUsers (must match)"
     }
 } catch {
-    Report-Result 'Permissions/Limit1/DataRespectsCap' $false $_.Exception.Message
+    Write-Result 'Permissions/Limit1/DataRespectsCap' $false $_.Exception.Message
 }
 
 # ─── Section 2: User detail — historyCount shape (PR #16 regression) ──────────
@@ -325,18 +325,18 @@ if ($aliceId) {
 
         # historyCount must be present and be an integer (not a boolean, not null)
         $hc = $u.historyCount
-        Report-Result 'UserDetail/HistoryCountPresent' `
+        Write-Result 'UserDetail/HistoryCountPresent' `
             ($null -ne $hc) `
             "historyCount=$hc"
 
-        Report-Result 'UserDetail/HistoryCountIsInt' `
+        Write-Result 'UserDetail/HistoryCountIsInt' `
             ($hc -is [int] -or $hc -is [long] -or $hc -match '^\d+$') `
             "type=$($hc.GetType().Name) value=$hc"
 
         # hasHistory must be the boolean equivalent of historyCount > 0
         $hh = $u.hasHistory
         $expected = ([int]$hc -gt 0)
-        Report-Result 'UserDetail/HasHistoryDerivesFromCount' `
+        Write-Result 'UserDetail/HasHistoryDerivesFromCount' `
             ($hh -eq $expected) `
             "hasHistory=$hh historyCount=$hc expected=$expected"
 
@@ -344,11 +344,11 @@ if ($aliceId) {
         # a freshly ingested principal may already have historyCount >= 1.
         # We just verify the field is a non-negative integer and that
         # hasHistory is consistent with it.
-        Report-Result 'UserDetail/FreshDataNoHistory' `
+        Write-Result 'UserDetail/FreshDataNoHistory' `
             ([int]$hc -ge 0 -and $hh -eq ([int]$hc -gt 0)) `
             "historyCount=$hc hasHistory=$hh"
     } catch {
-        Report-Result 'UserDetail/HistoryCountPresent' $false $_.Exception.Message
+        Write-Result 'UserDetail/HistoryCountPresent' $false $_.Exception.Message
     }
 } else {
     Write-Host "    SKIP  UserDetail tests — aliceId not resolved" -ForegroundColor Yellow
@@ -371,32 +371,32 @@ if ($groupAId) {
 
         # parentResourceCount must be present and be an integer
         $prc = $g.parentResourceCount
-        Report-Result 'ResourceDetail/ParentResourceCountPresent' `
+        Write-Result 'ResourceDetail/ParentResourceCountPresent' `
             ($null -ne $prc) `
             "parentResourceCount=$prc"
 
         # accessPackageCount must be present and be an integer
         $apc = $g.accessPackageCount
-        Report-Result 'ResourceDetail/AccessPackageCountPresent' `
+        Write-Result 'ResourceDetail/AccessPackageCountPresent' `
             ($null -ne $apc) `
             "accessPackageCount=$apc"
 
         # GroupA has 2 parents total
-        Report-Result 'ResourceDetail/ParentResourceCountCorrect' `
+        Write-Result 'ResourceDetail/ParentResourceCountCorrect' `
             ([int]$prc -eq 2) `
             "got $prc, expected 2 (BusinessRoleA + OtherParent)"
 
         # Only 1 of those parents is a BusinessRole
-        Report-Result 'ResourceDetail/AccessPackageCountOnlyCountsBR' `
+        Write-Result 'ResourceDetail/AccessPackageCountOnlyCountsBR' `
             ([int]$apc -eq 1) `
             "got $apc, expected 1 (BusinessRoleA only, not OtherParent which is Group)"
 
         # accessPackageCount must be <= parentResourceCount
-        Report-Result 'ResourceDetail/AccessPackageCountLeParentCount' `
+        Write-Result 'ResourceDetail/AccessPackageCountLeParentCount' `
             ([int]$apc -le [int]$prc) `
             "accessPackageCount=$apc parentResourceCount=$prc"
     } catch {
-        Report-Result 'ResourceDetail/ParentResourceCountPresent' $false $_.Exception.Message
+        Write-Result 'ResourceDetail/ParentResourceCountPresent' $false $_.Exception.Message
     }
 } else {
     Write-Host "    SKIP  ResourceDetail tests — groupAId not resolved" -ForegroundColor Yellow
@@ -415,32 +415,32 @@ if ($brId) {
 
         # historyCount must be a non-null integer
         $hc = $ap.historyCount
-        Report-Result 'APDetail/HistoryCountPresent' `
+        Write-Result 'APDetail/HistoryCountPresent' `
             ($null -ne $hc) `
             "historyCount=$hc"
 
-        Report-Result 'APDetail/HistoryCountIsInt' `
+        Write-Result 'APDetail/HistoryCountIsInt' `
             ($hc -is [int] -or $hc -is [long] -or ($hc -match '^\d+$')) `
             "type=$($hc.GetType().Name) value=$hc"
 
         # hasHistory consistent with historyCount
         $hh       = $ap.hasHistory
         $expected = ([int]$hc -gt 0)
-        Report-Result 'APDetail/HasHistoryDerivesFromCount' `
+        Write-Result 'APDetail/HasHistoryDerivesFromCount' `
             ($hh -eq $expected) `
             "hasHistory=$hh historyCount=$hc expected=$expected"
 
         # pendingRequestCount must be a non-null number (could be 0 — no pending requests)
         $prc = $ap.pendingRequestCount
-        Report-Result 'APDetail/PendingRequestCountPresent' `
+        Write-Result 'APDetail/PendingRequestCountPresent' `
             ($null -ne $prc) `
             "pendingRequestCount=$prc (was null before PR #16)"
 
-        Report-Result 'APDetail/PendingRequestCountIsInt' `
+        Write-Result 'APDetail/PendingRequestCountIsInt' `
             ($prc -is [int] -or $prc -is [long] -or $prc -match '^\d+$') `
             "type=$($prc.GetType().Name) value=$prc"
     } catch {
-        Report-Result 'APDetail/HistoryCountPresent' $false $_.Exception.Message
+        Write-Result 'APDetail/HistoryCountPresent' $false $_.Exception.Message
     }
 } else {
     Write-Host "    SKIP  APDetail tests — brId not resolved" -ForegroundColor Yellow

--- a/test/nightly/Test-IngestAPI.ps1
+++ b/test/nightly/Test-IngestAPI.ps1
@@ -41,7 +41,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -96,12 +96,12 @@ try {
     }
     if ($r.systemIds -and @($r.systemIds).Count -ge 1) {
         $systemId = @($r.systemIds)[0]
-        Report-Result 'Ingest/Systems/HappyPath' $true "systemId=$systemId"
+        Write-Result 'Ingest/Systems/HappyPath' $true "systemId=$systemId"
     } else {
-        Report-Result 'Ingest/Systems/HappyPath' $false 'response missing systemIds'
+        Write-Result 'Ingest/Systems/HappyPath' $false 'response missing systemIds'
     }
 } catch {
-    Report-Result 'Ingest/Systems/HappyPath' $false $_.Exception.Message
+    Write-Result 'Ingest/Systems/HappyPath' $false $_.Exception.Message
 }
 
 # ─── 2. POST /ingest/principals — happy path ─────────────────────
@@ -123,12 +123,12 @@ try {
     }
     $inserted = if ($r.PSObject.Properties.Name -contains 'inserted') { $r.inserted } else { 0 }
     if ($inserted -ge 1) {
-        Report-Result 'Ingest/Principals/HappyPath' $true "inserted=$inserted"
+        Write-Result 'Ingest/Principals/HappyPath' $true "inserted=$inserted"
     } else {
-        Report-Result 'Ingest/Principals/HappyPath' $false "inserted=$inserted (expected >= 1)"
+        Write-Result 'Ingest/Principals/HappyPath' $false "inserted=$inserted (expected >= 1)"
     }
 } catch {
-    Report-Result 'Ingest/Principals/HappyPath' $false $_.Exception.Message
+    Write-Result 'Ingest/Principals/HappyPath' $false $_.Exception.Message
 }
 
 # ─── 3. POST /ingest/resources — happy path ──────────────────────
@@ -150,12 +150,12 @@ try {
     }
     $inserted = if ($r.PSObject.Properties.Name -contains 'inserted') { $r.inserted } else { 0 }
     if ($inserted -ge 1) {
-        Report-Result 'Ingest/Resources/HappyPath' $true "inserted=$inserted"
+        Write-Result 'Ingest/Resources/HappyPath' $true "inserted=$inserted"
     } else {
-        Report-Result 'Ingest/Resources/HappyPath' $false "inserted=$inserted (expected >= 1)"
+        Write-Result 'Ingest/Resources/HappyPath' $false "inserted=$inserted (expected >= 1)"
     }
 } catch {
-    Report-Result 'Ingest/Resources/HappyPath' $false $_.Exception.Message
+    Write-Result 'Ingest/Resources/HappyPath' $false $_.Exception.Message
 }
 
 # ─── 4. POST /ingest/resource-assignments — happy path ───────────
@@ -174,21 +174,21 @@ try {
             }
         )
     }
-    Report-Result 'Ingest/ResourceAssignments/HappyPath' $true "ok"
+    Write-Result 'Ingest/ResourceAssignments/HappyPath' $true "ok"
 } catch {
-    Report-Result 'Ingest/ResourceAssignments/HappyPath' $false $_.Exception.Message
+    Write-Result 'Ingest/ResourceAssignments/HappyPath' $false $_.Exception.Message
 }
 
 # ─── 5. POST /ingest/systems — empty body → 400 ─────────────────
 try {
     Invoke-LocalApi -Path '/ingest/systems' -Method Post -Body @{} | Out-Null
-    Report-Result 'Ingest/Systems/EmptyBody' $false 'expected 400, got success'
+    Write-Result 'Ingest/Systems/EmptyBody' $false 'expected 400, got success'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'Ingest/Systems/EmptyBody' $true "got 400 (expected)"
+        Write-Result 'Ingest/Systems/EmptyBody' $true "got 400 (expected)"
     } else {
-        Report-Result 'Ingest/Systems/EmptyBody' $false "got $statusCode (expected 400)"
+        Write-Result 'Ingest/Systems/EmptyBody' $false "got $statusCode (expected 400)"
     }
 }
 
@@ -200,13 +200,13 @@ try {
             @{ externalId = 'x'; displayName = 'X'; principalType = 'User' }
         )
     } | Out-Null
-    Report-Result 'Ingest/Principals/MissingSysId' $false 'expected 400, got success'
+    Write-Result 'Ingest/Principals/MissingSysId' $false 'expected 400, got success'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'Ingest/Principals/MissingSysId' $true "got 400 (expected)"
+        Write-Result 'Ingest/Principals/MissingSysId' $true "got 400 (expected)"
     } else {
-        Report-Result 'Ingest/Principals/MissingSysId' $false "got $statusCode (expected 400)"
+        Write-Result 'Ingest/Principals/MissingSysId' $false "got $statusCode (expected 400)"
     }
 }
 
@@ -219,13 +219,13 @@ try {
             @{ externalId = 'x'; displayName = 'X'; principalType = 'User' }
         )
     } | Out-Null
-    Report-Result 'Ingest/Principals/InvalidSyncMode' $false 'expected 400, got success'
+    Write-Result 'Ingest/Principals/InvalidSyncMode' $false 'expected 400, got success'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'Ingest/Principals/InvalidSyncMode' $true "got 400 (expected)"
+        Write-Result 'Ingest/Principals/InvalidSyncMode' $true "got 400 (expected)"
     } else {
-        Report-Result 'Ingest/Principals/InvalidSyncMode' $false "got $statusCode (expected 400)"
+        Write-Result 'Ingest/Principals/InvalidSyncMode' $false "got $statusCode (expected 400)"
     }
 }
 
@@ -238,13 +238,13 @@ try {
             @{ externalId = 'x'; displayName = 'X'; resourceType = 'Group' }
         )
     } | Out-Null
-    Report-Result 'Ingest/Resources/NoAuth' $false 'expected 401, got success'
+    Write-Result 'Ingest/Resources/NoAuth' $false 'expected 401, got success'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 401) {
-        Report-Result 'Ingest/Resources/NoAuth' $true "got 401 (expected)"
+        Write-Result 'Ingest/Resources/NoAuth' $true "got 401 (expected)"
     } else {
-        Report-Result 'Ingest/Resources/NoAuth' $false "got $statusCode (expected 401)"
+        Write-Result 'Ingest/Resources/NoAuth' $false "got $statusCode (expected 401)"
     }
 }
 

--- a/test/nightly/Test-LLMSubstrate.ps1
+++ b/test/nightly/Test-LLMSubstrate.ps1
@@ -46,7 +46,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -78,29 +78,29 @@ Write-Host "`n=== LLM / Risk-scoring substrate ===" -ForegroundColor Cyan
 try {
     $r = Invoke-LocalApi -Path '/admin/llm/config'
     if ($r.providers -and ($r.providers -contains 'anthropic') -and ($r.providers -contains 'openai') -and ($r.providers -contains 'azure-openai')) {
-        Report-Result 'LLM/ConfigEndpoint' $true "providers=$($r.providers -join ',')"
+        Write-Result 'LLM/ConfigEndpoint' $true "providers=$($r.providers -join ',')"
     } else {
-        Report-Result 'LLM/ConfigEndpoint' $false "missing providers"
+        Write-Result 'LLM/ConfigEndpoint' $false "missing providers"
     }
     if ($r.PSObject.Properties.Name -contains 'apiKeySet') {
-        Report-Result 'LLM/ConfigShape' $true "apiKeySet=$($r.apiKeySet)"
+        Write-Result 'LLM/ConfigShape' $true "apiKeySet=$($r.apiKeySet)"
     } else {
-        Report-Result 'LLM/ConfigShape' $false 'missing apiKeySet flag'
+        Write-Result 'LLM/ConfigShape' $false 'missing apiKeySet flag'
     }
 } catch {
-    Report-Result 'LLM/ConfigEndpoint' $false $_.Exception.Message
+    Write-Result 'LLM/ConfigEndpoint' $false $_.Exception.Message
 }
 
 # ─── 2. /admin/llm/status ─────────────────────────────────────────
 try {
     $r = Invoke-LocalApi -Path '/admin/llm/status'
     if ($r.PSObject.Properties.Name -contains 'configured') {
-        Report-Result 'LLM/StatusEndpoint' $true "configured=$($r.configured)"
+        Write-Result 'LLM/StatusEndpoint' $true "configured=$($r.configured)"
     } else {
-        Report-Result 'LLM/StatusEndpoint' $false 'missing configured flag'
+        Write-Result 'LLM/StatusEndpoint' $false 'missing configured flag'
     }
 } catch {
-    Report-Result 'LLM/StatusEndpoint' $false $_.Exception.Message
+    Write-Result 'LLM/StatusEndpoint' $false $_.Exception.Message
 }
 
 # ─── 3-5. Risk profile / classifier / runs list endpoints ────────
@@ -108,12 +108,12 @@ foreach ($ep in @('/risk-profiles', '/risk-classifiers', '/risk-scoring/runs')) 
     try {
         $r = Invoke-LocalApi -Path $ep
         if ($r -and ($r.PSObject.Properties.Name -contains 'data')) {
-            Report-Result "LLM/ListEndpoint$ep" $true "rows=$(@($r.data).Count)"
+            Write-Result "LLM/ListEndpoint$ep" $true "rows=$(@($r.data).Count)"
         } else {
-            Report-Result "LLM/ListEndpoint$ep" $false 'missing data field'
+            Write-Result "LLM/ListEndpoint$ep" $false 'missing data field'
         }
     } catch {
-        Report-Result "LLM/ListEndpoint$ep" $false $_.Exception.Message
+        Write-Result "LLM/ListEndpoint$ep" $false $_.Exception.Message
     }
 }
 
@@ -121,10 +121,10 @@ foreach ($ep in @('/risk-profiles', '/risk-classifiers', '/risk-scoring/runs')) 
 try {
     $r = Invoke-LocalApi -Path '/risk-profiles/scraper-credentials'
     if ($null -ne $r) {
-        Report-Result 'LLM/ScraperCredsList' $true "count=$(@($r).Count)"
+        Write-Result 'LLM/ScraperCredsList' $true "count=$(@($r).Count)"
     }
 } catch {
-    Report-Result 'LLM/ScraperCredsList' $false $_.Exception.Message
+    Write-Result 'LLM/ScraperCredsList' $false $_.Exception.Message
 }
 
 # ─── 7. POST scrape with a public URL ────────────────────────────
@@ -138,16 +138,16 @@ try {
         urls = @(@{ url = 'https://example.com' })
     }
     if ($r.results -and $r.results[0].ok -and $r.results[0].bytes -gt 0) {
-        Report-Result 'LLM/ScrapeRoundTrip' $true "bytes=$($r.results[0].bytes)"
+        Write-Result 'LLM/ScrapeRoundTrip' $true "bytes=$($r.results[0].bytes)"
     } elseif ($r.results -and $r.results.Count -eq 1) {
         # The route is wired up — it returned a structured result. Network
         # failure is environmental, not a code regression we should flag.
-        Report-Result 'LLM/ScrapeRoundTrip' $true "endpoint reachable; outbound fetch skipped ($($r.results[0].error))"
+        Write-Result 'LLM/ScrapeRoundTrip' $true "endpoint reachable; outbound fetch skipped ($($r.results[0].error))"
     } else {
-        Report-Result 'LLM/ScrapeRoundTrip' $false 'unexpected response shape'
+        Write-Result 'LLM/ScrapeRoundTrip' $false 'unexpected response shape'
     }
 } catch {
-    Report-Result 'LLM/ScrapeRoundTrip' $true "skipped (no outbound network: $($_.Exception.Message))"
+    Write-Result 'LLM/ScrapeRoundTrip' $true "skipped (no outbound network: $($_.Exception.Message))"
 }
 
 # ─── 8. Secrets vault round-trip via the LLM config save/test/delete ──
@@ -167,20 +167,20 @@ try {
     } | Out-Null
     $check = Invoke-LocalApi -Path '/admin/llm/config'
     if ($check.apiKeySet -eq $true -and $check.config.provider -eq 'anthropic') {
-        Report-Result 'LLM/VaultRoundTrip-Save' $true 'config saved with apiKeySet=true'
+        Write-Result 'LLM/VaultRoundTrip-Save' $true 'config saved with apiKeySet=true'
     } else {
-        Report-Result 'LLM/VaultRoundTrip-Save' $false "apiKeySet=$($check.apiKeySet) provider=$($check.config.provider)"
+        Write-Result 'LLM/VaultRoundTrip-Save' $false "apiKeySet=$($check.apiKeySet) provider=$($check.config.provider)"
     }
 
     Invoke-LocalApi -Path '/admin/llm/config' -Method Delete | Out-Null
     $check2 = Invoke-LocalApi -Path '/admin/llm/config'
     if ($check2.apiKeySet -eq $false) {
-        Report-Result 'LLM/VaultRoundTrip-Delete' $true 'config wiped'
+        Write-Result 'LLM/VaultRoundTrip-Delete' $true 'config wiped'
     } else {
-        Report-Result 'LLM/VaultRoundTrip-Delete' $false 'config not cleared after DELETE'
+        Write-Result 'LLM/VaultRoundTrip-Delete' $false 'config not cleared after DELETE'
     }
 } catch {
-    Report-Result 'LLM/VaultRoundTrip' $false $_.Exception.Message
+    Write-Result 'LLM/VaultRoundTrip' $false $_.Exception.Message
     # Ensure no stale fake key is left behind even if a partial step failed
     try { Invoke-LocalApi -Path '/admin/llm/config' -Method Delete | Out-Null } catch { }
 }
@@ -189,12 +189,12 @@ try {
 try {
     $r = Invoke-LocalApi -Path '/admin/history-retention'
     if ($r.PSObject.Properties.Name -contains 'retentionDays') {
-        Report-Result 'LLM/HistoryRetention' $true "days=$($r.retentionDays)"
+        Write-Result 'LLM/HistoryRetention' $true "days=$($r.retentionDays)"
     } else {
-        Report-Result 'LLM/HistoryRetention' $false 'missing retentionDays'
+        Write-Result 'LLM/HistoryRetention' $false 'missing retentionDays'
     }
 } catch {
-    Report-Result 'LLM/HistoryRetention' $false $_.Exception.Message
+    Write-Result 'LLM/HistoryRetention' $false $_.Exception.Message
 }
 
 # ─── 10. Scoring with no active classifier should 412 ────────────
@@ -202,13 +202,13 @@ try {
 # response so the wizard can show "configure a classifier first".
 try {
     Invoke-LocalApi -Path '/risk-scoring/runs' -Method Post -Body @{} | Out-Null
-    Report-Result 'LLM/ScoringPreconditionCheck' $false 'expected 412/preconditions error, got success'
+    Write-Result 'LLM/ScoringPreconditionCheck' $false 'expected 412/preconditions error, got success'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 412 -or $statusCode -eq 404 -or $statusCode -eq 400) {
-        Report-Result 'LLM/ScoringPreconditionCheck' $true "got $statusCode (expected)"
+        Write-Result 'LLM/ScoringPreconditionCheck' $true "got $statusCode (expected)"
     } else {
-        Report-Result 'LLM/ScoringPreconditionCheck' $false "got $statusCode"
+        Write-Result 'LLM/ScoringPreconditionCheck' $false "got $statusCode"
     }
 }
 

--- a/test/nightly/Test-LoadAndBenchmark.ps1
+++ b/test/nightly/Test-LoadAndBenchmark.ps1
@@ -44,7 +44,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -90,9 +90,9 @@ try {
     $lineCount = if (Test-Path $assignmentsFile) {
         ([System.IO.File]::ReadAllLines($assignmentsFile).Count - 1)  # minus header
     } else { 0 }
-    Report-Result 'LoadTest/DataGenerated' ($lineCount -gt 1000000) "rows=$lineCount time=$([math]::Round($genDuration,1))s"
+    Write-Result 'LoadTest/DataGenerated' ($lineCount -gt 1000000) "rows=$lineCount time=$([math]::Round($genDuration,1))s"
 } catch {
-    Report-Result 'LoadTest/DataGenerated' $false $_.Exception.Message
+    Write-Result 'LoadTest/DataGenerated' $false $_.Exception.Message
     Write-Host "  Cannot continue load test without data." -ForegroundColor Red
     if (-not $WriteResult) { exit 1 }
     return
@@ -115,9 +115,9 @@ try {
         -ConfigPath $tempConfig `
         -ErrorAction Stop
     $ingestDuration = ((Get-Date) - $ingestStart).TotalSeconds
-    Report-Result 'LoadTest/CrawlerCompleted' $true "time=$([math]::Round($ingestDuration / 60, 1))min"
+    Write-Result 'LoadTest/CrawlerCompleted' $true "time=$([math]::Round($ingestDuration / 60, 1))min"
 } catch {
-    Report-Result 'LoadTest/CrawlerCompleted' $false $_.Exception.Message
+    Write-Result 'LoadTest/CrawlerCompleted' $false $_.Exception.Message
     Write-Host "  Cannot continue — crawler failed." -ForegroundColor Red
     if (-not $WriteResult) { exit 1 }
     return
@@ -130,12 +130,12 @@ Write-Host "  Step 3: Verifying dashboard counts..." -ForegroundColor Cyan
 try {
     $stats = Invoke-LocalApi -Path '/admin/dashboard-stats'
     $ok = $stats.assignments -ge 1400000
-    Report-Result 'LoadTest/AssignmentCount' $ok "assignments=$($stats.assignments) (expected >=1,400,000)"
-    Report-Result 'LoadTest/UserCount' ($stats.users -ge 75000) "users=$($stats.users)"
-    Report-Result 'LoadTest/ResourceCount' ($stats.resources -ge 75000) "resources=$($stats.resources)"
-    Report-Result 'LoadTest/SystemCount' ($stats.systems -ge 20) "systems=$($stats.systems)"
+    Write-Result 'LoadTest/AssignmentCount' $ok "assignments=$($stats.assignments) (expected >=1,400,000)"
+    Write-Result 'LoadTest/UserCount' ($stats.users -ge 75000) "users=$($stats.users)"
+    Write-Result 'LoadTest/ResourceCount' ($stats.resources -ge 75000) "resources=$($stats.resources)"
+    Write-Result 'LoadTest/SystemCount' ($stats.systems -ge 20) "systems=$($stats.systems)"
 } catch {
-    Report-Result 'LoadTest/AssignmentCount' $false $_.Exception.Message
+    Write-Result 'LoadTest/AssignmentCount' $false $_.Exception.Message
 }
 
 # ─── 4. Refresh materialized views ──────────────────────────────
@@ -144,9 +144,9 @@ try {
     $refreshStart = Get-Date
     $r = Invoke-LocalApi -Path '/ingest/refresh-views' -Method 'Post'
     $refreshDuration = ((Get-Date) - $refreshStart).TotalSeconds
-    Report-Result 'LoadTest/ViewRefresh' $true "time=$([math]::Round($refreshDuration,1))s"
+    Write-Result 'LoadTest/ViewRefresh' $true "time=$([math]::Round($refreshDuration,1))s"
 } catch {
-    Report-Result 'LoadTest/ViewRefresh' $false $_.Exception.Message
+    Write-Result 'LoadTest/ViewRefresh' $false $_.Exception.Message
 }
 
 # ─── 5. Test matrix performance at scale ─────────────────────────
@@ -156,9 +156,9 @@ try {
     $null = Invoke-LocalApi -Path '/permissions?userLimit=25'
     $matrixDuration = ((Get-Date) - $matrixStart).TotalSeconds
     $ok = $matrixDuration -lt 15  # must respond within 15 seconds
-    Report-Result 'LoadTest/MatrixPerformance' $ok "time=$([math]::Round($matrixDuration, 2))s (limit=15s)"
+    Write-Result 'LoadTest/MatrixPerformance' $ok "time=$([math]::Round($matrixDuration, 2))s (limit=15s)"
 } catch {
-    Report-Result 'LoadTest/MatrixPerformance' $false $_.Exception.Message
+    Write-Result 'LoadTest/MatrixPerformance' $false $_.Exception.Message
 }
 
 # ─── 6. Run benchmark suite ──────────────────────────────────────
@@ -168,12 +168,12 @@ if (Test-Path $benchmarkScript) {
         $benchLogFolder = Join-Path $LogFolder 'benchmark'
         if (-not (Test-Path $benchLogFolder)) { New-Item -ItemType Directory -Path $benchLogFolder -Force | Out-Null }
         & $benchmarkScript -ApiBaseUrl $ApiBaseUrl -OutputFolder $benchLogFolder -ErrorAction Stop
-        Report-Result 'LoadTest/BenchmarkCompleted' $true ''
+        Write-Result 'LoadTest/BenchmarkCompleted' $true ''
     } catch {
-        Report-Result 'LoadTest/BenchmarkCompleted' $false $_.Exception.Message
+        Write-Result 'LoadTest/BenchmarkCompleted' $false $_.Exception.Message
     }
 } else {
-    Report-Result 'LoadTest/BenchmarkCompleted' $true 'skipped (script missing)'
+    Write-Result 'LoadTest/BenchmarkCompleted' $true 'skipped (script missing)'
 }
 
 # ─── 7. Dashboard-stats query performance ────────────────────────
@@ -183,9 +183,9 @@ try {
     $null = Invoke-LocalApi -Path '/admin/dashboard-stats'
     $dashDuration = ((Get-Date) - $dashStart).TotalSeconds
     $ok = $dashDuration -lt 5  # reltuples path should be fast
-    Report-Result 'LoadTest/DashboardPerformance' $ok "time=$([math]::Round($dashDuration, 2))s (limit=5s)"
+    Write-Result 'LoadTest/DashboardPerformance' $ok "time=$([math]::Round($dashDuration, 2))s (limit=5s)"
 } catch {
-    Report-Result 'LoadTest/DashboardPerformance' $false $_.Exception.Message
+    Write-Result 'LoadTest/DashboardPerformance' $false $_.Exception.Message
 }
 
 Write-Host "`n  Load test complete." -ForegroundColor Green

--- a/test/nightly/Test-MatrixScopeStats.ps1
+++ b/test/nightly/Test-MatrixScopeStats.ps1
@@ -49,7 +49,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color  = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS'  } else { 'FAIL' }
@@ -83,70 +83,70 @@ Write-Host "`n=== Matrix Scope Statistics ===" -ForegroundColor Cyan
 # Assert invariants + cross-consistency rather than magic counts, so the test
 # is robust to dataset evolution and to other tests having added data first.
 $all = Invoke-ScopeApi -Path '/matrix/scope-stats' -Filter $allFilter
-Report-Result 'scope-stats: non-empty counts' `
+Write-Result 'scope-stats: non-empty counts' `
     (($all.subjectCount -gt 0) -and ($all.resourceCount -gt 0) -and ($all.assignmentCount -gt 0)) `
     "P=$($all.subjectCount) R=$($all.resourceCount) A=$($all.assignmentCount)"
 
 $splitOk = ($all.governedAssignmentCount + $all.ungovernedAssignmentCount) -eq $all.assignmentCount
-Report-Result 'scope-stats: governed split sums to total' $splitOk `
+Write-Result 'scope-stats: governed split sums to total' $splitOk `
     "$($all.governedAssignmentCount)+$($all.ungovernedAssignmentCount) vs $($all.assignmentCount)"
 
 # Governed is determined by business-role coverage (vw_UserPermissionAssignmentViaBusinessRole),
 # NOT the per-row managedByAccessPackage flag. On the demo data (business roles that
 # Contain groups + Governed role assignments) some access IS governed and some is not.
 # These guard against the regression where governed read as 0.
-Report-Result 'scope-stats: some access is governed (BR coverage)' ($all.governedAssignmentCount -gt 0) `
+Write-Result 'scope-stats: some access is governed (BR coverage)' ($all.governedAssignmentCount -gt 0) `
     "governed=$($all.governedAssignmentCount)"
-Report-Result 'scope-stats: some access is non-governed' ($all.ungovernedAssignmentCount -gt 0) `
+Write-Result 'scope-stats: some access is non-governed' ($all.ungovernedAssignmentCount -gt 0) `
     "non-governed=$($all.ungovernedAssignmentCount)"
 
 $expectPct = if ($all.assignmentCount -gt 0) { [math]::Round($all.governedAssignmentCount / $all.assignmentCount * 100, 1) } else { 0 }
-Report-Result 'scope-stats: governedPct consistent' ([math]::Abs($all.governedPct - $expectPct) -lt 0.2) `
+Write-Result 'scope-stats: governedPct consistent' ([math]::Abs($all.governedPct - $expectPct) -lt 0.2) `
     "api=$($all.governedPct) expected≈$expectPct"
 
 $eng = Invoke-ScopeApi -Path '/matrix/scope-stats' -Filter $engFilter
-Report-Result 'scope-stats: Engineering subset smaller than all' `
+Write-Result 'scope-stats: Engineering subset smaller than all' `
     (($eng.subjectCount -lt $all.subjectCount) -and ($eng.subjectCount -gt 0)) "eng=$($eng.subjectCount)"
 
 # ── 2. scope-breakdown ───────────────────────────────────────────────
 $bd = Invoke-ScopeApi -Path '/matrix/scope-breakdown?attribute=department' -Filter $allFilter
 $groups = @($bd.groups)
 $sumPrincipals = ($groups | Measure-Object -Property principals -Sum).Sum
-Report-Result 'breakdown: principals sum to total' ($sumPrincipals -eq $all.subjectCount) `
+Write-Result 'breakdown: principals sum to total' ($sumPrincipals -eq $all.subjectCount) `
     "sum=$sumPrincipals total=$($all.subjectCount)"
 
 # Every assignment pair belongs to exactly one department, so they must sum to
 # the total assignment count.
 $sumAssign = ($groups | Measure-Object -Property assignments -Sum).Sum
-Report-Result 'breakdown: assignments sum to total' ($sumAssign -eq $all.assignmentCount) `
+Write-Result 'breakdown: assignments sum to total' ($sumAssign -eq $all.assignmentCount) `
     "sum=$sumAssign total=$($all.assignmentCount)"
 
 $consistent = $true
 foreach ($g in $groups) {
     if ($g.governed -gt $g.assignments) { $consistent = $false }
 }
-Report-Result 'breakdown: governed <= assignments per group' $consistent ''
+Write-Result 'breakdown: governed <= assignments per group' $consistent ''
 
 # Cross-consistency: the Engineering breakdown row must equal a direct
 # Engineering-scoped scope-stats query (strong proof both code paths agree).
 $engGroup = $groups | Where-Object { $_.group -eq 'Engineering' } | Select-Object -First 1
-Report-Result 'breakdown: Engineering present' ($null -ne $engGroup) ''
+Write-Result 'breakdown: Engineering present' ($null -ne $engGroup) ''
 if ($engGroup) {
-    Report-Result 'breakdown: Engineering matches scope-stats' `
+    Write-Result 'breakdown: Engineering matches scope-stats' `
         (($engGroup.principals -eq $eng.subjectCount) -and ($engGroup.assignments -eq $eng.assignmentCount)) `
         "bd P=$($engGroup.principals)/A=$($engGroup.assignments) vs stats P=$($eng.subjectCount)/A=$($eng.assignmentCount)"
 }
 
 # ── 3. scope-timeseries ──────────────────────────────────────────────
 $ts = Invoke-ScopeApi -Path '/matrix/scope-timeseries' -Filter $allFilter
-Report-Result 'timeseries: has historyStart' ($null -ne $ts.historyStart) "start=$($ts.historyStart)"
-Report-Result 'timeseries: scopeMode is attribute' ($ts.scopeMode -eq 'attribute') "mode=$($ts.scopeMode)"
+Write-Result 'timeseries: has historyStart' ($null -ne $ts.historyStart) "start=$($ts.historyStart)"
+Write-Result 'timeseries: scopeMode is attribute' ($ts.scopeMode -eq 'attribute') "mode=$($ts.scopeMode)"
 
 $livePoints = @($ts.points | Where-Object { -not $_.beforeHistory })
-Report-Result 'timeseries: has at least one in-history point' ($livePoints.Count -ge 1) "n=$($livePoints.Count)"
+Write-Result 'timeseries: has at least one in-history point' ($livePoints.Count -ge 1) "n=$($livePoints.Count)"
 if ($livePoints.Count -ge 1) {
     $today = $livePoints[-1]
-    Report-Result 'timeseries: latest point equals live scope-stats' `
+    Write-Result 'timeseries: latest point equals live scope-stats' `
         (($today.assignments -eq $all.assignmentCount) -and ($today.governed -eq $all.governedAssignmentCount)) `
         "ts A=$($today.assignments)/G=$($today.governed) vs live A=$($all.assignmentCount)/G=$($all.governedAssignmentCount)"
 }
@@ -155,16 +155,16 @@ if ($livePoints.Count -ge 1) {
 if ($ExpectHistoryDepth) {
     $start = [datetime]$ts.historyStart
     $ageDays = ([datetime]::UtcNow - $start.ToUniversalTime()).TotalDays
-    Report-Result 'depth: historyStart is well in the past' ($ageDays -gt 90) "ageDays=$([math]::Round($ageDays))"
+    Write-Result 'depth: historyStart is well in the past' ($ageDays -gt 90) "ageDays=$([math]::Round($ageDays))"
 
     $distinctPct = @($livePoints | ForEach-Object { $_.governedPct } | Sort-Object -Unique)
-    Report-Result 'depth: governed % varies across the timeline' ($distinctPct.Count -ge 2) `
+    Write-Result 'depth: governed % varies across the timeline' ($distinctPct.Count -ge 2) `
         "distinct=$($distinctPct.Count)"
 
     # Governance should be monotonic-ish upward in the simulated story: the
     # earliest in-history point should be <= the latest.
     if ($livePoints.Count -ge 2) {
-        Report-Result 'depth: governed % grows from first to last point' `
+        Write-Result 'depth: governed % grows from first to last point' `
             ($livePoints[0].governedPct -le $livePoints[-1].governedPct) `
             "first=$($livePoints[0].governedPct) last=$($livePoints[-1].governedPct)"
     }

--- a/test/nightly/Test-RiskScoring.ps1
+++ b/test/nightly/Test-RiskScoring.ps1
@@ -45,7 +45,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -80,12 +80,12 @@ try {
     $userCount = if ($null -ne $users.total) { [int]$users.total } else { 0 }
     $resourceCount = if ($null -ne $resources.total) { [int]$resources.total } else { 0 }
     if ($userCount -eq 0 -or $resourceCount -eq 0) {
-        Report-Result 'Risk/DemoDataLoaded' $true "skipped (no demo data: $userCount users, $resourceCount resources)"
+        Write-Result 'Risk/DemoDataLoaded' $true "skipped (no demo data: $userCount users, $resourceCount resources)"
         if (-not $WriteResult) { exit 0 } else { return }
     }
-    Report-Result 'Risk/DemoDataLoaded' $true "users=$userCount resources=$resourceCount"
+    Write-Result 'Risk/DemoDataLoaded' $true "users=$userCount resources=$resourceCount"
 } catch {
-    Report-Result 'Risk/DemoDataLoaded' $true "skipped (pre-flight failed: $($_.Exception.Message))"
+    Write-Result 'Risk/DemoDataLoaded' $true "skipped (pre-flight failed: $($_.Exception.Message))"
     if (-not $WriteResult) { exit 0 } else { return }
 }
 
@@ -113,14 +113,14 @@ $profilePayload = @{
 try {
     $profileResp = Invoke-LocalApi -Path '/risk-profiles' -Method Post -Body $profilePayload
     if ($profileResp.id) {
-        Report-Result 'Risk/SaveProfile' $true "id=$($profileResp.id)"
+        Write-Result 'Risk/SaveProfile' $true "id=$($profileResp.id)"
         $script:profileId = $profileResp.id
     } else {
-        Report-Result 'Risk/SaveProfile' $false 'no id in response'
+        Write-Result 'Risk/SaveProfile' $false 'no id in response'
         if (-not $WriteResult) { exit 1 } else { return }
     }
 } catch {
-    Report-Result 'Risk/SaveProfile' $false $_.Exception.Message
+    Write-Result 'Risk/SaveProfile' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -172,14 +172,14 @@ $classifierPayload = @{
 try {
     $clsResp = Invoke-LocalApi -Path '/risk-classifiers' -Method Post -Body $classifierPayload
     if ($clsResp.id) {
-        Report-Result 'Risk/SaveClassifiers' $true "id=$($clsResp.id)"
+        Write-Result 'Risk/SaveClassifiers' $true "id=$($clsResp.id)"
         $script:classifierId = $clsResp.id
     } else {
-        Report-Result 'Risk/SaveClassifiers' $false 'no id in response'
+        Write-Result 'Risk/SaveClassifiers' $false 'no id in response'
         if (-not $WriteResult) { exit 1 } else { return }
     }
 } catch {
-    Report-Result 'Risk/SaveClassifiers' $false $_.Exception.Message
+    Write-Result 'Risk/SaveClassifiers' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -187,14 +187,14 @@ try {
 try {
     $runResp = Invoke-LocalApi -Path '/risk-scoring/runs' -Method Post -Body @{ classifierId = $script:classifierId }
     if ($runResp.id) {
-        Report-Result 'Risk/StartRun' $true "id=$($runResp.id) status=$($runResp.status)"
+        Write-Result 'Risk/StartRun' $true "id=$($runResp.id) status=$($runResp.status)"
         $script:runId = $runResp.id
     } else {
-        Report-Result 'Risk/StartRun' $false 'no id in response'
+        Write-Result 'Risk/StartRun' $false 'no id in response'
         if (-not $WriteResult) { exit 1 } else { return }
     }
 } catch {
-    Report-Result 'Risk/StartRun' $false $_.Exception.Message
+    Write-Result 'Risk/StartRun' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -212,22 +212,22 @@ for ($i = 0; $i -lt 30; $i++) {
 }
 
 if (-not $finalRun) {
-    Report-Result 'Risk/RunCompletes' $false 'timed out after 60 seconds'
+    Write-Result 'Risk/RunCompletes' $false 'timed out after 60 seconds'
     if (-not $WriteResult) { exit 1 } else { return }
 }
 if ($finalRun.status -ne 'completed') {
-    Report-Result 'Risk/RunCompletes' $false "ended in '$($finalRun.status)': $($finalRun.errorMessage)"
+    Write-Result 'Risk/RunCompletes' $false "ended in '$($finalRun.status)': $($finalRun.errorMessage)"
     if (-not $WriteResult) { exit 1 } else { return }
 }
-Report-Result 'Risk/RunCompletes' $true "scored=$($finalRun.scoredEntities) total=$($finalRun.totalEntities)"
+Write-Result 'Risk/RunCompletes' $true "scored=$($finalRun.scoredEntities) total=$($finalRun.totalEntities)"
 
 # ─── Step 5: Assert expected outcomes via /api/risk-scores ───────
 try {
     $scores = Invoke-LocalApi -Path '/risk-scores'
     if ($scores.available -and $scores.summary) {
-        Report-Result 'Risk/ScoresEndpoint' $true 'returned summary'
+        Write-Result 'Risk/ScoresEndpoint' $true 'returned summary'
     } else {
-        Report-Result 'Risk/ScoresEndpoint' $false 'no summary in response'
+        Write-Result 'Risk/ScoresEndpoint' $false 'no summary in response'
     }
 
     # Count entities that scored at least Minimal (direct classifier match)
@@ -254,9 +254,9 @@ try {
     # (?i) patterns (the April 2026 bug), no entity will score above None and
     # this assertion fails.
     if ($matchedCount -gt 0) {
-        Report-Result 'Risk/ClassifierMatchesRecorded' $true "entities with matches: $matchedCount (Minimal+)"
+        Write-Result 'Risk/ClassifierMatchesRecorded' $true "entities with matches: $matchedCount (Minimal+)"
     } else {
-        Report-Result 'Risk/ClassifierMatchesRecorded' $false 'ZERO matches recorded — regex compile may be broken'
+        Write-Result 'Risk/ClassifierMatchesRecorded' $false 'ZERO matches recorded — regex compile may be broken'
     }
 
     # We expect at least one Medium since we have a broad `admin` pattern.
@@ -264,12 +264,12 @@ try {
     # min(100, round(0.6 * 80)) = 48 = Medium tier.
     $mediumPlus = ($tiers['Medium'] ?? 0) + ($tiers['High'] ?? 0) + ($tiers['Critical'] ?? 0)
     if ($mediumPlus -gt 0) {
-        Report-Result 'Risk/HasMediumOrHigher' $true "Medium+: $mediumPlus"
+        Write-Result 'Risk/HasMediumOrHigher' $true "Medium+: $mediumPlus"
     } else {
-        Report-Result 'Risk/HasMediumOrHigher' $false "expected at least one Medium+, got $mediumPlus"
+        Write-Result 'Risk/HasMediumOrHigher' $false "expected at least one Medium+, got $mediumPlus"
     }
 } catch {
-    Report-Result 'Risk/ScoresEndpoint' $false $_.Exception.Message
+    Write-Result 'Risk/ScoresEndpoint' $false $_.Exception.Message
 }
 
 # ─── Cleanup ─────────────────────────────────────────────────────

--- a/test/nightly/Test-RiskScoringLLM.ps1
+++ b/test/nightly/Test-RiskScoringLLM.ps1
@@ -46,7 +46,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -85,12 +85,12 @@ Write-Host "`n=== Risk Scoring — full LLM flow ===" -ForegroundColor Cyan
 try {
     $status = Invoke-LocalApi -Path '/admin/llm/status' -TimeoutSec 10
     if (-not $status.configured) {
-        Report-Result 'RiskLLM/LLMConfigured' $true 'skipped (no LLM configured)'
+        Write-Result 'RiskLLM/LLMConfigured' $true 'skipped (no LLM configured)'
         if (-not $WriteResult) { exit 0 } else { return }
     }
-    Report-Result 'RiskLLM/LLMConfigured' $true 'yes'
+    Write-Result 'RiskLLM/LLMConfigured' $true 'yes'
 } catch {
-    Report-Result 'RiskLLM/LLMConfigured' $true "skipped (status check failed: $($_.Exception.Message))"
+    Write-Result 'RiskLLM/LLMConfigured' $true "skipped (status check failed: $($_.Exception.Message))"
     if (-not $WriteResult) { exit 0 } else { return }
 }
 
@@ -98,12 +98,12 @@ try {
 try {
     $users = Invoke-LocalApi -Path '/users?pageSize=1' -TimeoutSec 10
     if ([int]$users.total -eq 0) {
-        Report-Result 'RiskLLM/DemoData' $true 'skipped (no users loaded)'
+        Write-Result 'RiskLLM/DemoData' $true 'skipped (no users loaded)'
         if (-not $WriteResult) { exit 0 } else { return }
     }
-    Report-Result 'RiskLLM/DemoData' $true "users=$($users.total)"
+    Write-Result 'RiskLLM/DemoData' $true "users=$($users.total)"
 } catch {
-    Report-Result 'RiskLLM/DemoData' $true "skipped: $($_.Exception.Message)"
+    Write-Result 'RiskLLM/DemoData' $true "skipped: $($_.Exception.Message)"
     if (-not $WriteResult) { exit 0 } else { return }
 }
 
@@ -121,7 +121,7 @@ if (-not $TestDomain) {
     }
 }
 if (-not $TestDomain) { $TestDomain = 'novastream-fi.net' }
-Report-Result 'RiskLLM/TestDomain' $true $TestDomain
+Write-Result 'RiskLLM/TestDomain' $true $TestDomain
 
 # ─── Step 1: Generate profile (real LLM call) ────────────────────
 $generateStart = Get-Date
@@ -132,25 +132,25 @@ try {
     } -TimeoutSec 180
     $elapsed = [Math]::Round(((Get-Date) - $generateStart).TotalSeconds)
     if (-not $genResp.profile) {
-        Report-Result 'RiskLLM/GenerateProfile' $false "no profile field (${elapsed}s)"
+        Write-Result 'RiskLLM/GenerateProfile' $false "no profile field (${elapsed}s)"
         if (-not $WriteResult) { exit 1 } else { return }
     }
     $profile = $genResp.profile
     $regCount = if ($profile.regulations) { @($profile.regulations).Count } else { 0 }
     $roleCount = if ($profile.critical_roles) { @($profile.critical_roles).Count } else { 0 }
-    Report-Result 'RiskLLM/GenerateProfile' $true "model=$($genResp.llmModel) ${elapsed}s regulations=$regCount roles=$roleCount"
+    Write-Result 'RiskLLM/GenerateProfile' $true "model=$($genResp.llmModel) ${elapsed}s regulations=$regCount roles=$roleCount"
     if ($regCount -lt 1) {
-        Report-Result 'RiskLLM/ProfileHasRegulations' $false "expected >=1, got $regCount"
+        Write-Result 'RiskLLM/ProfileHasRegulations' $false "expected >=1, got $regCount"
     } else {
-        Report-Result 'RiskLLM/ProfileHasRegulations' $true $regCount
+        Write-Result 'RiskLLM/ProfileHasRegulations' $true $regCount
     }
     if ($roleCount -lt 3) {
-        Report-Result 'RiskLLM/ProfileHasCriticalRoles' $false "expected >=3, got $roleCount"
+        Write-Result 'RiskLLM/ProfileHasCriticalRoles' $false "expected >=3, got $roleCount"
     } else {
-        Report-Result 'RiskLLM/ProfileHasCriticalRoles' $true $roleCount
+        Write-Result 'RiskLLM/ProfileHasCriticalRoles' $true $roleCount
     }
 } catch {
-    Report-Result 'RiskLLM/GenerateProfile' $false $_.Exception.Message
+    Write-Result 'RiskLLM/GenerateProfile' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -162,9 +162,9 @@ try {
         makeActive  = $true
     } -TimeoutSec 30
     $script:profileId = $saveResp.id
-    Report-Result 'RiskLLM/SaveProfile' $true "id=$($saveResp.id)"
+    Write-Result 'RiskLLM/SaveProfile' $true "id=$($saveResp.id)"
 } catch {
-    Report-Result 'RiskLLM/SaveProfile' $false $_.Exception.Message
+    Write-Result 'RiskLLM/SaveProfile' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -176,21 +176,21 @@ try {
     } -TimeoutSec 240
     $elapsed = [Math]::Round(((Get-Date) - $generateStart).TotalSeconds)
     if (-not $clsResp.classifiers) {
-        Report-Result 'RiskLLM/GenerateClassifiers' $false "no classifiers field (${elapsed}s)"
+        Write-Result 'RiskLLM/GenerateClassifiers' $false "no classifiers field (${elapsed}s)"
         if (-not $WriteResult) { exit 1 } else { return }
     }
     $cls = $clsResp.classifiers
     $gc = if ($cls.groupClassifiers) { @($cls.groupClassifiers).Count } else { 0 }
     $uc = if ($cls.userClassifiers)  { @($cls.userClassifiers).Count }  else { 0 }
     $ac = if ($cls.agentClassifiers) { @($cls.agentClassifiers).Count } else { 0 }
-    Report-Result 'RiskLLM/GenerateClassifiers' $true "${elapsed}s groups=$gc users=$uc agents=$ac"
+    Write-Result 'RiskLLM/GenerateClassifiers' $true "${elapsed}s groups=$gc users=$uc agents=$ac"
     if ($gc -lt 3) {
-        Report-Result 'RiskLLM/HasGroupClassifiers' $false "expected >=3, got $gc"
+        Write-Result 'RiskLLM/HasGroupClassifiers' $false "expected >=3, got $gc"
     } else {
-        Report-Result 'RiskLLM/HasGroupClassifiers' $true $gc
+        Write-Result 'RiskLLM/HasGroupClassifiers' $true $gc
     }
 } catch {
-    Report-Result 'RiskLLM/GenerateClassifiers' $false $_.Exception.Message
+    Write-Result 'RiskLLM/GenerateClassifiers' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -203,9 +203,9 @@ try {
         makeActive  = $true
     } -TimeoutSec 30
     $script:classifierId = $saveResp.id
-    Report-Result 'RiskLLM/SaveClassifiers' $true "id=$($saveResp.id)"
+    Write-Result 'RiskLLM/SaveClassifiers' $true "id=$($saveResp.id)"
 } catch {
-    Report-Result 'RiskLLM/SaveClassifiers' $false $_.Exception.Message
+    Write-Result 'RiskLLM/SaveClassifiers' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -215,9 +215,9 @@ try {
         classifierId = $script:classifierId
     } -TimeoutSec 30
     $script:runId = $runResp.id
-    Report-Result 'RiskLLM/StartRun' $true "id=$($runResp.id)"
+    Write-Result 'RiskLLM/StartRun' $true "id=$($runResp.id)"
 } catch {
-    Report-Result 'RiskLLM/StartRun' $false $_.Exception.Message
+    Write-Result 'RiskLLM/StartRun' $false $_.Exception.Message
     if (-not $WriteResult) { exit 1 } else { return }
 }
 
@@ -235,11 +235,11 @@ for ($i = 0; $i -lt 60; $i++) {
 }
 
 if (-not $finalRun) {
-    Report-Result 'RiskLLM/RunCompletes' $false 'timed out after 120s'
+    Write-Result 'RiskLLM/RunCompletes' $false 'timed out after 120s'
 } elseif ($finalRun.status -ne 'completed') {
-    Report-Result 'RiskLLM/RunCompletes' $false "status=$($finalRun.status): $($finalRun.errorMessage)"
+    Write-Result 'RiskLLM/RunCompletes' $false "status=$($finalRun.status): $($finalRun.errorMessage)"
 } else {
-    Report-Result 'RiskLLM/RunCompletes' $true "scored=$($finalRun.scoredEntities)"
+    Write-Result 'RiskLLM/RunCompletes' $true "scored=$($finalRun.scoredEntities)"
 
     # Assert at least some classifier matches were produced. The LLM-generated
     # classifiers SHOULD match the example/demo data since they were generated for
@@ -253,12 +253,12 @@ if (-not $finalRun) {
             if ($scores.summary.usersByTier.$tier)  { $matched += [int]$scores.summary.usersByTier.$tier }
         }
         if ($matched -gt 0) {
-            Report-Result 'RiskLLM/EntitiesMatched' $true "$matched entities Minimal+"
+            Write-Result 'RiskLLM/EntitiesMatched' $true "$matched entities Minimal+"
         } else {
-            Report-Result 'RiskLLM/EntitiesMatched' $false "ZERO matches (regex compile or LLM output broken)"
+            Write-Result 'RiskLLM/EntitiesMatched' $false "ZERO matches (regex compile or LLM output broken)"
         }
     } catch {
-        Report-Result 'RiskLLM/EntitiesMatched' $false $_.Exception.Message
+        Write-Result 'RiskLLM/EntitiesMatched' $false $_.Exception.Message
     }
 }
 

--- a/test/nightly/Test-SecretsVault.ps1
+++ b/test/nightly/Test-SecretsVault.ps1
@@ -38,7 +38,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -89,13 +89,13 @@ try {
         apiKey   = $testPlaintext
     }
     if ($r.ok -eq $true) {
-        Report-Result 'Vault/SaveSecret' $true 'saved with ok=true'
+        Write-Result 'Vault/SaveSecret' $true 'saved with ok=true'
     } else {
-        Report-Result 'Vault/SaveSecret' $false "unexpected response: $($r | ConvertTo-Json -Depth 5 -Compress)"
+        Write-Result 'Vault/SaveSecret' $false "unexpected response: $($r | ConvertTo-Json -Depth 5 -Compress)"
         $abortRemaining = $true
     }
 } catch {
-    Report-Result 'Vault/SaveSecret' $false $_.Exception.Message
+    Write-Result 'Vault/SaveSecret' $false $_.Exception.Message
     $abortRemaining = $true
 }
 
@@ -105,13 +105,13 @@ if (-not $abortRemaining) {
         $r = Invoke-LocalApi -Path '/admin/llm/status'
         $keyIsSet = ($r.apiKeySet -eq $true) -or ($r.configured -eq $true)
         if ($keyIsSet) {
-            Report-Result 'Vault/KeyIsSet' $true "apiKeySet=$($r.apiKeySet) configured=$($r.configured)"
+            Write-Result 'Vault/KeyIsSet' $true "apiKeySet=$($r.apiKeySet) configured=$($r.configured)"
         } else {
-            Report-Result 'Vault/KeyIsSet' $false "apiKeySet=$($r.apiKeySet) configured=$($r.configured)"
+            Write-Result 'Vault/KeyIsSet' $false "apiKeySet=$($r.apiKeySet) configured=$($r.configured)"
             $abortRemaining = $true
         }
     } catch {
-        Report-Result 'Vault/KeyIsSet' $false $_.Exception.Message
+        Write-Result 'Vault/KeyIsSet' $false $_.Exception.Message
         $abortRemaining = $true
     }
 }
@@ -121,16 +121,16 @@ if (-not $abortRemaining) {
     try {
         $ciphertext = Invoke-Psql -Sql "SELECT ciphertext FROM ""Secrets"" WHERE id = 'llm.apikey'"
         if ([string]::IsNullOrWhiteSpace($ciphertext)) {
-            Report-Result 'Vault/EncryptionVerified' $false 'no ciphertext row found in Secrets table'
+            Write-Result 'Vault/EncryptionVerified' $false 'no ciphertext row found in Secrets table'
             $abortRemaining = $true
         } elseif ($ciphertext -eq $testPlaintext) {
-            Report-Result 'Vault/EncryptionVerified' $false 'ciphertext equals plaintext — secret stored unencrypted!'
+            Write-Result 'Vault/EncryptionVerified' $false 'ciphertext equals plaintext — secret stored unencrypted!'
             $abortRemaining = $true
         } else {
-            Report-Result 'Vault/EncryptionVerified' $true "ciphertext differs from plaintext (len=$($ciphertext.Length))"
+            Write-Result 'Vault/EncryptionVerified' $true "ciphertext differs from plaintext (len=$($ciphertext.Length))"
         }
     } catch {
-        Report-Result 'Vault/EncryptionVerified' $false $_.Exception.Message
+        Write-Result 'Vault/EncryptionVerified' $false $_.Exception.Message
         $abortRemaining = $true
     }
 }
@@ -141,7 +141,7 @@ if (-not $abortRemaining) {
         $updateResult = Invoke-Psql -Sql "UPDATE ""Secrets"" SET ""authTag"" = 'tampered' WHERE id = 'llm.apikey'"
         # psql should return something like "UPDATE 1"
         if ($updateResult -notmatch 'UPDATE\s+1') {
-            Report-Result 'Vault/TamperDetected' $false "psql UPDATE did not affect 1 row: $updateResult"
+            Write-Result 'Vault/TamperDetected' $false "psql UPDATE did not affect 1 row: $updateResult"
         } else {
             # Try to USE the key — /admin/llm/test decrypts the secret to make
             # an LLM call. With a tampered authTag, GCM decryption should fail.
@@ -150,28 +150,28 @@ if (-not $abortRemaining) {
             try {
                 $null = Invoke-LocalApi -Path '/admin/llm/test' -Method Post
                 # If it somehow succeeds, tamper wasn't detected (bad)
-                Report-Result 'Vault/TamperDetected' $false 'LLM test succeeded after tamper — integrity check failed'
+                Write-Result 'Vault/TamperDetected' $false 'LLM test succeeded after tamper — integrity check failed'
             } catch {
                 # Any error is good — it means decryption/use of the tampered key failed
                 $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
-                Report-Result 'Vault/TamperDetected' $true "LLM test failed after tamper (status=$statusCode) — integrity check worked"
+                Write-Result 'Vault/TamperDetected' $true "LLM test failed after tamper (status=$statusCode) — integrity check worked"
             }
         }
     } catch {
-        Report-Result 'Vault/TamperDetected' $false $_.Exception.Message
+        Write-Result 'Vault/TamperDetected' $false $_.Exception.Message
     }
 }
 
 # ─── 5. Cleanup ──────────────────────────────────────────────────
 try {
     $r = Invoke-LocalApi -Path '/admin/llm/config' -Method Delete
-    Report-Result 'Vault/Cleanup' $true 'test secret deleted'
+    Write-Result 'Vault/Cleanup' $true 'test secret deleted'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 200 -or $statusCode -eq 204 -or $statusCode -eq 404) {
-        Report-Result 'Vault/Cleanup' $true "cleanup ok (status=$statusCode)"
+        Write-Result 'Vault/Cleanup' $true "cleanup ok (status=$statusCode)"
     } else {
-        Report-Result 'Vault/Cleanup' $false "DELETE failed: $($_.Exception.Message)"
+        Write-Result 'Vault/Cleanup' $false "DELETE failed: $($_.Exception.Message)"
         # Best-effort: try to wipe via psql so we don't leave test data behind
         try { Invoke-Psql -Sql "DELETE FROM ""Secrets"" WHERE id = 'llm.apikey'" | Out-Null } catch { }
     }

--- a/test/nightly/Test-SoakTest.ps1
+++ b/test/nightly/Test-SoakTest.ps1
@@ -41,7 +41,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -74,13 +74,13 @@ $initialMemory = Get-WebContainerMemory
 if ($null -eq $initialMemory) {
     $msg = '/admin/container-stats unavailable — skipping soak test'
     Write-Host "    SKIP  $msg" -ForegroundColor Yellow
-    Report-Result 'Soak/InitialMemory' $true "skipped: container stats unavailable"
+    Write-Result 'Soak/InitialMemory' $true "skipped: container stats unavailable"
     if (-not $WriteResult) { exit $standaloneFailures }
     return
 }
 
 $initialMB = [math]::Round($initialMemory / 1MB, 1)
-Report-Result 'Soak/InitialMemory' $true "${initialMB} MB"
+Write-Result 'Soak/InitialMemory' $true "${initialMB} MB"
 
 # ─── 2. Sustained request loop ───────────────────────────────────
 $endpoints = @(
@@ -135,10 +135,10 @@ while ((Get-Date) -lt $deadline) {
 # ─── 3. Final memory ─────────────────────────────────────────────
 $finalMemory = Get-WebContainerMemory
 if ($null -eq $finalMemory) {
-    Report-Result 'Soak/FinalMemory' $false 'could not read final memory'
+    Write-Result 'Soak/FinalMemory' $false 'could not read final memory'
 } else {
     $finalMB = [math]::Round($finalMemory / 1MB, 1)
-    Report-Result 'Soak/FinalMemory' $true "${finalMB} MB"
+    Write-Result 'Soak/FinalMemory' $true "${finalMB} MB"
     $memorySamples += [PSCustomObject]@{
         timestamp     = (Get-Date).ToString('o')
         memUsageBytes = $finalMemory
@@ -149,20 +149,20 @@ if ($null -eq $finalMemory) {
 if ($null -ne $finalMemory -and $initialMemory -gt 0) {
     $ratio = [math]::Round($finalMemory / $initialMemory, 2)
     if ($finalMemory -lt (2 * $initialMemory)) {
-        Report-Result 'Soak/NoMemoryLeak' $true "ratio=${ratio}x (${initialMB} MB -> ${finalMB} MB)"
+        Write-Result 'Soak/NoMemoryLeak' $true "ratio=${ratio}x (${initialMB} MB -> ${finalMB} MB)"
     } else {
-        Report-Result 'Soak/NoMemoryLeak' $false "ratio=${ratio}x exceeds 2x threshold (${initialMB} MB -> ${finalMB} MB)"
+        Write-Result 'Soak/NoMemoryLeak' $false "ratio=${ratio}x exceeds 2x threshold (${initialMB} MB -> ${finalMB} MB)"
     }
 } else {
-    Report-Result 'Soak/NoMemoryLeak' $false 'could not compare memory (missing final reading)'
+    Write-Result 'Soak/NoMemoryLeak' $false 'could not compare memory (missing final reading)'
 }
 
 # ─── 5. Throughput and error rate ─────────────────────────────────
 $errorRate = if ($totalRequests -gt 0) { [math]::Round(($totalErrors / $totalRequests) * 100, 2) } else { 100 }
 if ($errorRate -lt 1) {
-    Report-Result 'Soak/ThroughputOK' $true "$totalRequests requests, ${errorRate}% error rate"
+    Write-Result 'Soak/ThroughputOK' $true "$totalRequests requests, ${errorRate}% error rate"
 } else {
-    Report-Result 'Soak/ThroughputOK' $false "$totalRequests requests, ${errorRate}% error rate (threshold: <1%)"
+    Write-Result 'Soak/ThroughputOK' $false "$totalRequests requests, ${errorRate}% error rate (threshold: <1%)"
 }
 
 # ─── 6. Memory samples CSV ───────────────────────────────────────

--- a/test/nightly/dry-run-assertions.ps1
+++ b/test/nightly/dry-run-assertions.ps1
@@ -11,7 +11,7 @@
 
 $ApiBaseUrl = 'http://localhost:3001/api'
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }

--- a/test/unit/AzureRMCrawlerPhases.Tests.ps1
+++ b/test/unit/AzureRMCrawlerPhases.Tests.ps1
@@ -202,13 +202,13 @@ Describe 'Get-AzureMgDisplayName' {
     }
 }
 
-Describe 'Ensure-AzureAssignmentScope' {
+Describe 'Confirm-AzureAssignmentScope' {
     It 'creates a resource-group node + ancestor sub edge, tracked in KnownPaths' {
         $ctx = New-TestCtx
         [void]$ctx.KnownPaths.Add('/subscriptions/sub-1')
         $ctx.ScopePaths.Add('/subscriptions/sub-1')
         $rg = '/subscriptions/sub-1/resourceGroups/rg1'
-        $id = Ensure-AzureAssignmentScope -Ctx $ctx -ScopePath $rg -OwningSubPath '/subscriptions/sub-1'
+        $id = Confirm-AzureAssignmentScope -Ctx $ctx -ScopePath $rg -OwningSubPath '/subscriptions/sub-1'
         $id | Should -Be (Get-ScopeNodeId -ArmScopePath $rg)
         $ctx.KnownPaths.Contains($rg) | Should -BeTrue
         @($ctx.ScopeResources | Where-Object { $_.resourceType -eq 'AzureResourceGroup' }).Count | Should -Be 1
@@ -219,7 +219,7 @@ Describe 'Ensure-AzureAssignmentScope' {
         Mock Invoke-ARMGet { @{ properties = @{ displayName = 'Platform MG' } } }
         $ctx = New-TestCtx
         $mg = '/providers/Microsoft.Management/managementGroups/mg1'
-        Ensure-AzureAssignmentScope -Ctx $ctx -ScopePath $mg -OwningSubPath '/subscriptions/sub-1' | Out-Null
+        Confirm-AzureAssignmentScope -Ctx $ctx -ScopePath $mg -OwningSubPath '/subscriptions/sub-1' | Out-Null
         @($ctx.ScopeResources | Where-Object { $_.resourceType -eq 'AzureManagementGroup' }).Count | Should -Be 1
         $edge = $ctx.ContainsEdges | Where-Object { $_.parentResourceId -eq (Get-ScopeNodeId -ArmScopePath $mg) -and $_.childResourceId -eq (Get-ScopeNodeId -ArmScopePath '/subscriptions/sub-1') }
         @($edge).Count | Should -Be 1
@@ -227,7 +227,7 @@ Describe 'Ensure-AzureAssignmentScope' {
 
     It 'shapes the tenant root (/) as an AzureScope named Tenant Root' {
         $ctx = New-TestCtx
-        Ensure-AzureAssignmentScope -Ctx $ctx -ScopePath '/' -OwningSubPath '/subscriptions/sub-1' | Out-Null
+        Confirm-AzureAssignmentScope -Ctx $ctx -ScopePath '/' -OwningSubPath '/subscriptions/sub-1' | Out-Null
         $root = $ctx.ScopeResources | Where-Object { $_.externalId -eq '/' }
         @($root).Count | Should -Be 1
         $root.displayName  | Should -Be 'Tenant Root'

--- a/test/unit/MidpointCrawlerTransform.Tests.ps1
+++ b/test/unit/MidpointCrawlerTransform.Tests.ps1
@@ -110,7 +110,7 @@ Describe 'ConvertTo-MidpointOrgContextRecord' {
     }
 }
 
-Describe 'Sort-MidpointContextsTopologically' {
+Describe 'Get-MidpointContextsInTopologicalOrder' {
 
     It 'orders parents before children regardless of input order' {
         $records = @(
@@ -118,13 +118,13 @@ Describe 'Sort-MidpointContextsTopologically' {
             [pscustomobject]@{ id = 'b'; parentContextId = 'a' }
             [pscustomobject]@{ id = 'a'; parentContextId = $null }
         )
-        $sorted = Sort-MidpointContextsTopologically -Records $records
+        $sorted = Get-MidpointContextsInTopologicalOrder -Records $records
         ($sorted | ForEach-Object { $_.id }) -join '' | Should -Be 'abc'
     }
 
     It 'nulls out a parent that is outside the synced set (treats it as a root)' {
         $records = @([pscustomobject]@{ id = 'x'; parentContextId = 'not-synced' })
-        $sorted = Sort-MidpointContextsTopologically -Records $records
+        $sorted = Get-MidpointContextsInTopologicalOrder -Records $records
         $sorted[0].parentContextId | Should -BeNullOrEmpty
     }
 
@@ -133,12 +133,12 @@ Describe 'Sort-MidpointContextsTopologically' {
             [pscustomobject]@{ id = 'b'; parentContextId = 'a' }
             [pscustomobject]@{ id = 'a'; parentContextId = $null }
         )
-        $sorted = Sort-MidpointContextsTopologically -Records $records
+        $sorted = Get-MidpointContextsInTopologicalOrder -Records $records
         ($sorted | Where-Object { $_.id -eq 'b' }).parentContextId | Should -Be 'a'
     }
 
     It 'returns an empty array for no records' {
-        @(Sort-MidpointContextsTopologically -Records @()).Count | Should -Be 0
+        @(Get-MidpointContextsInTopologicalOrder -Records @()).Count | Should -Be 0
     }
 }
 

--- a/test/unit/OmadaCrawlerFunctions.Tests.ps1
+++ b/test/unit/OmadaCrawlerFunctions.Tests.ps1
@@ -47,23 +47,23 @@ BeforeAll {
     $script:phases = [System.Collections.Generic.List[object]]::new()
 }
 
-# ─── Map-ResourceCategory ─────────────────────────────────────────────────────
-Describe 'Map-ResourceCategory' {
+# ─── ConvertTo-AtlasResourceCategory ─────────────────────────────────────────────────────
+Describe 'ConvertTo-AtlasResourceCategory' {
     It "maps 'Role' to BusinessRole" {
-        Map-ResourceCategory -Category 'Role' | Should -Be 'BusinessRole'
+        ConvertTo-AtlasResourceCategory -Category 'Role' | Should -Be 'BusinessRole'
     }
     It "maps 'Permission' to Resource" {
-        Map-ResourceCategory -Category 'Permission' | Should -Be 'Resource'
+        ConvertTo-AtlasResourceCategory -Category 'Permission' | Should -Be 'Resource'
     }
     It 'maps an unknown category to the catch-all (Resource)' {
-        Map-ResourceCategory -Category 'SomethingElse' | Should -Be 'Resource'
+        ConvertTo-AtlasResourceCategory -Category 'SomethingElse' | Should -Be 'Resource'
     }
     It 'maps an empty category to the catch-all (Resource)' {
-        Map-ResourceCategory -Category '' | Should -Be 'Resource'
+        ConvertTo-AtlasResourceCategory -Category '' | Should -Be 'Resource'
     }
     It 'returns the literal Resource fallback when no catch-all entry exists' {
         $script:ResourceCategoryMapping = @( @{ category = 'Role'; resourceType = 'BusinessRole' } )
-        Map-ResourceCategory -Category 'Unmapped' | Should -Be 'Resource'
+        ConvertTo-AtlasResourceCategory -Category 'Unmapped' | Should -Be 'Resource'
         # restore for other tests
         $script:ResourceCategoryMapping = @(
             @{ category = 'Role';       resourceType = 'BusinessRole' }
@@ -73,51 +73,51 @@ Describe 'Map-ResourceCategory' {
     }
 }
 
-# ─── Map-IdentityTypeToAtlas ──────────────────────────────────────────────────
-Describe 'Map-IdentityTypeToAtlas' {
+# ─── ConvertTo-AtlasIdentityType ──────────────────────────────────────────────────
+Describe 'ConvertTo-AtlasIdentityType' {
     It "maps 'Employee' to User" {
-        Map-IdentityTypeToAtlas -OmadaType 'Employee' | Should -Be 'User'
+        ConvertTo-AtlasIdentityType -OmadaType 'Employee' | Should -Be 'User'
     }
     It "maps 'Contractor' to ExternalUser" {
-        Map-IdentityTypeToAtlas -OmadaType 'Contractor' | Should -Be 'ExternalUser'
+        ConvertTo-AtlasIdentityType -OmadaType 'Contractor' | Should -Be 'ExternalUser'
     }
     It "maps 'Service Account' to ServicePrincipal" {
-        Map-IdentityTypeToAtlas -OmadaType 'Service Account' | Should -Be 'ServicePrincipal'
+        ConvertTo-AtlasIdentityType -OmadaType 'Service Account' | Should -Be 'ServicePrincipal'
     }
     It "maps 'Machine' to ServicePrincipal" {
-        Map-IdentityTypeToAtlas -OmadaType 'Machine' | Should -Be 'ServicePrincipal'
+        ConvertTo-AtlasIdentityType -OmadaType 'Machine' | Should -Be 'ServicePrincipal'
     }
     It "defaults an unknown type to 'User' (with a warning)" {
-        Map-IdentityTypeToAtlas -OmadaType 'Wizard' | Should -Be 'User'
+        ConvertTo-AtlasIdentityType -OmadaType 'Wizard' | Should -Be 'User'
     }
 }
 
-# ─── Map-ResourceTypeToAtlas ──────────────────────────────────────────────────
-Describe 'Map-ResourceTypeToAtlas' {
+# ─── ConvertTo-AtlasResourceType ──────────────────────────────────────────────────
+Describe 'ConvertTo-AtlasResourceType' {
     It "maps the configured 'Business Role' to BusinessRole" {
-        Map-ResourceTypeToAtlas -OmadaType 'Business Role' | Should -Be 'BusinessRole'
+        ConvertTo-AtlasResourceType -OmadaType 'Business Role' | Should -Be 'BusinessRole'
     }
     It 'strips whitespace from an unmapped multi-word type' {
-        Map-ResourceTypeToAtlas -OmadaType 'Custom Resource Type' | Should -Be 'CustomResourceType'
+        ConvertTo-AtlasResourceType -OmadaType 'Custom Resource Type' | Should -Be 'CustomResourceType'
     }
     It 'returns a single-word unmapped type unchanged' {
-        Map-ResourceTypeToAtlas -OmadaType 'Widget' | Should -Be 'Widget'
+        ConvertTo-AtlasResourceType -OmadaType 'Widget' | Should -Be 'Widget'
     }
 }
 
-# ─── Map-ContextTypeToAtlas ───────────────────────────────────────────────────
-Describe 'Map-ContextTypeToAtlas' {
+# ─── ConvertTo-AtlasContextType ───────────────────────────────────────────────────
+Describe 'ConvertTo-AtlasContextType' {
     It "maps 'Organisational Unit' to OrgUnit" {
-        Map-ContextTypeToAtlas -OmadaType 'Organisational Unit' | Should -Be 'OrgUnit'
+        ConvertTo-AtlasContextType -OmadaType 'Organisational Unit' | Should -Be 'OrgUnit'
     }
     It "maps 'Cost Center' to CostCenter" {
-        Map-ContextTypeToAtlas -OmadaType 'Cost Center' | Should -Be 'CostCenter'
+        ConvertTo-AtlasContextType -OmadaType 'Cost Center' | Should -Be 'CostCenter'
     }
     It "maps 'Department' to Department" {
-        Map-ContextTypeToAtlas -OmadaType 'Department' | Should -Be 'Department'
+        ConvertTo-AtlasContextType -OmadaType 'Department' | Should -Be 'Department'
     }
     It 'strips whitespace from an unmapped multi-word context type' {
-        Map-ContextTypeToAtlas -OmadaType 'Some Region' | Should -Be 'SomeRegion'
+        ConvertTo-AtlasContextType -OmadaType 'Some Region' | Should -Be 'SomeRegion'
     }
 }
 

--- a/test/unit/OmadaCrawlerTransform.Tests.ps1
+++ b/test/unit/OmadaCrawlerTransform.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
 
     # Omada reference helpers used by the transforms.
     . (Join-Path $script:omadaRoot 'Get-OmadaHelpers.ps1')
-    # Map-ContextTypeToAtlas (reads $script:TypeMappings) — used by the Orgunit mapper.
+    # ConvertTo-AtlasContextType (reads $script:TypeMappings) — used by the Orgunit mapper.
     . (Join-Path $script:omadaRoot 'OmadaCrawler.Functions.ps1')
     # The unit under test.
     . (Join-Path $script:omadaRoot 'OmadaCrawler.Transform.ps1')
@@ -31,7 +31,7 @@ BeforeAll {
         contextTypeToIdentityAtlas  = @{ 'OrgUnit' = 'OrgUnit'; 'Organisational Unit' = 'OrgUnit'; Department = 'Department' }
         identityTypeToIdentityAtlas = @{ Employee = 'User'; Contractor = 'ExternalUser'; 'Service Account' = 'ServicePrincipal' }
     }
-    # Map-ResourceCategory iterates this ordered list; '' is the catch-all.
+    # ConvertTo-AtlasResourceCategory iterates this ordered list; '' is the catch-all.
     $script:ResourceCategoryMapping = @(
         @{ category = 'Business Role'; resourceType = 'BusinessRole' }
         @{ category = '';             resourceType = 'Resource' }
@@ -143,7 +143,7 @@ Describe 'ConvertTo-OmadaFlatContextRecord' {
     }
 }
 
-Describe 'Sort-OmadaContextsTopologically' {
+Describe 'Get-OmadaContextsInTopologicalOrder' {
 
     It 'orders parents before their children regardless of input order' {
         $records = @(
@@ -151,7 +151,7 @@ Describe 'Sort-OmadaContextsTopologically' {
             [pscustomobject]@{ id = 'b'; parentContextId = 'a' }
             [pscustomobject]@{ id = 'a'; parentContextId = $null }
         )
-        $sorted = Sort-OmadaContextsTopologically -Records $records
+        $sorted = Get-OmadaContextsInTopologicalOrder -Records $records
         ($sorted | ForEach-Object { $_.id }) -join '' | Should -Be 'abc'
     }
 
@@ -160,11 +160,11 @@ Describe 'Sort-OmadaContextsTopologically' {
             [pscustomobject]@{ id = 'x'; parentContextId = 'y' }
             [pscustomobject]@{ id = 'y'; parentContextId = 'x' }
         )
-        @(Sort-OmadaContextsTopologically -Records $records).Count | Should -Be 2
+        @(Get-OmadaContextsInTopologicalOrder -Records $records).Count | Should -Be 2
     }
 
     It 'returns an empty array for no records' {
-        @(Sort-OmadaContextsTopologically -Records @()).Count | Should -Be 0
+        @(Get-OmadaContextsInTopologicalOrder -Records @()).Count | Should -Be 0
     }
 }
 

--- a/tools/crawlers/CLAUDE.md
+++ b/tools/crawlers/CLAUDE.md
@@ -235,7 +235,7 @@ If your test doesn't use `$ApiKey` (e.g. a library-only test like `Test-ODataCra
 
 ### Failure contract
 
-Test scripts MUST `throw` or call `exit 1` on failure. The CI runner uses `try/catch` to detect failures — a test that runs clean but never asserts anything will silently pass. Use `Write-Error` + `exit 1` or the `Report-Result` helper pattern from existing tests.
+Test scripts MUST `throw` or call `exit 1` on failure. The CI runner uses `try/catch` to detect failures — a test that runs clean but never asserts anything will silently pass. Use `Write-Error` + `exit 1` or the `Write-Result` helper pattern from existing tests.
 
 ### Shared utilities
 

--- a/tools/crawlers/azure-rm/AzureRMCrawler.Phases.ps1
+++ b/tools/crawlers/azure-rm/AzureRMCrawler.Phases.ps1
@@ -284,7 +284,7 @@ function Get-AzureMgDisplayName {
 # missing ancestors) so the effective-access engine can inherit through the Contains
 # hierarchy. Management groups / the tenant root sit above the subscription, so they
 # link down to the owning subscription. Returns the scope node id.
-function Ensure-AzureAssignmentScope {
+function Confirm-AzureAssignmentScope {
     [CmdletBinding()]
     param([hashtable]$Ctx, [string]$ScopePath, [string]$OwningSubPath)
     $aboveSub = ($ScopePath -eq '/' -or $ScopePath -match '^/providers/Microsoft\.Management/managementGroups/')
@@ -296,7 +296,7 @@ function Ensure-AzureAssignmentScope {
             $parentPath = Get-ParentScopePath -ScopePath $ScopePath
             $Ctx.ScopeResources.Add((New-AzureBelowSubScopeRecord -ScopePath $ScopePath))
             if ($parentPath) {
-                [void](Ensure-AzureAssignmentScope -Ctx $Ctx -ScopePath $parentPath -OwningSubPath $OwningSubPath)
+                [void](Confirm-AzureAssignmentScope -Ctx $Ctx -ScopePath $parentPath -OwningSubPath $OwningSubPath)
                 Add-AzureContainsEdge -Ctx $Ctx -ParentPath $parentPath -ChildPath $ScopePath
             }
         }
@@ -373,7 +373,7 @@ function Add-AzureAssignment {
     $roleDefId = ($Assignment.properties.roleDefinitionId -split '/')[-1]
     if (-not $Ctx.RoleDefs.ContainsKey($roleDefId)) { return }   # filtered (e.g. custom role excluded)
 
-    $scopeNodeId = Ensure-AzureAssignmentScope -Ctx $Ctx -ScopePath $declaredScope -OwningSubPath $SubPath
+    $scopeNodeId = Confirm-AzureAssignmentScope -Ctx $Ctx -ScopePath $declaredScope -OwningSubPath $SubPath
     if (-not $Ctx.AssignSeen.Add([string]$Assignment.name)) { return }   # same Azure assignment via another sub
 
     $roleName = $Ctx.RoleDefs[$roleDefId].name

--- a/tools/crawlers/csv/Test-CSVCrawler.ps1
+++ b/tools/crawlers/csv/Test-CSVCrawler.ps1
@@ -45,7 +45,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -117,15 +117,15 @@ try {
         )
     } | Out-Null
     # If we get here the API accepted it — that could be valid (systemType not strictly enforced at API level)
-    Report-Result 'CSV/MissingColumns' $true 'API accepted record (systemType not enforced at ingest level)'
+    Write-Result 'CSV/MissingColumns' $true 'API accepted record (systemType not enforced at ingest level)'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'CSV/MissingColumns' $true "got 400 (expected validation error)"
+        Write-Result 'CSV/MissingColumns' $true "got 400 (expected validation error)"
     } elseif ($statusCode -eq 500) {
-        Report-Result 'CSV/MissingColumns' $false "got 500 — API should return 400 for missing required columns"
+        Write-Result 'CSV/MissingColumns' $false "got 500 — API should return 400 for missing required columns"
     } else {
-        Report-Result 'CSV/MissingColumns' $false "unexpected status $statusCode : $($_.Exception.Message)"
+        Write-Result 'CSV/MissingColumns' $false "unexpected status $statusCode : $($_.Exception.Message)"
     }
 }
 
@@ -140,15 +140,15 @@ try {
         records  = @()
     } | Out-Null
     # 200 with inserted:0 is acceptable
-    Report-Result 'CSV/HeaderOnly' $true 'API accepted empty records (graceful)'
+    Write-Result 'CSV/HeaderOnly' $true 'API accepted empty records (graceful)'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'CSV/HeaderOnly' $true "got 400 (empty records rejected, expected)"
+        Write-Result 'CSV/HeaderOnly' $true "got 400 (empty records rejected, expected)"
     } elseif ($statusCode -eq 500) {
-        Report-Result 'CSV/HeaderOnly' $false "got 500 — API should return 400 or 200 for empty records"
+        Write-Result 'CSV/HeaderOnly' $false "got 500 — API should return 400 or 200 for empty records"
     } else {
-        Report-Result 'CSV/HeaderOnly' $false "unexpected status $statusCode : $($_.Exception.Message)"
+        Write-Result 'CSV/HeaderOnly' $false "unexpected status $statusCode : $($_.Exception.Message)"
     }
 }
 
@@ -163,15 +163,15 @@ try {
             }
         )
     } | Out-Null
-    Report-Result 'CSV/EmptyDisplayName' $true 'API accepted empty displayName (graceful)'
+    Write-Result 'CSV/EmptyDisplayName' $true 'API accepted empty displayName (graceful)'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'CSV/EmptyDisplayName' $true "got 400 (empty displayName rejected, expected)"
+        Write-Result 'CSV/EmptyDisplayName' $true "got 400 (empty displayName rejected, expected)"
     } elseif ($statusCode -eq 500) {
-        Report-Result 'CSV/EmptyDisplayName' $false "got 500 — API should return 400 for empty required field"
+        Write-Result 'CSV/EmptyDisplayName' $false "got 500 — API should return 400 for empty required field"
     } else {
-        Report-Result 'CSV/EmptyDisplayName' $false "unexpected status $statusCode : $($_.Exception.Message)"
+        Write-Result 'CSV/EmptyDisplayName' $false "unexpected status $statusCode : $($_.Exception.Message)"
     }
 }
 
@@ -191,15 +191,15 @@ try {
             }
         )
     } | Out-Null
-    Report-Result 'CSV/LongField' $true 'API accepted 10K-char description'
+    Write-Result 'CSV/LongField' $true 'API accepted 10K-char description'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'CSV/LongField' $true "got 400 (long field rejected with clear error)"
+        Write-Result 'CSV/LongField' $true "got 400 (long field rejected with clear error)"
     } elseif ($statusCode -eq 500) {
-        Report-Result 'CSV/LongField' $false "got 500 — API should handle long fields gracefully (accept or 400)"
+        Write-Result 'CSV/LongField' $false "got 500 — API should handle long fields gracefully (accept or 400)"
     } else {
-        Report-Result 'CSV/LongField' $false "unexpected status $statusCode : $($_.Exception.Message)"
+        Write-Result 'CSV/LongField' $false "unexpected status $statusCode : $($_.Exception.Message)"
     }
 }
 
@@ -218,13 +218,13 @@ try {
             }
         )
     } | Out-Null
-    Report-Result 'CSV/SpecialChars' $true 'API accepted special characters (no SQL injection, no crash)'
+    Write-Result 'CSV/SpecialChars' $true 'API accepted special characters (no SQL injection, no crash)'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 500) {
-        Report-Result 'CSV/SpecialChars' $false "got 500 — possible SQL injection vulnerability or unescaped special chars"
+        Write-Result 'CSV/SpecialChars' $false "got 500 — possible SQL injection vulnerability or unescaped special chars"
     } else {
-        Report-Result 'CSV/SpecialChars' $false "unexpected status $statusCode : $($_.Exception.Message)"
+        Write-Result 'CSV/SpecialChars' $false "unexpected status $statusCode : $($_.Exception.Message)"
     }
 }
 
@@ -248,18 +248,18 @@ try {
             }
         )
     } | Out-Null
-    Report-Result 'CSV/DuplicateIds' $true 'API handled duplicate externalIds in batch (upsert)'
+    Write-Result 'CSV/DuplicateIds' $true 'API handled duplicate externalIds in batch (upsert)'
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
     if ($statusCode -eq 400) {
-        Report-Result 'CSV/DuplicateIds' $true "got 400 (duplicates rejected explicitly)"
+        Write-Result 'CSV/DuplicateIds' $true "got 400 (duplicates rejected explicitly)"
     } elseif ($statusCode -eq 500) {
         # Sending two records with the same UUID in one batch is a degenerate
         # edge case. Postgres can't handle duplicate keys in a single
         # INSERT...ON CONFLICT statement. Acceptable known limitation.
-        Report-Result 'CSV/DuplicateIds' $true "got 500 (known limitation: duplicate UUIDs in single batch)"
+        Write-Result 'CSV/DuplicateIds' $true "got 500 (known limitation: duplicate UUIDs in single batch)"
     } else {
-        Report-Result 'CSV/DuplicateIds' $false "unexpected status $statusCode : $($_.Exception.Message)"
+        Write-Result 'CSV/DuplicateIds' $false "unexpected status $statusCode : $($_.Exception.Message)"
     }
 }
 
@@ -285,13 +285,13 @@ try {
         records  = @(@{ contextExternalId = $posKey; memberExternalId = 'edge-ID1'; memberType = 'Identity'; addedBy = 'sync' })
     }
     if ($r.inserted -ge 1 -or $r.updated -ge 1) {
-        Report-Result 'CSV/ContextMemberExternalId' $true "context-member resolved by externalId (inserted=$($r.inserted) updated=$($r.updated))"
+        Write-Result 'CSV/ContextMemberExternalId' $true "context-member resolved by externalId (inserted=$($r.inserted) updated=$($r.updated))"
     } else {
-        Report-Result 'CSV/ContextMemberExternalId' $false "call succeeded but nothing written: $($r | ConvertTo-Json -Compress)"
+        Write-Result 'CSV/ContextMemberExternalId' $false "call succeeded but nothing written: $($r | ConvertTo-Json -Compress)"
     }
 } catch {
     $statusCode = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
-    Report-Result 'CSV/ContextMemberExternalId' $false "context-member by externalId failed (status $statusCode) — externalId resolution regression: $($_.Exception.Message)"
+    Write-Result 'CSV/ContextMemberExternalId' $false "context-member by externalId failed (status $statusCode) — externalId resolution regression: $($_.Exception.Message)"
 }
 
 # ─── Cleanup ─────────────────────────────────────────────────────

--- a/tools/crawlers/custom-connector/Test-CustomConnectorCrawler.ps1
+++ b/tools/crawlers/custom-connector/Test-CustomConnectorCrawler.ps1
@@ -40,7 +40,7 @@ Param(
 $ErrorActionPreference = 'Continue'
 $standaloneFailures = 0
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -64,16 +64,16 @@ try {
         -Body (@{ displayName = 'Nightly-Test-Connector'; description = 'Automated test — safe to delete' } | ConvertTo-Json)
     $connectorKey = $r.apiKey
     $ok = $null -ne $connectorKey -and $connectorKey.StartsWith('fgc_')
-    Report-Result 'CustomConnector/Register' $ok "id=$($r.id) keyPrefix=$($connectorKey.Substring(0,8))..."
+    Write-Result 'CustomConnector/Register' $ok "id=$($r.id) keyPrefix=$($connectorKey.Substring(0,8))..."
 } catch {
-    Report-Result 'CustomConnector/Register' $false $_.Exception.Message
+    Write-Result 'CustomConnector/Register' $false $_.Exception.Message
 }
 
 if (-not $connectorKey) {
-    Report-Result 'CustomConnector/Whoami' $false 'skipped: no API key from registration'
-    Report-Result 'CustomConnector/IngestSystem' $false 'skipped: no API key'
-    Report-Result 'CustomConnector/IngestUser' $false 'skipped: no API key'
-    Report-Result 'CustomConnector/DataLanded' $false 'skipped: no API key'
+    Write-Result 'CustomConnector/Whoami' $false 'skipped: no API key from registration'
+    Write-Result 'CustomConnector/IngestSystem' $false 'skipped: no API key'
+    Write-Result 'CustomConnector/IngestUser' $false 'skipped: no API key'
+    Write-Result 'CustomConnector/DataLanded' $false 'skipped: no API key'
     if (-not $WriteResult) { exit $standaloneFailures }
     return
 }
@@ -84,9 +84,9 @@ $headers = @{ 'Authorization' = "Bearer $connectorKey"; 'Content-Type' = 'applic
 try {
     $whoami = Invoke-RestMethod -Uri "$ApiBaseUrl/crawlers/whoami" -Headers $headers -TimeoutSec 10
     $ok = $whoami.displayName -eq 'Nightly-Test-Connector'
-    Report-Result 'CustomConnector/Whoami' $ok "name=$($whoami.displayName)"
+    Write-Result 'CustomConnector/Whoami' $ok "name=$($whoami.displayName)"
 } catch {
-    Report-Result 'CustomConnector/Whoami' $false $_.Exception.Message
+    Write-Result 'CustomConnector/Whoami' $false $_.Exception.Message
 }
 
 # ─── 3. Push a test system ───────────────────────────────────────
@@ -103,9 +103,9 @@ try {
         } | ConvertTo-Json -Depth 5) -TimeoutSec 30
     $systemId = if ($r.systemIds) { $r.systemIds[0] } else { $null }
     $ok = $null -ne $systemId
-    Report-Result 'CustomConnector/IngestSystem' $ok "systemId=$systemId"
+    Write-Result 'CustomConnector/IngestSystem' $ok "systemId=$systemId"
 } catch {
-    Report-Result 'CustomConnector/IngestSystem' $false $_.Exception.Message
+    Write-Result 'CustomConnector/IngestSystem' $false $_.Exception.Message
 }
 
 # ─── 4. Push a test user ─────────────────────────────────────────
@@ -123,12 +123,12 @@ if ($systemId) {
                 })
             } | ConvertTo-Json -Depth 5) -TimeoutSec 30
         $ok = $r.inserted -ge 1 -or $r.updated -ge 1
-        Report-Result 'CustomConnector/IngestUser' $ok "inserted=$($r.inserted) updated=$($r.updated)"
+        Write-Result 'CustomConnector/IngestUser' $ok "inserted=$($r.inserted) updated=$($r.updated)"
     } catch {
-        Report-Result 'CustomConnector/IngestUser' $false $_.Exception.Message
+        Write-Result 'CustomConnector/IngestUser' $false $_.Exception.Message
     }
 } else {
-    Report-Result 'CustomConnector/IngestUser' $false 'skipped: no systemId'
+    Write-Result 'CustomConnector/IngestUser' $false 'skipped: no systemId'
 }
 
 # ─── 5. Verify data landed ──────────────────────────────────────
@@ -136,9 +136,9 @@ try {
     $users = Invoke-RestMethod -Uri "$ApiBaseUrl/users?search=Custom+Connector+Test" -TimeoutSec 10
     $list = if ($users.data) { $users.data } else { $users }
     $found = @($list | Where-Object { $_.displayName -like '*Custom Connector Test*' })
-    Report-Result 'CustomConnector/DataLanded' ($found.Count -ge 1) "found=$($found.Count)"
+    Write-Result 'CustomConnector/DataLanded' ($found.Count -ge 1) "found=$($found.Count)"
 } catch {
-    Report-Result 'CustomConnector/DataLanded' $false $_.Exception.Message
+    Write-Result 'CustomConnector/DataLanded' $false $_.Exception.Message
 }
 
 Write-Host "`n  Custom connector round-trip complete." -ForegroundColor Green

--- a/tools/crawlers/entra-id/Test-EntraIdCrawler.ps1
+++ b/tools/crawlers/entra-id/Test-EntraIdCrawler.ps1
@@ -114,7 +114,7 @@ if (-not (Test-Path $LogFolder)) {
 # When run standalone, we keep our own counter so the script can return a
 # meaningful exit code.
 $standaloneFailures = 0
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }
@@ -259,10 +259,10 @@ function Invoke-Scenario {
             config      = $configPayload
         }
     } catch {
-        Report-Result "EntraID/$Name/CreateConfig" $false $_.Exception.Message
+        Write-Result "EntraID/$Name/CreateConfig" $false $_.Exception.Message
         return
     }
-    Report-Result "EntraID/$Name/CreateConfig" $true "id=$($config.id)"
+    Write-Result "EntraID/$Name/CreateConfig" $true "id=$($config.id)"
 
     # 2. Queue the job
     try {
@@ -271,10 +271,10 @@ function Invoke-Scenario {
             configId = $config.id
         }
     } catch {
-        Report-Result "EntraID/$Name/QueueJob" $false $_.Exception.Message
+        Write-Result "EntraID/$Name/QueueJob" $false $_.Exception.Message
         return
     }
-    Report-Result "EntraID/$Name/QueueJob" $true "jobId=$($job.id)"
+    Write-Result "EntraID/$Name/QueueJob" $true "jobId=$($job.id)"
 
     # 3. Wait for the job to finish
     $waitResult = Wait-ForJob -JobId $job.id -ScenarioName $Name
@@ -284,7 +284,7 @@ function Invoke-Scenario {
         if ($waitResult.job -and $waitResult.job.errorMessage) {
             $detail += " | $($waitResult.job.errorMessage)"
         }
-        Report-Result "EntraID/$Name/JobCompleted" $false $detail
+        Write-Result "EntraID/$Name/JobCompleted" $false $detail
         # Still drop a per-scenario log file with the final job state for debugging
         if ($waitResult.job) {
             $waitResult.job | ConvertTo-Json -Depth 10 |
@@ -292,7 +292,7 @@ function Invoke-Scenario {
         }
         return
     }
-    Report-Result "EntraID/$Name/JobCompleted" $true "${duration}s"
+    Write-Result "EntraID/$Name/JobCompleted" $true "${duration}s"
 
     # 4. Save the final job state for forensic review
     $waitResult.job | ConvertTo-Json -Depth 10 |
@@ -303,7 +303,7 @@ function Invoke-Scenario {
         try {
             & $ExtraAssertions
         } catch {
-            Report-Result "EntraID/$Name/Assertions" $false $_.Exception.Message
+            Write-Result "EntraID/$Name/Assertions" $false $_.Exception.Message
         }
     }
 }
@@ -329,32 +329,32 @@ try {
         }
     }
     if (-not $vr.valid) {
-        Report-Result 'EntraID/Validate-Only' $false ($vr.error ?? 'validation returned valid=false')
+        Write-Result 'EntraID/Validate-Only' $false ($vr.error ?? 'validation returned valid=false')
         if ($WriteResult) { & $WriteResult 'EntraID-Crawler-Tests' $false 'pre-flight validation failed' }
         return
     }
     $grantedProps = @($vr.permissions.PSObject.Properties | Where-Object { $_.Value })
     $missingProps = @($vr.permissions.PSObject.Properties | Where-Object { -not $_.Value })
     $grantedCount = $grantedProps.Count
-    Report-Result 'EntraID/Validate-Only' $true "org=$($vr.organization) · $grantedCount permissions granted"
+    Write-Result 'EntraID/Validate-Only' $true "org=$($vr.organization) · $grantedCount permissions granted"
 
     # Per-permission assertions — one row per permission in the response so a
     # single missing grant stands out in the results table.
     foreach ($p in $vr.permissions.PSObject.Properties) {
-        Report-Result "EntraID/Validate-Only/Permission/$($p.Name)" ([bool]$p.Value) $(if ($p.Value) { 'granted' } else { 'NOT granted' })
+        Write-Result "EntraID/Validate-Only/Permission/$($p.Name)" ([bool]$p.Value) $(if ($p.Value) { 'granted' } else { 'NOT granted' })
     }
 
     if ($StrictPermissions -and $missingProps.Count -gt 0) {
         $names = ($missingProps | ForEach-Object { $_.Name }) -join ', '
-        Report-Result 'EntraID/Validate-Only/AllGranted' $false "missing: $names"
+        Write-Result 'EntraID/Validate-Only/AllGranted' $false "missing: $names"
         if ($WriteResult) { & $WriteResult 'EntraID-Crawler-Tests' $false "pre-flight: $($missingProps.Count) permission(s) missing" }
         return
     }
     if ($StrictPermissions) {
-        Report-Result 'EntraID/Validate-Only/AllGranted' $true "all $grantedCount permissions granted"
+        Write-Result 'EntraID/Validate-Only/AllGranted' $true "all $grantedCount permissions granted"
     }
 } catch {
-    Report-Result 'EntraID/Validate-Only' $false $_.Exception.Message
+    Write-Result 'EntraID/Validate-Only' $false $_.Exception.Message
     if ($WriteResult) { & $WriteResult 'EntraID-Crawler-Tests' $false 'pre-flight validation threw' }
     return
 }
@@ -374,12 +374,12 @@ function Assert-ApiCount {
         elseif ($r.PSObject.Properties.Name -contains 'data') { $count = $r.data.Count }
         elseif ($r -is [array]) { $count = $r.Count }
         if ($count -ge $MinExpected) {
-            Report-Result $Name $true "count=$count"
+            Write-Result $Name $true "count=$count"
         } else {
-            Report-Result $Name $false "expected >=$MinExpected, got $count"
+            Write-Result $Name $false "expected >=$MinExpected, got $count"
         }
     } catch {
-        Report-Result $Name $false $_.Exception.Message
+        Write-Result $Name $false $_.Exception.Message
     }
 }
 
@@ -405,15 +405,15 @@ function Assert-MatrixWorks {
         $totalUsers = if ($perm.PSObject.Properties.Name -contains 'totalUsers') { [int]$perm.totalUsers } else { 0 }
 
         if ($rows -lt $MinRows) {
-            Report-Result "$NamePrefix/MatrixRowCount" $false "expected >=$MinRows rows, got $rows"
+            Write-Result "$NamePrefix/MatrixRowCount" $false "expected >=$MinRows rows, got $rows"
             return
         }
-        Report-Result "$NamePrefix/MatrixRowCount" $true "rows=$rows"
+        Write-Result "$NamePrefix/MatrixRowCount" $true "rows=$rows"
 
         if ($totalUsers -lt $MinUsers) {
-            Report-Result "$NamePrefix/MatrixTotalUsers" $false "expected >=$MinUsers users, got $totalUsers"
+            Write-Result "$NamePrefix/MatrixTotalUsers" $false "expected >=$MinUsers users, got $totalUsers"
         } else {
-            Report-Result "$NamePrefix/MatrixTotalUsers" $true "totalUsers=$totalUsers"
+            Write-Result "$NamePrefix/MatrixTotalUsers" $true "totalUsers=$totalUsers"
         }
 
         # Sanity-check the row shape — the frontend reads these specific fields
@@ -422,36 +422,36 @@ function Assert-MatrixWorks {
         $hasMember   = $first -and ($first.PSObject.Properties.Name -contains 'memberId')   -and $first.memberId
         $hasType     = $first -and ($first.PSObject.Properties.Name -contains 'membershipType')
         if ($hasResource -and $hasMember -and $hasType) {
-            Report-Result "$NamePrefix/MatrixRowShape" $true 'has resourceId/memberId/membershipType'
+            Write-Result "$NamePrefix/MatrixRowShape" $true 'has resourceId/memberId/membershipType'
         } else {
-            Report-Result "$NamePrefix/MatrixRowShape" $false "missing fields (res=$hasResource mem=$hasMember type=$hasType)"
+            Write-Result "$NamePrefix/MatrixRowShape" $false "missing fields (res=$hasResource mem=$hasMember type=$hasType)"
         }
 
         # AP→group mapping endpoint — drives the AP coloring on cells
         try {
             $apGroups = Invoke-LocalApi -Path '/access-package-groups'
             if ($apGroups -is [array] -or ($apGroups -and $apGroups.GetType().Name -eq 'Object[]')) {
-                Report-Result "$NamePrefix/MatrixAPMapping" $true "ap-group-rows=$($apGroups.Count)"
+                Write-Result "$NamePrefix/MatrixAPMapping" $true "ap-group-rows=$($apGroups.Count)"
             } else {
-                Report-Result "$NamePrefix/MatrixAPMapping" $false "unexpected response type: $($apGroups.GetType().Name)"
+                Write-Result "$NamePrefix/MatrixAPMapping" $false "unexpected response type: $($apGroups.GetType().Name)"
             }
         } catch {
-            Report-Result "$NamePrefix/MatrixAPMapping" $false $_.Exception.Message
+            Write-Result "$NamePrefix/MatrixAPMapping" $false $_.Exception.Message
         }
 
         # Group-nesting metadata — matrix toolbar uses this
         try {
             $nested = Invoke-LocalApi -Path '/groups-with-nested'
             if ($nested -and $nested.PSObject.Properties.Name -contains 'groupIds') {
-                Report-Result "$NamePrefix/MatrixGroupsWithNested" $true "groupIds=$(@($nested.groupIds).Count)"
+                Write-Result "$NamePrefix/MatrixGroupsWithNested" $true "groupIds=$(@($nested.groupIds).Count)"
             } else {
-                Report-Result "$NamePrefix/MatrixGroupsWithNested" $false 'response missing groupIds'
+                Write-Result "$NamePrefix/MatrixGroupsWithNested" $false 'response missing groupIds'
             }
         } catch {
-            Report-Result "$NamePrefix/MatrixGroupsWithNested" $false $_.Exception.Message
+            Write-Result "$NamePrefix/MatrixGroupsWithNested" $false $_.Exception.Message
         }
     } catch {
-        Report-Result "$NamePrefix/MatrixWorks" $false $_.Exception.Message
+        Write-Result "$NamePrefix/MatrixWorks" $false $_.Exception.Message
     }
 }
 
@@ -467,18 +467,18 @@ function Assert-BusinessRolesWork {
         $resp = Invoke-LocalApi -Path '/access-packages?limit=200'
         $rows = if ($resp -and $resp.data) { @($resp.data) } else { @() }
         if ($rows.Count -eq 0) {
-            Report-Result "$NamePrefix/BusinessRolesList" $false 'no rows returned'
+            Write-Result "$NamePrefix/BusinessRolesList" $false 'no rows returned'
             return
         }
-        Report-Result "$NamePrefix/BusinessRolesList" $true "rows=$($rows.Count)"
+        Write-Result "$NamePrefix/BusinessRolesList" $true "rows=$($rows.Count)"
 
         # At least one row should have totalAssignments >= MinAssignments
         $withAssign = @($rows | Where-Object { $_.totalAssignments -ge $MinAssignments })
         if ($withAssign.Count -gt 0) {
             $maxAssign = ($rows | Measure-Object -Property totalAssignments -Maximum).Maximum
-            Report-Result "$NamePrefix/BusinessRolesAssignments" $true "withAssign=$($withAssign.Count) max=$maxAssign"
+            Write-Result "$NamePrefix/BusinessRolesAssignments" $true "withAssign=$($withAssign.Count) max=$maxAssign"
         } else {
-            Report-Result "$NamePrefix/BusinessRolesAssignments" $false "no row has totalAssignments >= $MinAssignments (this was the April 2026 regression)"
+            Write-Result "$NamePrefix/BusinessRolesAssignments" $false "no row has totalAssignments >= $MinAssignments (this was the April 2026 regression)"
         }
 
         # Per-AP detail endpoint reachable for the first row
@@ -486,13 +486,13 @@ function Assert-BusinessRolesWork {
         try {
             $detail = Invoke-LocalApi -Path "/access-package/$firstId"
             if ($detail) {
-                Report-Result "$NamePrefix/BusinessRoleDetail" $true 'detail endpoint reachable'
+                Write-Result "$NamePrefix/BusinessRoleDetail" $true 'detail endpoint reachable'
             }
         } catch {
-            Report-Result "$NamePrefix/BusinessRoleDetail" $false $_.Exception.Message
+            Write-Result "$NamePrefix/BusinessRoleDetail" $false $_.Exception.Message
         }
     } catch {
-        Report-Result "$NamePrefix/BusinessRolesWork" $false $_.Exception.Message
+        Write-Result "$NamePrefix/BusinessRolesWork" $false $_.Exception.Message
     }
 }
 
@@ -512,10 +512,10 @@ function Assert-SyncLogShape {
         $entries = Invoke-LocalApi -Path '/sync-log?limit=50'
         $count = if ($entries -is [array]) { $entries.Count } else { 0 }
         if ($count -lt 1) {
-            Report-Result "$NamePrefix/SyncLogEntries" $false 'no entries'
+            Write-Result "$NamePrefix/SyncLogEntries" $false 'no entries'
             return
         }
-        Report-Result "$NamePrefix/SyncLogEntries" $true "entries=$count"
+        Write-Result "$NamePrefix/SyncLogEntries" $true "entries=$count"
 
         if ($ExpectFullCrawlerEntry) {
             # The Entra crawler script writes one EntraID-FullCrawl entry at the
@@ -524,21 +524,21 @@ function Assert-SyncLogShape {
             # data loader, CSV import) don't and shouldn't.
             $fullRows = @($entries | Where-Object { $_.SyncType -like '*FullCrawl*' -or $_.SyncType -like 'EntraID-*' })
             if ($fullRows.Count -gt 0) {
-                Report-Result "$NamePrefix/SyncLogFullCrawlerEntry" $true "found ($($fullRows[0].SyncType))"
+                Write-Result "$NamePrefix/SyncLogFullCrawlerEntry" $true "found ($($fullRows[0].SyncType))"
             } else {
-                Report-Result "$NamePrefix/SyncLogFullCrawlerEntry" $false 'no EntraID-FullCrawl entry — crawler did not write end-of-sync log row'
+                Write-Result "$NamePrefix/SyncLogFullCrawlerEntry" $false 'no EntraID-FullCrawl entry — crawler did not write end-of-sync log row'
             }
         }
 
         # All entries should have a numeric DurationSeconds (the UI formats it h/m/s)
         $bad = @($entries | Where-Object { $null -eq $_.DurationSeconds })
         if ($bad.Count -eq 0) {
-            Report-Result "$NamePrefix/SyncLogDurations" $true 'all rows have DurationSeconds'
+            Write-Result "$NamePrefix/SyncLogDurations" $true 'all rows have DurationSeconds'
         } else {
-            Report-Result "$NamePrefix/SyncLogDurations" $false "$($bad.Count) rows missing DurationSeconds"
+            Write-Result "$NamePrefix/SyncLogDurations" $false "$($bad.Count) rows missing DurationSeconds"
         }
     } catch {
-        Report-Result "$NamePrefix/SyncLogShape" $false $_.Exception.Message
+        Write-Result "$NamePrefix/SyncLogShape" $false $_.Exception.Message
     }
 }
 
@@ -566,20 +566,20 @@ function Assert-PostSyncEndpoints {
         try {
             $r = Invoke-LocalApi -Path $ep.Path
             if ($null -eq $r) {
-                Report-Result "$NamePrefix/Endpoint$($ep.Path)" $false 'null response'
+                Write-Result "$NamePrefix/Endpoint$($ep.Path)" $false 'null response'
                 continue
             }
             if ($ep.Field) {
                 if ($r.PSObject.Properties.Name -contains $ep.Field) {
-                    Report-Result "$NamePrefix/Endpoint$($ep.Path)" $true "has $($ep.Field)"
+                    Write-Result "$NamePrefix/Endpoint$($ep.Path)" $true "has $($ep.Field)"
                 } else {
-                    Report-Result "$NamePrefix/Endpoint$($ep.Path)" $false "missing field $($ep.Field)"
+                    Write-Result "$NamePrefix/Endpoint$($ep.Path)" $false "missing field $($ep.Field)"
                 }
             } else {
-                Report-Result "$NamePrefix/Endpoint$($ep.Path)" $true 'reachable'
+                Write-Result "$NamePrefix/Endpoint$($ep.Path)" $true 'reachable'
             }
         } catch {
-            Report-Result "$NamePrefix/Endpoint$($ep.Path)" $false $_.Exception.Message
+            Write-Result "$NamePrefix/Endpoint$($ep.Path)" $false $_.Exception.Message
         }
     }
 }
@@ -591,7 +591,7 @@ foreach ($scenario in $Scenarios) {
         'Validate-Only' {
             # Already covered by pre-flight above. Recording as an explicit
             # entry too so it shows up under each run for traceability.
-            Report-Result 'EntraID/Validate-Only/Scenario' $true 'covered by pre-flight'
+            Write-Result 'EntraID/Validate-Only/Scenario' $true 'covered by pre-flight'
         }
 
         'Identity-Only' {
@@ -605,9 +605,9 @@ foreach ($scenario in $Scenarios) {
                     # identities endpoint is queryable instead.
                     try {
                         Invoke-LocalApi -Path '/identities?pageSize=1' | Out-Null
-                        Report-Result 'EntraID/Identity-Only/IdentitiesQueryable' $true ''
+                        Write-Result 'EntraID/Identity-Only/IdentitiesQueryable' $true ''
                     } catch {
-                        Report-Result 'EntraID/Identity-Only/IdentitiesQueryable' $false $_.Exception.Message
+                        Write-Result 'EntraID/Identity-Only/IdentitiesQueryable' $false $_.Exception.Message
                     }
                 }
         }
@@ -661,12 +661,12 @@ foreach ($scenario in $Scenarios) {
                         $usersPage = Invoke-LocalApi -Path '/users?limit=2000'
                         $spCount = @($usersPage.data | Where-Object { $_.principalType -eq 'ServicePrincipal' -or $_.principalType -eq 'ManagedIdentity' -or $_.principalType -eq 'AIAgent' }).Count
                         if ($spCount -ge 1) {
-                            Report-Result 'EntraID/Full-Sync/ServicePrincipals' $true "spCount=$spCount"
+                            Write-Result 'EntraID/Full-Sync/ServicePrincipals' $true "spCount=$spCount"
                         } else {
-                            Report-Result 'EntraID/Full-Sync/ServicePrincipals' $false 'no principals with principalType in (ServicePrincipal,ManagedIdentity,AIAgent)'
+                            Write-Result 'EntraID/Full-Sync/ServicePrincipals' $false 'no principals with principalType in (ServicePrincipal,ManagedIdentity,AIAgent)'
                         }
                     } catch {
-                        Report-Result 'EntraID/Full-Sync/ServicePrincipals' $false $_.Exception.Message
+                        Write-Result 'EntraID/Full-Sync/ServicePrincipals' $false $_.Exception.Message
                     }
 
                     # OAuth2 delegated grants — best-effort: prove the
@@ -682,9 +682,9 @@ foreach ($scenario in $Scenarios) {
                     # zero eligible rows, which is correct.
                     try {
                         Invoke-LocalApi -Path '/permissions?userLimit=1' | Out-Null
-                        Report-Result 'EntraID/Full-Sync/PimEndpoint' $true 'permissions endpoint queryable'
+                        Write-Result 'EntraID/Full-Sync/PimEndpoint' $true 'permissions endpoint queryable'
                     } catch {
-                        Report-Result 'EntraID/Full-Sync/PimEndpoint' $false $_.Exception.Message
+                        Write-Result 'EntraID/Full-Sync/PimEndpoint' $false $_.Exception.Message
                     }
 
                     # App roles — the crawler now imports enterprise apps +
@@ -712,12 +712,12 @@ foreach ($scenario in $Scenarios) {
                     try {
                         $ts = Invoke-LocalApi -Path '/admin/dashboard-timeseries?days=30'
                         if ($null -ne $ts.days -and $null -ne $ts.data) {
-                            Report-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $true "days=$($ts.days) rows=$(@($ts.data).Count)"
+                            Write-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $true "days=$($ts.days) rows=$(@($ts.data).Count)"
                         } else {
-                            Report-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $false 'response missing days or data fields'
+                            Write-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $false 'response missing days or data fields'
                         }
                     } catch {
-                        Report-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $false $_.Exception.Message
+                        Write-Result 'EntraID/Full-Sync/DashboardTimeseriesEndpoint' $false $_.Exception.Message
                     }
 
                     # /identities/by-user smoke — the secondary query in this
@@ -733,15 +733,15 @@ foreach ($scenario in $Scenarios) {
                             $principalId = $page.data[0].primaryAccountId
                             if ($principalId) {
                                 Invoke-LocalApi -Path "/identities/by-user/$principalId" | Out-Null
-                                Report-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $true 'by-user returned 200'
+                                Write-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $true 'by-user returned 200'
                             } else {
-                                Report-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $true 'no primaryAccountId on first identity — skipped'
+                                Write-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $true 'no primaryAccountId on first identity — skipped'
                             }
                         } else {
-                            Report-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $true 'no identities in this run — skipped'
+                            Write-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $true 'no identities in this run — skipped'
                         }
                     } catch {
-                        Report-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $false $_.Exception.Message
+                        Write-Result 'EntraID/Full-Sync/IdentityByUserEndpoint' $false $_.Exception.Message
                     }
 
                     # Matrix badge invariant — after migration 025, the matrix
@@ -755,12 +755,12 @@ foreach ($scenario in $Scenarios) {
                         $seen = @($perm.data | ForEach-Object { $_.membershipType } | Where-Object { $_ } | Select-Object -Unique)
                         $bad = @($seen | Where-Object { $allowed -notcontains $_ })
                         if ($bad.Count -eq 0) {
-                            Report-Result 'EntraID/Full-Sync/MatrixBadgeInvariant' $true "membershipTypes=$($seen -join ',')"
+                            Write-Result 'EntraID/Full-Sync/MatrixBadgeInvariant' $true "membershipTypes=$($seen -join ',')"
                         } else {
-                            Report-Result 'EntraID/Full-Sync/MatrixBadgeInvariant' $false "matview leaked source-attribute types: $($bad -join ',')"
+                            Write-Result 'EntraID/Full-Sync/MatrixBadgeInvariant' $false "matview leaked source-attribute types: $($bad -join ',')"
                         }
                     } catch {
-                        Report-Result 'EntraID/Full-Sync/MatrixBadgeInvariant' $false $_.Exception.Message
+                        Write-Result 'EntraID/Full-Sync/MatrixBadgeInvariant' $false $_.Exception.Message
                     }
 
                     # Deep regression checks. These exist because the naive
@@ -791,9 +791,9 @@ foreach ($scenario in $Scenarios) {
                     # users with employeeId. We just verify the endpoint responds.
                     try {
                         Invoke-LocalApi -Path '/identities?pageSize=1' | Out-Null
-                        Report-Result 'EntraID/With-Identity-Filter/IdentitiesQueryable' $true ''
+                        Write-Result 'EntraID/With-Identity-Filter/IdentitiesQueryable' $true ''
                     } catch {
-                        Report-Result 'EntraID/With-Identity-Filter/IdentitiesQueryable' $false $_.Exception.Message
+                        Write-Result 'EntraID/With-Identity-Filter/IdentitiesQueryable' $false $_.Exception.Message
                     }
                 }
         }

--- a/tools/crawlers/midpoint/MidpointCrawler.Phases.ps1
+++ b/tools/crawlers/midpoint/MidpointCrawler.Phases.ps1
@@ -143,7 +143,7 @@ function Sync-MidpointOrgs {
         $raw = @($orgs | ForEach-Object {
             ConvertTo-MidpointOrgContextRecord -Org $_ -OrgContextMapping $OrgContextMapping -SystemId $MidpointSystemId
         } | Where-Object { $_.id -and $_.displayName })
-        $records = Sort-MidpointContextsTopologically -Records $raw
+        $records = Get-MidpointContextsInTopologicalOrder -Records $raw
 
         # Scope the reconcile by variant + scopeSystemId only (a single sync can emit
         # several context types under org->contextType remapping; the crawler owns

--- a/tools/crawlers/midpoint/MidpointCrawler.Transform.ps1
+++ b/tools/crawlers/midpoint/MidpointCrawler.Transform.ps1
@@ -103,7 +103,7 @@ function ConvertTo-MidpointOrgContextRecord {
 # Topologically sorts context records so a parent precedes its children. A parent
 # OID outside the synced set is treated as a root (its parentContextId is nulled
 # out to avoid an FK violation). Verbatim from the inline Orgs-phase sort.
-function Sort-MidpointContextsTopologically {
+function Get-MidpointContextsInTopologicalOrder {
     [CmdletBinding()]
     param($Records)
     $recs      = @($Records)

--- a/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
+++ b/tools/crawlers/midpoint/Test-MidpointCrawler.ps1
@@ -128,29 +128,29 @@ try {
         $cfg = Invoke-AtlasApi -Method POST -Path '/admin/crawler-configs' -Body @{ crawlerType = 'midpoint'; displayName = "midpoint-it-$runTag"; config = $config }
         $configId = $cfg.id
         Write-Host "  Crawler config registered: $configId" -ForegroundColor Gray
-    } catch { Report-Result 'Midpoint/Setup — register crawler config' $false $_.Exception.Message; throw }
+    } catch { Write-Result 'Midpoint/Setup — register crawler config' $false $_.Exception.Message; throw }
 
     $job = Invoke-AtlasApi -Method POST -Path '/admin/crawler-jobs' -Body @{ jobType = 'midpoint'; configId = $configId }
     Write-Host "  Job queued: $($job.id)" -ForegroundColor Gray
 
     $completed = Wait-JobComplete -JobId $job.id -TimeoutSec 120
-    if ($null -eq $completed) { Report-Result 'Midpoint/Job — completed within 120s' $false '(timed out)'; throw 'Job timed out' }
-    Report-Result 'Midpoint/Job — completed successfully' ($completed.status -eq 'completed') "(status: $($completed.status))"
+    if ($null -eq $completed) { Write-Result 'Midpoint/Job — completed within 120s' $false '(timed out)'; throw 'Job timed out' }
+    Write-Result 'Midpoint/Job — completed successfully' ($completed.status -eq 'completed') "(status: $($completed.status))"
 
     # ── Assert: midPoint system registered (identified by the unique mock port) ──
     $thisSystem = $null
     try {
         $systems    = Invoke-RestMethod -Uri "$ApiBaseUrl/systems" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
         $thisSystem = @($systems) | Where-Object { $_.displayName -like "*:$($mock.Port)*" } | Select-Object -First 1
-        Report-Result 'Midpoint/Data — system registered' ($null -ne $thisSystem) "$(if ($thisSystem) { "($($thisSystem.displayName))" } else { '(not found)' })"
-    } catch { Report-Result 'Midpoint/Data — system registered' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — system registered' ($null -ne $thisSystem) "$(if ($thisSystem) { "($($thisSystem.displayName))" } else { '(not found)' })"
+    } catch { Write-Result 'Midpoint/Data — system registered' $false $_.Exception.Message }
 
     # ── Assert: user principal ingested (unique email) ──
     try {
         $usersResp = Invoke-RestMethod -Uri "$ApiBaseUrl/users?search=midpoint.citest&limit=5" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
         $cnt = if ($usersResp.users) { $usersResp.users.Count } elseif ($usersResp.data) { $usersResp.data.Count } elseif ($usersResp -is [array]) { $usersResp.Count } else { 0 }
-        Report-Result 'Midpoint/Data — user principal ingested' ($cnt -ge 1) "($cnt matching 'midpoint.citest')"
-    } catch { Report-Result 'Midpoint/Data — user principal ingested' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — user principal ingested' ($cnt -ge 1) "($cnt matching 'midpoint.citest')"
+    } catch { Write-Result 'Midpoint/Data — user principal ingested' $false $_.Exception.Message }
 
     # ── Assert: department derived from the user's org membership (parentOrgRef → org name) ──
     # The mock user sits in 'midPoint CI Org' via parentOrgRef; Resolve-MidpointDepartment
@@ -161,16 +161,16 @@ try {
         $focus     = @($ident.members) | Where-Object { $_.principalId -eq $userOid } | Select-Object -First 1
         $princDept = if ($focus) { $focus.department } else { $null }
         $ok = ($identDept -eq 'midPoint CI Org') -and ($princDept -eq 'midPoint CI Org')
-        Report-Result 'Midpoint/Data — department from org membership (Identity + Principal)' $ok "(identity: '$identDept', principal: '$princDept'; expected 'midPoint CI Org')"
-    } catch { Report-Result 'Midpoint/Data — department from org membership (Identity + Principal)' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — department from org membership (Identity + Principal)' $ok "(identity: '$identDept', principal: '$princDept'; expected 'midPoint CI Org')"
+    } catch { Write-Result 'Midpoint/Data — department from org membership (Identity + Principal)' $false $_.Exception.Message }
 
     # ── Assert: role resource ingested (scoped to this run's system) ──
     try {
         $sid = if ($thisSystem) { $thisSystem.id } else { 0 }
         $res = Invoke-RestMethod -Uri "$ApiBaseUrl/resources?systemId=$sid&limit=20" -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
         $rcnt = if ($res.data) { $res.data.Count } elseif ($res -is [array]) { $res.Count } else { 0 }
-        Report-Result 'Midpoint/Data — resource ingested' ($rcnt -ge 1) "($rcnt resource(s) in system $sid)"
-    } catch { Report-Result 'Midpoint/Data — resource ingested' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — resource ingested' ($rcnt -ge 1) "($rcnt resource(s) in system $sid)"
+    } catch { Write-Result 'Midpoint/Data — resource ingested' $false $_.Exception.Message }
 
     # ── Assert: entitlement shadow became a Resource (Entitlement), not a user ──
     try {
@@ -183,8 +183,8 @@ try {
         $ents = @($list) | Where-Object { $_.resourceType -eq 'Entitlement' }
         # Two entitlements expected: one reached via legacy association[], one via 4.9
         # referenceAttributes.group[]. Both code paths must have produced a resource.
-        Report-Result 'Midpoint/Data — entitlements mapped as resources (assoc + referenceAttributes)' ($ents.Count -ge 2) "($($ents.Count) Entitlement resource(s) in system $resSid; expected >= 2)"
-    } catch { Report-Result 'Midpoint/Data — entitlement mapped as resource' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — entitlements mapped as resources (assoc + referenceAttributes)' ($ents.Count -ge 2) "($($ents.Count) Entitlement resource(s) in system $resSid; expected >= 2)"
+    } catch { Write-Result 'Midpoint/Data — entitlement mapped as resource' $false $_.Exception.Message }
 
     # ── Assert: inherited role membership imported as a Direct membership ──
     # The user is only DIRECTLY assigned $roleOid, but midPoint's roleMembershipRef also
@@ -197,8 +197,8 @@ try {
         $inhHit = @($inhAssign) | Where-Object { $_.principalId -eq $userOid -and $_.assignmentType -eq 'Direct' }
         $mgrHit = @($mgrAssign) | Where-Object { $_.principalId -eq $userOid }
         $ok = ($inhHit.Count -ge 1) -and ($mgrHit.Count -eq 0)
-        Report-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $ok "(inherited: $($inhHit.Count) Direct; manager: $($mgrHit.Count) — expected inherited>=1, manager=0)"
-    } catch { Report-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $ok "(inherited: $($inhHit.Count) Direct; manager: $($mgrHit.Count) — expected inherited>=1, manager=0)"
+    } catch { Write-Result 'Midpoint/Data — inherited role membership imported (manager relation excluded)' $false $_.Exception.Message }
 
     # ── Assert: construction inducements became Contains edges (role → entitlements) ──
     # The role grants two AD groups via construction: $entOid by associationTargetSearch DN
@@ -210,8 +210,8 @@ try {
         $searchHit  = @($brSearch)  | Where-Object { $_.businessRoleId -eq $roleOid }
         $literalHit = @($brLiteral) | Where-Object { $_.businessRoleId -eq $roleOid }
         $ok = ($searchHit.Count -ge 1) -and ($literalHit.Count -ge 1)
-        Report-Result 'Midpoint/Data — construction inducements → Contains edges (associationTargetSearch + shadowRef)' $ok "(targetSearch: $($searchHit.Count), shadowRef: $($literalHit.Count) — both expected >= 1)"
-    } catch { Report-Result 'Midpoint/Data — construction inducements → Contains edges (associationTargetSearch + shadowRef)' $false $_.Exception.Message }
+        Write-Result 'Midpoint/Data — construction inducements → Contains edges (associationTargetSearch + shadowRef)' $ok "(targetSearch: $($searchHit.Count), shadowRef: $($literalHit.Count) — both expected >= 1)"
+    } catch { Write-Result 'Midpoint/Data — construction inducements → Contains edges (associationTargetSearch + shadowRef)' $false $_.Exception.Message }
 
 } catch {
     Write-Host "  Fatal test error: $($_.Exception.Message)" -ForegroundColor Red

--- a/tools/crawlers/odata/Test-ODataCrawler.ps1
+++ b/tools/crawlers/odata/Test-ODataCrawler.ps1
@@ -80,9 +80,9 @@ try {
             Connect-ODataAPI -BaseUrl $baseUrl -AuthMethod $case.Method @extraParams
             $result = Invoke-ODataGetRequest -Path '/TestEntities'
             $passed = $null -ne $result -and $result.Count -gt 0
-            Report-Result "OData/$($case.Method) — auth + data fetch" $passed "($($result.Count) entities returned)"
+            Write-Result "OData/$($case.Method) — auth + data fetch" $passed "($($result.Count) entities returned)"
         } catch {
-            Report-Result "OData/$($case.Method) — auth + data fetch" $false $_.Exception.Message
+            Write-Result "OData/$($case.Method) — auth + data fetch" $false $_.Exception.Message
         }
     }
 
@@ -92,9 +92,9 @@ try {
         Connect-ODataAPI -BaseUrl $baseUrl -AuthMethod BasicAuth -Username testuser -Password testpass
         $result = Invoke-ODataGetRequest -Path '/Paginated'
         $passed = $null -ne $result -and $result.Count -eq 2
-        Report-Result 'OData/Pagination — @odata.nextLink followed' $passed "($($result.Count) total entities across pages)"
+        Write-Result 'OData/Pagination — @odata.nextLink followed' $passed "($($result.Count) total entities across pages)"
     } catch {
-        Report-Result 'OData/Pagination — @odata.nextLink followed' $false $_.Exception.Message
+        Write-Result 'OData/Pagination — @odata.nextLink followed' $false $_.Exception.Message
     }
 
     # ── 401 error handling ────────────────────────────────────────────────────
@@ -103,9 +103,9 @@ try {
     try {
         Connect-ODataAPI -BaseUrl $baseUrl -AuthMethod ApiToken -ApiToken 'mock-api-token'
         Invoke-ODataGetRequest -Path '/TestEntities' -MaxRetries 0 | Out-Null
-        Report-Result 'OData/Error — 401 throws exception' $false '(expected throw, but succeeded)'
+        Write-Result 'OData/Error — 401 throws exception' $false '(expected throw, but succeeded)'
     } catch {
-        Report-Result 'OData/Error — 401 throws exception' $true "($($_.Exception.Message.Split('.')[0]))"
+        Write-Result 'OData/Error — 401 throws exception' $true "($($_.Exception.Message.Split('.')[0]))"
     }
     Set-MockControl @{ reset = $true }
 
@@ -123,10 +123,10 @@ try {
             -TokenEndpoint "http://localhost:$($mock.Port)/oauth/token"
         $result = Invoke-ODataGetRequest -Path '/TestEntities'
         $passed = $null -ne $result -and $result.Count -gt 0
-        Report-Result 'OData/TokenRefresh — OAuth2CC proactive refresh on expired token' $passed `
+        Write-Result 'OData/TokenRefresh — OAuth2CC proactive refresh on expired token' $passed `
             "($($result.Count) entities returned after auto-refresh)"
     } catch {
-        Report-Result 'OData/TokenRefresh — OAuth2CC proactive refresh on expired token' $false $_.Exception.Message
+        Write-Result 'OData/TokenRefresh — OAuth2CC proactive refresh on expired token' $false $_.Exception.Message
     } finally {
         Set-MockControl @{ reset = $true }   # restore default token TTL for remaining tests
     }
@@ -136,9 +136,9 @@ try {
         Connect-ODataAPI -BaseUrl $baseUrl -AuthMethod BasicAuth -Username testuser -Password testpass
         $result = Invoke-ODataPagedRequest -Path '/Items' -PageSize 2
         $passed = $null -ne $result -and $result.Count -eq 3
-        Report-Result 'OData/Pagination — $skip walk (Invoke-ODataPagedRequest)' $passed "($($result.Count) total entities)"
+        Write-Result 'OData/Pagination — $skip walk (Invoke-ODataPagedRequest)' $passed "($($result.Count) total entities)"
     } catch {
-        Report-Result 'OData/Pagination — $skip walk (Invoke-ODataPagedRequest)' $false $_.Exception.Message
+        Write-Result 'OData/Pagination — $skip walk (Invoke-ODataPagedRequest)' $false $_.Exception.Message
     }
 
 } finally {
@@ -157,9 +157,9 @@ try {
         $passed = $null -ne $result -and $result -is [array] -and $result.Count -eq 0
         $detail = if ($null -eq $result) { '(null — function returned $null for empty collection)' }
                   else { "(type: $($result.GetType().Name), count: $($result.Count))" }
-        Report-Result 'OData/EdgeCase — empty value array returns empty array (not null/throw)' $passed $detail
+        Write-Result 'OData/EdgeCase — empty value array returns empty array (not null/throw)' $passed $detail
     } catch {
-        Report-Result 'OData/EdgeCase — empty value array returns empty array (not null/throw)' $false $_.Exception.Message
+        Write-Result 'OData/EdgeCase — empty value array returns empty array (not null/throw)' $false $_.Exception.Message
     }
 } finally {
     if ($mock) { Stop-MockODataServer -Mock $mock }
@@ -174,10 +174,10 @@ try {
     try {
         $sets = Get-ODataEntitySets
         $passed = $sets -contains 'Users' -and $sets -contains 'Roles'
-        Report-Result 'OData/EntitySets — $metadata discovery' $passed `
+        Write-Result 'OData/EntitySets — $metadata discovery' $passed `
             "($($sets.Count) entity sets: $($sets -join ', '))"
     } catch {
-        Report-Result 'OData/EntitySets — $metadata discovery' $false $_.Exception.Message
+        Write-Result 'OData/EntitySets — $metadata discovery' $false $_.Exception.Message
     }
 } finally {
     if ($mock) { Stop-MockODataServer -Mock $mock }

--- a/tools/crawlers/omada/OmadaCrawler.Functions.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Functions.ps1
@@ -11,7 +11,7 @@
 
 #region Functions
 
-function Map-ResourceCategory {
+function ConvertTo-AtlasResourceCategory {
     [CmdletBinding()]
     param([string]$Category)
     foreach ($M in $ResourceCategoryMapping) {
@@ -55,7 +55,7 @@ function Merge-OmadaOverrideValue {
     return $Override
 }
 
-function Map-IdentityTypeToAtlas {
+function ConvertTo-AtlasIdentityType {
     [CmdletBinding()]
     param([string]$OmadaType)
     $Map = $TypeMappings['identityTypeToIdentityAtlas']
@@ -64,7 +64,7 @@ function Map-IdentityTypeToAtlas {
     return 'User'
 }
 
-function Map-ResourceTypeToAtlas {
+function ConvertTo-AtlasResourceType {
     [CmdletBinding()]
     param([string]$OmadaType)
     $Map = $TypeMappings['resourceTypeToIdentityAtlas']
@@ -73,7 +73,7 @@ function Map-ResourceTypeToAtlas {
     return $OmadaType -replace '\s+', ''
 }
 
-function Map-ContextTypeToAtlas {
+function ConvertTo-AtlasContextType {
     [CmdletBinding()]
     param([string]$OmadaType)
     $Map = $TypeMappings['contextTypeToIdentityAtlas']

--- a/tools/crawlers/omada/OmadaCrawler.Phases.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Phases.ps1
@@ -212,7 +212,7 @@ function Sync-OmadaContexts {
                 $RawRecords = @($Items | ForEach-Object {
                     ConvertTo-OmadaOrgUnitContextRecord -OrgUnit $_ -DefaultContextType $ContextType
                 } | Where-Object { $_.externalId -and $_.displayName })
-                $Records = Sort-OmadaContextsTopologically -Records $RawRecords
+                $Records = Get-OmadaContextsInTopologicalOrder -Records $RawRecords
             } else {
                 $Records = @($Items | ForEach-Object {
                     ConvertTo-OmadaFlatContextRecord -Item $_ -ContextType $ContextType

--- a/tools/crawlers/omada/OmadaCrawler.Transform.ps1
+++ b/tools/crawlers/omada/OmadaCrawler.Transform.ps1
@@ -91,7 +91,7 @@ function ConvertTo-OmadaIdentityRecord {
 }
 
 # Maps one Omada Orgunit entity → a synced context record, carrying the parent
-# hierarchy link. Map-ContextTypeToAtlas (OmadaCrawler.Functions.ps1) resolves the
+# hierarchy link. ConvertTo-AtlasContextType (OmadaCrawler.Functions.ps1) resolves the
 # context type. Verbatim from the inline Orgunit `ForEach-Object { ... }` block.
 function ConvertTo-OmadaOrgUnitContextRecord {
     [CmdletBinding()]
@@ -99,7 +99,7 @@ function ConvertTo-OmadaOrgUnitContextRecord {
         [Parameter(Mandatory)] $OrgUnit,
         [string]$DefaultContextType
     )
-    $CtxType   = Map-ContextTypeToAtlas -OmadaType (Get-OmadaRefValue -Ref $OrgUnit.OUTYPE -Fallback $DefaultContextType)
+    $CtxType   = ConvertTo-AtlasContextType -OmadaType (Get-OmadaRefValue -Ref $OrgUnit.OUTYPE -Fallback $DefaultContextType)
     $ParentUid = Get-OmadaRefUid -Ref $OrgUnit.PARENTOU
     return [PSCustomObject]@{
         id              = [string]$OrgUnit.UId
@@ -133,7 +133,7 @@ function ConvertTo-OmadaFlatContextRecord {
 # Topologically sorts context records so a parent always precedes its children
 # (records with an unresolved/absent parent come first). Any records left in a
 # cycle after MaxPasses are appended as-is. Verbatim from the inline sort.
-function Sort-OmadaContextsTopologically {
+function Get-OmadaContextsInTopologicalOrder {
     [CmdletBinding()]
     param($Records)
     $Sorted    = [System.Collections.Generic.List[object]]::new()
@@ -157,7 +157,7 @@ function Sort-OmadaContextsTopologically {
 
 # Maps one Omada User entity → an ingest/principals record, resolving principalType
 # from the linked Identity's type via $IdentityLookup (IDENTITYID -> { uid; identityType })
-# and Map-IdentityTypeToAtlas. Verbatim from the inline account `ForEach-Object`.
+# and ConvertTo-AtlasIdentityType. Verbatim from the inline account `ForEach-Object`.
 function ConvertTo-OmadaAccountRecord {
     [CmdletBinding()]
     param(
@@ -171,7 +171,7 @@ function ConvertTo-OmadaAccountRecord {
     $PrincipalType = 'User'
     $IdentId = if ($Account.IDENTITYREF) { [string]$Account.IDENTITYREF.IDENTITYID } else { $Null }
     if ($IdentId -and $IdentityLookup.ContainsKey($IdentId)) {
-        $PrincipalType = Map-IdentityTypeToAtlas -OmadaType $IdentityLookup[$IdentId].identityType
+        $PrincipalType = ConvertTo-AtlasIdentityType -OmadaType $IdentityLookup[$IdentId].identityType
     }
 
     return [PSCustomObject]@{
@@ -209,7 +209,7 @@ function ConvertTo-OmadaIdentityMemberRecord {
 }
 
 # Maps one Omada Resource entity → an ingest/resources record, or $null when it has
-# no UId/name. Map-ResourceCategory (OmadaCrawler.Functions.ps1) resolves the Atlas
+# no UId/name. ConvertTo-AtlasResourceCategory (OmadaCrawler.Functions.ps1) resolves the Atlas
 # resourceType; $UserGroupMap resolves USERGROUPREF -> display name. The caller keeps
 # the system-grouping. Verbatim from the inline `foreach ($Item in $AllResources)`.
 function ConvertTo-OmadaResourceRecord {
@@ -219,7 +219,7 @@ function ConvertTo-OmadaResourceRecord {
         [hashtable]$UserGroupMap = @{}
     )
     $OmadaCat   = Get-OmadaEnumStr $Resource.ROLECATEGORY
-    $AtlasType  = Map-ResourceCategory -Category $OmadaCat
+    $AtlasType  = ConvertTo-AtlasResourceCategory -Category $OmadaCat
     $SysName    = Get-OmadaRefValue -Ref $Resource.SYSTEMREF   -Fallback ''
     $RoleType   = Get-OmadaRefValue -Ref $Resource.ROLETYPEREF -Fallback ''
     $FolderName = Get-OmadaRefValue -Ref $Resource.ROLEFOLDER  -Fallback ''

--- a/tools/crawlers/omada/Test-OmadaCrawler.ps1
+++ b/tools/crawlers/omada/Test-OmadaCrawler.ps1
@@ -146,7 +146,7 @@ try {
         $configId = $cfgResult.id
         Write-Host "  Crawler config registered: $configId" -ForegroundColor Gray
     } catch {
-        Report-Result 'Omada/Setup — register crawler config' $false $_.Exception.Message
+        Write-Result 'Omada/Setup — register crawler config' $false $_.Exception.Message
         throw
     }
 
@@ -159,19 +159,19 @@ try {
         }
         Write-Host "  Job queued: $($job.id)" -ForegroundColor Gray
     } catch {
-        Report-Result 'Omada/Setup — queue crawler job' $false $_.Exception.Message
+        Write-Result 'Omada/Setup — queue crawler job' $false $_.Exception.Message
         throw
     }
 
     # ── Wait for completion ───────────────────────────────────────────────────
     $completed = Wait-JobComplete -JobId $job.id -TimeoutSec 120
     if ($null -eq $completed) {
-        Report-Result 'Omada/Job — completed within 120s' $false '(timed out)'
+        Write-Result 'Omada/Job — completed within 120s' $false '(timed out)'
         throw 'Job timed out'
     }
 
     $passed = $completed.status -eq 'completed'
-    Report-Result 'Omada/Job — completed successfully' $passed "(status: $($completed.status))"
+    Write-Result 'Omada/Job — completed successfully' $passed "(status: $($completed.status))"
 
     if (-not $passed) {
         Write-Host "  Job log: $ApiBaseUrl/admin/crawler-jobs/$($job.id)/log" -ForegroundColor Yellow
@@ -188,10 +188,10 @@ try {
         $systems = Invoke-RestMethod -Uri "$ApiBaseUrl/systems" `
             -Headers @{ Authorization = "Bearer $ApiKey" } -ErrorAction Stop
         $thisSystem = @($systems) | Where-Object { $_.displayName -like "*:$($mock.Port)/*" } | Select-Object -First 1
-        Report-Result 'Omada/Data — system registered' ($null -ne $thisSystem) `
+        Write-Result 'Omada/Data — system registered' ($null -ne $thisSystem) `
             "$(if ($thisSystem) { "($($thisSystem.displayName))" } else { '(not found — port $($mock.Port) not in any system displayName)' })"
     } catch {
-        Report-Result 'Omada/Data — system registered' $false $_.Exception.Message
+        Write-Result 'Omada/Data — system registered' $false $_.Exception.Message
     }
 
     # Diagnostic: log the systems API's own principalCount/resourceCount so we can
@@ -211,10 +211,10 @@ try {
                           elseif ($usersResp.data)        { $usersResp.data.Count }
                           elseif ($usersResp -is [array]) { $usersResp.Count }
                           else { 0 }
-        Report-Result 'Omada/Data — principal ingested' ($principalCount -ge 1) `
+        Write-Result 'Omada/Data — principal ingested' ($principalCount -ge 1) `
             "($principalCount user(s) matching 'integration.testuser')"
     } catch {
-        Report-Result 'Omada/Data — principal ingested' $false $_.Exception.Message
+        Write-Result 'Omada/Data — principal ingested' $false $_.Exception.Message
     }
 
     # ── Assert: resource ingested (scoped to this run's system via systemId) ───
@@ -226,10 +226,10 @@ try {
         $resourceCount = if ($resResp.data)           { $resResp.data.Count }
                          elseif ($resResp -is [array]) { $resResp.Count }
                          else { 0 }
-        Report-Result 'Omada/Data — resource ingested' ($resourceCount -ge 1) `
+        Write-Result 'Omada/Data — resource ingested' ($resourceCount -ge 1) `
             "($resourceCount resource(s) in system $systemId)"
     } catch {
-        Report-Result 'Omada/Data — resource ingested' $false $_.Exception.Message
+        Write-Result 'Omada/Data — resource ingested' $false $_.Exception.Message
     }
 
     # ── Assert: sync log entry created ───────────────────────────────────────
@@ -239,10 +239,10 @@ try {
         $syncEntries = if ($syncLog -is [array]) { $syncLog.Count }
                        elseif ($syncLog.data) { $syncLog.data.Count }
                        else { 0 }
-        Report-Result 'Omada/Data — sync log entry created' ($syncEntries -ge 1) `
+        Write-Result 'Omada/Data — sync log entry created' ($syncEntries -ge 1) `
             "($syncEntries sync log entries)"
     } catch {
-        Report-Result 'Omada/Data — sync log entry created' $false $_.Exception.Message
+        Write-Result 'Omada/Data — sync log entry created' $false $_.Exception.Message
     }
 
     # ── Test: partial failure (mock returns 500 mid-crawl) ────────────────────
@@ -275,10 +275,10 @@ try {
         }
         $completed2 = Wait-JobComplete -JobId $job2.id -TimeoutSec 60
         $pfPassed = ($null -ne $completed2) -and ($completed2.status -eq 'failed')
-        Report-Result 'Omada/Error — partial failure (500 mid-crawl) detected' $pfPassed `
+        Write-Result 'Omada/Error — partial failure (500 mid-crawl) detected' $pfPassed `
             "(status: $($completed2.status))"
     } catch {
-        Report-Result 'Omada/Error — partial failure setup' $false $_.Exception.Message
+        Write-Result 'Omada/Error — partial failure setup' $false $_.Exception.Message
     } finally {
         # Reset mock to normal state for any tests that might follow
         try {

--- a/tools/crawlers/shared/Test-Helpers.ps1
+++ b/tools/crawlers/shared/Test-Helpers.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Dot-source this file from any Test-*.ps1 script that needs the
-    Report-Result helper. Expects $WriteResult (scriptblock or $null) and
+    Write-Result helper. Expects $WriteResult (scriptblock or $null) and
     $script:standaloneFailures to be defined in the caller's scope.
 
     Usage:
@@ -14,7 +14,7 @@
 [CmdletBinding()]
 param()
 
-function Report-Result {
+function Write-Result {
     param([string]$Name, [bool]$Passed, [string]$Detail = '')
     $color  = if ($Passed) { 'Green' } else { 'Red' }
     $status = if ($Passed) { 'PASS' } else { 'FAIL' }


### PR DESCRIPTION
Closes #601.

`PSUseApprovedVerbs` was in the PSScriptAnalyzer `excludeRules`, so unapproved-verb function names went unflagged. This renames every offender (definitions **and** all call sites + unit tests) to an approved verb, then removes the rule from `excludeRules` so future unapproved verbs fail CI.

### Renames (behaviour-preserving)
| Old | New | Rationale |
|-----|-----|-----------|
| `Map-ResourceCategory` | `ConvertTo-AtlasResourceCategory` | `ConvertTo-` is the repo's transform-helper idiom |
| `Map-IdentityTypeToAtlas` | `ConvertTo-AtlasIdentityType` | |
| `Map-ResourceTypeToAtlas` | `ConvertTo-AtlasResourceType` | |
| `Map-ContextTypeToAtlas` | `ConvertTo-AtlasContextType` | |
| `Ensure-AzureAssignmentScope` | `Confirm-AzureAssignmentScope` | matches the `Confirm-FG*` idempotent-helper idiom in the SDK |
| `Sort-MidpointContextsTopologically` | `Get-MidpointContextsInTopologicalOrder` | no approved `Sort` verb |
| `Sort-OmadaContextsTopologically` | `Get-OmadaContextsInTopologicalOrder` | |
| `Report-Result` | `Write-Result` | shared test-harness result emitter |

### Verification
- PSScriptAnalyzer reports **0** `PSUseApprovedVerbs` violations across the scanned roots — and **0** total under the full CI config with the rule now enforced.
- The **121** affected Pester unit tests pass (`OmadaCrawlerFunctions`, `OmadaCrawlerTransform`, `MidpointCrawlerTransform`, `AzureRMCrawlerPhases`).
- Renames applied at byte level, so the diff is token-only (no line-ending churn). Generated coverage HTML under `docs/coverage/` is left to regenerate; the historical `CHANGES.md` mention is left as-is (never hand-edited).

### Notes
- `Report-Result` → `Write-Result` also swept the (un-scanned) `test/nightly/*.ps1` harnesses so the name is consistent everywhere, not split-brain.
- Independent of the other in-flight PRs. Minor heads-up: it touches `.github/workflows/pr.yml` (a different job/section than #652's coverage-ratchet edit) and renames a function inside the Omada/Midpoint `*.Transform.ps1` files that #650 mutation-tests (config targets the file, not the function) — non-overlapping, but whichever of #650/#652 merges after this may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
