### PR TITLE
ci(dependabot): match codeql-action sub-paths so the group bundles them into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,15 @@ updates:
       # "Loaded a configuration file for version X, but running version Y".
       # Group them so Dependabot bumps all three in a single PR instead of one
       # PR per sub-action (which is never internally consistent).
+      #
+      # Dependabot identifies these by their FULL sub-paths — `github/codeql-action/init`,
+      # `.../autobuild`, `.../analyze` (see the per-PR dependabot branch names). The bare
+      # `github/codeql-action*` glob did NOT match those sub-paths, so Dependabot still cut
+      # one PR per sub-action (#635/#639). Match the sub-paths explicitly instead.
       codeql-action:
         patterns:
-          - "github/codeql-action*"
+          - "github/codeql-action"
+          - "github/codeql-action/*"
 
   # Worker container (PowerShell)
   - package-ecosystem: "docker"


### PR DESCRIPTION
Fixes the dependency-grouping problem behind #639 / #635 **at the source** (replaces the closed #656, which I couldn't reopen after deleting its branch — my mistake).

### The actual bug
The `codeql-action` group already exists in `.github/dependabot.yml` (added in #559, 2026-07-02) — but dependabot **still** opened one PR per sub-action (#635 `autobuild`, #639 `init`) a week later. The group's pattern `github/codeql-action*` wasn't matching: dependabot identifies these by their full sub-paths — `github/codeql-action/init`, `.../autobuild`, `.../analyze` (visible in the per-PR dependabot branch names) — and the bare glob didn't catch them, so each bump fell out of the group into its own PR. That's the split the group was meant to prevent, and the one that would leave init/autobuild/analyze on mismatched versions (which CodeQL rejects).

### The fix
Match the sub-paths explicitly:
```yaml
      codeql-action:
        patterns:
          - "github/codeql-action"
          - "github/codeql-action/*"
```
On its next run, dependabot will bundle all three into a single grouped PR instead of splitting them.

### Follow-up
Once this merges, the split PRs #639/#635 are superseded — dependabot will re-propose 4.37.0 as one grouped PR. Config-only change; no changelog fragment required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
