### PR TITLE
ci: bump github/codeql-action to v4.37.0 (init + autobuild + analyze together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,16 +42,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: /language:javascript-typescript


### PR DESCRIPTION
Supersedes #639 and #635.

`codeql.yml` pins **three** codeql-action entry points — `init`, `autobuild`, and `analyze` — to the *same* SHA. They're one action (`github/codeql-action`) and must share a version: CodeQL rejects a run where the steps are on mismatched releases.

Dependabot split the 4.37.0 bump into per-entry-point PRs — #639 (`init`) and #635 (`autobuild`) — and didn't cover `analyze` at all. Merging either alone leaves the three SHAs mismatched. This bumps all three to `99df26d4…` (v4.37.0) in one commit, which is the only coherent way to do it.

Once merged, dependabot auto-closes #639/#635 (I've also asked it to close them now). CI/config-only change — no changelog fragment required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
