### PR TITLE
ci: gate pr-integration readiness waits on schemaReady too (#691 follow-through)

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -265,14 +265,21 @@ jobs:
 
       - name: Wait for API ready
         run: |
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:3001/api/admin/status > /dev/null 2>&1; then
-              echo "API ready after $((i*2))s"
+          # #691 opens the port BEFORE running DB migrations, so a 200 on a
+          # liveness endpoint no longer means the schema exists. Wait for the
+          # real readiness signal — /api/health → schemaReady:true, which flips
+          # once migrateDatabase() completes — before hitting schema-dependent
+          # endpoints (and before reading the worker key that bootstrapWorker
+          # creates after the schema is ready); otherwise they race the
+          # background migration and 500 / come back empty.
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:3001/api/health 2>/dev/null | grep -q '"schemaReady":true'; then
+              echo "schema ready after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::API did not become ready within 120s"
+          echo "::error::schema did not become ready within 180s"
           docker compose -f docker-compose.ci.yml logs web
           exit 1
 
@@ -739,9 +746,10 @@ jobs:
 
       - name: Wait for API ready
         run: |
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:3001/api/admin/status > /dev/null 2>&1; then
-              echo "API ready after $((i*2))s"
+          # Wait for schemaReady, not just the open port — see the note above.
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:3001/api/health 2>/dev/null | grep -q '"schemaReady":true'; then
+              echo "schema ready after $((i*2))s"
               break
             fi
             sleep 2
@@ -850,14 +858,21 @@ jobs:
 
       - name: Wait for API ready
         run: |
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:3001/api/admin/status > /dev/null 2>&1; then
-              echo "API ready after $((i*2))s"
+          # #691 opens the port BEFORE running DB migrations, so a 200 on a
+          # liveness endpoint no longer means the schema exists. Wait for the
+          # real readiness signal — /api/health → schemaReady:true, which flips
+          # once migrateDatabase() completes — before hitting schema-dependent
+          # endpoints (and before reading the worker key that bootstrapWorker
+          # creates after the schema is ready); otherwise they race the
+          # background migration and 500 / come back empty.
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:3001/api/health 2>/dev/null | grep -q '"schemaReady":true'; then
+              echo "schema ready after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::API did not become ready within 120s"
+          echo "::error::schema did not become ready within 180s"
           docker compose -f docker-compose.ci.yml logs web
           exit 1
 


### PR DESCRIPTION
## Why

Follow-through to #695, which fixed the `docker-publish` smoke test's readiness gate but **only that workflow** — the second commit (this one) didn't make it into the #695 merge, so `pr-integration.yml` still has the bug on `main`.

`pr-integration.yml`'s three "Wait for API ready" steps poll `/api/admin/status` (port-open). After #691 the port opens **before** DB migrations run, so those gates pass early and:
- the **Integration Tests** job reads the built-in worker key that `bootstrapWorker()` only writes after `markSchemaReady()` → "Could not read built-in worker API key",
- the **Playwright E2E** job drives the UI against schema-dependent endpoints that 500 → tables never render (`toBeVisible` timeout).

This is why PRs against `main` (e.g. #690) show failing **Integration Tests** / **Playwright E2E** even though their own unit + contract checks pass — it's the #691 race, not the PR's code.

## Fix

Wait for `/api/health → schemaReady:true` (flips once `migrateDatabase()` completes) in all three gates, matching the `docker-publish` fix in #695. The CI stack (`docker-compose.ci.yml`) runs `USE_SQL: "true"`, so the gate arms.

**Workflow-only** — no product code, no changelog fragment.

Related: #691 (root cause), #695 (docker-publish half), #696 (the product-side 503-vs-500 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
