### PR TITLE
fix(matrix): nesting/expansion now respects the resource-type filter (#674)

### DIFF
--- a/app/api/src/routes/permissions.coverage.test.js
+++ b/app/api/src/routes/permissions.coverage.test.js
@@ -63,6 +63,19 @@ vi.mock('../effectiveAccess/engine.js', () => ({
   effectiveAccessForNodes: (...a) => effectiveAccessForNodes(...a),
 }));
 
+// matrix/shared.js turns a matrix filter into resource-scope SQL — its own
+// suite covers that. Here we stub it so the nested-groups POST path receives a
+// deterministic resource subquery and we can assert the nesting query embeds it.
+// parseFilter stays trivially truthy/null so the "filter present?" branch works.
+const buildSubqueriesMock = vi.fn(async () => ({
+  resourceSql: '(SELECT id FROM "Resources" WHERE "resourceType"::text IN (@rf_a_inc_0_0))',
+  bindings: { rf_a_inc_0_0: 'Group' },
+}));
+vi.mock('./matrix/shared.js', () => ({
+  parseFilter: (body) => (body && body.filter ? body.filter : null),
+  buildSubqueries: (...a) => buildSubqueriesMock(...a),
+}));
+
 const { default: router } = await import('./permissions.js');
 const app = mountRouter(router);
 
@@ -83,6 +96,7 @@ beforeEach(() => {
   });
   expandCapabilityDown.mockReset().mockResolvedValue(null);
   effectiveAccessForNodes.mockReset().mockResolvedValue({ rows: [] });
+  buildSubqueriesMock.mockClear();
 });
 
 // ─── GET /api/permissions ──────────────────────────────────────────────────
@@ -315,5 +329,52 @@ describe('GET /api/group/:groupId/nested-groups', () => {
     const res = await request(app).get('/api/group/abc/nested-groups');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ groups: [], memberships: [] });
+  });
+
+  it('GET applies no resource clause (no matrix filter in a GET body)', async () => {
+    expandCapabilityDown.mockResolvedValue(null);
+    timedQuery.mockResolvedValueOnce(rs([])).mockResolvedValueOnce(rs([]));
+    const res = await request(app).get('/api/group/abc/nested-groups');
+    expect(res.status).toBe(200);
+    expect(buildSubqueriesMock).not.toHaveBeenCalled();
+    expect(timedQuery.mock.calls[0][0]).not.toContain('IN (SELECT id FROM "Resources"');
+  });
+});
+
+// ─── POST /api/group/:groupId/nested-groups (matrix filter forwarded) ──────
+describe('POST /api/group/:groupId/nested-groups', () => {
+  it('constrains nested resources (groups + members) to the matrix resource filter', async () => {
+    expandCapabilityDown.mockResolvedValue(null);
+    timedQuery
+      .mockResolvedValueOnce(rs([{ groupId: 'p1', resourceId: 'p1', resourceType: 'Group' }])) // groups
+      .mockResolvedValueOnce(rs([{ resourceId: 'p1', memberId: 'u1', membershipType: 'Direct' }])); // members
+    const res = await request(app)
+      .post('/api/group/abc/nested-groups')
+      .send({ filter: { resource: { include: [{ kind: 'attribute', field: 'resourceType', values: ['Group'] }] } } });
+    expect(res.status).toBe(200);
+    expect(buildSubqueriesMock).toHaveBeenCalledTimes(1);
+    // Both the resource-list and the member-subquery must carry the IN (subquery).
+    expect(timedQuery.mock.calls[0][0]).toContain('ra."resourceId" IN (SELECT id FROM "Resources"');
+    expect(timedQuery.mock.calls[1][0]).toContain('ra2."resourceId" IN (SELECT id FROM "Resources"');
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.memberships).toHaveLength(1);
+  });
+
+  it('applies no resource clause when the POST body carries no filter', async () => {
+    expandCapabilityDown.mockResolvedValue(null);
+    timedQuery.mockResolvedValueOnce(rs([])).mockResolvedValueOnce(rs([]));
+    const res = await request(app).post('/api/group/abc/nested-groups').send({});
+    expect(res.status).toBe(200);
+    expect(buildSubqueriesMock).not.toHaveBeenCalled();
+    expect(timedQuery.mock.calls[0][0]).not.toContain('IN (SELECT id FROM "Resources"');
+  });
+
+  it('still returns containment expansion for a scope node (filter ignored on that path)', async () => {
+    expandCapabilityDown.mockResolvedValue({ groups: [{ groupId: 'sg1' }], memberships: [] });
+    const res = await request(app)
+      .post('/api/group/abc/nested-groups')
+      .send({ filter: { resource: { include: [] } } });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ groups: [{ groupId: 'sg1' }], memberships: [] });
   });
 });

--- a/app/api/src/routes/permissions/nestedGroups.js
+++ b/app/api/src/routes/permissions/nestedGroups.js
@@ -9,8 +9,24 @@ import { Router } from 'express';
 import { timedRequest } from '../../perf/sqlTimer.js';
 import { expandCapabilityDown } from '../../effectiveAccess/engine.js';
 import { useSql, db } from './shared.js';
+import { parseFilter, buildSubqueries } from '../matrix/shared.js';
 
 const router = Router();
