### PR TITLE
fix(api): resilient startup — bind port before DB migrations (no more crash-loop on slow migrations)

### DIFF
--- a/app/api/src/app.js
+++ b/app/api/src/app.js
@@ -50,11 +50,24 @@ import dataExportRouter from './routes/dataExport.js';
 import bulkListsRouter from './routes/bulkLists.js';
 import updatesRouter from './routes/updates.js';
 import { isAuthEnabled, getTenantId, getClientId } from './config/authConfig.js';
+import { isSchemaReady } from './startupState.js';
 import swaggerUi from 'swagger-ui-express';
 import YAML from 'yamljs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const isProduction = process.env.NODE_ENV === 'production';
+
+// Worker data-plane gate: while the DB schema is still migrating (see
+// index.js + startupState.js) the crawler job-claim/complete and ingest
+// endpoints return 503, so no crawler runs against a mid-migration schema.
+// Inert in tests / mock mode (isSchemaReady() is true unless index.js armed
+// the gate at real startup), and scoped to the worker paths only — human/UI
+// endpoints stay available.
+function schemaMigratingGate(req, res, next) {
+  if (isSchemaReady()) return next();
+  res.set('Retry-After', '30');
+  return res.status(503).json({ error: 'Schema migration in progress, please retry shortly' });
+}
 
 // Minimum compose file version this image expects. Bump this whenever
 // docker-compose.prod.yml changes in a way that affects runtime behavior
