### PR TITLE
Trust-section copy: LLM optional + name Socket Firewall vendor

### DIFF
--- a/changes/feature-site-llm-optional-copy.md
+++ b/changes/feature-site-llm-optional-copy.md
@@ -1,0 +1,1 @@
+- Marketing site: clarified that the LLM risk-scoring layer is optional (and still sees public context only), and credited the package-firewall vendor (Socket Firewall) by name.

--- a/site/index.html
+++ b/site/index.html
@@ -585,8 +585,8 @@
             <p>Open to read, fork, challenge and contribute. Adopting it means forking the MIT repo, so all code lives inside your tenant. You control updates.</p>
           </div>
           <div class="trust-item reveal">
-            <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M2 12h20M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18"/></svg>LLM sees public context only</div>
-            <p>Risk scoring profiles your org from public-domain information. No identity data is ever sent to any model.</p>
+            <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M2 12h20M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18"/></svg>LLM is optional, public context only</div>
+            <p>Risk scoring is an optional layer you switch on. When you do, the model profiles your org from public-domain information only — no identity data is ever sent to it.</p>
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Secrets encrypted</div>

--- a/site/index.html
+++ b/site/index.html
@@ -602,7 +602,7 @@
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5M12 22V12"/></svg>Supply-chain guarded</div>
-            <p>A published SBOM, Dependabot keeping dependencies current, and a package-reputation firewall vetting new packages. Built on PostgreSQL 16.</p>
+            <p>A published SBOM, Dependabot keeping dependencies current, and <a href="https://socket.dev" target="_blank" rel="noopener">Socket Firewall</a> vetting new packages against supply-chain attacks before they land. Built on PostgreSQL 16.</p>
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>Built by a real team</div>


### PR DESCRIPTION
Follow-up to #692 (the marketing site, now merged). Two small Trust-section copy fixes:

- **LLM point is now explicitly optional.** "LLM sees public context only" → **"LLM is optional, public context only"**, with body copy clarifying risk scoring is an optional layer you switch on. Matches the What-section risk-scoring pillar, which already says the same.
- **Names the package-firewall vendor.** "a package-reputation firewall" → **Socket Firewall** (linked to socket.dev). This credits the tool by name for accuracy and to satisfy its freely-available licensing terms — consistent with the attribution already in `docs/about.md`.

Copy-only, no functional code. Verified on SK2 (light/dark, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)