### PR TITLE
fix(risk): single-entity risk score always returned null displayName (#661)

### DIFF
--- a/app/api/src/routes/riskScores.coverage.test.js
+++ b/app/api/src/routes/riskScores.coverage.test.js
@@ -16,12 +16,14 @@ process.env.USE_SQL = 'true';
 // is the table-check returning a present table.
 let tableExists = true;
 const queryScript = []; // FIFO of { match?: RegExp, recordset } applied to .query() calls (excluding the table check)
+const capturedSql = []; // every SQL string handed to .query(), so tests can assert the emitted SQL
 
 vi.mock('../perf/sqlTimer.js', () => ({
   timedRequest: (_p, label) => ({
     _inputs: {},
     input(name, value) { this._inputs[name] = value; return this; },
     async query(sql) {
+      capturedSql.push(sql);
       if (/to_regclass/.test(sql)) {
         return { recordset: [{ tbl: tableExists ? 'public.RiskScores' : null }] };
       }
@@ -50,6 +52,7 @@ const VALID = '11111111-1111-1111-1111-111111111111';
 beforeEach(() => {
   tableExists = true;
   queryScript.length = 0;
+  capturedSql.length = 0;
   queryRiskScoresPage.mockClear();
 });
 
@@ -108,6 +111,23 @@ describe('GET /risk-scores/:type/:id', () => {
     expect(res.status).toBe(200);
     expect(res.body.displayName).toBe('Bob');
     expect(res.body.effectiveScore).toBe(70);
+    // Regression guard (#661): the entity-name lookup must query the real
+    // mapped table with Postgres identifier quoting — not the literal string
+    // "tableName" in SQL-Server [brackets], which threw and nulled displayName.
+    const entitySql = capturedSql.find(s => s.includes('SELECT "displayName" FROM'));
+    expect(entitySql).toContain('FROM "Principals"');
+    expect(entitySql).not.toContain('[tableName]');
+    expect(entitySql).not.toContain('[Principals]');
+  });
+
+  it('200 — maps a Resource (group) to the Resources table for the name lookup', async () => {
+    queryScript.push([{ id: 'g', entityType: 'Resource', riskScore: 40, riskOverride: null }]); // single score
+    queryScript.push([{ displayName: 'Finance Group' }]);                                        // entity name
+    const res = await request(app).get(`/api/risk-scores/groups/${VALID}`);
+    expect(res.status).toBe(200);
+    expect(res.body.displayName).toBe('Finance Group');
+    const entitySql = capturedSql.find(s => s.includes('SELECT "displayName" FROM'));
+    expect(entitySql).toContain('FROM "Resources"');
   });
 
   it('404 when no score row exists', async () => {

--- a/app/api/src/routes/riskScores/entity.js
+++ b/app/api/src/routes/riskScores/entity.js
@@ -127,9 +127,14 @@ router.get('/risk-scores/:type/:id', async (req, res) => {
     const tableName = entityTableMap[entityType];
     if (tableName) {
       try {
+        // tableName comes from the fixed entityTableMap allow-list above, so
+        // interpolating it (double-quoted, as Postgres requires) is injection-
+        // safe. The previous form interpolated the literal string "tableName"
+        // and used SQL-Server [bracket] quoting, so this always threw against
+        // Postgres and displayName was silently null for every entity.
         const ent = await timedRequest(p, 'risk-score-entity-name', res)
           .input('id', id)
-          .query(`SELECT "displayName" FROM [${"tableName"}] WHERE id = @id AND ${TEMPORAL_FILTER}`);
+          .query(`SELECT "displayName" FROM "${tableName}" WHERE id = @id AND ${TEMPORAL_FILTER}`);
         displayName = ent.recordset[0]?.displayName || null;
       } catch { /* entity table may not exist */ }
     }

--- a/changes/risk-score-displayname-661.md
+++ b/changes/risk-score-displayname-661.md
@@ -1,0 +1,1 @@
+- Fixed the single-entity risk score view always showing a blank name — the endpoint's entity-name lookup used an invalid query that silently failed, so `displayName` came back empty for every user, group, resource, context, and identity. The entity's name is now returned correctly.


### PR DESCRIPTION
Closes #661.

## Problem
`GET /api/risk-scores/:type/:id` enriches the response with the entity's `displayName`, but the lookup query was malformed:

```js
SELECT "displayName" FROM [${"tableName"}] WHERE id = @id AND ...
```

1. **Literal string, not the variable** — `${"tableName"}` interpolates the *string* `"tableName"`, so every request queried `FROM [tableName]`, never the mapped table.
2. **SQL-Server bracket quoting** — `[...]` is a syntax error in Postgres (identifiers are `"double-quoted"`).

The query threw on every call; the surrounding `try/catch` swallowed it ("entity table may not exist"), so `displayName` was silently `null` for **every** user, group, resource, context, and identity.

## Fix
Reference the variable and use Postgres identifier quoting:

```js
SELECT "displayName" FROM "${tableName}" WHERE id = @id AND ...
```

`entityTableMap` is a fixed allow-list (`Principals` / `Resources` / `Contexts` / `Identities`), so interpolating the mapped name is injection-safe. (`TEMPORAL_FILTER` is `1=1`, valid for every table.)

## Test
The existing unit test asserted `displayName === 'Bob'` and **passed despite the bug**, because the SQL-blind mock never parses the query text — the exact gap #661 calls out. I added SQL-capture assertions (`FROM "Principals"` / `FROM "Resources"`, and *not* `[tableName]`) so a regression of this defect now fails the unit test — **verified by temporarily reintroducing the bug** (both new assertions failed as expected).

Real-Postgres (contract) coverage of this endpoint remains tracked by **#679**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