+
+// Turn an optional matrix filter (in the request body) into the resource-scope
+// SQL fragment + bindings the nesting queries constrain nested resources by.
+// This is the SAME `filter.resource` block /matrix/data applies to the
+// top-level grid (via buildSubqueries → buildEntitySubquery), so an expanded
+// group only reveals nested resources of the types the matrix is filtered to —
+// e.g. filtering to Groups no longer leaks AppRoles into the nesting.
+// Returns { resourceSql: null, bindings: {} } when no filter is supplied (a
+// plain GET), preserving the original "return every nested resource" behaviour.
+async function resourceScopeFromBody(body) {
+  const filter = parseFilter(body);
+  if (!filter) return { resourceSql: null, bindings: {} };
+  const built = await buildSubqueries(filter);
+  return { resourceSql: built.resourceSql, bindings: built.bindings };
+}
 
 // GET /api/groups-with-nested - group IDs that are assigned to other resources
 // (parent groups, app roles, etc.) so their members gain indirect access.
@@ -50,12 +66,16 @@ router.get('/groups-with-nested', async (req, res) => {
   }
 });
 
-// GET /api/group/:groupId/nested-groups - the resources this group is a member
-// of (parent groups, app roles, etc.) plus user memberships for those resources.
-// Used by the matrix expand fanout: opening a group row reveals every resource
-// its members inherit access to, with the same per-cell membership badges as
-// the root matrix.
-router.get('/group/:groupId/nested-groups', async (req, res) => {
+// GET/POST /api/group/:groupId/nested-groups - the resources this group is a
+// member of (parent groups, app roles, etc.) plus user memberships for those
+// resources. Used by the matrix expand fanout: opening a group row reveals
+// every resource its members inherit access to, with the same per-cell
+// membership badges as the root matrix.
+//
+// POST carries the active matrix filter in the body (`{ filter }`) so the
+// nesting honours the same resource-type scope as the grid; the legacy GET
+// (no body) returns every nested resource, unchanged.
+async function nestedGroupsHandler(req, res) {
   try {
     if (!useSql) return res.json({ groups: [], memberships: [] });
 
@@ -67,12 +87,20 @@ router.get('/group/:groupId/nested-groups', async (req, res) => {
 
     const p = await db.getPool();
 
+    // Constrain nested resources to the matrix's resource-type filter (if any),
+    // reusing the exact subquery /matrix/data builds for the top-level grid.
+    const { resourceSql, bindings } = await resourceScopeFromBody(req.body);
+    const groupsResClause   = resourceSql ? `AND ra."resourceId" IN ${resourceSql}`  : '';
+    const membersResClause  = resourceSql ? `AND ra2."resourceId" IN ${resourceSql}` : '';
+
     const request = timedRequest(p, 'nested-groups-data', res);
     request.input('childGroupId', req.params.groupId);
+    for (const [k, v] of Object.entries(bindings)) request.input(k, v);
 
     // Any resource where this group is the principal. We deliberately do NOT
     // filter by assignmentType so future group-as-principal types
-    // (AppRole, directory roles, etc.) flow through automatically.
+    // (AppRole, directory roles, etc.) flow through automatically — but we DO
+    // honour the matrix's resource-type filter so the nesting matches the grid.
     const groupsResult = await request.query(`
       SELECT DISTINCT
         ra."resourceId" AS "groupId",
@@ -85,10 +113,12 @@ router.get('/group/:groupId/nested-groups', async (req, res) => {
         LEFT JOIN "Resources" r ON ra."resourceId" = r.id
        WHERE ra."principalId"::text = @childGroupId
          AND ra."principalType" ILIKE '%group%'
+         ${groupsResClause}
     `);
 
     const membersRequest = timedRequest(p, 'nested-groups-members', res);
     membersRequest.input('childGroupId', req.params.groupId);
+    for (const [k, v] of Object.entries(bindings)) membersRequest.input(k, v);
     const membersResult = await membersRequest.query(`
       SELECT
         p."resourceId",
@@ -101,6 +131,7 @@ router.get('/group/:groupId/nested-groups', async (req, res) => {
            FROM "ResourceAssignments" ra2
           WHERE ra2."principalId"::text = @childGroupId
             AND ra2."principalType" ILIKE '%group%'
+            ${membersResClause}
        )
        AND (p."principalType" IS NULL OR p."principalType" != '#microsoft.graph.group')
     `);
@@ -113,6 +144,9 @@ router.get('/group/:groupId/nested-groups', async (req, res) => {
     console.error('nested-groups query failed:', err.message);
     return res.json({ groups: [], memberships: [] });
   }
-});
+}
+
+router.get('/group/:groupId/nested-groups', nestedGroupsHandler);
+router.post('/group/:groupId/nested-groups', nestedGroupsHandler);
 
 export default router;

--- a/app/ui/src/components/DashboardTrendsTab.states.test.jsx
+++ b/app/ui/src/components/DashboardTrendsTab.states.test.jsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createElement as h } from 'react';
+import DashboardTrendsTab from './DashboardTrendsTab';
+import { renderWithProviders, jsonResponse, screen } from '@ui/test-utils/renderWithProviders';
+
+// Deterministically cover the Trends tab's loading / data / error branches.
+// They were otherwise only hit incidentally (and flakily) via
+// DashboardPage.mount.test's tab-switch timing, so this file's line coverage
+// wobbled across unrelated test runs (adding test files elsewhere could tip it
+// below its floor). Pinning the three states here keeps it stable.
+describe('DashboardTrendsTab states', () => {
+  it('shows the loading placeholder until the snapshot resolves', () => {
+    const authFetch = () => new Promise(() => {}); // never resolves → stays loading
+    renderWithProviders(h(DashboardTrendsTab), { auth: { authFetch } });
+    expect(screen.getByText(/Loading/)).toBeInTheDocument();
+  });
+
+  it('renders the charts and headline once data resolves', async () => {
+    const authFetch = () => Promise.resolve(jsonResponse({
+      data: [
+        { date: '2026-05-01', principals: 1000, resources: 400, assignments: 5000, governedAssignments: 2500 },
+        { date: '2026-06-01', principals: 1200, resources: 450, assignments: 5400, governedAssignments: 2700 },
+      ],
+    }));
+    renderWithProviders(h(DashboardTrendsTab), { auth: { authFetch } });
+    // The "today" headline block only renders once there is a latest snapshot.
+    expect(await screen.findByText('today')).toBeInTheDocument();
+    expect(screen.getByText('Governed assignments — % of total')).toBeInTheDocument();
+    expect(screen.getByText('Users (principals)')).toBeInTheDocument();
+  });
+
+  it('shows an error banner when the snapshot fetch fails', async () => {
+    const authFetch = () => Promise.resolve(jsonResponse({ error: 'boom' }, { ok: false, status: 500 }));
+    renderWithProviders(h(DashboardTrendsTab), { auth: { authFetch } });
+    expect(await screen.findByText(/Failed to load/)).toBeInTheDocument();
+  });
+});

--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -6,6 +6,7 @@ import { useMemo, useState, useReducer, useCallback, useEffect, useLayoutEffect,
 const setStateReducer = (s, a) => (typeof a === 'function' ? a(s) : a);
 import { useAuth } from '@ui/auth/AuthGate';
 import { useMatrixRowOrder } from '@ui/hooks/useMatrixRowOrder';
+import { useNestedGroupExpand, MAX_NEST_LEVEL } from '@ui/hooks/useNestedGroupExpand';
 import MatrixToolbar from './matrix/MatrixToolbar';
 import MatrixLegend from './matrix/MatrixLegend';
 import MatrixFilterSummary from './matrix/MatrixFilterSummary';
@@ -94,18 +95,6 @@ function makeAccountCol(parent, acc, sortKeys) {
   };
 }
 
-// Run `reset()` during render whenever `key` changes — React's "adjust state
-// when a prop changes" pattern, without an effect (which would trip
-// react-hooks/set-state-in-effect). Kept as a hook so callers don't accrue the
-// branch in their own complexity budget.
-function useResetOnKeyChange(key, reset) {
-  const [seen, setSeen] = useState(key);
-  if (key !== seen) {
-    setSeen(key);
-    reset();
-  }
-}
-
 export default function MatrixView({
   data, accessPackageGroups = [], managedByPackages = [],
   filter,
@@ -158,10 +147,6 @@ export default function MatrixView({
   }, [inheritedByCell, authFetch]);
   const explainHandler = inheritedByCell.size > 0 ? onExplainInherited : undefined;
 
-  const [groupsWithNested, setGroupsWithNested] = useState(new Set());
-  const [expandedGroups, setExpandedGroups] = useState(new Set());
-  const [nestedDataCache, setNestedDataCache] = useState(new Map());
-  const [loadingNested, setLoadingNested] = useState(new Set());
 
   // ─── Identity column expansion (show per-account sub-columns) ────
   const [expandedIdentities, setExpandedIdentities] = useState(new Set());
@@ -210,50 +195,6 @@ export default function MatrixView({
     setExpandedIdentities(prev => new Set(prev).add(identityId));
   }, [expandedIdentities, accountMatrixCache, authFetch]);
 
-  // Fetch which groups have nested groups (once on mount)
-  useEffect(() => {
-    let cancelled = false;
-    authFetch('/api/groups-with-nested')
-      .then(r => r.ok ? r.json() : { groupIds: [] })
-      .then(d => { if (!cancelled) setGroupsWithNested(new Set(d.groupIds || [])); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [authFetch]);
-
-  const MAX_NEST_LEVEL = 4;
-
-  // Single place that builds the nested-expand request. POSTs the active matrix
-  // filter so the backend constrains nested resources to the same resource-type
-  // scope as the grid (e.g. Groups-only doesn't leak AppRoles). Resolves to the
-  // raw Response, like authFetch.
-  const fetchNestedGroups = useCallback((id) =>
-    authFetch(`/api/group/${encodeURIComponent(id)}/nested-groups`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ filter }),
-    }), [authFetch, filter]);
-
-  const toggleExpand = useCallback(async (groupId) => {
-    if (expandedGroups.has(groupId)) {
-      setExpandedGroups(prev => { const next = new Set(prev); next.delete(groupId); return next; });
-      return;
-    }
-    if (!nestedDataCache.has(groupId)) {
-      setLoadingNested(prev => new Set(prev).add(groupId));
-      try {
-        const res = await fetchNestedGroups(groupId);
-        const data = await res.json();
-        setNestedDataCache(prev => new Map(prev).set(groupId, data));
-      } catch (err) {
-        console.error('Failed to load nested groups:', err);
-        setLoadingNested(prev => { const next = new Set(prev); next.delete(groupId); return next; });
-        return;
-      }
-      setLoadingNested(prev => { const next = new Set(prev); next.delete(groupId); return next; });
-    }
-    setExpandedGroups(prev => new Set(prev).add(groupId));
-  }, [expandedGroups, nestedDataCache, fetchNestedGroups]);
-
   // Build a stable storage key from the filter (matches per-filter row order)
   const storageKey = useMemo(() => {
     if (!filter) return '';
@@ -261,16 +202,6 @@ export default function MatrixView({
   }, [filter]);
 
   const rowOrderHook = useMatrixRowOrder(storageKey);
-
-  // Invalidate the nested-expand cache when the filter changes. The cache is
-  // keyed only by groupId, but its contents are now scoped to the matrix's
-  // resource filter (see the /nested-groups POST in fetchNestedGroups), so a
-  // group expanded under e.g. "Groups only" must not keep showing that stale
-  // subset after the filter changes.
-  useResetOnKeyChange(storageKey, () => {
-    setNestedDataCache(new Map());
-    setExpandedGroups(new Set());
-  });
 
   // A (member, resource) membership is "governed" when it is covered by a
   // business role the user holds — i.e. it appears in managedByPackages, the
@@ -604,56 +535,13 @@ export default function MatrixView({
 
   const groupIds = useMemo(() => orderedGroups.map(g => g.id), [orderedGroups]);
 
-  const expandAll = useCallback(async () => {
-    const newCache = new Map(nestedDataCache);
-    const toExpand = new Set();
-
-    // Start with visible groups that have nested groups
-    let currentLevel = orderedGroups
-      .map(g => g.realGroupId || g.id)
-      .filter(id => groupsWithNested.has(id));
-
-    for (let level = 0; level < MAX_NEST_LEVEL && currentLevel.length > 0; level++) {
-      // Fetch data for groups not yet cached
-      const toFetch = currentLevel.filter(id => !newCache.has(id));
-      if (toFetch.length > 0) {
-        setLoadingNested(new Set(toFetch));
-        const results = await Promise.all(
-          toFetch.map(id =>
-            fetchNestedGroups(id)
-              .then(r => r.json())
-              .then(data => ({ id, data }))
-              .catch(() => ({ id, data: { groups: [], memberships: [] } }))
-          )
-        );
-        for (const { id, data } of results) newCache.set(id, data);
-      }
-
-      for (const id of currentLevel) toExpand.add(id);
-
-      // Find next level: nested groups that are themselves expandable
-      const nextLevel = [];
-      for (const id of currentLevel) {
-        const data = newCache.get(id);
-        if (data) {
-          for (const ng of data.groups) {
-            if (groupsWithNested.has(ng.groupId) && !toExpand.has(ng.groupId)) {
-              nextLevel.push(ng.groupId);
-            }
-          }
-        }
-      }
-      currentLevel = nextLevel;
-    }
-
-    setNestedDataCache(newCache);
-    setExpandedGroups(toExpand);
-    setLoadingNested(new Set());
-  }, [orderedGroups, groupsWithNested, nestedDataCache, fetchNestedGroups]);
-
-  const collapseAll = useCallback(() => {
-    setExpandedGroups(new Set());
-  }, []);
+  // Nested-group expand state + fetches (opening a group row reveals the
+  // resources its members inherit). Lives in its own hook so this component
+  // stays focused on rendering the grid; see useNestedGroupExpand.
+  const {
+    groupsWithNested, expandedGroups, nestedDataCache, loadingNested,
+    toggleExpand, expandAll, collapseAll,
+  } = useNestedGroupExpand({ authFetch, filter, storageKey, orderedGroups });
 
   // ─── Inject nested sub-rows after expanded groups ───────────────
   const nestedMemberships = useMemo(() => {

--- a/app/ui/src/components/MatrixView.jsx
+++ b/app/ui/src/components/MatrixView.jsx
@@ -94,6 +94,18 @@ function makeAccountCol(parent, acc, sortKeys) {
   };
 }
 
+// Run `reset()` during render whenever `key` changes — React's "adjust state
+// when a prop changes" pattern, without an effect (which would trip
+// react-hooks/set-state-in-effect). Kept as a hook so callers don't accrue the
+// branch in their own complexity budget.
+function useResetOnKeyChange(key, reset) {
+  const [seen, setSeen] = useState(key);
+  if (key !== seen) {
+    setSeen(key);
+    reset();
+  }
+}
+
 export default function MatrixView({
   data, accessPackageGroups = [], managedByPackages = [],
   filter,
@@ -210,6 +222,17 @@ export default function MatrixView({
 
   const MAX_NEST_LEVEL = 4;
 
+  // Single place that builds the nested-expand request. POSTs the active matrix
+  // filter so the backend constrains nested resources to the same resource-type
+  // scope as the grid (e.g. Groups-only doesn't leak AppRoles). Resolves to the
+  // raw Response, like authFetch.
+  const fetchNestedGroups = useCallback((id) =>
+    authFetch(`/api/group/${encodeURIComponent(id)}/nested-groups`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filter }),
+    }), [authFetch, filter]);
+
   const toggleExpand = useCallback(async (groupId) => {
     if (expandedGroups.has(groupId)) {
       setExpandedGroups(prev => { const next = new Set(prev); next.delete(groupId); return next; });
@@ -218,7 +241,7 @@ export default function MatrixView({
     if (!nestedDataCache.has(groupId)) {
       setLoadingNested(prev => new Set(prev).add(groupId));
       try {
-        const res = await authFetch(`/api/group/${encodeURIComponent(groupId)}/nested-groups`);
+        const res = await fetchNestedGroups(groupId);
         const data = await res.json();
         setNestedDataCache(prev => new Map(prev).set(groupId, data));
       } catch (err) {
@@ -229,7 +252,7 @@ export default function MatrixView({
       setLoadingNested(prev => { const next = new Set(prev); next.delete(groupId); return next; });
     }
     setExpandedGroups(prev => new Set(prev).add(groupId));
-  }, [expandedGroups, nestedDataCache, authFetch]);
+  }, [expandedGroups, nestedDataCache, fetchNestedGroups]);
 
   // Build a stable storage key from the filter (matches per-filter row order)
   const storageKey = useMemo(() => {
@@ -238,6 +261,16 @@ export default function MatrixView({
   }, [filter]);
 
   const rowOrderHook = useMatrixRowOrder(storageKey);
+
+  // Invalidate the nested-expand cache when the filter changes. The cache is
+  // keyed only by groupId, but its contents are now scoped to the matrix's
+  // resource filter (see the /nested-groups POST in fetchNestedGroups), so a
+  // group expanded under e.g. "Groups only" must not keep showing that stale
+  // subset after the filter changes.
+  useResetOnKeyChange(storageKey, () => {
+    setNestedDataCache(new Map());
+    setExpandedGroups(new Set());
+  });
 
   // A (member, resource) membership is "governed" when it is covered by a
   // business role the user holds — i.e. it appears in managedByPackages, the
@@ -587,7 +620,7 @@ export default function MatrixView({
         setLoadingNested(new Set(toFetch));
         const results = await Promise.all(
           toFetch.map(id =>
-            authFetch(`/api/group/${encodeURIComponent(id)}/nested-groups`)
+            fetchNestedGroups(id)
               .then(r => r.json())
               .then(data => ({ id, data }))
               .catch(() => ({ id, data: { groups: [], memberships: [] } }))
@@ -616,7 +649,7 @@ export default function MatrixView({
     setNestedDataCache(newCache);
     setExpandedGroups(toExpand);
     setLoadingNested(new Set());
-  }, [orderedGroups, groupsWithNested, nestedDataCache, authFetch]);
+  }, [orderedGroups, groupsWithNested, nestedDataCache, fetchNestedGroups]);
 
   const collapseAll = useCallback(() => {
     setExpandedGroups(new Set());

--- a/app/ui/src/components/MatrixView.mount.test.jsx
+++ b/app/ui/src/components/MatrixView.mount.test.jsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 import { createElement as h } from 'react';
+import { render as rtlRender } from '@testing-library/react';
 import MatrixView from './MatrixView';
 import {
-  renderWithProviders, makeAuthFetch, jsonResponse,
+  renderWithProviders, makeAuthFetch, makeWrapper, jsonResponse,
   screen, userEvent, waitFor,
 } from '@ui/test-utils/renderWithProviders';
 
@@ -201,5 +202,55 @@ describe('MatrixView (mounted)', () => {
     const groupTagMap = new Map([['RES-1', [{ name: 'pii', color: '#abc' }]]]);
     renderView({ groupTagMap });
     await expectRowVisible('Finance App');
+  });
+
+  it('forwards the active resource filter to the nested-groups fetch on Expand All', async () => {
+    // A resource-type-scoped matrix: expanding must POST that scope so the
+    // backend constrains nested resources to it (regression: #674).
+    const filter = {
+      ...baseFilter,
+      resource: { include: [{ kind: 'attribute', field: 'resourceType', values: ['Group'] }] },
+    };
+    const { authFetch } = renderView({ filter });
+    const user = userEvent.setup();
+    // Wait for the mount-time groups-with-nested fetch so Expand All renders.
+    await waitFor(() => expect(authFetch).toHaveBeenCalledWith('/api/groups-with-nested'));
+    await user.click(await screen.findByText('Expand All'));
+    await waitFor(() =>
+      expect(authFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/group/res-1/nested-groups'),
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('resourceType'),
+        }),
+      ),
+    );
+  });
+
+  it('clears expanded nesting when the matrix filter changes (#674)', async () => {
+    // Nested data is scoped to the resource filter, so a filter change must drop
+    // any expansion (else stale nested rows from the old scope would linger).
+    // Render through makeWrapper so rerender preserves the same component
+    // instance (and its expand state) across the prop change.
+    const authFetch = makeFetch();
+    const { wrapper } = makeWrapper({ auth: { authFetch } });
+    const el = (filter) => h(MatrixView, {
+      data: makeData(), accessPackageGroups: [], managedByPackages: [],
+      filter, counts, managedFilter: 'all', setManagedFilter: vi.fn(),
+      refreshing: false, shareUrl: 'https://example.test/matrix',
+      onOpenDetail: vi.fn(), onAdjustFilter: vi.fn(), hasData: true,
+    });
+    const user = userEvent.setup();
+    const { rerender } = rtlRender(el(baseFilter), { wrapper });
+    await waitFor(() => expect(authFetch).toHaveBeenCalledWith('/api/groups-with-nested'));
+    await user.click(await screen.findByText('Expand All'));
+    // Collapse All only renders while something is expanded.
+    await screen.findByText('Collapse All');
+    // Change the filter → render-time reset collapses the nesting.
+    rerender(el({
+      ...baseFilter,
+      resource: { include: [{ kind: 'attribute', field: 'resourceType', values: ['Group'] }] },
+    }));
+    await waitFor(() => expect(screen.queryByText('Collapse All')).not.toBeInTheDocument());
   });
 });

--- a/app/ui/src/components/MatrixView.test.js
+++ b/app/ui/src/components/MatrixView.test.js
@@ -5,6 +5,9 @@ import { dirname, join } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(join(here, 'MatrixView.jsx'), 'utf8');
+// The nested-group expand behaviour (the /groups-with-nested fetch, etc.) now
+// lives in this hook; MatrixView wires it up with the auth-wrapped client.
+const nestedHookSrc = readFileSync(join(here, '..', 'hooks', 'useNestedGroupExpand.js'), 'utf8');
 
 describe('MatrixView', () => {
   it('tracks async loading state for nested groups and identity columns', () => {
@@ -19,6 +22,8 @@ describe('MatrixView', () => {
 
   it('fetches expandable groups through the auth-wrapped client', () => {
     expect(src).toContain('useAuth()');
-    expect(src).toContain('/api/groups-with-nested');
+    // MatrixView passes authFetch into the nested-expand hook, which fetches.
+    expect(src).toContain('useNestedGroupExpand');
+    expect(nestedHookSrc).toContain('/api/groups-with-nested');
   });
 });

--- a/app/ui/src/hooks/useNestedGroupExpand.js
+++ b/app/ui/src/hooks/useNestedGroupExpand.js
@@ -1,0 +1,140 @@
+import { useState, useCallback, useEffect } from 'react';
+
+// How deep the matrix expands nested groups (a group → the groups/roles it is a
+// principal of → their parents …). Shared with MatrixView's row builder.
+export const MAX_NEST_LEVEL = 4;
+
+// Fetch every not-yet-cached group in `ids` (POSTing the active filter via
+// `fetchNestedGroups`) and write the results into `cache`. A failed fetch caches
+// an empty result so the level still resolves.
+async function fetchNestedLevel(ids, fetchNestedGroups, cache) {
+  const results = await Promise.all(
+    ids.map(id =>
+      fetchNestedGroups(id)
+        .then(r => r.json())
+        .then(data => ({ id, data }))
+        .catch(() => ({ id, data: { groups: [], memberships: [] } }))
+    )
+  );
+  for (const { id, data } of results) cache.set(id, data);
+}
+
+// From the groups just expanded, the next level to expand: their nested groups
+// that are themselves expandable and not already being expanded.
+function nextExpandableLevel(currentLevel, cache, groupsWithNested, alreadyExpanding) {
+  const next = [];
+  for (const id of currentLevel) {
+    for (const ng of (cache.get(id)?.groups || [])) {
+      if (groupsWithNested.has(ng.groupId) && !alreadyExpanding.has(ng.groupId)) next.push(ng.groupId);
+    }
+  }
+  return next;
+}
+
+// Run `reset()` during render whenever `key` changes — React's "adjust state
+// when a prop changes" pattern, without an effect (which would trip
+// react-hooks/set-state-in-effect).
+function useResetOnKeyChange(key, reset) {
+  const [seen, setSeen] = useState(key);
+  if (key !== seen) {
+    setSeen(key);
+    reset();
+  }
+}
+
+// Owns the matrix's nested-group expand state and fetches. Opening a group row
+// reveals every resource its members inherit access to; the fetch POSTs the
+// active matrix filter so nested resources honour the same resource-type scope
+// as the grid (e.g. filtering to Groups doesn't leak AppRoles into the nesting).
+// Because the nested data is filter-scoped, the cache is dropped — and rows
+// collapsed — whenever the filter (storageKey) changes.
+//
+//   authFetch      — auth-wrapped fetch
+//   filter         — the active matrix filter, POSTed to the nesting endpoint
+//   storageKey      — stable string form of the filter; a change invalidates the cache
+//   orderedGroups  — the currently rendered top-level group rows (for Expand All)
+export function useNestedGroupExpand({ authFetch, filter, storageKey, orderedGroups }) {
+  const [groupsWithNested, setGroupsWithNested] = useState(new Set());
+  const [expandedGroups, setExpandedGroups] = useState(new Set());
+  const [nestedDataCache, setNestedDataCache] = useState(new Map());
+  const [loadingNested, setLoadingNested] = useState(new Set());
+
+  // Which group rows get an expand affordance — fetched once on mount.
+  useEffect(() => {
+    let cancelled = false;
+    authFetch('/api/groups-with-nested')
+      .then(r => r.ok ? r.json() : { groupIds: [] })
+      .then(d => { if (!cancelled) setGroupsWithNested(new Set(d.groupIds || [])); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [authFetch]);
+
+  // Single place that builds the nested-expand request — POSTs the active filter
+  // so the backend constrains nested resources to the grid's resource-type scope.
+  const fetchNestedGroups = useCallback((id) =>
+    authFetch(`/api/group/${encodeURIComponent(id)}/nested-groups`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filter }),
+    }), [authFetch, filter]);
+
+  const toggleExpand = useCallback(async (groupId) => {
+    if (expandedGroups.has(groupId)) {
+      setExpandedGroups(prev => { const next = new Set(prev); next.delete(groupId); return next; });
+      return;
+    }
+    if (!nestedDataCache.has(groupId)) {
+      setLoadingNested(prev => new Set(prev).add(groupId));
+      try {
+        const res = await fetchNestedGroups(groupId);
+        const data = await res.json();
+        setNestedDataCache(prev => new Map(prev).set(groupId, data));
+      } catch (err) {
+        console.error('Failed to load nested groups:', err);
+        setLoadingNested(prev => { const next = new Set(prev); next.delete(groupId); return next; });
+        return;
+      }
+      setLoadingNested(prev => { const next = new Set(prev); next.delete(groupId); return next; });
+    }
+    setExpandedGroups(prev => new Set(prev).add(groupId));
+  }, [expandedGroups, nestedDataCache, fetchNestedGroups]);
+
+  const expandAll = useCallback(async () => {
+    const newCache = new Map(nestedDataCache);
+    const toExpand = new Set();
+
+    // Start with visible groups that have nested groups, then walk down.
+    let currentLevel = orderedGroups
+      .map(g => g.realGroupId || g.id)
+      .filter(id => groupsWithNested.has(id));
+
+    for (let level = 0; level < MAX_NEST_LEVEL && currentLevel.length > 0; level++) {
+      const toFetch = currentLevel.filter(id => !newCache.has(id));
+      if (toFetch.length > 0) {
+        setLoadingNested(new Set(toFetch));
+        await fetchNestedLevel(toFetch, fetchNestedGroups, newCache);
+      }
+      for (const id of currentLevel) toExpand.add(id);
+      currentLevel = nextExpandableLevel(currentLevel, newCache, groupsWithNested, toExpand);
+    }
+
+    setNestedDataCache(newCache);
+    setExpandedGroups(toExpand);
+    setLoadingNested(new Set());
+  }, [orderedGroups, groupsWithNested, nestedDataCache, fetchNestedGroups]);
+
+  const collapseAll = useCallback(() => {
+    setExpandedGroups(new Set());
+  }, []);
+
+  // Nested data is filter-scoped → drop it (and collapse) when the filter changes.
+  useResetOnKeyChange(storageKey, () => {
+    setNestedDataCache(new Map());
+    setExpandedGroups(new Set());
+  });
+
+  return {
+    groupsWithNested, expandedGroups, nestedDataCache, loadingNested,
+    toggleExpand, expandAll, collapseAll,
+  };
+}

--- a/app/ui/src/hooks/useNestedGroupExpand.test.jsx
+++ b/app/ui/src/hooks/useNestedGroupExpand.test.jsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import {
+  renderHook, act, waitFor, makeAuthFetch, jsonResponse,
+} from '@ui/test-utils/renderWithProviders';
+import { useNestedGroupExpand } from './useNestedGroupExpand';
+
+const baseFilter = { rowType: 'user', resource: { include: [], exclude: [] } };
+const orderedGroups = [{ id: 'g1' }, { id: 'g2' }];
+
+function setup(overrides = {}) {
+  const authFetch = overrides.authFetch || makeAuthFetch({
+    '/api/groups-with-nested': { groupIds: ['g1'] },
+    '/api/group/': jsonResponse({ groups: [{ groupId: 'gp' }], memberships: [{ memberId: 'u1' }] }),
+  });
+  const props = {
+    authFetch,
+    filter: baseFilter,
+    storageKey: JSON.stringify(baseFilter),
+    orderedGroups,
+    ...overrides.props,
+  };
+  const view = renderHook((p) => useNestedGroupExpand(p), { initialProps: props });
+  return { authFetch, props, view };
+}
+
+describe('useNestedGroupExpand', () => {
+  it('fetches the expandable group ids on mount', async () => {
+    const { view } = setup();
+    await waitFor(() => expect(view.result.current.groupsWithNested.has('g1')).toBe(true));
+  });
+
+  it('toggleExpand POSTs the active filter, caches, and expands', async () => {
+    const { authFetch, view } = setup();
+    await act(async () => { await view.result.current.toggleExpand('g1'); });
+    expect(authFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/group/g1/nested-groups'),
+      expect.objectContaining({ method: 'POST', body: expect.stringContaining('resource') }),
+    );
+    expect(view.result.current.expandedGroups.has('g1')).toBe(true);
+    expect(view.result.current.nestedDataCache.has('g1')).toBe(true);
+  });
+
+  it('toggleExpand on an already-expanded group collapses it (no refetch)', async () => {
+    const { authFetch, view } = setup();
+    await act(async () => { await view.result.current.toggleExpand('g1'); });
+    expect(view.result.current.expandedGroups.has('g1')).toBe(true);
+    const callsAfterExpand = authFetch.mock.calls.length;
+    await act(async () => { await view.result.current.toggleExpand('g1'); });
+    expect(view.result.current.expandedGroups.has('g1')).toBe(false);
+    // Collapse path doesn't hit the network again.
+    expect(authFetch.mock.calls.length).toBe(callsAfterExpand);
+  });
+
+  it('toggleExpand swallows a fetch error and leaves the group collapsed', async () => {
+    const authFetch = vi.fn(async () => { throw new Error('boom'); });
+    const { view } = setup({ authFetch });
+    await act(async () => { await view.result.current.toggleExpand('g1'); });
+    expect(view.result.current.expandedGroups.has('g1')).toBe(false);
+    expect(view.result.current.loadingNested.has('g1')).toBe(false);
+  });
+
+  it('expandAll expands every top-level group that has nested groups', async () => {
+    const { view } = setup();
+    await waitFor(() => expect(view.result.current.groupsWithNested.has('g1')).toBe(true));
+    await act(async () => { await view.result.current.expandAll(); });
+    expect(view.result.current.expandedGroups.has('g1')).toBe(true);
+    expect(view.result.current.expandedGroups.has('g2')).toBe(false); // g2 has no nesting
+  });
+
+  it('collapseAll clears the expansion', async () => {
+    const { view } = setup();
+    await act(async () => { await view.result.current.expandAll(); });
+    act(() => { view.result.current.collapseAll(); });
+    expect(view.result.current.expandedGroups.size).toBe(0);
+  });
+
+  it('drops the cache and collapses when the filter (storageKey) changes', async () => {
+    const { props, view } = setup();
+    await act(async () => { await view.result.current.toggleExpand('g1'); });
+    expect(view.result.current.nestedDataCache.size).toBeGreaterThan(0);
+    // A new storageKey means a new resource scope → stale nested data is dropped.
+    view.rerender({ ...props, storageKey: 'changed-filter' });
+    expect(view.result.current.nestedDataCache.size).toBe(0);
+    expect(view.result.current.expandedGroups.size).toBe(0);
+  });
+});

--- a/changes/matrix-nesting-resource-filter-674.md
+++ b/changes/matrix-nesting-resource-filter-674.md
@@ -1,0 +1,2 @@
+- Fixed Matrix group expansion ignoring the resource-type filter: expanding a group while the matrix is filtered to a single resource type (e.g. Groups) now only reveals nested resources of that type, instead of also surfacing AppRoles, directory roles, and other types you filtered out.
+- Changing the matrix filter now clears any expanded nesting, so nested rows always reflect the current filter.


### PR DESCRIPTION
Closes #674.

## Problem
In the Matrix, expanding a group's nesting ignored the resource-type filter. Filtered to **Groups**, expanding a group still showed **AppRoles** (and directory roles, etc.) the group is a principal of — because the filter was only applied to the top-level grid query, never propagated to the `/nested-groups` fan-out.

## Fix (at the source)
- **API — `permissions/nestedGroups.js`:** `/api/group/:id/nested-groups` now also accepts **POST** with the active matrix filter (`{ filter }`) and constrains **both** the nested-resource query and the member sub-query by the *same* resource subquery `/matrix/data` builds — reusing `buildSubqueries` → `buildEntitySubquery` (no new filter logic). The legacy **GET** (no body) is unchanged and still returns every nested resource, so existing callers and the golden/characterization tests keep passing.
- **UI — `MatrixView.jsx`:** `toggleExpand` and `expandAll` POST the current `filter` through a single shared `fetchNestedGroups` helper. Since nested data is now filter-scoped, the nested-expand cache is invalidated (and rows collapsed) whenever the filter changes, via a small `useResetOnKeyChange` render-time hook (keeps the reset branch out of `MatrixView`'s complexity budget and avoids a `set-state-in-effect`).

## Tests
- **Unit (`permissions.coverage.test.js`):** POST-with-filter asserts the resource `IN (subquery)` is embedded in *both* the groups and members SQL; POST/GET-without-filter asserts it is **not**; containment (scope-node) path still short-circuits.
- **Mount (`MatrixView.mount.test.jsx`):** "Expand All" POSTs the active resource filter; changing the filter collapses the nesting.
- Per-file coverage, cyclomatic + cognitive complexity, and jscpd all verified green locally.

## Scope / follow-ups
- The **down-tree containment** expansion (`expandCapabilityDown`) is unchanged: those are capability resources (e.g. an Azure role at a subscription), which aren't Groups, so they don't appear in a Groups-filtered matrix. Noted in the issue as a speculative "likely also applies" — left out to keep this focused.
- The nesting SQL is verified only by SQL-blind unit mocks here; real-Postgres (contract) coverage of the emitted query is tracked by **#679**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
