### PR TITLE
refactor(api): dedup the risk-score endpoints (#647)

### DIFF
--- a/.ci/complexity-baseline.json
+++ b/.ci/complexity-baseline.json
@@ -68,9 +68,6 @@
       25,
       24
     ],
-    "app/api/src/routes/riskScores/entity.js": [
-      27
-    ],
     "app/api/src/routes/riskScores/list.js": [
       37
     ],

--- a/app/api/src/routes/riskScores.coverage.test.js
+++ b/app/api/src/routes/riskScores.coverage.test.js
@@ -26,8 +26,10 @@ vi.mock('../perf/sqlTimer.js', () => ({
         return { recordset: [{ tbl: tableExists ? 'public.RiskScores' : null }] };
       }
       // Pop the next scripted response (if any) for non-table-check queries.
+      // Push an Error to simulate a failing query (exercises the 500 catch paths).
       const next = queryScript.shift();
       if (next === undefined) return { recordset: [] };
+      if (next instanceof Error) throw next;
       return { recordset: next };
     },
   }),
@@ -152,6 +154,13 @@ describe('PUT /risk-scores/:type/:id/override', () => {
     expect(res.status).toBe(404);
   });
 
+  it('500 when the update query fails', async () => {
+    queryScript.push([{ riskDirectScore: 10, riskMembershipScore: 0, riskStructuralScore: 0, riskPropagatedScore: 0 }]); // read ok
+    queryScript.push(new Error('update boom')); // risk-override-set throws
+    const res = await request(app).put(`/api/risk-scores/users/${VALID}/override`).send({ adjustment: 5, reason: 'valid reason' });
+    expect(res.status).toBe(500);
+  });
+
   it('400 on an invalid type', async () => {
     expect((await request(app).put(`/api/risk-scores/bogus/${VALID}/override`).send({ adjustment: 5, reason: 'valid reason' })).status).toBe(400);
   });
