### PR TITLE
Site: coverage link + fix broken /stable/ deep docs links

### DIFF
--- a/changes/feature-site-qa-coverage-link.md
+++ b/changes/feature-site-qa-coverage-link.md
@@ -1,0 +1,1 @@
+- Marketing site: the "Extensive quality assurance" trust card now links "code-coverage ratchets" to the published Test Coverage report.

--- a/site/index.html
+++ b/site/index.html
@@ -598,7 +598,7 @@
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Extensive quality assurance</div>
-            <p>Unit tests (Vitest + Pester), enforced <a href="https://fortigi.github.io/IdentityAtlas/reference/coverage/" target="_blank" rel="noopener">code-coverage ratchets</a>, file-size &amp; complexity gates, a duplication gate, Playwright E2E, and load/soak tests.</p>
+            <p>Unit tests (Vitest + Pester), enforced <a href="https://fortigi.github.io/IdentityAtlas/stable/reference/coverage/" target="_blank" rel="noopener">code-coverage ratchets</a>, file-size &amp; complexity gates, a duplication gate, Playwright E2E, and load/soak tests.</p>
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5M12 22V12"/></svg>Supply-chain guarded</div>
@@ -606,7 +606,7 @@
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>Built by a real team</div>
-            <p>A number of Fortigi developers, over a longer project history. Fortigi is an established Dutch IAM consultancy. <a href="https://fortigi.github.io/IdentityAtlas/history/" target="_blank" rel="noopener">See the history ↗</a></p>
+            <p>A number of Fortigi developers, over a longer project history. Fortigi is an established Dutch IAM consultancy. <a href="https://fortigi.github.io/IdentityAtlas/stable/history/" target="_blank" rel="noopener">See the history ↗</a></p>
           </div>
         </div>
 
@@ -656,7 +656,7 @@
           <h4>Resources</h4>
           <a href="https://fortigi.github.io/IdentityAtlas" target="_blank" rel="noopener">Documentation ↗</a>
           <a href="https://github.com/Fortigi/IdentityAtlas" target="_blank" rel="noopener">Source on GitHub ↗</a>
-          <a href="https://fortigi.github.io/IdentityAtlas/history/" target="_blank" rel="noopener">Project history ↗</a>
+          <a href="https://fortigi.github.io/IdentityAtlas/stable/history/" target="_blank" rel="noopener">Project history ↗</a>
           <a href="https://github.com/Fortigi/IdentityAtlas/blob/main/LICENSE" target="_blank" rel="noopener">MIT License ↗</a>
         </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -598,7 +598,7 @@
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>Extensive quality assurance</div>
-            <p>Unit tests (Vitest + Pester), enforced code-coverage ratchets, file-size &amp; complexity gates, a duplication gate, Playwright E2E, and load/soak tests.</p>
+            <p>Unit tests (Vitest + Pester), enforced <a href="https://fortigi.github.io/IdentityAtlas/reference/coverage/" target="_blank" rel="noopener">code-coverage ratchets</a>, file-size &amp; complexity gates, a duplication gate, Playwright E2E, and load/soak tests.</p>
           </div>
           <div class="trust-item reveal">
             <div class="th"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5M12 22V12"/></svg>Supply-chain guarded</div>


### PR DESCRIPTION
Two things:

1. **Links the QA trust card to the coverage report.** "code-coverage ratchets" in the *Extensive quality assurance* card now links to the live Test Coverage page.

2. **Fixes broken deep docs links.** The docs site is versioned with **mike**, so the root redirects to `/stable/` and any deep link *without* a version segment 404s. This was hitting the coverage link and both project-history links. Fixed to:
   - `…/stable/reference/coverage/`
   - `…/stable/history/`

   Generic "Docs" / "Read the docs" links keep pointing at the version-agnostic root redirect, which is correct.

Verified: every external link on the page now returns 200 (socket.dev 200 under a normal browser UA; it just blocks curl). Copy/href-only, no functional code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)