### PR TITLE
refactor(api): remove dead GraphUsers/GraphGroups fallback code (#667)

### DIFF
--- a/app/api/src/routes/admin.coverage.test.js
+++ b/app/api/src/routes/admin.coverage.test.js
@@ -321,14 +321,12 @@ describe('POST /admin/import/curated', () => {
     expect(res.body.stats.catsInserted).toBe(1);
   });
 
-  it('500 when ensureTagTables setup throws via a rejected query', async () => {
-    // tableExists for the first to_regclass resolves, but the tag upsert path
-    // is never reached because we make getPool-driven setup blow up: simplest
-    // is to reject the to_regclass existence check.
+  it('500 when an import query rejects', async () => {
+    // The category upsert is the first db.query the import runs; reject it.
     query.mockRejectedValueOnce(new Error('boom'));
     const res = await request(app)
       .post('/api/admin/import/curated')
-      .send({ tags: [], categories: [] });
+      .send({ tags: [], categories: [{ name: 'Finance', color: '#3b82f6' }] });
     expect(res.status).toBe(500);
   });
 });

--- a/app/api/src/routes/admin/curatedData.js
+++ b/app/api/src/routes/admin/curatedData.js
@@ -119,29 +119,21 @@ router.get('/admin/export/curated', exportBulk, async (req, res) => {
     // ── Tags + assignments ────────────────────────────────────────
     let tags = [];
     if (await tableExists(pool, 'GraphTags')) {
-      // Detect which tables exist for display-name resolution
-      const hasPrincipals = await tableExists(pool, 'Principals');
-      const hasResources  = await tableExists(pool, 'Resources');
-
       // Postgres: tag entityIds are stored as text. Cast to uuid only when the
       // value is shaped like a uuid, otherwise the cast errors out and breaks
       // the whole query. uuid_or_null() is a tiny inline plpgsql helper.
-      const userJoin = hasPrincipals
-        ? `LEFT JOIN "Principals" gu ON t."entityType" = 'user'
+      const userJoin = `LEFT JOIN "Principals" gu ON t."entityType" = 'user'
              AND ta."entityId" ~* '^[0-9a-f-]{36}$'
-             AND gu.id = ta."entityId"::uuid`
-        : '';
-      const resourceJoin = hasResources
-        ? `LEFT JOIN "Resources" r ON t."entityType" IN ('resource','group')
+             AND gu.id = ta."entityId"::uuid`;
+      const resourceJoin = `LEFT JOIN "Resources" r ON t."entityType" IN ('resource','group')
              AND ta."entityId" ~* '^[0-9a-f-]{36}$'
-             AND r.id = ta."entityId"::uuid`
-        : '';
+             AND r.id = ta."entityId"::uuid`;
 
       const tagRows = await pool.request().query(`
         SELECT t.id, t.name, t.color, t."entityType",
                ta."entityId",
                COALESCE(gu."displayName", r."displayName") AS "entityDisplayName",
-               ${hasResources ? 'r."resourceType"' : 'NULL'} AS "resourceType"
+               r."resourceType" AS "resourceType"
         FROM "GraphTags" t
         LEFT JOIN "GraphTagAssignments" ta ON ta."tagId" = t.id
         ${userJoin}
@@ -249,10 +241,6 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
     await ensureTagTables(pool);
     await ensureCategoryTables(pool);
 
-    // Detect available tables for entity resolution
-    const hasPrincipals = await tableExists(pool, 'Principals');
-    const hasResources  = await tableExists(pool, 'Resources');
-
     // ── Helper: resolve entity GUID ──────────────────────────────
     // NB: no temporal (ValidTo) filter — the SQL-Server-era system-versioned
     // columns were dropped in the postgres migration, so a `ValidTo` predicate
@@ -262,9 +250,7 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
       // 1. GUID match — check if the entity still exists with this ID
       let exists = false;
       try {
-        const tbl = entityType === 'user'
-          ? (hasPrincipals ? 'Principals' : 'GraphUsers')
-          : (hasResources ? 'Resources' : 'GraphGroups');
+        const tbl = entityType === 'user' ? 'Principals' : 'Resources';
         const r = await pool.request()
           .input('id', entityId)
           .query(`SELECT COUNT(*) AS n FROM "${tbl}" WHERE UPPER((id)::text) = UPPER(@id)`);
@@ -277,7 +263,7 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
       if (!displayName) return null;
       try {
         if (entityType === 'user') {
-          const tbl = hasPrincipals ? 'Principals' : 'GraphUsers';
+          const tbl = 'Principals';
           const r = await pool.request()
             .input('displayName', displayName)
             .query(`SELECT UPPER((id)::text) AS id FROM "${tbl}"
@@ -285,10 +271,10 @@ router.post('/admin/import/curated', writeCsv, async (req, res) => {
           if (r.recordset.length > 0) return { id: r.recordset[0].id, softMatched: true };
         } else {
           // group / resource — match on displayName + resourceType if available
-          const tbl = hasResources ? 'Resources' : 'GraphGroups';
+          const tbl = 'Resources';
           let req2 = pool.request().input('displayName', displayName);
           let rtClause = '';
-          if (resourceType && hasResources) {
+          if (resourceType) {
             req2 = req2.input('resourceType', resourceType);
             rtClause = 'AND "resourceType" = @resourceType';
           }

--- a/app/api/src/routes/admin/maintenance.js
+++ b/app/api/src/routes/admin/maintenance.js
@@ -49,8 +49,6 @@ router.post('/admin/clean-database', writeSystems, adminDestructiveLimiter, asyn
     'Systems',
     // Crawler runtime artifacts (jobs, sync log) — but NOT configs
     'CrawlerJobs', 'SyncLog', 'GraphSyncLog',
-    // Legacy tables
-    'GraphGroupMembers', 'GraphGroupOwners', 'GraphGroups', 'GraphUsers',
   ];
 
   try {

--- a/app/api/src/routes/details/accessPackage.js
+++ b/app/api/src/routes/details/accessPackage.js
@@ -317,12 +317,9 @@ router.get('/access-package/:id/requests', async (req, res) => {
   if (!useSql) return res.json([]);
   try {
     const pool = await db.getPool();
-    let r;
-    try {
-      // Try Principals first (new model — email instead of userPrincipalName)
-      r = await timedRequest(pool, 'ap-requests', res)
-        .input('id', req.params.id)
-        .query(`
+    const r = await timedRequest(pool, 'ap-requests', res)
+      .input('id', req.params.id)
+      .query(`
         SELECT
           req.id, req."requestType", req."requestState", req."requestStatus",
           req.justification, req."createdDateTime", req."completedDateTime",
@@ -333,22 +330,6 @@ router.get('/access-package/:id/requests', async (req, res) => {
           AND req."requestState" IN ('PendingApproval', 'Delivering', 'Accepted')
         ORDER BY req."createdDateTime" DESC
       `);
-    } catch {
-      // Fall back to GraphUsers (old model)
-      r = await timedRequest(pool, 'ap-requests-legacy', res)
-        .input('id', req.params.id)
-        .query(`
-        SELECT
-          req.id, req."requestType", req."requestState", req."requestStatus",
-          req.justification, req."createdDateTime", req."completedDateTime",
-          u."displayName" AS "requestorDisplayName", u.userPrincipalName AS "requestorUPN"
-        FROM "AssignmentRequests" req
-        LEFT JOIN GraphUsers u ON req."requestorId" = u.id
-        WHERE req."resourceId" = @id
-          AND req."requestState" IN ('PendingApproval', 'Delivering', 'Accepted')
-        ORDER BY req."createdDateTime" DESC
-      `);
-    }
     res.json(r.recordset);
   } catch (err) {
     res.json([]);

--- a/app/api/src/routes/details/group.js
+++ b/app/api/src/routes/details/group.js
@@ -14,7 +14,7 @@ const router = Router();
 
 // ────────────────────────────────────────────────────────────────
 // GET /api/group/:id — Lightweight: attributes, tags, counts only
-// Now queries Resources table (new model) with GraphGroups fallback
+// Queries the Resources table (v5).
 // ────────────────────────────────────────────────────────────────
 router.get('/group/:id', async (req, res) => {
   if (!UUID_RE.test(req.params.id)) return res.status(400).json({ error: 'Invalid ID format' });
@@ -23,17 +23,10 @@ router.get('/group/:id', async (req, res) => {
     const pool = await db.getPool();
     const groupId = req.params.id;
 
-    // 1. Current attributes — try Resources first, fall back to GraphGroups
-    let groupResult;
-    try {
-      groupResult = await timedRequest(pool, 'group-attributes', res)
-        .input('id', groupId)
-        .query(`SELECT * FROM "Resources" WHERE id = @id`);
-    } catch {
-      groupResult = await timedRequest(pool, 'group-attributes-legacy', res)
-        .input('id', groupId)
-        .query('SELECT * FROM GraphGroups WHERE id = @id');
-    }
+    // 1. Current attributes from the Resources table (v5).
+    const groupResult = await timedRequest(pool, 'group-attributes', res)
+      .input('id', groupId)
+      .query(`SELECT * FROM "Resources" WHERE id = @id`);
 
     if (groupResult.recordset.length === 0) {
       return res.status(404).json({ error: 'Group not found' });

--- a/app/api/src/routes/identities/detail.js
+++ b/app/api/src/routes/identities/detail.js
@@ -34,15 +34,13 @@ router.get('/identities/:id', async (req, res) => {
 
     const identity = identityResult.recordset[0];
 
-    // Fetch all member accounts — try Principals first (userId column), fall back to GraphUsers
-    // IdentityMembers stores displayName opportunistically; many rows have
-    // null there so we coalesce with the Principals record and pull UPN out
-    // of Principals.email (v5 has no separate userPrincipalName column).
-    let membersResult;
-    try {
-      membersResult = await timedRequest(p, 'identity-members', res)
-        .input('identityId', identityId)
-        .query(`
+    // Fetch all member accounts from Principals (v5). IdentityMembers stores
+    // displayName opportunistically; many rows have null there so we coalesce
+    // with the Principals record and pull UPN out of Principals.email (v5 has
+    // no separate userPrincipalName column).
+    const membersResult = await timedRequest(p, 'identity-members', res)
+      .input('identityId', identityId)
+      .query(`
           SELECT m."identityId", m."principalId", m."isPrimary", m."isHrAuthoritative",
                  m."accountType", m."accountTypePattern", m."accountEnabled",
                  m."linkSignals", m."linkConfidence", m."hrScore",
@@ -56,43 +54,18 @@ router.get('/identities/:id', async (req, res) => {
           WHERE m."identityId" = @identityId
           ORDER BY m."isPrimary" DESC NULLS LAST, m."accountType" ASC
         `);
-    } catch (e) {
-      if (!isMissingSchema(e)) throw e;
-      membersResult = await timedRequest(p, 'identity-members-legacy', res)
-        .input('identityId', identityId)
-        .query(`
-          SELECT m.*, u.department, u."jobTitle", u.lastSignInDateTime, u."createdDateTime", u."accountEnabled" AS "userAccountEnabled"
-          FROM "IdentityMembers" m
-          LEFT JOIN GraphUsers u ON m."principalId" = u.id
-          WHERE m."identityId" = @identityId
-          ORDER BY m."isPrimary" DESC, m."accountType" ASC
-        `);
-    }
 
-    // Enrich members with risk scores (optional — try Principals then GraphUsers)
+    // Enrich members with risk scores (optional).
     let riskRows = [];
     try {
-      let riskResult;
-      try {
-        riskResult = await timedRequest(p, 'identity-member-risks', res)
-          .input('identityId', identityId)
-          .query(`
+      const riskResult = await timedRequest(p, 'identity-member-risks', res)
+        .input('identityId', identityId)
+        .query(`
             SELECT m."principalId", u."riskScore", u."riskTier"
             FROM "IdentityMembers" m
             LEFT JOIN "Principals" u ON m."principalId" = u.id
             WHERE m."identityId" = @identityId
           `);
-      } catch (e) {
-        if (!isMissingSchema(e)) throw e;
-        riskResult = await timedRequest(p, 'identity-member-risks-legacy', res)
-          .input('identityId', identityId)
-          .query(`
-            SELECT m."principalId", u."riskScore", u."riskTier"
-            FROM "IdentityMembers" m
-            LEFT JOIN GraphUsers u ON m."principalId" = u.id
-            WHERE m."identityId" = @identityId
-          `);
-      }
       riskRows = riskResult.recordset;
     } catch (e) { if (!isMissingSchema(e)) throw e; /* risk columns may not exist yet */ }
 

--- a/app/api/src/routes/permissions.coverage.test.js
+++ b/app/api/src/routes/permissions.coverage.test.js
@@ -147,17 +147,6 @@ describe('GET /api/permissions', () => {
     expect(res.status).toBe(200);
   });
 
-  it('falls back to GraphGroups columns when Resources columns are missing', async () => {
-    poolRequestQuery.mockResolvedValueOnce(PRINCIPALS_EXISTS);
-    getResourceColumns.mockRejectedValue(Object.assign(new Error('no Resources'), { code: '42P01' }));
-    timedQuery
-      .mockResolvedValueOnce(rs([]))
-      .mockResolvedValueOnce(rs([{ totalUsers: 0 }]))
-      .mockResolvedValueOnce(rs([]));
-    const res = await request(app).get('/api/permissions');
-    expect(res.status).toBe(200);
-  });
-
   it('userLimit top-N branch returns data + AP mapping', async () => {
     poolRequestQuery.mockResolvedValueOnce(PRINCIPALS_EXISTS);
     timedQuery

--- a/app/api/src/routes/permissions/grid.js
+++ b/app/api/src/routes/permissions/grid.js
@@ -8,7 +8,7 @@
 import { Router } from 'express';
 import { permissionAssignments } from '../../mock/data.js';
 import { ensureTagTables } from '../tags.js';
-import { getGroupColumns, getResourceColumns, getPrincipalOrUserColumns, getPrincipalOrUserColumnValues } from '../../db/columnCache.js';
+import { getResourceColumns, getPrincipalOrUserColumns, getPrincipalOrUserColumnValues } from '../../db/columnCache.js';
 import { timedRequest } from '../../perf/sqlTimer.js';
 import { buildContextFilterSql, parseAndResolveContextFilters } from '../../contexts/contextFilters.js';
 import { effectiveAccessForNodes } from '../../effectiveAccess/engine.js';
@@ -20,7 +20,7 @@ const router = Router();
 // Columns always handled with explicit aliases (not included in dynamic list)
 const ALIASED_COLS = new Set(['displayName', 'userPrincipalName']);
 
-// Aliases: Resources/GraphGroups column names → permission query aliases
+// Aliases: Resources column names → permission query aliases
 // New model uses resourceDisplayName/resourceDescription, but we keep group aliases for backward compat
 const GROUP_COL_ALIASES = { displayName: 'resourceDisplayName', description: 'resourceDescription' };
 const GROUP_ALIAS_TO_COL = {
@@ -30,7 +30,7 @@ const GROUP_ALIAS_TO_COL = {
 };
 
 // ─── GET /api/user-columns ────────────────────────────────────────
-// Returns column names + distinct values from GraphUsers for filter dropdowns.
+// Returns column names + distinct values from Principals for filter dropdowns.
 // Values come from the FULL dataset (not limited by userLimit), so dropdowns
 // show all possible options regardless of which page of users is loaded.
 router.get('/user-columns', async (req, res) => {
@@ -98,7 +98,7 @@ router.get('/user-columns', async (req, res) => {
 // Query params:
 //   userLimit (int)  - limit to top N users by assignment count
 //   filters  (JSON)  - server-side filters: {"department":"HR","groupTypeCalculated":"Security Group"}
-//                       User columns (GraphUsers) and group columns (GraphGroups) both supported.
+//                       Principal (user) columns and resource (group) columns both supported.
 router.get('/permissions', async (req, res) => {
   try {
     const userLimit = Math.min(Math.max(parseInt(req.query.userLimit) || 0, 0), 10000);
@@ -128,14 +128,8 @@ router.get('/permissions', async (req, res) => {
       // Discover user and group columns dynamically
       const allCols = await getPrincipalOrUserColumns(p);
       const colNames = new Set(allCols.map(c => c.name));
-      // Use Resources columns if available, fall back to GraphGroups
-      let allGroupCols;
-      try {
-        allGroupCols = await getResourceColumns(p);
-      } catch (e) {
-        if (!isMissingSchema(e)) throw e;
-        allGroupCols = await getGroupColumns(p);
-      }
+      // Resource columns for the group dimension (v5).
+      const allGroupCols = await getResourceColumns(p);
       const groupColNames = new Set(allGroupCols.map(c => GROUP_COL_ALIASES[c.name] || c.name));
 
       // Build dynamic user column SELECT (exclude aliased cols handled explicitly).

--- a/app/api/src/routes/permissions/syncLog.js
+++ b/app/api/src/routes/permissions/syncLog.js
@@ -37,8 +37,8 @@ router.get('/sync-log', async (req, res) => {
 
     // Mock data: generate realistic sync log entries
     const syncTypes = [
-      { type: 'Users', table: 'GraphUsers', records: 1247 },
-      { type: 'Groups', table: 'GraphGroups', records: 389 },
+      { type: 'Users', table: 'Principals', records: 1247 },
+      { type: 'Groups', table: 'Resources', records: 389 },
       { type: 'GroupMembers', table: 'GraphGroupMembers', records: 4521 },
       { type: 'GroupTransitiveMembers', table: 'GraphGroupTransitiveMembers', records: 8932 },
       { type: 'GroupEligibleMembers', table: 'GraphGroupEligibleMembers', records: 156 },
@@ -51,7 +51,7 @@ router.get('/sync-log', async (req, res) => {
       { type: 'AccessPackageAssignmentRequests', table: 'AssignmentRequests', records: 2103 },
       { type: 'AccessPackageAccessReviews', table: 'CertificationDecisions', records: 45 },
       { type: 'MaterializedViews', table: 'mat_UserPermissionAssignments', records: 0 },
-      { type: 'RiskScoring', table: 'GraphUsers,GraphGroups', records: 1636 },
+      { type: 'RiskScoring', table: 'Principals,Resources', records: 1636 },
     ];
     const mockLogs = [];
     let id = 1;

--- a/app/api/src/routes/systems.js
+++ b/app/api/src/routes/systems.js
@@ -151,9 +151,9 @@ router.get('/systems/:id/owners', async (req, res) => {
     const result = await timedRequest(p, 'system-owners', res)
       .input('id', req.params.id)
       .query(`
-        SELECT so.*, u."displayName" AS "userDisplayName", u.userPrincipalName
+        SELECT so.*, u."displayName" AS "userDisplayName", u.email AS "userPrincipalName"
         FROM "SystemOwners" so
-        LEFT JOIN GraphUsers u ON so."userId" = u.id
+        LEFT JOIN "Principals" u ON so."userId" = u.id
         WHERE so."systemId" = @id
         ORDER BY u."displayName"
       `);

--- a/app/api/src/routes/tags.coverage.test.js
+++ b/app/api/src/routes/tags.coverage.test.js
@@ -229,10 +229,8 @@ describe('POST /tags/:id/assign-by-filter', () => {
 
   it('200 inserts matched entities (user + search + filters)', async () => {
     queryOne.mockResolvedValueOnce({ id: VALID, targetType: 'Principal' });
-    // Pool queries: 1) to_regclass Principals check, 2) the INSERT
-    poolQuery
-      .mockResolvedValueOnce({ recordset: [{ principalsExists: 'Principals' }] })
-      .mockResolvedValueOnce({ rowsAffected: [3] });
+    // Pool query: the INSERT (v5 always uses Principals — no table probe)
+    poolQuery.mockResolvedValueOnce({ rowsAffected: [3] });
     const res = await request(app)
       .post(`/api/tags/${VALID}/assign-by-filter`)
       .send({ entityType: 'user', search: 'alice', filters: { department: 'IT' } });

--- a/app/api/src/routes/tags/crud.js
+++ b/app/api/src/routes/tags/crud.js
@@ -243,21 +243,14 @@ router.post('/tags/:id/assign-by-filter', writeTags, async (req, res) => {
       [tagId]
     );
     if (!ctx) return res.status(404).json({ error: 'Tag not found' });
-    // Determine user table: prefer Principals for users
-    let userTableForTags = 'GraphUsers';
-    if (entityType === 'user') {
-      try {
-        const tc = await p.request().query(`SELECT to_regclass('"Principals"') AS "principalsExists"`);
-        if (tc.recordset[0].principalsExists) userTableForTags = 'Principals';
-      } catch { /* ignore */ }
-    }
-    const table = entityType === 'user' ? userTableForTags
+    // Users live in Principals (v5); groups/resources in Resources.
+    const table = entityType === 'user' ? 'Principals'
                  : entityType === 'resource' ? 'Resources'
                  : entityType === 'identity' ? 'Identities'
-                 : 'GraphGroups';
+                 : 'Resources';
     const alias = 'e';
     const search = (rawSearch || '').trim().slice(0, 200);
-    const upnColForSearch = userTableForTags === 'Principals' ? 'email' : 'userPrincipalName';
+    const upnColForSearch = 'email';
 
     const request = p.request().input('tagId', tagId);
     let where = '1=1';

--- a/changes/remove-graphusers-dead-code-667.md
+++ b/changes/remove-graphusers-dead-code-667.md
@@ -1,0 +1,1 @@
+- Fixed the system owners list (Admin → Systems) returning no owners — it queried the removed `GraphUsers` table instead of the current `Principals` table.


### PR DESCRIPTION
Closes #667

The pre-v3.1 `GraphUsers`/`GraphGroups` tables aren't created by the v5 migrations, so the "try `Principals`/`Resources` → fall back to `Graph*`" branches and the always-true `to_regclass`/`hasPrincipals` probes were dead — the fallback query always fails on a missing table, ending at the same result. Removed across:

- `admin/curatedData.js` — dropped the `hasPrincipals`/`hasResources` probes; the joins/table selections are unconditionally `Principals`/`Resources`.
- `details/accessPackage.js`, `details/group.js`, `identities/detail.js` (×2) — removed the `catch → Graph*` fallbacks.
- `tags/crud.js` — the `userTableForTags` `to_regclass` probe is always `Principals`.
- `permissions/grid.js` — removed the `getResourceColumns → getGroupColumns` fallback (+ dropped the now-unused import) and refreshed the comments.
- `admin/maintenance.js` — dropped the legacy tables from the wipe list.
- `permissions/syncLog.js` — updated the mock strings.

**Behaviour-preserving on a v5 schema**, verified by the full unit suite (1804 passing; two fallback-testing cases removed/retargeted since the paths they covered are gone).

### Also fixes a live bug (not dead code)

`routes/systems.js` `GET /systems/:id/owners` joined the non-existent `GraphUsers` **directly** (no `Principals` attempt), so the query always threw and the endpoint returned an **empty owners list** on v5. Now joins `Principals` (`email` → `userPrincipalName`). This is a real behaviour fix — see the follow-up issue for the missing test that let it ship.

### Out of scope (per request, logged separately)

- `tags/entities.js`'s `GraphGroups` references are **coupled to the `SELECT TOP 0` probe bug (#662)** — fixing that probe makes its `getGroupCols` fallback dead, so they should be removed together there rather than half-touched here.
- The routes touched here have **no contract-test coverage** — the SQL-blind unit mocks are exactly why the `systems.js` `GraphUsers` bug shipped undetected. Tracked in a new follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