@@ -202,6 +211,13 @@ describe('DELETE /risk-scores/:type/:id/override', () => {
     queryScript.push([]);
     const res = await request(app).delete(`/api/risk-scores/users/${VALID}/override`);
     expect(res.status).toBe(404);
+  });
+
+  it('500 when the clear query fails', async () => {
+    queryScript.push([{ riskDirectScore: 10, riskMembershipScore: 0, riskStructuralScore: 0, riskPropagatedScore: 0 }]); // read ok
+    queryScript.push(new Error('clear boom')); // risk-override-clear throws
+    const res = await request(app).delete(`/api/risk-scores/users/${VALID}/override`);
+    expect(res.status).toBe(500);
   });
 
   it('400 on an invalid type', async () => {

--- a/app/api/src/routes/riskScores.summary.test.js
+++ b/app/api/src/routes/riskScores.summary.test.js
@@ -1,15 +1,20 @@
-// Guards that the risk-dashboard summary endpoint bounds its "top N" queries.
+// Tests for the risk-dashboard summary endpoint (GET /risk-scores):
+//  - the "top N" queries stay bounded (the UI only shows a few, so these must
+//    not fetch/sort every risk-scored row),
+//  - the tier/totals aggregation builds the summary object, and
+//  - the failure paths (whole-summary 500, swallowed resource-type breakdown).
 //
-// The UI shows only the top few, so these queries must not fetch/sort every
-// risk-scored row. Mocks the DB layer to capture each query's SQL and asserts
-// the LIMITs are present.
-import { describe, it, expect, vi } from 'vitest';
+// Mocks the DB layer so each query's SQL/label is captured and its result (or a
+// thrown error) can be scripted per label.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
 process.env.USE_SQL = 'true'; // module loads its db import + useSql at eval time
 
 const captured = [];
+// Per-label response overrides: an array becomes the recordset; an Error is thrown.
+let responses = {};
 vi.mock('../perf/sqlTimer.js', () => ({
   timedRequest: (_p, label) => ({
     input() { return this; },
@@ -17,7 +22,9 @@ vi.mock('../perf/sqlTimer.js', () => ({
       captured.push({ label, sql });
       // riskTableExists must see the table so the handler reaches the top-N queries.
       if (label === 'risk-table-check') return { recordset: [{ tbl: 'public.RiskScores' }] };
-      return { recordset: [] };
+      const r = responses[label];
+      if (r instanceof Error) throw r;
+      return { recordset: r ?? [] };
     },
   }),
 }));
@@ -30,12 +37,49 @@ const app = express().use(express.json()).use(riskScoresRouter);
 
 const sqlFor = (label) => captured.find(c => c.label === label)?.sql || '';
 
-describe('GET /risk-scores summary — top-N queries are bounded', () => {
+beforeEach(() => { captured.length = 0; responses = {}; });
+
+describe('GET /risk-scores summary', () => {
   it('caps top users/resources at LIMIT 10 and scored-at at LIMIT 1', async () => {
     const res = await request(app).get('/risk-scores');
     expect(res.status).toBe(200);
     expect(sqlFor('risk-top-users')).toMatch(/LIMIT\s+10/);
     expect(sqlFor('risk-top-resources')).toMatch(/LIMIT\s+10/);
     expect(sqlFor('risk-scored-at')).toMatch(/LIMIT\s+1\b/);
+  });
+
+  it('aggregates tier distribution and totals into the summary object', async () => {
+    responses = {
+      'risk-tier-distribution': [
+        { entityType: 'Principal', riskTier: 'High', count: 3 },
+        { entityType: 'Resource',  riskTier: null,   count: 2 }, // null tier → 'None'
+      ],
+      'risk-totals': [{ entityType: 'Principal', total: 5, overrides: 1 }],
+      'risk-top-users':     [{ riskScore: 90 }],
+      'risk-top-resources': [{ riskScore: 80 }],
+      'risk-resource-types': [{ resourceType: 'Group', count: 4, avgScore: 50 }],
+      'risk-scored-at':     [{ riskScoredAt: '2026-01-01T00:00:00Z' }],
+    };
+    const res = await request(app).get('/risk-scores');
+    expect(res.status).toBe(200);
+    expect(res.body.summary.usersByTier).toEqual({ High: 3 });
+    expect(res.body.summary.groupsByTier).toEqual({ None: 2 });
+    expect(res.body.summary.totalUsers).toBe(5);
+    expect(res.body.summary.userOverrides).toBe(1);
+    expect(res.body.summary.resourceTypeBreakdown).toEqual([{ resourceType: 'Group', count: 4, avgScore: 50 }]);
+    expect(res.body.scoredAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('nulls resourceTypeBreakdown when its query fails (swallowed)', async () => {
+    responses = { 'risk-resource-types': new Error('no perms on Resources') };
+    const res = await request(app).get('/risk-scores');
+    expect(res.status).toBe(200);
+    expect(res.body.summary.resourceTypeBreakdown).toBeNull();
+  });
+
+  it('returns 500 when a summary query fails', async () => {
+    responses = { 'risk-tier-distribution': new Error('db down') };
+    const res = await request(app).get('/risk-scores');
+    expect(res.status).toBe(500);
   });
 });

--- a/app/api/src/routes/riskScores/entity.js
+++ b/app/api/src/routes/riskScores/entity.js
@@ -30,20 +30,71 @@ function mapEntityType(urlType) {
   }
 }
 
+// Shared preamble for all three :type/:id handlers: require SQL mode and validate
+// the path params. On any failure it sends the 400 and returns null (caller
+// should `return`); otherwise returns { type, id, entityType }.
+function parseEntityParams(req, res) {
+  if (!useSql) { res.status(400).json({ error: 'SQL mode required' }); return null; }
+  const { type, id } = req.params;
+  if (!VALID_TYPES.has(type)) {
+    res.status(400).json({ error: `Type must be one of: ${[...VALID_TYPES].join(', ')}` });
+    return null;
+  }
+  if (!UUID_RE.test(id)) {
+    res.status(400).json({ error: 'Invalid entity ID format' });
+    return null;
+  }
+  return { type, id, entityType: mapEntityType(type) };
+}
+
+// Read the four component scores for an entity and recompute its effective score
+// (clamped 0–100) plus tier, applying `adjustment` (0 for a clear). On a missing
+// row it sends the 404 and returns null; otherwise returns { newScore, newTier }.
+async function recomputeScore(p, res, id, entityType, adjustment = 0) {
+  const current = await timedRequest(p, 'risk-override-read', res)
+    .input('id', id)
+    .input('entityType', entityType)
+    .query(`
+        SELECT "riskDirectScore", "riskMembershipScore", "riskStructuralScore", "riskPropagatedScore"
+        FROM "RiskScores"
+        WHERE "entityId" = @id AND "entityType" = @entityType
+      `);
+
+  if (current.recordset.length === 0) {
+    res.status(404).json({ error: 'Entity not found or not yet scored' });
+    return null;
+  }
+
+  const row = current.recordset[0];
+  const baseScore = (row.riskDirectScore || 0) + (row.riskMembershipScore || 0)
+    + (row.riskStructuralScore || 0) + (row.riskPropagatedScore || 0);
+  const newScore = Math.max(0, Math.min(100, baseScore + adjustment));
+  return { newScore, newTier: tierFor(newScore) };
+}
+
+// Denormalize a recomputed score/tier onto the entity's own table (best-effort —
+// the entity table may not carry risk columns yet, so failures are swallowed).
+async function denormalizeScore(p, res, id, entityType, newScore, newTier) {
+  try {
+    if (entityType === 'Principal') {
+      await timedRequest(p, 'risk-override-denorm', res)
+        .input('id', id).input('newScore', newScore).input('newTier', newTier)
+        .query(`UPDATE "Principals" SET "riskScore" = @newScore, "riskTier" = @newTier WHERE id = @id`);
+    } else if (entityType === 'Resource') {
+      await timedRequest(p, 'risk-override-denorm', res)
+        .input('id', id).input('newScore', newScore).input('newTier', newTier)
+        .query(`UPDATE "Resources" SET "riskScore" = @newScore, "riskTier" = @newTier WHERE id = @id`);
+    }
+  } catch { /* entity table may not have risk columns yet */ }
+}
+
 // ─── GET /api/risk-scores/:type/:id ──────────────────────────────────
 router.get('/risk-scores/:type/:id', async (req, res) => {
   try {
-    if (!useSql) return res.status(400).json({ error: 'SQL mode required' });
+    const parsed = parseEntityParams(req, res);
+    if (!parsed) return;
+    const { id, entityType } = parsed;
 
-    const { type, id } = req.params;
-    if (!VALID_TYPES.has(type)) {
-      return res.status(400).json({ error: `Type must be one of: ${[...VALID_TYPES].join(', ')}` });
-    }
-    if (!UUID_RE.test(id)) {
-      return res.status(400).json({ error: 'Invalid entity ID format' });
-    }
-
-    const entityType = mapEntityType(type);
     const p = await db.getPool();
     if (!await riskTableExists(p, res)) {
       return res.status(404).json({ error: 'Risk scores not available' });
@@ -95,15 +146,9 @@ router.get('/risk-scores/:type/:id', async (req, res) => {
 // Body: { adjustment: number (-50 to +50), reason: string (required) }
 router.put('/risk-scores/:type/:id/override', writeRisk, async (req, res) => {
   try {
-    if (!useSql) return res.status(400).json({ error: 'SQL mode required' });
-
-    const { type, id } = req.params;
-    if (!VALID_TYPES.has(type)) {
-      return res.status(400).json({ error: `Type must be one of: ${[...VALID_TYPES].join(', ')}` });
-    }
-    if (!UUID_RE.test(id)) {
-      return res.status(400).json({ error: 'Invalid entity ID format' });
-    }
+    const parsed = parseEntityParams(req, res);
+    if (!parsed) return;
+    const { id, entityType } = parsed;
 
     const { adjustment, reason } = req.body || {};
     if (typeof adjustment !== 'number' || adjustment < -50 || adjustment > 50 || !Number.isInteger(adjustment)) {
@@ -116,33 +161,15 @@ router.put('/risk-scores/:type/:id/override', writeRisk, async (req, res) => {
       return res.status(400).json({ error: 'Reason must be 500 characters or fewer' });
     }
 
-    const entityType = mapEntityType(type);
     const assignedBy = req.user?.preferred_username || req.user?.name || 'Unknown';
     const p = await db.getPool();
-
     if (!await riskTableExists(p, res)) {
       return res.status(404).json({ error: 'Risk scores not available' });
     }
 
-    // Read current component scores
-    const current = await timedRequest(p, 'risk-override-read', res)
-      .input('id', id)
-      .input('entityType', entityType)
-      .query(`
-        SELECT "riskDirectScore", "riskMembershipScore", "riskStructuralScore", "riskPropagatedScore"
-        FROM "RiskScores"
-        WHERE "entityId" = @id AND "entityType" = @entityType
-      `);
-
-    if (current.recordset.length === 0) {
-      return res.status(404).json({ error: 'Entity not found or not yet scored' });
-    }
-
-    const row = current.recordset[0];
-    const baseScore = (row.riskDirectScore || 0) + (row.riskMembershipScore || 0)
-      + (row.riskStructuralScore || 0) + (row.riskPropagatedScore || 0);
-    const newScore = Math.max(0, Math.min(100, baseScore + adjustment));
-    const newTier = tierFor(newScore);
+    const recomputed = await recomputeScore(p, res, id, entityType, adjustment);
+    if (!recomputed) return;
+    const { newScore, newTier } = recomputed;
 
     // Update RiskScores table
     await timedRequest(p, 'risk-override-set', res)
@@ -161,18 +188,7 @@ router.put('/risk-scores/:type/:id/override', writeRisk, async (req, res) => {
         WHERE "entityId" = @id AND "entityType" = @entityType
       `);
 
-    // Denormalize to entity table
-    try {
-      if (entityType === 'Principal') {
-        await timedRequest(p, 'risk-override-denorm', res)
-          .input('id', id).input('newScore', newScore).input('newTier', newTier)
-          .query(`UPDATE "Principals" SET "riskScore" = @newScore, "riskTier" = @newTier WHERE id = @id`);
-      } else if (entityType === 'Resource') {
-        await timedRequest(p, 'risk-override-denorm', res)
-          .input('id', id).input('newScore', newScore).input('newTier', newTier)
-          .query(`UPDATE "Resources" SET "riskScore" = @newScore, "riskTier" = @newTier WHERE id = @id`);
-      }
-    } catch { /* entity table may not have risk columns yet */ }
+    await denormalizeScore(p, res, id, entityType, newScore, newTier);
 
     return res.json({ success: true, adjustment, reason: reason.trim(), riskScore: newScore, riskTier: newTier, assignedBy });
   } catch (err) {
@@ -185,42 +201,18 @@ router.put('/risk-scores/:type/:id/override', writeRisk, async (req, res) => {
 // Remove an analyst override from an entity.
 router.delete('/risk-scores/:type/:id/override', writeRisk, async (req, res) => {
   try {
-    if (!useSql) return res.status(400).json({ error: 'SQL mode required' });
+    const parsed = parseEntityParams(req, res);
+    if (!parsed) return;
+    const { id, entityType } = parsed;
 
-    const { type, id } = req.params;
-    if (!VALID_TYPES.has(type)) {
-      return res.status(400).json({ error: `Type must be one of: ${[...VALID_TYPES].join(', ')}` });
-    }
-    if (!UUID_RE.test(id)) {
-      return res.status(400).json({ error: 'Invalid entity ID format' });
-    }
-
-    const entityType = mapEntityType(type);
     const p = await db.getPool();
-
     if (!await riskTableExists(p, res)) {
       return res.status(404).json({ error: 'Risk scores not available' });
     }
 
-    // Read current component scores
-    const current = await timedRequest(p, 'risk-override-read', res)
-      .input('id', id)
-      .input('entityType', entityType)
-      .query(`
-        SELECT "riskDirectScore", "riskMembershipScore", "riskStructuralScore", "riskPropagatedScore"
-        FROM "RiskScores"
-        WHERE "entityId" = @id AND "entityType" = @entityType
-      `);
-
-    if (current.recordset.length === 0) {
-      return res.status(404).json({ error: 'Entity not found or not yet scored' });
-    }
-
-    const row = current.recordset[0];
-    const newScore = Math.max(0, Math.min(100,
-      (row.riskDirectScore || 0) + (row.riskMembershipScore || 0)
-      + (row.riskStructuralScore || 0) + (row.riskPropagatedScore || 0)));
-    const newTier = tierFor(newScore);
+    const recomputed = await recomputeScore(p, res, id, entityType);
+    if (!recomputed) return;
+    const { newScore, newTier } = recomputed;
 
     // Clear override in RiskScores table
     await timedRequest(p, 'risk-override-clear', res)
@@ -237,18 +229,7 @@ router.delete('/risk-scores/:type/:id/override', writeRisk, async (req, res) => 
         WHERE "entityId" = @id AND "entityType" = @entityType
       `);
 
-    // Denormalize to entity table
-    try {
-      if (entityType === 'Principal') {
-        await timedRequest(p, 'risk-override-denorm', res)
-          .input('id', id).input('newScore', newScore).input('newTier', newTier)
-          .query(`UPDATE "Principals" SET "riskScore" = @newScore, "riskTier" = @newTier WHERE id = @id`);
-      } else if (entityType === 'Resource') {
-        await timedRequest(p, 'risk-override-denorm', res)
-          .input('id', id).input('newScore', newScore).input('newTier', newTier)
-          .query(`UPDATE "Resources" SET "riskScore" = @newScore, "riskTier" = @newTier WHERE id = @id`);
-      }
-    } catch { /* entity table may not have risk columns yet */ }
+    await denormalizeScore(p, res, id, entityType, newScore, newTier);
 
     return res.json({ success: true, riskScore: newScore, riskTier: newTier });
   } catch (err) {

--- a/app/api/src/routes/riskScores/list.js
+++ b/app/api/src/routes/riskScores/list.js
@@ -126,171 +126,95 @@ router.get('/risk-scores', async (req, res) => {
   }
 });
 
-// ─── GET /api/risk-scores/users ───────────────────────────────────────
-router.get('/risk-scores/users', async (req, res) => {
-  try {
-    if (!useSql) return res.json({ data: [], total: 0, available: false });
-    const p = await db.getPool();
-    if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
+// ─── Per-type paginated lists ─────────────────────────────────────────
+// The five /risk-scores/<type> endpoints are structurally identical — same
+// availability guards, same limit/offset/tier/search/overridesOnly parsing,
+// same queryRiskScoresPage call and error handling. Only the entity table it
+// joins, the columns it selects, the search columns, one optional extra filter,
+// and the response's `useResources` flag differ. `defineListRoute` captures the
+// shared shape; RISK_LIST_TYPES holds the per-type differences.
+//
+// Every derived string comes from `name`:
+//   path  = /risk-scores/<name>   label = risk-<name>   log = "Risk <name> query failed"
+function defineListRoute({ name, entityType, fromClause, selectCols, searchColumns, extraFilter = null, responseExtra = {} }) {
+  router.get(`/risk-scores/${name}`, async (req, res) => {
+    try {
+      if (!useSql) return res.json({ data: [], total: 0, available: false });
+      const p = await db.getPool();
+      if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
 
-    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
-    const offset = parseInt(req.query.offset, 10) || 0;
-    const tier         = req.query.tier || '';
-    const search       = req.query.search || '';
-    const department   = req.query.department || '';
-    const overridesOnly = req.query.overridesOnly === 'true';
+      const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
+      const offset = parseInt(req.query.offset, 10) || 0;
+      const tier          = req.query.tier || '';
+      const search        = req.query.search || '';
+      const overridesOnly = req.query.overridesOnly === 'true';
 
-    let whereClause = `WHERE rs."entityType" = 'Principal'`;
-    const params = [];
-    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                                                 params.push({ name: 'tier',       value: tier }); }
-    if (search)      { whereClause += ' AND (p."displayName" ILIKE @search OR p.email ILIKE @search OR p.department ILIKE @search)';                params.push({ name: 'search',     value: `%${search}%` }); }
-    if (department)  { whereClause += ' AND p.department = @department';                                                                            params.push({ name: 'department', value: department }); }
-    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
+      let whereClause = `WHERE rs."entityType" = '${entityType}'`;
+      const params = [];
+      if (tier)   { whereClause += ' AND rs."riskTier" = @tier';  params.push({ name: 'tier',   value: tier }); }
+      if (search) { whereClause += ` AND ${searchColumns}`;       params.push({ name: 'search', value: `%${search}%` }); }
+      if (extraFilter) {
+        const value = req.query[extraFilter.name] || '';
+        if (value) { whereClause += ` AND ${extraFilter.clause}`; params.push({ name: extraFilter.name, value }); }
+      }
+      if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
 
-    const { data, total } = await queryRiskScoresPage(p, res, {
-      label:      'risk-users',
-      fromClause: `INNER JOIN "Principals" p ON rs."entityId" = p.id AND ${TEMPORAL_FILTER}`,
-      selectCols: `p."displayName", p.email AS "userPrincipalName", p.department, p."jobTitle", p."companyName"`,
-      whereClause, params, limit, offset,
-    });
-    return res.json({ data: data.map(parseJsonColumns), total, available: true });
-  } catch (err) {
-    console.error('Risk users query failed:', err.message);
-    return res.status(500).json({ error: 'Failed to load risk scores' });
-  }
-});
+      const { data, total } = await queryRiskScoresPage(p, res, {
+        label: `risk-${name}`,
+        fromClause, selectCols, whereClause, params, limit, offset,
+      });
+      return res.json({ data: data.map(parseJsonColumns), total, available: true, ...responseExtra });
+    } catch (err) {
+      console.error(`Risk ${name} query failed:`, err.message);
+      return res.status(500).json({ error: 'Failed to load risk scores' });
+    }
+  });
+}
 
-// ─── GET /api/risk-scores/groups ──────────────────────────────────────
-router.get('/risk-scores/groups', async (req, res) => {
-  try {
-    if (!useSql) return res.json({ data: [], total: 0, available: false });
-    const p = await db.getPool();
-    if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
-
-    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
-    const offset = parseInt(req.query.offset, 10) || 0;
-    const tier          = req.query.tier || '';
-    const search        = req.query.search || '';
-    const resourceType  = req.query.resourceType || '';
-    const overridesOnly = req.query.overridesOnly === 'true';
-
-    let whereClause = `WHERE rs."entityType" = 'Resource'`;
-    const params = [];
-    if (tier)          { whereClause += ' AND rs."riskTier" = @tier';                                              params.push({ name: 'tier',          value: tier }); }
-    if (search)        { whereClause += ' AND (r."displayName" ILIKE @search OR r.description ILIKE @search)';    params.push({ name: 'search',        value: `%${search}%` }); }
-    if (resourceType)  { whereClause += ' AND r.resourceType = @resourceType';                                     params.push({ name: 'resourceType',  value: resourceType }); }
-    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
-
-    const { data, total } = await queryRiskScoresPage(p, res, {
-      label:      'risk-groups',
-      fromClause: `INNER JOIN "Resources" r ON rs."entityId" = r.id AND ${TEMPORAL_FILTER}`,
-      selectCols: `r."displayName", r.description, r."resourceType", r.mail`,
-      whereClause, params, limit, offset,
-    });
-    return res.json({ data: data.map(parseJsonColumns), total, available: true, useResources: true });
-  } catch (err) {
-    console.error('Risk groups query failed:', err.message);
-    return res.status(500).json({ error: 'Failed to load risk scores' });
-  }
-});
-
-// ─── GET /api/risk-scores/business-roles ─────────────────────────────
-router.get('/risk-scores/business-roles', async (req, res) => {
-  try {
-    if (!useSql) return res.json({ data: [], total: 0, available: false });
-    const p = await db.getPool();
-    if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
-
-    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
-    const offset = parseInt(req.query.offset, 10) || 0;
-    const tier          = req.query.tier || '';
-    const search        = req.query.search || '';
-    const overridesOnly = req.query.overridesOnly === 'true';
-
-    let whereClause = `WHERE rs."entityType" = 'BusinessRole'`;
-    const params = [];
-    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                params.push({ name: 'tier',    value: tier }); }
-    if (search)      { whereClause += ' AND (br."displayName" ILIKE @search OR br.description ILIKE @search)';    params.push({ name: 'search',  value: `%${search}%` }); }
-    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
-
-    const { data, total } = await queryRiskScoresPage(p, res, {
-      label:      'risk-business-roles',
-      fromClause: `INNER JOIN "Resources" br ON rs."entityId" = br.id AND br."resourceType" = 'BusinessRole' AND ${TEMPORAL_FILTER}
+const RISK_LIST_TYPES = [
+  {
+    name: 'users',
+    entityType: 'Principal',
+    fromClause: `INNER JOIN "Principals" p ON rs."entityId" = p.id AND ${TEMPORAL_FILTER}`,
+    selectCols: `p."displayName", p.email AS "userPrincipalName", p.department, p."jobTitle", p."companyName"`,
+    searchColumns: '(p."displayName" ILIKE @search OR p.email ILIKE @search OR p.department ILIKE @search)',
+    extraFilter: { name: 'department', clause: 'p.department = @department' },
+  },
+  {
+    name: 'groups',
+    entityType: 'Resource',
+    fromClause: `INNER JOIN "Resources" r ON rs."entityId" = r.id AND ${TEMPORAL_FILTER}`,
+    selectCols: `r."displayName", r.description, r."resourceType", r.mail`,
+    searchColumns: '(r."displayName" ILIKE @search OR r.description ILIKE @search)',
+    extraFilter: { name: 'resourceType', clause: 'r.resourceType = @resourceType' },
+    responseExtra: { useResources: true },
+  },
+  {
+    name: 'business-roles',
+    entityType: 'BusinessRole',
+    fromClause: `INNER JOIN "Resources" br ON rs."entityId" = br.id AND br."resourceType" = 'BusinessRole' AND ${TEMPORAL_FILTER}
       LEFT JOIN "GovernanceCatalogs" c ON br."catalogId" = c.id AND ${TEMPORAL_FILTER}`,
-      selectCols: `br."displayName", br.description, br."catalogId", c."displayName" AS "catalogName"`,
-      whereClause, params, limit, offset,
-    });
-    return res.json({ data: data.map(parseJsonColumns), total, available: true });
-  } catch (err) {
-    console.error('Risk business-roles query failed:', err.message);
-    return res.status(500).json({ error: 'Failed to load risk scores' });
-  }
-});
-
-// ─── GET /api/risk-scores/contexts ──────────────────────────────────
-router.get('/risk-scores/contexts', async (req, res) => {
-  try {
-    if (!useSql) return res.json({ data: [], total: 0, available: false });
-    const p = await db.getPool();
-    if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
-
-    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
-    const offset = parseInt(req.query.offset, 10) || 0;
-    const tier          = req.query.tier || '';
-    const search        = req.query.search || '';
-    const overridesOnly = req.query.overridesOnly === 'true';
-
-    let whereClause = `WHERE rs."entityType" = 'Context'`;
-    const params = [];
-    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                    params.push({ name: 'tier',   value: tier }); }
-    if (search)      { whereClause += ' AND (ou."displayName" ILIKE @search OR ou.department ILIKE @search)';          params.push({ name: 'search', value: `%${search}%` }); }
-    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
-
-    const { data, total } = await queryRiskScoresPage(p, res, {
-      label:      'risk-contexts',
-      fromClause: `INNER JOIN "Contexts" ou ON rs."entityId" = ou.id AND ${TEMPORAL_FILTER}
+    selectCols: `br."displayName", br.description, br."catalogId", c."displayName" AS "catalogName"`,
+    searchColumns: '(br."displayName" ILIKE @search OR br.description ILIKE @search)',
+  },
+  {
+    name: 'contexts',
+    entityType: 'Context',
+    fromClause: `INNER JOIN "Contexts" ou ON rs."entityId" = ou.id AND ${TEMPORAL_FILTER}
       LEFT JOIN "Principals" p ON ou."managerId" = p.id AND ${TEMPORAL_FILTER}`,
-      selectCols: `ou."displayName", ou.department, ou."memberCount", ou."managerId", p."displayName" AS "managerName"`,
-      whereClause, params, limit, offset,
-    });
-    return res.json({ data: data.map(parseJsonColumns), total, available: true });
-  } catch (err) {
-    console.error('Risk contexts query failed:', err.message);
-    return res.status(500).json({ error: 'Failed to load risk scores' });
-  }
-});
+    selectCols: `ou."displayName", ou.department, ou."memberCount", ou."managerId", p."displayName" AS "managerName"`,
+    searchColumns: '(ou."displayName" ILIKE @search OR ou.department ILIKE @search)',
+  },
+  {
+    name: 'identities',
+    entityType: 'Identity',
+    fromClause: `INNER JOIN "Identities" i ON rs."entityId" = i.id AND ${TEMPORAL_FILTER}`,
+    selectCols: `i."displayName", i."accountCount", i."linkConfidence", i.department, i."jobTitle", i.email`,
+    searchColumns: '(i."displayName" ILIKE @search OR i.department ILIKE @search OR i.email ILIKE @search)',
+  },
+];
 
-// ─── GET /api/risk-scores/identities ────────────────────────────────
-router.get('/risk-scores/identities', async (req, res) => {
-  try {
-    if (!useSql) return res.json({ data: [], total: 0, available: false });
-    const p = await db.getPool();
-    if (!await riskTableExists(p, res)) return res.json({ data: [], total: 0, available: false });
-
-    const limit  = Math.min(parseInt(req.query.limit,  10) || 100, 500);
-    const offset = parseInt(req.query.offset, 10) || 0;
-    const tier          = req.query.tier || '';
-    const search        = req.query.search || '';
-    const overridesOnly = req.query.overridesOnly === 'true';
-
-    let whereClause = `WHERE rs."entityType" = 'Identity'`;
-    const params = [];
-    if (tier)        { whereClause += ' AND rs."riskTier" = @tier';                                                                             params.push({ name: 'tier',   value: tier }); }
-    if (search)      { whereClause += ' AND (i."displayName" ILIKE @search OR i.department ILIKE @search OR i.email ILIKE @search)';            params.push({ name: 'search', value: `%${search}%` }); }
-    if (overridesOnly) whereClause += ' AND rs."riskOverride" IS NOT NULL';
-
-    const { data, total } = await queryRiskScoresPage(p, res, {
-      label:      'risk-identities',
-      fromClause: `INNER JOIN "Identities" i ON rs."entityId" = i.id AND ${TEMPORAL_FILTER}`,
-      selectCols: `i."displayName", i."accountCount", i."linkConfidence", i.department, i."jobTitle", i.email`,
-      whereClause, params, limit, offset,
-    });
-    return res.json({ data: data.map(parseJsonColumns), total, available: true });
-  } catch (err) {
-    console.error('Risk identities query failed:', err.message);
-    return res.status(500).json({ error: 'Failed to load risk scores' });
-  }
-});
+for (const type of RISK_LIST_TYPES) defineListRoute(type);
 
 
 export default router;

--- a/changes/dedup-riskscores-endpoints-647.md
+++ b/changes/dedup-riskscores-endpoints-647.md
@@ -1,0 +1,1 @@
+- Reduced code duplication in the risk-score API endpoints — the five per-type list endpoints now share one implementation, and the single-entity read/override handlers share their validation and score-recompute logic. No change to behaviour or responses.


### PR DESCRIPTION
First slice of #647 (reduce jscpd clone duplication in the API). Tackles the biggest **product-code** hotspot the issue names: the `riskScores/` endpoints (8 of the 20 product↔product clone pairs).

### What

- **`riskScores/list.js`** — the five `/risk-scores/<type>` list handlers (`users`, `groups`, `business-roles`, `contexts`, `identities`) were ~90% identical. Collapsed into a `defineListRoute` factory + a `RISK_LIST_TYPES` config table (entity table/join, select & search columns, one optional extra filter, the `useResources` flag). Every derived string comes from one `name`.
- **`riskScores/entity.js`** — the single-entity `GET` / override `PUT` / `DELETE` handlers repeated their `:type/:id` validation, component-score read+recompute, and entity-denormalize blocks verbatim. Extracted `parseEntityParams` / `recomputeScore` / `denormalizeScore`.

### No behaviour change

Same routes, SQL, params, and responses. Filter-application order (tier → search → extra → overridesOnly) and every error message/status preserved. Verified by the existing `riskScores` unit suite; added two 500-path tests (via a small Error-sentinel in the coverage test's query mock) that legitimately raise coverage.

### Gate impact

- **jscpd** `app/api/src`: clone pairs **40 → 33** (riskScores **8 → 1**; the one residual is the irreducible handler-setup preamble shared across two HTTP verbs — a HOF wrapper to kill it would trade duplication for indirection, so left as-is). Aggregate % 1.13 → 0.91.
- **Complexity ratchet**: `entity.js` cyclomatic ceiling drops **27 → 18**, so its baseline entry is removed (locks in the gain). `list.js`'s untouched summary handler keeps its `37`.
- **Coverage**: full API suite 1788/1788 green; global coverage clears the committed thresholds. Diff-coverage: all *changed* lines (the new helpers/factory) are exercised.

### Noted, not fixed here (out of scope for a no-behaviour-change dedup)

`entity.js` GET has a latent bug: `FROM [${"tableName"}]` interpolates the string literal `"tableName"` (not the `tableName` variable) and uses SQL-Server bracket syntax in a Postgres query — so the display-name lookup always throws into its swallowing catch and `displayName` stays `null`. Preserved verbatim here; worth a separate fix.

Follow-up slices for #647 (separate PRs): the other intra-file product clones (`matrix/inheritedAccess.js`, `categories.js`, `permissions/grid.js`, `jobs/runs.js`, cross-file `matrix.js ↔ matrix/scope.js`), and the test-mock boilerplate — which, note, **can't** use the simple shared-helper the issue proposed (vitest hoists `vi.mock` above imports); it needs a `src/db/__mocks__/connection.js` manual mock instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
