### PR TITLE
Dashboard: link the marketing website from the Resources card

### DIFF
--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -23,6 +23,7 @@ import { docsUrl } from '@ui/utils/docsUrl';
 const DashboardTrendsTab = lazy(() => import('./DashboardTrendsTab'));
 
 const GITHUB_BASE = 'https://github.com/Fortigi/IdentityAtlas';
+const WEBSITE_URL = 'https://identityatlas.io';
 const SUPPORT_EMAIL = 'support@identityatlas.io';
 
 function changesUrl(v) {
@@ -229,6 +230,7 @@ export default function DashboardPage({ onNavigate }) {
             <h3 className="text-sm font-bold text-gray-900 dark:text-white">Resources</h3>
           </div>
           <ul className="space-y-2.5 text-sm">
+            <li><a href={WEBSITE_URL} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>Website</a></li>
             <li><a href={docsUrl(version?.version)} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>Documentation</a></li>
             <li><a href={GITHUB_BASE} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>GitHub repository</a></li>
             <li><a href={`${GITHUB_BASE}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer" className="text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"><span>→</span>License</a></li>

--- a/app/ui/src/components/DashboardPage.mount.test.jsx
+++ b/app/ui/src/components/DashboardPage.mount.test.jsx
@@ -56,6 +56,13 @@ describe('DashboardPage (mounted)', () => {
     expect(screen.getByText('v5.3.20260419.1430')).toBeInTheDocument();
   });
 
+  it('links the marketing website from the Resources card', async () => {
+    renderWithProviders(h(DashboardPage), { auth: { authFetch: routes() } });
+    const link = await screen.findByRole('link', { name: /Website/i });
+    expect(link).toHaveAttribute('href', 'https://identityatlas.io');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
   it('navigates when a populated stat card is clicked', async () => {
     const onNavigate = vi.fn();
     renderWithProviders(h(DashboardPage, { onNavigate }), { auth: { authFetch: routes() } });

--- a/changes/feature-dashboard-website-link.md
+++ b/changes/feature-dashboard-website-link.md
@@ -1,0 +1,1 @@
+- Added a link to the Identity Atlas website (identityatlas.io) at the top of the dashboard's Resources card.


### PR DESCRIPTION
The in-app dashboard's **Resources** card (Documentation / GitHub repository / License / Releases) now also links the public marketing site.

- Adds **Website → https://identityatlas.io** as the first item in the card, above Documentation.
- New `WEBSITE_URL` constant next to `GITHUB_BASE`.
- Kept the License link (there's room in the vertical list); trivial to drop if we'd rather keep it at four.
- Mount test asserts the Website link and its `href` / `target`.

Verified: `DashboardPage.mount.test.jsx` passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)