### PR TITLE
ci: gate docker-publish smoke test on schemaReady, not port-open

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -169,14 +169,20 @@ jobs:
 
       - name: Wait for API ready
         run: |
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:3001/api/admin/status > /dev/null 2>&1; then
-              echo "✅ API ready after $((i*2))s"
+          # #691 opens the port BEFORE running DB migrations (so Azure's startup
+          # probe can't kill a slow migration mid-flight), so a 200 on a liveness
+          # endpoint no longer means the schema exists. Wait for the real
+          # readiness signal — /api/health → schemaReady:true, which flips once
+          # migrateDatabase() completes — before smoke-testing; otherwise the
+          # matview-backed read endpoints race the background migration and 500.
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:3001/api/health 2>/dev/null | grep -q '"schemaReady":true'; then
+              echo "✅ schema ready after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::API did not become ready within 120s"
+          echo "::error::schema did not become ready within 180s"
           docker compose -f docker-compose.qa.yml logs web
           exit 1
 


### PR DESCRIPTION
## Problem

The **Publish Docker Images** workflow is failing on `main` (run 29331608857, build 5.436), blocking the `:edge` push. The smoke test reports:

```
✅ /api/version   ✅ /api/admin/status   ✅ /api/systems
❌ /api/users?limit=1 → 500
❌ /api/resources?limit=1 → 500
❌ /api/permissions?userLimit=1 → 500
✅ /api/openapi.json
```

The **same endpoint code passed in the previous build** (5.435), so this is a **race, not a handler regression**.

## Root cause

#691 made the web app **bind its port before running DB migrations** (so a migration slower than Azure App Service's startup probe can't be killed mid-run and crash-loop the container). It gates only the *worker* data-plane (`/crawlers/jobs`, `/ingest`) behind `isSchemaReady()`.

But the workflow's **"Wait for API ready"** gate still polled `/api/admin/status`, which now answers `200` as soon as the port is open — **before migrations create the schema**. The smoke test then immediately hits the matview-backed read endpoints (`/users`, `/resources`, `/permissions`) while migrations are still running, and they `500`. It's non-deterministic: usually the migration wins the sub-second race, occasionally it loses.

## Fix

Wait for the real readiness signal #691 exposed for exactly this: `/api/health` → `schemaReady:true`, which flips once `migrateDatabase()` completes. Then smoke-test. Deterministic, and strictly stronger than the port-open gate that was already (flakily) passing.

**Workflow-only** — no product code, no changelog fragment. Validated by the next `docker-publish` run on `main` after merge (this workflow triggers on `workflow_run`, so it can't run on the PR itself).

## Known limitation (possible follow-up — not fixed here)

#691 deliberately keeps human/UI read endpoints available during migration, but on a real ~11-min production migration those endpoints currently return a raw **500** (schema absent) rather than a graceful **503 Retry-After** like the worker plane. Aligning them (or narrowing #691's "UI stays available" claim) is a separate design call — tracked in #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