@@ -190,8 +203,13 @@ export function createApp() {
   app.use('/api', authedApiLimiter);
 
   // Unauthenticated endpoints (rate-limited)
+  // Always 200 so the platform startup/health probe passes as soon as the port
+  // is open — even while migrations still run in the background (see index.js).
+  // A non-200 here would let App Service kill the container mid-migration and
+  // recreate the crash loop this design fixes. `schemaReady` reports the real
+  // migration state for observability without failing the probe.
   app.get('/api/health', publicLimiter, (req, res) => {
-    res.json({ status: 'ok' });
+    res.json({ status: 'ok', schemaReady: isSchemaReady() });
   });
 
   app.get('/api/version', publicLimiter, (req, res) => {
@@ -336,6 +354,12 @@ export function createApp() {
   // Crawler jobs (Entra ID auth) — /api/admin/crawler-jobs/*, /api/admin/status — gated per-route.
   app.use('/api', authMiddleware, jobsRouter);
   // Crawler self-service (API key auth) — /api/crawlers/whoami, /api/crawlers/rotate
+  // Gate the worker data-plane (job claim/complete/phases/fail under
+  // /crawlers/jobs, and ingest) while the schema migrates — BEFORE crawler auth
+  // runs, so we 503 without touching the DB or reading a large body. whoami and
+  // rotate stay reachable so the worker can authenticate and back off cleanly.
+  app.use('/api/crawlers/jobs', schemaMigratingGate);
+  app.use('/api/ingest', schemaMigratingGate);
   app.use('/api', crawlerAuthMiddleware, selfServiceCrawlersRouter);
   // Ingest endpoints (API key auth) — /api/ingest/*
   // Ingest body size cap. Crawler chunks at 5,000 records per batch; with

--- a/app/api/src/app.schemaGate.test.js
+++ b/app/api/src/app.schemaGate.test.js
@@ -1,0 +1,65 @@
+// Verifies the resilient-startup gate wired into the Express app: /api/health
+// stays 200 (so the platform startup probe passes) while reporting readiness,
+// and the worker data-plane (job claim + ingest) returns 503 until the schema
+// is ready — without blocking human/UI endpoints.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// crawlerAuth.js captures USE_SQL at module-load time; set it before the app
+// (and its middleware) are imported so the worker mounts behave like the real
+// SQL path (401 without a key) instead of the mock-mode "SQL not configured"
+// 503 — otherwise we couldn't tell our migration-gate 503 apart from theirs.
+vi.hoisted(() => { process.env.USE_SQL = 'true'; });
+import request from 'supertest';
+import { createApp } from './app.js';
+import { armStartupGate, markSchemaReady, _resetForTest } from './startupState.js';
+
+describe('schema-migrating gate', () => {
+  let app;
+  beforeEach(() => {
+    _resetForTest();
+    app = createApp();
+  });
+  afterEach(() => _resetForTest());
+
+  it('health is always 200 and reports schemaReady before and after migration', async () => {
+    armStartupGate();
+    const during = await request(app).get('/api/health');
+    expect(during.status).toBe(200);
+    expect(during.body).toMatchObject({ status: 'ok', schemaReady: false });
+
+    markSchemaReady();
+    const after = await request(app).get('/api/health');
+    expect(after.status).toBe(200);
+    expect(after.body.schemaReady).toBe(true);
+  });
+
+  it('returns 503 with Retry-After on ingest while migrating', async () => {
+    armStartupGate();
+    const res = await request(app).post('/api/ingest/contexts').send({ records: [] });
+    expect(res.status).toBe(503);
+    expect(res.headers['retry-after']).toBe('30');
+    expect(res.body.error).toMatch(/migration in progress/i);
+  });
+
+  it('returns 503 on the worker job-claim endpoint while migrating', async () => {
+    armStartupGate();
+    const res = await request(app).post('/api/crawlers/jobs/claim').send({});
+    expect(res.status).toBe(503);
+  });
+
+  it('stops gating once the schema is ready (falls through to auth, not 503)', async () => {
+    armStartupGate();
+    markSchemaReady();
+    const ingest = await request(app).post('/api/ingest/contexts').send({ records: [] });
+    expect(ingest.status).not.toBe(503);
+    const claim = await request(app).post('/api/crawlers/jobs/claim').send({});
+    expect(claim.status).not.toBe(503);
+  });
+
+  it('never gates when the gate was not armed (tests / mock mode)', async () => {
+    // No armStartupGate() call — isSchemaReady() is true, so the worker
+    // endpoints behave exactly as before this change.
+    const ingest = await request(app).post('/api/ingest/contexts').send({ records: [] });
+    expect(ingest.status).not.toBe(503);
+  });
+});

--- a/app/api/src/index.js
+++ b/app/api/src/index.js
@@ -11,6 +11,7 @@ import { createApp } from './app.js';
 import { enable as enablePerf, isEnabled as isPerfEnabled } from './perf/collector.js';
 import { loadAuthConfig, isAuthEnabled } from './config/authConfig.js';
 import { bootstrapWorker, migrateDatabase } from './bootstrap.js';
+import { armStartupGate, markSchemaReady, markSchemaFailed } from './startupState.js';
 
 const port       = process.env.PORT || 3001;
 // Desktop mode binds to 127.0.0.1 only — the portable is a local app and should
@@ -53,27 +54,51 @@ loadAuthConfig().catch(err => {
 
 const app = createApp();
 
-// Apply database migrations BEFORE binding the port (see migrateDatabase). The
-// worker container starts polling for crawler jobs as soon as the web port is
-// up, so the schema must be fully upgraded first — otherwise a crawler can run
-// against a mid-migration schema and deadlock against the migration's locks.
-// On failure, exit non-zero: Docker restarts the container and retries, and
-// because the port never opened, no crawler ever ran against a broken schema.
-try {
-  await migrateDatabase();
-} catch (err) {
-  console.error('Database migration failed — refusing to start:', err.message);
-  process.exit(1);
+// ─── Bind the port FIRST, migrate in the background ──────────────
+// Migrations used to run to completion BEFORE app.listen(). That made a slow
+// migration fatal on Azure App Service: the platform kills a container that
+// doesn't answer on its port within a startup-probe window (230s by default),
+// so a migration slower than that left the port closed, got killed mid-run,
+// rolled back, and re-ran forever — a permanent "Application Error" crash loop.
+//
+// Now the port opens immediately (the probe passes) and migrations run after.
+// The invariant that no crawler runs against a mid-migration schema is kept by
+// arming a startup gate: the worker data-plane (job claim + ingest, wired in
+// app.js) returns 503 until markSchemaReady() runs. On failure we do NOT exit
+// (that recreates the crash loop); we log and retry with backoff, leaving the
+// port open so operators can reach logs and the app self-heals once the DB
+// issue clears.
+if (process.env.USE_SQL === 'true') armStartupGate();
+
+// Backoff schedule for migration retries; the last value repeats.
+const MIGRATION_RETRY_MS = [5_000, 15_000, 30_000, 60_000];
+
+async function startSchemaAndWorker(attempt = 0) {
+  try {
+    await migrateDatabase();
+    markSchemaReady();
+    console.log('Schema ready — worker (crawler) endpoints enabled');
+    // Auto-create built-in worker crawler + infrastructure tables.
+    await bootstrapWorker();
+  } catch (err) {
+    markSchemaFailed(err);
+    const delay = MIGRATION_RETRY_MS[Math.min(attempt, MIGRATION_RETRY_MS.length - 1)];
+    console.error(
+      `CRITICAL: database migration failed (attempt ${attempt + 1}). ` +
+      `Worker endpoints stay disabled; retrying in ${delay / 1000}s. Cause: ${err.message}`
+    );
+    setTimeout(() => startSchemaAndWorker(attempt + 1), delay).unref();
+  }
 }
 
-const server = app.listen(port, host, async () => {
+const server = app.listen(port, host, () => {
   console.log(`Identity Atlas running on http://localhost:${port}`);
   console.log(`Mode: ${process.env.USE_SQL === 'true' ? 'SQL' : 'Mock data'}`);
   console.log(`Auth: ${isAuthEnabled() ? 'Entra ID' : 'Disabled'}`);
   console.log(`Perf: ${isPerfEnabled() ? 'Enabled (Server-Timing headers + /api/perf)' : 'Disabled'}`);
 
-  // Auto-create built-in worker crawler + infrastructure tables
-  await bootstrapWorker();
+  // Run migrations + worker bootstrap WITHOUT blocking the now-open port.
+  void startSchemaAndWorker();
 });
 
 server.on('error', (err) => {

--- a/app/api/src/index.test.js
+++ b/app/api/src/index.test.js
@@ -11,8 +11,8 @@ const startup = vi.hoisted(() => {
   return {
     calls,
     // migrateDatabase deliberately yields to the event loop before recording,
-    // so if a regression ever called app.listen() WITHOUT awaiting migrations
-    // first, 'listen' would be recorded before 'migrate' and the test fails.
+    // so a regression that awaited it BEFORE app.listen() (the old, fatal
+    // ordering) would record 'migrate' before 'listen' and fail the test.
     migrateDatabase: vi.fn(async () => {
       await new Promise(resolve => setTimeout(resolve, 20));
       calls.push('migrate');
@@ -23,6 +23,9 @@ const startup = vi.hoisted(() => {
       if (cb) cb();
       return { on: vi.fn() };
     }),
+    armStartupGate: vi.fn(() => calls.push('arm')),
+    markSchemaReady: vi.fn(() => calls.push('ready')),
+    markSchemaFailed: vi.fn(() => calls.push('failed')),
   };
 });
 
@@ -31,25 +34,40 @@ vi.mock('./bootstrap.js', () => ({
   migrateDatabase: startup.migrateDatabase,
   bootstrapWorker: startup.bootstrapWorker,
 }));
+vi.mock('./startupState.js', () => ({
+  armStartupGate: startup.armStartupGate,
+  markSchemaReady: startup.markSchemaReady,
+  markSchemaFailed: startup.markSchemaFailed,
+}));
 vi.mock('./perf/collector.js', () => ({ enable: vi.fn(), isEnabled: () => false }));
 vi.mock('./config/authConfig.js', () => ({
   loadAuthConfig: vi.fn(async () => {}),
   isAuthEnabled: () => false,
 }));
 
-describe('startup ordering — migrations run first', () => {
-  it('applies migrations before the server binds its port', async () => {
-    // Importing index.js runs its top-level startup sequence. The dynamic
-    // import resolves only after index.js's top-level `await migrateDatabase()`
-    // settles, so by the time this await returns the ordering is final.
-    await import('./index.js');
+describe('resilient startup ordering — bind first, migrate in background', () => {
+  it('arms the gate before binding, opens the port before migrating, then readies + bootstraps', async () => {
+    const prev = process.env.USE_SQL;
+    process.env.USE_SQL = 'true';
+    try {
+      // Importing index.js runs its startup sequence. app.listen() no longer
+      // awaits migrations, so wait for the background chain to settle.
+      await import('./index.js');
+      await vi.waitFor(() => expect(startup.calls).toContain('bootstrap'));
 
-    // Migrations must have run, and must be the very first recorded step —
-    // guards against someone dropping `await migrateDatabase()` from index.js
-    // (the fn would never be called) or moving it after app.listen().
-    expect(startup.migrateDatabase).toHaveBeenCalledTimes(1);
-    expect(startup.calls[0]).toBe('migrate');
-    expect(startup.calls.indexOf('migrate')).toBeLessThan(startup.calls.indexOf('listen'));
+      // Gate armed BEFORE the port opens — no window where a worker could hit a
+      // mid-migration schema.
+      expect(startup.calls.indexOf('arm')).toBeLessThan(startup.calls.indexOf('listen'));
+      // Port opens BEFORE migrations finish — the whole point (probe passes fast,
+      // no crash loop on a slow migration).
+      expect(startup.calls.indexOf('listen')).toBeLessThan(startup.calls.indexOf('migrate'));
+      // Schema readied only after migrations, and worker bootstrap after that.
+      expect(startup.calls.indexOf('migrate')).toBeLessThan(startup.calls.indexOf('ready'));
+      expect(startup.calls.indexOf('ready')).toBeLessThan(startup.calls.indexOf('bootstrap'));
+      expect(startup.markSchemaFailed).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.USE_SQL; else process.env.USE_SQL = prev;
+    }
   });
 });
 

--- a/app/api/src/startupState.js
+++ b/app/api/src/startupState.js
@@ -1,0 +1,61 @@
+// Schema-readiness state for the resilient startup sequence.
+//
+// The web server now binds its port BEFORE database migrations run, so a slow
+// migration can never leave the port closed and crash-loop the container into
+// an Azure "Application Error" (migrations that exceeded App Service's 230s
+// startup probe used to be killed mid-run, roll back, and re-run forever). The
+// migration + worker bootstrap runs in the background after app.listen().
+//
+// To preserve the invariant that NO crawler ever runs against a mid-migration
+// schema, the worker data-plane endpoints (job claim/complete + ingest) consult
+// isSchemaReady() and return 503 until the schema is upgraded. See index.js
+// (which drives the state) and app.js (which applies the gate).
+//
+// The gate is INERT until the real process entry point (index.js) arms it, so
+// unit tests that build the app with createApp() are unaffected — they never
+// arm it, so isSchemaReady() stays true and the worker endpoints behave as
+// before.
+
+let armed = false;         // index.js sets this at real startup; tests never do
+let ready = false;         // flipped true once migrations complete
+let lastError = null;      // message of the most recent migration failure
+let failedAttempts = 0;    // how many migration attempts have thrown
+
+// Arm the gate at the start of a real boot (SQL mode). Until markSchemaReady()
+// runs, the worker data-plane is closed.
+export function armStartupGate() {
+  armed = true;
+  ready = false;
+  lastError = null;
+}
+
+// Migrations completed — open the worker data-plane.
+export function markSchemaReady() {
+  ready = true;
+  lastError = null;
+}
+
+// Migrations threw — keep the gate closed and record why (for logs / health).
+export function markSchemaFailed(err) {
+  ready = false;
+  lastError = err?.message ?? String(err);
+  failedAttempts += 1;
+}
+
+// The gate consults this. True (open) unless the gate was armed and the schema
+// isn't ready yet — so it is a no-op in tests and in non-SQL/mock mode.
+export function isSchemaReady() {
+  return !armed || ready;
+}
+
+export function getStartupStatus() {
+  return { armed, schemaReady: ready, lastError, failedAttempts };
+}
+
+// Test-only: reset module state between cases.
+export function _resetForTest() {
+  armed = false;
+  ready = false;
+  lastError = null;
+  failedAttempts = 0;
+}

--- a/app/api/src/startupState.test.js
+++ b/app/api/src/startupState.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  armStartupGate,
+  markSchemaReady,
+  markSchemaFailed,
+  isSchemaReady,
+  getStartupStatus,
+  _resetForTest,
+} from './startupState.js';
+
+describe('startupState', () => {
+  beforeEach(() => _resetForTest());
+
+  it('is ready by default (inert until armed) so tests/mock mode are unaffected', () => {
+    expect(isSchemaReady()).toBe(true);
+    expect(getStartupStatus()).toMatchObject({ armed: false, schemaReady: false });
+  });
+
+  it('closes the gate once armed, opens it when the schema is marked ready', () => {
+    armStartupGate();
+    expect(isSchemaReady()).toBe(false);
+    markSchemaReady();
+    expect(isSchemaReady()).toBe(true);
+    expect(getStartupStatus()).toMatchObject({ armed: true, schemaReady: true });
+  });
+
+  it('records failures, counts attempts, and keeps the gate closed', () => {
+    armStartupGate();
+    markSchemaFailed(new Error('boom'));
+    expect(isSchemaReady()).toBe(false);
+    expect(getStartupStatus()).toMatchObject({ failedAttempts: 1, lastError: 'boom' });
+
+    markSchemaFailed(new Error('again'));
+    expect(getStartupStatus().failedAttempts).toBe(2);
+    expect(getStartupStatus().lastError).toBe('again');
+  });
+
+  it('coerces a non-Error failure to a string', () => {
+    armStartupGate();
+    markSchemaFailed('plain string failure');
+    expect(getStartupStatus().lastError).toBe('plain string failure');
+  });
+
+  it('markSchemaReady clears a prior error and opens the gate', () => {
+    armStartupGate();
+    markSchemaFailed(new Error('boom'));
+    markSchemaReady();
+    expect(isSchemaReady()).toBe(true);
+    expect(getStartupStatus().lastError).toBeNull();
+  });
+});

--- a/azure/main.json
+++ b/azure/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "1861829179006836607"
+      "templateHash": "16364297160833833680"
     }
   },
   "parameters": {
@@ -907,7 +907,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.43.8.12551",
-              "templateHash": "16066790737795264958"
+              "templateHash": "18428901815397905413"
             }
           },
           "parameters": {
@@ -1060,6 +1060,10 @@
                     {
                       "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
                       "value": "false"
+                    },
+                    {
+                      "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",
+                      "value": "1800"
                     },
                     {
                       "name": "NODE_ENV",

--- a/azure/modules/app-service.bicep
+++ b/azure/modules/app-service.bicep
@@ -112,6 +112,13 @@ resource web 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'DOCKER_REGISTRY_SERVER_URL', value: 'https://ghcr.io' }
         { name: 'WEBSITES_PORT', value: '3001' }
         { name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE', value: 'false' }
+        // Cold-start probe ceiling. The web container binds its port BEFORE
+        // running DB migrations (they run in the background — see index.js), so
+        // a slow migration no longer blocks startup. We still raise this from
+        // the 230s default to the 1800s platform max as defence in depth for
+        // very large one-time schema upgrades. See
+        // docs/architecture/azure-deployment.md ("Startup & migrations").
+        { name: 'WEBSITES_CONTAINER_START_TIME_LIMIT', value: '1800' }
         // App config
         { name: 'NODE_ENV', value: 'production' }
         { name: 'USE_SQL', value: 'true' }

--- a/changes/resilient-migration-startup.md
+++ b/changes/resilient-migration-startup.md
@@ -1,0 +1,5 @@
+- Fixed: a slow database migration could take the whole app down on Azure (the "Application Error" page) by exceeding the container startup probe and crash-looping. The web app now starts and stays reachable while migrations run in the background, and comes up as soon as they finish.
+- Crawlers and data ingest now wait (and automatically retry) while a schema upgrade is in progress, so a crawler never runs against a half-migrated database.
+- A failed migration no longer crash-loops the app — it stays up, logs the error, and retries automatically, self-healing once the underlying issue is resolved.
+- The health endpoint now reports whether the schema is fully migrated (`schemaReady`).
+- Azure deployments now allow up to 30 minutes for a one-time migration as an added safeguard for very large databases.

--- a/docs/architecture/azure-deployment.md
+++ b/docs/architecture/azure-deployment.md
@@ -115,6 +115,31 @@ The deployment's outputs include `logAnalyticsCreated: true|false` so you can te
 
 ## Operational notes
 
+### Startup & migrations
+
+The web container **binds its port before running DB migrations** — migrations
+run in the background right after the server starts listening. This matters on
+App Service: the platform kills a container that doesn't answer on its port
+within the cold-start probe window (`WEBSITES_CONTAINER_START_TIME_LIMIT`, 230s
+by default), so a migration slower than that used to leave the port closed and
+crash-loop the container into an "Application Error" page.
+
+- The app comes up immediately and `/api/health` returns `200` (with a
+  `schemaReady` field) while a migration is still running.
+- Crawler job-claim and ingest endpoints return `503 Retry-After: 30` until the
+  schema is ready, so no crawler runs against a half-migrated database. The
+  worker just retries.
+- If a migration fails, the container no longer crash-loops — it stays up, logs
+  the error, and retries with backoff, self-healing once the cause clears.
+- The template also sets `WEBSITES_CONTAINER_START_TIME_LIMIT=1800` (the 30-min
+  platform max) as an extra backstop for very large one-time schema upgrades.
+
+**Track `:latest`, not `:edge`, in production.** `:latest` is the stable
+customer release; `:edge` is the latest merged commit on `main` and may carry
+unvetted migrations that reach your production the moment they merge. Pin the
+channel by redeploying with `webImage=ghcr.io/fortigi/identity-atlas:latest`
+(and the matching `workerImage`), or a specific version tag.
+
 ### Updating the container images
 
 ```powershell


### PR DESCRIPTION
## Why

A large customer's Azure deployment showed **":( Application Error"** in a multi-day crash loop. Root cause: migrations run **before** the web server binds its port ([`index.js`](../blob/main/app/api/src/index.js)), and migration `055_history_timeline_indexes.sql` (six index builds on the large `_history` table) took **~11 minutes** on their data. Azure App Service kills a container that doesn't answer on its port within the cold-start probe window (**230s default**), so the container was killed mid-migration, the transaction rolled back (nothing recorded), and every restart re-ran the same migration and timed out again — a permanent, unrecoverable loop.

This isn't a bug in the migration; it's a structural coupling. Any migration slower than the probe window takes the whole app down, on Azure and (via a slow first boot) docker-compose.

## What changed

**Bind the port first, migrate in the background.**
- The web server now calls `app.listen()` immediately; migrations + worker bootstrap run in the background. `/api/health` returns `200` right away (probe passes) with a `schemaReady` field for observability.
- The invariant that **no crawler runs against a mid-migration schema** is preserved by a startup gate ([`startupState.js`](../blob/main/app/api/src/startupState.js)): the worker **job-claim** (`/api/crawlers/jobs/*`) and **ingest** (`/api/ingest/*`) endpoints return `503 Retry-After: 30` until migrations finish. The worker just retries — same effect as "port not open yet" today.
- A **failed** migration no longer `exit(1)`s (which recreated the crash loop). It logs `CRITICAL`, keeps the port open, and retries with backoff — self-healing once the DB issue clears.

**Backstop + docs.**
- `azure/modules/app-service.bicep` now sets `WEBSITES_CONTAINER_START_TIME_LIMIT=1800` (the 30-min platform max) as defence in depth. `main.json` recompiled.
- Docs: new "Startup & migrations" section, and guidance to **track `:latest`, not `:edge`, in production** (this deployment was on `:edge`, which is what let an unvetted migration reach prod on merge).

## The gate, precisely

`schemaMigratingGate` is **inert unless armed** by the real entry point (`index.js`), so `createApp()`-based tests are unaffected. It's scoped to the two worker mounts only — human/UI endpoints stay reachable during a migration (a transient degradation, not the total outage a closed port caused).

## Tests

- `startupState.test.js` — gate state machine (armed/ready/failed, error capture).
- `app.schemaGate.test.js` — health stays 200 + reports `schemaReady`; ingest and job-claim return 503 while migrating, pass through once ready, and never gate when unarmed.
- `index.test.js` — rewritten to encode the **new** invariant: gate armed → port opens → migrate → ready → bootstrap (previously asserted migrate-before-listen).
- Full API suite green (1818 passing; the one local failure is a gitignored scratch `test/demo-dataset/demo-company.json` absent from the repo/CI).

## Follow-ups (recommended as stacked PRs, not here)

1. **Online DDL** so migrations stop being `O(table size)` under a lock: `CREATE INDEX CONCURRENTLY` (needs a non-transactional migration flag in the runner) and `CHECK ... NOT VALID` + `VALIDATE`. Kept separate because it changes the migration runner's transaction model.
2. **CI migration-runtime budget** test to catch a slow migration before it ships.

Once (1) lands these migrations are fast too; this PR makes a slow migration *non-fatal* regardless.