### PR TITLE
fix: purge v4 SQL Server code from PowerShell and the UI, guard against it, and run it in CI (#707, #712, #710, #709)

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -389,6 +389,28 @@ jobs:
           done
           if [ $FAILED -gt 0 ]; then exit 1; fi
 
+      # The step above is a smoke check — "did any rows arrive on 4 endpoints".
+      # This is the real verification of the same data: 35 assertions on row
+      # counts, referential integrity and business logic (principal types,
+      # governance flags, context hierarchy). The demo crawler queued above
+      # ingests test/demo-dataset/demo-company.json, which is exactly what this
+      # runner asserts against.
+      #
+      # It runs here for the first time. Until #707 it still spoke v4 SQL Server
+      # and no workflow ever invoked it, so it rotted two schema generations
+      # behind unnoticed — it never failed CI because it never ran (#709).
+      #
+      # Must be before the clean step below, which empties the database.
+      # -PgPassword: the CI stack uses ci_test, not the local-compose default.
+      - name: 'Test: Verify demo dataset'
+        shell: pwsh
+        run: |
+          & test/demo-dataset/Verify-DemoDataset.ps1 `
+            -ApiBaseUrl http://localhost:3001/api `
+            -ComposeFile docker-compose.ci.yml `
+            -PgPassword ci_test
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
       # ── Clean + verify empty ─────────────────────────────────────
       - name: 'Test: Clean database and verify empty'
         run: |

--- a/app/api/src/config/authConfig.js
+++ b/app/api/src/config/authConfig.js
@@ -1,7 +1,7 @@
 // Auth configuration loader.
 //
 // Identity Atlas's Entra ID SSO settings (AUTH_ENABLED, AUTH_TENANT_ID,
-// AUTH_CLIENT_ID, AUTH_REQUIRED_ROLES) live in dbo.WorkerConfig so they survive
+// AUTH_CLIENT_ID, AUTH_REQUIRED_ROLES) live in "WorkerConfig" so they survive
 // container restarts and can be inspected without rebuilding the image. They
 // are written *only* via the CLI tool at cli/auth-config.js, run from the host
 // via `docker compose exec web node ...`, followed by `docker compose restart web`.

--- a/app/api/src/db/nativePg.guard.test.js
+++ b/app/api/src/db/nativePg.guard.test.js
@@ -47,7 +47,14 @@ function walk(dir, keep) {
   }
   return out;
 }
-const FILES = walk(SRC, (n) => /\.(js|jsx)$/.test(n) && !/\.test\./.test(n));
+const isProdJs = (n) => /\.(js|jsx)$/.test(n) && !/\.test\./.test(n);
+
+// Tiers 1-2 are about the API's pool, so they stay scoped to app/api/src.
+const FILES = walk(SRC, isProdJs);
+// Tier 4 is about T-SQL appearing anywhere a reader would trust it, so it also
+// covers the UI and the crawler plugins. `dbo.Systems.displayName` sat in the CSV
+// wizard's help text — rendered to users, and outside every gate (#710).
+const ALL_JS = ['app/api/src', 'app/ui/src', 'tools'].flatMap((r) => walk(join(REPO_ROOT, r), isProdJs));
 // Every directory in the repo that holds PowerShell.
 const PS_FILES = ['test', 'tools'].flatMap((r) => walk(join(REPO_ROOT, r), (n) => /\.psm?1$/.test(n)));
 
@@ -162,9 +169,14 @@ describe('no T-SQL dialect in production JS (Tier 4)', () => {
     { name: 'LEN() (postgres spells it LENGTH)', re: /\bLEN\s*\(/ },
   ];
 
+  it('finds JS to scan across api, ui and crawler plugins', () => {
+    // A silent zero would make every assertion below vacuously pass.
+    expect(ALL_JS.length).toBeGreaterThan(100);
+  });
+
   for (const { name, re } of TSQL) {
     it(`no production file uses T-SQL: ${name}`, () => {
-      const offenders = scan(re);
+      const offenders = scan(re, { files: ALL_JS, relTo: REPO_ROOT });
       expect(offenders, `T-SQL dialect in postgres code:\n${offenders.join('\n')}`).toEqual([]);
     });
   }

--- a/app/api/src/db/nativePg.guard.test.js
+++ b/app/api/src/db/nativePg.guard.test.js
@@ -17,6 +17,13 @@
 //     own `System.Data.SqlClient` connection straight to the DB. Those kept
 //     working against v4 SQL Server long after the v5 postgres port and rotted
 //     unnoticed (#707) — nothing imports them, so no JS guard could catch it.
+//   Tier 4 — no SQL-Server *dialect* in production JS. Tier 1 bans the shim's
+//     API surface, not the SQL written through it, so `db.query('SELECT TOP 0 *
+//     FROM dbo.Resources')` passed every gate. #690 argued native pg makes
+//     leftover T-SQL fail loudly at author time — true only where something
+//     executes the query. It didn't: a `SELECT TOP 0 * FROM Resources` probe ran
+//     on every column-discovery request, threw on postgres every time, was
+//     silently swallowed, and had to be found by hand (see CHANGES.md).
 //
 // Test files are deliberately NOT scanned by Tiers 1-2: a few legitimately mock
 // the old `{ recordset }` shape to prove native callers still read it during the
@@ -129,6 +136,66 @@ describe('single pg surface — only connection.js owns the pool (Tier 2)', () =
   it('no other file imports pg or constructs a Pool', () => {
     const offenders = scan(/\bnew Pool\b|from ['"]pg['"]|require\(['"]pg['"]\)/, { allow: ALLOW });
     expect(offenders, `pg/Pool used outside the governed surface:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});
+
+describe('no T-SQL dialect in production JS (Tier 4)', () => {
+  // Matched CASE-SENSITIVELY, and that is load-bearing rather than an oversight.
+  // SQL here is written with uppercase keywords, while JavaScript is camelCase —
+  // so case-insensitive `\bGETDATE\s*\(` matches `.getDate()` and every
+  // date-formatting helper in the tree becomes an offender (scheduler.js,
+  // scopeHistory.js, EntityTimeline.jsx all trip it). The trade is that a
+  // lowercase `isnull(` would slip through; that has never appeared here, and a
+  // guard that cries wolf gets suppressed, which is worse than one narrow miss.
+  const TSQL = [
+    { name: 'dbo. schema prefix', re: /\bdbo\./ },
+    { name: 'SELECT TOP n', re: /\bSELECT\s+TOP\s/ },
+    { name: 'ISNULL()', re: /\bISNULL\s*\(/ },
+    { name: 'GETDATE() / GETUTCDATE()', re: /\bGETU?T?C?DATE\s*\(/ },
+    { name: 'NEWID()', re: /\bNEWID\s*\(/ },
+    { name: '@@ROWCOUNT / @@IDENTITY', re: /@@(?:ROWCOUNT|IDENTITY)\b/ },
+    { name: 'sp_executesql', re: /\bsp_executesql\b/ },
+    { name: 'WITH (NOLOCK)', re: /\bNOLOCK\b/ },
+    { name: 'CROSS / OUTER APPLY', re: /\b(?:CROSS|OUTER)\s+APPLY\b/ },
+    { name: 'NVARCHAR / DATETIME2 types', re: /\bNVARCHAR\b|\bDATETIME2\b/ },
+    { name: 'IIF() / TRY_CAST()', re: /\bIIF\s*\(|\bTRY_CAST\s*\(/ },
+    { name: 'LEN() (postgres spells it LENGTH)', re: /\bLEN\s*\(/ },
+  ];
+
+  for (const { name, re } of TSQL) {
+    it(`no production file uses T-SQL: ${name}`, () => {
+      const offenders = scan(re);
+      expect(offenders, `T-SQL dialect in postgres code:\n${offenders.join('\n')}`).toEqual([]);
+    });
+  }
+
+  // Pin the case-sensitivity trade-off in both directions. If someone "helpfully"
+  // adds /i these fail, rather than the tree filling with false offenders.
+  describe('does not fire on postgres-legal or plain-JavaScript code', () => {
+    const hits = (line) => TSQL.filter(({ re }) => re.test(line)).map(({ name }) => name);
+
+    it.each([
+      ['JS Date methods', 'const k = `${d.getFullYear()}-${d.getDate()}`;'],
+      ['JS UTC Date methods', 'const k = now.getUTCDate() + now.getUTCMonth();'],
+      ['postgres IS NULL, not T-SQL ISNULL()', 'WHERE ra."deletedAt" IS NULL'],
+      ['postgres LENGTH(), not T-SQL LEN()', 'SELECT LENGTH("displayName") FROM "Resources"'],
+      ['a column merely named "top"', 'SELECT "top" FROM "Layout"'],
+      ['LIMIT, the postgres spelling', 'SELECT * FROM "Resources" LIMIT 10'],
+    ])('%s', (_label, line) => {
+      expect(hits(line)).toEqual([]);
+    });
+
+    it.each([
+      ['SELECT TOP', "db.query('SELECT TOP 0 * FROM Resources')", 'SELECT TOP n'],
+      ['dbo. prefix', "db.query('SELECT 1 FROM dbo.Systems')", 'dbo. schema prefix'],
+      ['ISNULL(', "db.query('SELECT ISNULL(x, 0)')", 'ISNULL()'],
+      ['GETDATE(', "db.query('SELECT GETDATE()')", 'GETDATE() / GETUTCDATE()'],
+      ['GETUTCDATE(', "db.query('SELECT GETUTCDATE()')", 'GETDATE() / GETUTCDATE()'],
+      ['NOLOCK', "db.query('SELECT 1 FROM t WITH (NOLOCK)')", 'WITH (NOLOCK)'],
+      ['LEN(', "db.query('SELECT LEN(name) FROM t')", 'LEN() (postgres spells it LENGTH)'],
+    ])('still catches %s', (_label, line, expected) => {
+      expect(hits(line)).toContain(expected);
+    });
   });
 });
 

--- a/app/api/src/db/nativePg.guard.test.js
+++ b/app/api/src/db/nativePg.guard.test.js
@@ -11,9 +11,15 @@
 //     `.input(`, `.recordset(s)`, `.rowsAffected`, and `@name` SQL params.
 //   Tier 2 — only db/connection.js (and the standalone auth CLI) may import
 //     `pg` or construct a Pool, so the pool stays a single governed surface.
+//   Tier 3 — no PowerShell script talks to the database with a SQL Server
+//     client. Tiers 1-2 only cover `app/api/src`, so they could never see the
+//     *other* T-SQL surface: test scripts that bypass the API and open their
+//     own `System.Data.SqlClient` connection straight to the DB. Those kept
+//     working against v4 SQL Server long after the v5 postgres port and rotted
+//     unnoticed (#707) — nothing imports them, so no JS guard could catch it.
 //
-// Test files are deliberately NOT scanned: a few legitimately mock the old
-// `{ recordset }` shape to prove native callers still read it during the
+// Test files are deliberately NOT scanned by Tiers 1-2: a few legitimately mock
+// the old `{ recordset }` shape to prove native callers still read it during the
 // transition. Comment lines are skipped so the JSDoc `@param`/`@returns` tags
 // and this file's own explanatory prose don't trip the scan.
 
@@ -23,32 +29,66 @@ import { join, dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
 
 const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = join(SRC, '..', '..', '..');
 
-function walk(dir) {
+function walk(dir, keep) {
   const out = [];
   for (const name of readdirSync(dir)) {
     const p = join(dir, name);
-    if (statSync(p).isDirectory()) out.push(...walk(p));
-    else if (/\.(js|jsx)$/.test(name) && !/\.test\./.test(name)) out.push(p);
+    if (statSync(p).isDirectory()) { if (name !== 'node_modules') out.push(...walk(p, keep)); }
+    else if (keep(name)) out.push(p);
   }
   return out;
 }
-const FILES = walk(SRC);
-const rel = (f) => relative(SRC, f).replace(/\\/g, '/');
+const FILES = walk(SRC, (n) => /\.(js|jsx)$/.test(n) && !/\.test\./.test(n));
+// Every directory in the repo that holds PowerShell.
+const PS_FILES = ['test', 'tools'].flatMap((r) => walk(join(REPO_ROOT, r), (n) => /\.psm?1$/.test(n)));
 
-// Skip single-line and block-comment lines — the ban is about live code, not the
-// prose that documents the migration away from the shim.
+// The ban is about live code, not the prose that documents the migration away
+// from the shim — this very file, and PgQuery.psm1's header, name the banned
+// tokens in order to explain them. Each stripper blanks comments while keeping
+// one output line per input line, so reported line numbers stay accurate.
+
+// Skip single-line and block-comment lines.
 const isComment = (line) => {
   const t = line.trim();
   return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
 };
+const stripJs = (text) => text.split('\n').map((l) => (isComment(l) ? '' : l));
 
-function scan(re, { allow = new Set() } = {}) {
+// PowerShell has `#` to end-of-line and `<# ... #>` blocks. Comment-based help
+// (the .SYNOPSIS header every script here opens with) is a block comment, so a
+// line-at-a-time test can't see it — this tracks block state.
+const stripPs = (text) => {
+  const out = [];
+  let inBlock = false;
+  for (const line of text.split('\n')) {
+    let l = line;
+    if (inBlock) {
+      const close = l.indexOf('#>');
+      if (close === -1) { out.push(''); continue; }
+      l = l.slice(close + 2);
+      inBlock = false;
+    }
+    const open = l.indexOf('<#');
+    if (open !== -1) {
+      const close = l.indexOf('#>', open + 2);
+      if (close === -1) { inBlock = true; out.push(l.slice(0, open)); continue; }
+      l = l.slice(0, open) + l.slice(close + 2);
+    }
+    const hash = l.indexOf('#');
+    out.push(hash === -1 ? l : l.slice(0, hash));
+  }
+  return out;
+};
+
+function scan(re, { files = FILES, relTo = SRC, strip = stripJs, allow = new Set() } = {}) {
   const offenders = [];
-  for (const f of FILES) {
-    if (allow.has(rel(f))) continue;
-    readFileSync(f, 'utf8').split('\n').forEach((line, i) => {
-      if (!isComment(line) && re.test(line)) offenders.push(`${rel(f)}:${i + 1}  ${line.trim()}`);
+  for (const f of files) {
+    const r = relative(relTo, f).replace(/\\/g, '/');
+    if (allow.has(r)) continue;
+    strip(readFileSync(f, 'utf8')).forEach((line, i) => {
+      if (re.test(line)) offenders.push(`${r}:${i + 1}  ${line.trim()}`);
     });
   }
   return offenders;
@@ -90,4 +130,68 @@ describe('single pg surface — only connection.js owns the pool (Tier 2)', () =
     const offenders = scan(/\bnew Pool\b|from ['"]pg['"]|require\(['"]pg['"]\)/, { allow: ALLOW });
     expect(offenders, `pg/Pool used outside the governed surface:\n${offenders.join('\n')}`).toEqual([]);
   });
+});
+
+describe('no SQL Server client in PowerShell (Tier 3)', () => {
+  // PowerShell reaches postgres through test/lib/PgQuery.psm1 (psql over `docker
+  // compose exec`) — never a SQL Server driver, and never v4 T-SQL.
+  //
+  // Each pattern below is a *SQL-Server-only* token, chosen so it cannot collide
+  // with legitimate data. Notably we do NOT ban the bare word `ValidTo`: Omada
+  // genuinely carries validFrom/validTo fields in its own source records
+  // (OmadaCrawler.Transform.ps1 maps them into extendedAttributes), and those are
+  // unrelated to the v4 temporal column this repo dropped. The dead giveaway of a
+  // temporal *predicate* is the sentinel value, so that is what we match.
+  const BANNED_PS = [
+    { name: 'System.Data.SqlClient (MSSQL driver)', re: /\b(?:System|Microsoft)\.Data\.SqlClient\b/ },
+    { name: 'SqlConnection / SqlCommand / SqlDataAdapter', re: /\bSql(?:Connection|Command|DataAdapter)\b/ },
+    { name: 'TrustServerCertificate (MSSQL conn string)', re: /\bTrustServerCertificate\b/ },
+    { name: 'dbo. schema prefix (T-SQL)', re: /\bdbo\./ },
+    { name: 'v4 temporal sentinel (ValidTo = 9999-12-31…)', re: /9999-12-31[ T]23:59:59/ },
+  ];
+
+  it('finds PowerShell to scan', () => {
+    // A silent zero here would make every assertion below vacuously pass.
+    expect(PS_FILES.length).toBeGreaterThan(20);
+  });
+
+  // stripPs is what stops this guard flagging the prose that explains it. If it
+  // over-reached it would quietly blank real code and the scan would pass by
+  // seeing nothing — so pin both directions.
+  describe('stripPs', () => {
+    const banned = /\bSql(?:Connection|Command|DataAdapter)\b/;
+
+    it('blanks <# .. #> block comments (comment-based help)', () => {
+      const lines = stripPs('<#\n  Do not use SqlConnection here.\n#>\n$x = 1');
+      expect(lines.some((l) => banned.test(l))).toBe(false);
+      expect(lines).toHaveLength(4);
+    });
+
+    it('blanks # line comments', () => {
+      expect(stripPs('# uses SqlConnection, historically').some((l) => banned.test(l))).toBe(false);
+    });
+
+    it('still sees real code after a block comment closes', () => {
+      const lines = stripPs('<#\n help\n#>\n$c = New-Object System.Data.SqlClient.SqlConnection($s)');
+      expect(lines.some((l) => banned.test(l))).toBe(true);
+    });
+
+    it('still sees real code on a line with a trailing comment', () => {
+      expect(stripPs('$c = [SqlConnection]::new()  # legacy').some((l) => banned.test(l))).toBe(true);
+    });
+
+    it('keeps line numbers aligned with the source', () => {
+      const src = '$a = 1\n<#\n c\n#>\n$b = SqlConnection';
+      const lines = stripPs(src);
+      expect(lines).toHaveLength(5);
+      expect(banned.test(lines[4])).toBe(true);
+    });
+  });
+
+  for (const { name, re } of BANNED_PS) {
+    it(`no .ps1/.psm1 uses: ${name}`, () => {
+      const offenders = scan(re, { files: PS_FILES, relTo: REPO_ROOT, strip: stripPs });
+      expect(offenders, `SQL Server / T-SQL surface in PowerShell:\n${offenders.join('\n')}`).toEqual([]);
+    });
+  }
 });

--- a/changes/ci-verify-demo-dataset.md
+++ b/changes/ci-verify-demo-dataset.md
@@ -1,0 +1,1 @@
+- The demo dataset is now checked on every pull request. Its verification runner was previously never run by anything, which is how it drifted two database generations out of date without anyone noticing — the pull request check only confirmed that some rows had arrived, not that the data was correct.

--- a/changes/guard-tsql-dialect-in-js.md
+++ b/changes/guard-tsql-dialect-in-js.md
@@ -1,0 +1,1 @@
+- CI now fails if SQL Server syntax appears in the API's database code. Previously only the old SQL Server connection style was blocked, not the queries written through it — which is how a broken SQL Server query survived on the resource column-discovery endpoint, failing on every request until someone found it by hand.

--- a/changes/port-ps-db-scripts-to-postgres.md
+++ b/changes/port-ps-db-scripts-to-postgres.md
@@ -1,0 +1,9 @@
+- Fixed the demo-dataset verification runner, which could not check anything against a v5 database — it still spoke SQL Server (issue #707). It now verifies the full demo dataset: 35/35 checks pass against a real ingest.
+- Fixed the Docker test suite's data verification, which had the same problem plus two checks that could never pass: it looked for "Governed" and "Owner" assignment types that the data model retired.
+- Removed the "Has Owner assignments" check outright rather than port it — the demo dataset contains no ownership data for it to assert on. It should come back when the generator emits ownership.
+- Verification checks now count only live rows. Removed accounts and resources are kept as tombstones in v5, and the old checks would have counted them as current.
+- The demo-dataset context check no longer depends on whether the worker has run — it counts the dataset's own contexts instead of a total that grew as tag roots and generated contexts appeared.
+- Fixed the nightly schema check reporting two tables as missing on every run: one is now a compatibility view, and the other was removed in the context redesign.
+- Fixed the Docker suite's worker checks, which always failed because they looked for a container under the project's old name.
+- A failing database query now reports itself as a failed check instead of silently reading as "0 rows", so a broken check can no longer look like a passing one.
+- CI now fails if any PowerShell script talks to the database with a SQL Server client or v4 T-SQL, so these scripts cannot silently rot behind the schema again.

--- a/changes/remove-dbo-references.md
+++ b/changes/remove-dbo-references.md
@@ -1,0 +1,2 @@
+- Fixed the CSV crawler setup wizard telling users their system name is "Recorded in dbo.Systems.displayName" — that SQL Server schema hasn't existed since the PostgreSQL move, so anyone following the hint got an error.
+- CI now checks the UI and crawler plugins for leftover SQL Server syntax too, not just the API, so stale database references can't reappear in what users read.

--- a/test/demo-dataset/Verify-DemoDataset.ps1
+++ b/test/demo-dataset/Verify-DemoDataset.ps1
@@ -3,14 +3,28 @@
     Verifies the demo dataset was ingested correctly — row counts, relationships, business logic.
 
 .DESCRIPTION
-    Runs against the SQL database and API to verify every aspect of the demo dataset.
-    Returns exit code 0 if all checks pass, non-zero = number of failures.
+    Runs against the postgres database and the API to verify every aspect of the
+    demo dataset. Returns exit code 0 if all checks pass, non-zero = number of failures.
 
-.PARAMETER SqlConnectionString
-    SQL connection string (default: local Docker)
+    Database access goes through test/lib/PgQuery.psm1 (psql inside the postgres
+    container). v5 has no SQL Server, and `System.Data.SqlClient` — which this
+    script used until #707 — does not exist on PowerShell 7.
+
+    Two v4-isms are gone from the queries below:
+      * `ValidTo = '9999-12-31...'` — temporal tables were dropped in v5. The
+        equivalent "current rows" filter is now `deletedAt IS NULL` on the
+        soft-delete tables (Principals / Resources / ResourceAssignments); other
+        tables have no lifecycle column. Get-PgLiveCount handles this per table.
+      * `dbo.[Table]` — postgres has no `dbo` schema, and the migrations create
+        tables with quoted PascalCase names, so identifiers must be
+        double-quoted ("Resources", "principalType") or they fold to lowercase
+        and fail to resolve.
 
 .PARAMETER ApiBaseUrl
     API base URL (default: http://localhost:3001/api)
+
+.PARAMETER PgService
+    docker compose service name of the postgres container.
 
 .EXAMPLE
     .\Verify-DemoDataset.ps1
@@ -18,14 +32,20 @@
 
 [CmdletBinding()]
 Param(
-    [string]$SqlConnectionString = "Server=localhost;Database=GraphData;User Id=sa;Password=FortigiGraph_Local1!;TrustServerCertificate=True",
-    [string]$ApiBaseUrl = 'http://localhost:3001/api'
+    [string]$ApiBaseUrl = 'http://localhost:3001/api',
+    [string]$PgService = 'postgres',
+    [string]$PgUser = 'identity_atlas',
+    [string]$PgPassword = 'identity_atlas_local',
+    [string]$PgDatabase = 'identity_atlas'
 )
 
 $ErrorActionPreference = 'Continue'
 $passed = 0
 $failed = 0
 $results = @()
+
+Import-Module (Join-Path $PSScriptRoot '..' 'lib' 'PgQuery.psm1') -Force
+Set-PgConnection -Service $PgService -User $PgUser -Password $PgPassword -Database $PgDatabase
 
 function Assert-Check {
     param([string]$Name, [bool]$Condition, [string]$Detail = '')
@@ -39,31 +59,19 @@ function Assert-Check {
     $script:results += @{ Name = $Name; Passed = $Condition; Detail = $Detail }
 }
 
-function Invoke-Sql {
-    param([string]$Query)
-    $conn = New-Object System.Data.SqlClient.SqlConnection($SqlConnectionString)
-    $conn.Open()
-    $cmd = $conn.CreateCommand()
-    $cmd.CommandText = $Query
-    $adapter = New-Object System.Data.SqlClient.SqlDataAdapter($cmd)
-    $table = New-Object System.Data.DataTable
-    $adapter.Fill($table) | Out-Null
-    $conn.Close()
-    return $table
+# Every DB check funnels through here so a broken query is reported as a failed
+# check rather than taking the whole run down — and never as a silent 0.
+function Assert-Count {
+    param([string]$Name, [string]$Query, [int]$Min, [int]$Max = [int]::MaxValue, [string]$Label = '')
+    try {
+        $count = Get-PgCount -Query $Query
+        $expected = if ($Label) { $Label } elseif ($Max -eq [int]::MaxValue) { ">= $Min" } else { "$Min-$Max" }
+        Assert-Check $Name ($count -ge $Min -and $count -le $Max) "Got $count (expected $expected)"
+    }
+    catch {
+        Assert-Check $Name $false "Query failed: $($_.Exception.Message)"
+    }
 }
-
-function Get-SqlScalar {
-    param([string]$Query)
-    $conn = New-Object System.Data.SqlClient.SqlConnection($SqlConnectionString)
-    $conn.Open()
-    $cmd = $conn.CreateCommand()
-    $cmd.CommandText = $Query
-    $result = $cmd.ExecuteScalar()
-    $conn.Close()
-    return $result
-}
-
-$CURRENT = "'9999-12-31 23:59:59.9999999'"
 
 Write-Host "`n=== Demo Dataset Verification ===" -ForegroundColor Cyan
 
@@ -79,7 +87,6 @@ $counts = @{
     'ResourceRelationships'  = @{ Min = 9;  Max = 9 }
     'Identities'             = @{ Min = 20; Max = 25 }
     'IdentityMembers'        = @{ Min = 20; Max = 40 }
-    'Contexts'               = @{ Min = 7;  Max = 8 }
     'GovernanceCatalogs'     = @{ Min = 2;  Max = 2 }
     'AssignmentPolicies'     = @{ Min = 3;  Max = 3 }
     'CertificationDecisions' = @{ Min = 2;  Max = 2 }
@@ -88,8 +95,7 @@ $counts = @{
 
 foreach ($table in $counts.Keys | Sort-Object) {
     try {
-        $count = Get-SqlScalar "SELECT COUNT(*) FROM dbo.[$table] WHERE ValidTo = $CURRENT"
-        if ($null -eq $count) { $count = Get-SqlScalar "SELECT COUNT(*) FROM dbo.[$table]" }  # Non-temporal tables
+        $count = Get-PgLiveCount -Table $table
         $min = $counts[$table].Min
         $max = $counts[$table].Max
         Assert-Check "RowCount-$table" ($count -ge $min -and $count -le $max) "Got $count (expected $min-$max)"
@@ -99,85 +105,127 @@ foreach ($table in $counts.Keys | Sort-Object) {
     }
 }
 
+# Contexts are counted separately, filtered to the dataset's own. In the v6
+# model a Context carries a `variant`: the demo dataset ingests 8 'synced' ones
+# (1 admin unit + 5 departments + 2 teams), while the API creates 'manual' Tag
+# roots at bootstrap and the context-algorithm plugins emit 'generated' ones
+# whenever the worker runs. A bare COUNT(*) therefore drifts with runtime state —
+# it read 8 before the worker started and 9 after. Filtering by variant makes
+# this deterministic.
+Assert-Count 'RowCount-Contexts' -Min 8 -Max 8 -Query @'
+SELECT COUNT(*) FROM "Contexts" WHERE "variant" = 'synced'
+'@
+
 # ─── Referential Integrity ────────────────────────────────────────
 
 Write-Host "`n--- Referential Integrity ---" -ForegroundColor Yellow
 
-# Assignments reference existing resources
-$orphanAssignRes = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments ra WHERE ra.ValidTo = $CURRENT AND NOT EXISTS (SELECT 1 FROM Resources r WHERE r.id = ra.resourceId AND r.ValidTo = $CURRENT)"
-Assert-Check 'FK-Assignments-Resources' ($orphanAssignRes -eq 0) "Orphaned: $orphanAssignRes"
+# A live assignment must not point at a tombstoned or missing resource/principal.
+Assert-Count 'FK-Assignments-Resources' -Max 0 -Min 0 -Label '0 orphans' -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+WHERE ra."deletedAt" IS NULL
+  AND NOT EXISTS (SELECT 1 FROM "Resources" r WHERE r."id" = ra."resourceId" AND r."deletedAt" IS NULL)
+'@
 
-# Assignments reference existing principals
-$orphanAssignPrinc = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments ra WHERE ra.ValidTo = $CURRENT AND NOT EXISTS (SELECT 1 FROM Principals p WHERE p.id = ra.principalId AND p.ValidTo = $CURRENT)"
-Assert-Check 'FK-Assignments-Principals' ($orphanAssignPrinc -eq 0) "Orphaned: $orphanAssignPrinc"
+Assert-Count 'FK-Assignments-Principals' -Max 0 -Min 0 -Label '0 orphans' -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+WHERE ra."deletedAt" IS NULL
+  AND NOT EXISTS (SELECT 1 FROM "Principals" p WHERE p."id" = ra."principalId" AND p."deletedAt" IS NULL)
+'@
 
-# Identity members reference existing identities
-$orphanIdMem = Get-SqlScalar "SELECT COUNT(*) FROM IdentityMembers im WHERE im.ValidTo = $CURRENT AND NOT EXISTS (SELECT 1 FROM Identities i WHERE i.id = im.identityId AND i.ValidTo = $CURRENT)"
-Assert-Check 'FK-IdentityMembers-Identities' ($orphanIdMem -eq 0) "Orphaned: $orphanIdMem"
+Assert-Count 'FK-IdentityMembers-Identities' -Max 0 -Min 0 -Label '0 orphans' -Query @'
+SELECT COUNT(*) FROM "IdentityMembers" im
+WHERE NOT EXISTS (SELECT 1 FROM "Identities" i WHERE i."id" = im."identityId")
+'@
 
-# Identity members reference existing principals
-$orphanIdPrinc = Get-SqlScalar "SELECT COUNT(*) FROM IdentityMembers im WHERE im.ValidTo = $CURRENT AND NOT EXISTS (SELECT 1 FROM Principals p WHERE p.id = im.principalId AND p.ValidTo = $CURRENT)"
-Assert-Check 'FK-IdentityMembers-Principals' ($orphanIdPrinc -eq 0) "Orphaned: $orphanIdPrinc"
+Assert-Count 'FK-IdentityMembers-Principals' -Max 0 -Min 0 -Label '0 orphans' -Query @'
+SELECT COUNT(*) FROM "IdentityMembers" im
+WHERE NOT EXISTS (SELECT 1 FROM "Principals" p WHERE p."id" = im."principalId" AND p."deletedAt" IS NULL)
+'@
 
-# Context parent references
-$orphanCtxParent = Get-SqlScalar "SELECT COUNT(*) FROM Contexts c WHERE c.ValidTo = $CURRENT AND c.parentContextId IS NOT NULL AND NOT EXISTS (SELECT 1 FROM Contexts p WHERE p.id = c.parentContextId AND p.ValidTo = $CURRENT)"
-Assert-Check 'FK-Contexts-ParentContext' ($orphanCtxParent -eq 0) "Orphaned: $orphanCtxParent"
+Assert-Count 'FK-Contexts-ParentContext' -Max 0 -Min 0 -Label '0 orphans' -Query @'
+SELECT COUNT(*) FROM "Contexts" c
+WHERE c."parentContextId" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "Contexts" p WHERE p."id" = c."parentContextId")
+'@
 
 # ─── Business Logic ───────────────────────────────────────────────
 
 Write-Host "`n--- Business Logic ---" -ForegroundColor Yellow
 
 # Principal types
-$spCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE principalType = 'ServicePrincipal' AND ValidTo = $CURRENT"
-Assert-Check 'Has-ServicePrincipal' ($spCount -ge 1) "Count: $spCount"
+Assert-Count 'Has-ServicePrincipal' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "principalType" = 'ServicePrincipal' AND "deletedAt" IS NULL
+'@
 
-$aiCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE principalType = 'AIAgent' AND ValidTo = $CURRENT"
-Assert-Check 'Has-AIAgent' ($aiCount -ge 1) "Count: $aiCount"
+Assert-Count 'Has-AIAgent' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "principalType" = 'AIAgent' AND "deletedAt" IS NULL
+'@
 
-$extCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE principalType = 'ExternalUser' AND ValidTo = $CURRENT"
-Assert-Check 'Has-ExternalUser' ($extCount -ge 1) "Count: $extCount"
+Assert-Count 'Has-ExternalUser' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "principalType" = 'ExternalUser' AND "deletedAt" IS NULL
+'@
 
-$disabledCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE accountEnabled = 0 AND ValidTo = $CURRENT"
-Assert-Check 'Has-DisabledAccount' ($disabledCount -ge 1) "Count: $disabledCount"
+# accountEnabled is a real boolean in postgres — `= 0` is a type error, not a filter.
+Assert-Count 'Has-DisabledAccount' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "accountEnabled" = false AND "deletedAt" IS NULL
+'@
 
 # Resource types
-$brCount = Get-SqlScalar "SELECT COUNT(*) FROM Resources WHERE resourceType = 'BusinessRole' AND ValidTo = $CURRENT"
-Assert-Check 'BusinessRole-Count' ($brCount -eq 4) "Got $brCount (expected 4)"
+Assert-Count 'BusinessRole-Count' -Min 4 -Max 4 -Query @'
+SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'BusinessRole' AND "deletedAt" IS NULL
+'@
 
-$dirRoleCount = Get-SqlScalar "SELECT COUNT(*) FROM Resources WHERE resourceType = 'EntraDirectoryRole' AND ValidTo = $CURRENT"
-Assert-Check 'DirectoryRole-Count' ($dirRoleCount -eq 2) "Got $dirRoleCount (expected 2)"
+Assert-Count 'DirectoryRole-Count' -Min 2 -Max 2 -Query @'
+SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'EntraDirectoryRole' AND "deletedAt" IS NULL
+'@
 
-# Assignment types — governance is now the `governed` flag (not a 'Governed' type)
-$govCount = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments WHERE governed = true AND ValidTo = $CURRENT"
-Assert-Check 'Has-Governed-Assignments' ($govCount -ge 10) "Count: $govCount"
+# Assignment types — governance is the `governed` flag, not a 'Governed' type.
+Assert-Count 'Has-Governed-Assignments' -Min 10 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" WHERE "governed" = true AND "deletedAt" IS NULL
+'@
 
-$eligCount = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments WHERE assignmentType = 'Eligible' AND ValidTo = $CURRENT"
-Assert-Check 'Has-Eligible-Assignments' ($eligCount -ge 1) "Count: $eligCount"
+Assert-Count 'Has-Eligible-Assignments' -Min 1 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" WHERE "assignmentType" = 'Eligible' AND "deletedAt" IS NULL
+'@
 
-# Relationship types
-$containsCount = Get-SqlScalar "SELECT COUNT(*) FROM ResourceRelationships WHERE relationshipType = 'Contains' AND ValidTo = $CURRENT"
-Assert-Check 'Contains-Relationships' ($containsCount -ge 8) "Count: $containsCount"
+# Relationship types (ResourceRelationships has no soft-delete column)
+Assert-Count 'Contains-Relationships' -Min 8 -Query @'
+SELECT COUNT(*) FROM "ResourceRelationships" WHERE "relationshipType" = 'Contains'
+'@
 
-$grantsCount = Get-SqlScalar "SELECT COUNT(*) FROM ResourceRelationships WHERE relationshipType = 'GrantsAccessTo' AND ValidTo = $CURRENT"
-Assert-Check 'GrantsAccessTo-Relationships' ($grantsCount -ge 1) "Count: $grantsCount"
+Assert-Count 'GrantsAccessTo-Relationships' -Min 1 -Query @'
+SELECT COUNT(*) FROM "ResourceRelationships" WHERE "relationshipType" = 'GrantsAccessTo'
+'@
 
 # Context hierarchy
-$rootCtx = Get-SqlScalar "SELECT COUNT(*) FROM Contexts WHERE displayName = 'Fortigi Demo Corp' AND parentContextId IS NULL AND ValidTo = $CURRENT"
-Assert-Check 'Context-RootExists' ($rootCtx -eq 1) "Count: $rootCtx"
+Assert-Count 'Context-RootExists' -Min 1 -Max 1 -Query @'
+SELECT COUNT(*) FROM "Contexts" WHERE "displayName" = 'Fortigi Demo Corp' AND "parentContextId" IS NULL
+'@
 
-$engCtx = Get-SqlScalar "SELECT COUNT(*) FROM Contexts c1 INNER JOIN Contexts c2 ON c1.parentContextId = c2.id WHERE c1.displayName = 'Engineering' AND c2.displayName = 'Fortigi Demo Corp' AND c1.ValidTo = $CURRENT AND c2.ValidTo = $CURRENT"
-Assert-Check 'Context-EngineeringUnderRoot' ($engCtx -eq 1) "Count: $engCtx"
+Assert-Count 'Context-EngineeringUnderRoot' -Min 1 -Max 1 -Query @'
+SELECT COUNT(*) FROM "Contexts" c1
+INNER JOIN "Contexts" c2 ON c1."parentContextId" = c2."id"
+WHERE c1."displayName" = 'Engineering' AND c2."displayName" = 'Fortigi Demo Corp'
+'@
 
 # Governance
-$certApprove = Get-SqlScalar "SELECT COUNT(*) FROM CertificationDecisions WHERE decision = 'Approve' AND ValidTo = $CURRENT"
-Assert-Check 'Certification-HasApprove' ($certApprove -ge 1) "Count: $certApprove"
+Assert-Count 'Certification-HasApprove' -Min 1 -Query @'
+SELECT COUNT(*) FROM "CertificationDecisions" WHERE "decision" = 'Approve'
+'@
 
-$certDeny = Get-SqlScalar "SELECT COUNT(*) FROM CertificationDecisions WHERE decision = 'Deny' AND ValidTo = $CURRENT"
-Assert-Check 'Certification-HasDeny' ($certDeny -ge 1) "Count: $certDeny"
+Assert-Count 'Certification-HasDeny' -Min 1 -Query @'
+SELECT COUNT(*) FROM "CertificationDecisions" WHERE "decision" = 'Deny'
+'@
 
-# Multi-system identity
-$multiAccount = Get-SqlScalar "SELECT COUNT(*) FROM IdentityMembers WHERE ValidTo = $CURRENT GROUP BY identityId HAVING COUNT(*) > 1"
-Assert-Check 'Has-MultiSystem-Identity' ($multiAccount -ge 1) "Identities with 2+ accounts: $multiAccount"
+# Multi-system identity. The v4 query ran GROUP BY ... HAVING through a scalar
+# read, which returns the FIRST GROUP'S member count — not the number of
+# multi-account identities it claimed to report. Wrap it and count the groups.
+Assert-Count 'Has-MultiSystem-Identity' -Min 1 -Label 'identities with 2+ accounts' -Query @'
+SELECT COUNT(*) FROM (
+  SELECT "identityId" FROM "IdentityMembers" GROUP BY "identityId" HAVING COUNT(*) > 1
+) multi
+'@
 
 # ─── API Verification ─────────────────────────────────────────────
 

--- a/test/demo-dataset/Verify-DemoDataset.ps1
+++ b/test/demo-dataset/Verify-DemoDataset.ps1
@@ -36,7 +36,9 @@ Param(
     [string]$PgService = 'postgres',
     [string]$PgUser = 'identity_atlas',
     [string]$PgPassword = 'identity_atlas_local',
-    [string]$PgDatabase = 'identity_atlas'
+    [string]$PgDatabase = 'identity_atlas',
+    # CI runs its stack from docker-compose.ci.yml; empty = plain `docker compose`.
+    [string]$ComposeFile = ''
 )
 
 $ErrorActionPreference = 'Continue'
@@ -45,7 +47,7 @@ $failed = 0
 $results = @()
 
 Import-Module (Join-Path $PSScriptRoot '..' 'lib' 'PgQuery.psm1') -Force
-Set-PgConnection -Service $PgService -User $PgUser -Password $PgPassword -Database $PgDatabase
+Set-PgConnection -Service $PgService -User $PgUser -Password $PgPassword -Database $PgDatabase -ComposeFile $ComposeFile
 
 function Assert-Check {
     param([string]$Name, [bool]$Condition, [string]$Detail = '')

--- a/test/lib/PgQuery.psm1
+++ b/test/lib/PgQuery.psm1
@@ -40,12 +40,15 @@ Set-StrictMode -Version Latest
 # Set-StrictMode throws on reading a never-assigned variable.
 $script:SoftDeleteTables = $null
 
-# Defaults match docker-compose.yml.
+# Defaults match docker-compose.yml. ComposeFile empty = plain `docker compose`,
+# which resolves docker-compose.yml in the working directory; CI runs its stack
+# from docker-compose.ci.yml and must pass that explicitly.
 $script:PgConn = @{
-    Service  = 'postgres'
-    User     = 'identity_atlas'
-    Password = 'identity_atlas_local'
-    Database = 'identity_atlas'
+    Service     = 'postgres'
+    User        = 'identity_atlas'
+    Password    = 'identity_atlas_local'
+    Database    = 'identity_atlas'
+    ComposeFile = ''
 }
 
 function Set-PgConnection {
@@ -58,9 +61,10 @@ function Set-PgConnection {
         [string]$Service,
         [string]$User,
         [string]$Password,
-        [string]$Database
+        [string]$Database,
+        [string]$ComposeFile
     )
-    foreach ($k in 'Service', 'User', 'Password', 'Database') {
+    foreach ($k in 'Service', 'User', 'Password', 'Database', 'ComposeFile') {
         if ($PSBoundParameters.ContainsKey($k)) { $script:PgConn[$k] = $PSBoundParameters[$k] }
     }
 }
@@ -127,12 +131,18 @@ function Invoke-Psql {
         [Parameter(Mandatory)][hashtable]$Connection
     )
 
+    # `docker compose -f <file>` when the caller named one (CI runs its stack from
+    # docker-compose.ci.yml); plain `docker compose` otherwise.
+    $composeArgs = @('compose')
+    if ($Connection.ComposeFile) { $composeArgs += @('-f', $Connection.ComposeFile) }
+    $composeArgs += @('exec', '-T', '-e', "PGPASSWORD=$($Connection.Password)", $Connection.Service,
+                      'psql', '-U', $Connection.User, '-d', $Connection.Database, '-A', '-t', '-v', 'ON_ERROR_STOP=1')
+
     $had = Test-Path Env:MSYS_NO_PATHCONV
     $prev = if ($had) { $env:MSYS_NO_PATHCONV } else { $null }
     $env:MSYS_NO_PATHCONV = '1'
     try {
-        $out = $Query | & docker compose exec -T -e "PGPASSWORD=$($Connection.Password)" $Connection.Service `
-            psql -U $Connection.User -d $Connection.Database -A -t -v ON_ERROR_STOP=1 2>&1
+        $out = $Query | & docker @composeArgs 2>&1
         return @{ Output = @($out); ExitCode = $LASTEXITCODE }
     }
     finally {

--- a/test/lib/PgQuery.psm1
+++ b/test/lib/PgQuery.psm1
@@ -1,0 +1,263 @@
+<#
+.SYNOPSIS
+    Query the Identity Atlas postgres database from PowerShell test scripts.
+
+.DESCRIPTION
+    The one way PowerShell reaches the database. v5 dropped SQL Server, so there
+    is no MSSQL driver to use — and `System.Data.SqlClient` isn't available on
+    PowerShell 7 anyway. Everything goes through psql inside the postgres
+    container via `docker compose exec`.
+
+    Enforced by the Tier 3 scan in app/api/src/db/nativePg.guard.test.js: no .ps1
+    may name a SQL Server client, the `dbo.` schema, or the v4 temporal sentinel.
+
+    One rule for callers writing SQL: quote identifiers. The migrations create
+    tables as `CREATE TABLE "Resources"`, so the PascalCase sticks. Unquoted
+    `FROM Resources` folds to `resources` and does not resolve. Same for
+    camelCase columns: `"principalType"`, not `principalType`.
+
+    Ordinary single-quoted SQL literals ('ServicePrincipal') are fine. Note that
+    Run-NightlyLocal.ps1 carries a comment claiming single quotes do not survive
+    the PowerShell -> docker compose exec -> sh -> psql chain on Windows, and
+    dollar-quotes ($$public$$) to work around it. That was tested against this
+    module and is not true for SQL sent on **stdin** — `WHERE schemaname =
+    'public'` round-trips correctly. The quoting hazard is real only for SQL
+    passed as a `-c` argument, where it crosses argv boundaries. This module
+    never uses -c, so callers can write normal SQL.
+
+    Errors are loud: psql runs with ON_ERROR_STOP=1 and any error throws rather
+    than returning $null. A silent $null is what let the v4 queries in these
+    scripts look "passing-ish" instead of broken.
+
+.EXAMPLE
+    Import-Module "$PSScriptRoot/../lib/PgQuery.psm1"
+    Get-PgCount "SELECT COUNT(*) FROM ""Principals"" WHERE ""principalType"" = 'User'"
+#>
+
+Set-StrictMode -Version Latest
+
+# Populated on first use by Get-PgSoftDeleteTables. Must be initialised:
+# Set-StrictMode throws on reading a never-assigned variable.
+$script:SoftDeleteTables = $null
+
+# Defaults match docker-compose.yml.
+$script:PgConn = @{
+    Service  = 'postgres'
+    User     = 'identity_atlas'
+    Password = 'identity_atlas_local'
+    Database = 'identity_atlas'
+}
+
+function Set-PgConnection {
+    <#
+    .SYNOPSIS
+        Override the postgres connection defaults for this session.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Service,
+        [string]$User,
+        [string]$Password,
+        [string]$Database
+    )
+    foreach ($k in 'Service', 'User', 'Password', 'Database') {
+        if ($PSBoundParameters.ContainsKey($k)) { $script:PgConn[$k] = $PSBoundParameters[$k] }
+    }
+}
+
+function Get-PgConnection {
+    [CmdletBinding()]
+    param()
+    return $script:PgConn.Clone()
+}
+
+# psql diagnostics, and the `(N rows)` footer. Anything else on stdout is data.
+$script:PsqlNoiseRe = '^(ERROR|FATAL|PANIC|DETAIL|HINT|CONTEXT|STATEMENT|LINE \d+)\b|^\(\d+ rows?\)$'
+$script:PsqlErrorRe = '^(ERROR|FATAL|PANIC)\b'
+
+function ConvertFrom-PsqlOutput {
+    <#
+    .SYNOPSIS
+        Split raw psql output into data rows and error lines.
+
+    .DESCRIPTION
+        Kept separate from the transport so it can be unit-tested without Docker.
+        `docker compose exec ... 2>&1` merges stderr into the stream as
+        ErrorRecord objects, which have no .Trim() — coerce to string first.
+    #>
+    [CmdletBinding()]
+    param([AllowNull()][object[]]$Output)
+
+    $rows = [System.Collections.Generic.List[string]]::new()
+    $errors = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($line in @($Output)) {
+        if ($null -eq $line) { continue }
+        $isErrRecord = $line -is [System.Management.Automation.ErrorRecord]
+        $text = ([string]$line).Trim()
+        if ($text -eq '') { continue }
+
+        if ($text -match $script:PsqlErrorRe) { $errors.Add($text); continue }
+        # A non-error line on stderr is still diagnostic noise, not data.
+        if ($isErrRecord) { $errors.Add($text); continue }
+        if ($text -match $script:PsqlNoiseRe) { continue }
+        $rows.Add($text)
+    }
+
+    return [pscustomobject]@{
+        Rows   = $rows.ToArray()
+        Errors = $errors.ToArray()
+    }
+}
+
+function Invoke-Psql {
+    <#
+    .SYNOPSIS
+        Run one SQL statement through psql in the postgres container.
+
+    .DESCRIPTION
+        The transport, isolated so tests can mock it. SQL goes in on stdin —
+        never as a -c argument — so nothing in it has to survive shell quoting.
+        MSYS_NO_PATHCONV stops Git Bash on Windows from rewriting the psql args
+        as paths.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Query,
+        [Parameter(Mandatory)][hashtable]$Connection
+    )
+
+    $had = Test-Path Env:MSYS_NO_PATHCONV
+    $prev = if ($had) { $env:MSYS_NO_PATHCONV } else { $null }
+    $env:MSYS_NO_PATHCONV = '1'
+    try {
+        $out = $Query | & docker compose exec -T -e "PGPASSWORD=$($Connection.Password)" $Connection.Service `
+            psql -U $Connection.User -d $Connection.Database -A -t -v ON_ERROR_STOP=1 2>&1
+        return @{ Output = @($out); ExitCode = $LASTEXITCODE }
+    }
+    finally {
+        if ($had) { $env:MSYS_NO_PATHCONV = $prev }
+        else { Remove-Item Env:MSYS_NO_PATHCONV -ErrorAction SilentlyContinue }
+    }
+}
+
+function Invoke-PgQuery {
+    <#
+    .SYNOPSIS
+        Run a query and return its rows as strings (one per line, -A -t format).
+
+    .DESCRIPTION
+        Throws if psql reports an error or exits non-zero — a broken query must
+        not look like an empty result set.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Query)
+
+    $result = Invoke-Psql -Query $Query -Connection $script:PgConn
+    $parsed = ConvertFrom-PsqlOutput -Output $result.Output
+
+    if ($parsed.Errors.Count -gt 0 -or $result.ExitCode -ne 0) {
+        $detail = if ($parsed.Errors.Count -gt 0) { $parsed.Errors -join '; ' } else { "exit code $($result.ExitCode)" }
+        throw "psql failed: $detail`nQuery: $Query"
+    }
+    # Leading comma stops PowerShell unwrapping a one-row result into a bare
+    # string — assigning the result always yields an array, so .Count is safe.
+    # Consequence: `Invoke-PgQuery ... | ForEach-Object` would see the array as a
+    # single item. Assign first, then iterate. Do NOT wrap the call in @() either
+    # — that re-wraps the emitted array into a 1-element array of arrays.
+    return , $parsed.Rows
+}
+
+function Invoke-PgScalar {
+    <#
+    .SYNOPSIS
+        Run a query and return the first column of the first row, or $null.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Query)
+
+    $rows = Invoke-PgQuery -Query $Query
+    if ($null -eq $rows -or $rows.Count -eq 0) { return $null }
+    return ($rows[0] -split '\|')[0]
+}
+
+function Reset-PgSchemaCache {
+    <#
+    .SYNOPSIS
+        Drop the cached soft-delete table list (call after a migration, or in tests).
+    #>
+    [CmdletBinding()]
+    param()
+    $script:SoftDeleteTables = $null
+}
+
+function Get-PgSoftDeleteTables {
+    <#
+    .SYNOPSIS
+        Tables that use the v5 soft-delete lifecycle, read from the live schema.
+
+    .DESCRIPTION
+        Discovered rather than hard-coded so the list cannot drift from the
+        migrations: today it's Principals / Resources / ResourceAssignments
+        (040_soft_delete.sql), but a later migration adding "deletedAt" elsewhere
+        is picked up for free. Cached — the schema doesn't move mid-run.
+    #>
+    [CmdletBinding()]
+    param()
+    if ($null -eq $script:SoftDeleteTables) {
+        $script:SoftDeleteTables = Invoke-PgQuery -Query @'
+SELECT table_name FROM information_schema.columns
+WHERE column_name = 'deletedAt' AND table_schema = 'public'
+ORDER BY table_name
+'@
+    }
+    return , $script:SoftDeleteTables
+}
+
+function Get-PgLiveCount {
+    <#
+    .SYNOPSIS
+        Count the live (non-tombstoned) rows in a table.
+
+    .DESCRIPTION
+        The v5 replacement for the v4 `WHERE ValidTo = '9999-12-31...'` predicate.
+        v5 dropped temporal tables but did NOT stop hiding removed entities — it
+        soft-deletes them by stamping "deletedAt" (040_soft_delete.sql), and the
+        live views filter `deletedAt IS NULL`. So a v4 temporal check ports to
+        this, NOT to an unfiltered COUNT(*): dropping the predicate outright would
+        silently start counting tombstoned leavers and deleted resources.
+
+        Tables without a "deletedAt" column are counted unfiltered.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Table)
+
+    $where = if ((Get-PgSoftDeleteTables) -contains $Table) { ' WHERE "deletedAt" IS NULL' } else { '' }
+    return Get-PgCount -Query "SELECT COUNT(*) FROM ""$Table""$where"
+}
+
+function Get-PgCount {
+    <#
+    .SYNOPSIS
+        Run a COUNT query and return the number.
+
+    .DESCRIPTION
+        Throws on a non-numeric result rather than coercing it to 0 — a query
+        that returned something unexpected is a bug, not a zero.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Query)
+
+    $value = Invoke-PgScalar -Query $Query
+    if ($null -eq $value -or $value -eq '') { return 0 }
+
+    $parsed = 0
+    if (-not [int]::TryParse($value, [ref]$parsed)) {
+        throw "Expected a number from: $Query`nGot: $value"
+    }
+    return $parsed
+}
+
+Export-ModuleMember -Function Set-PgConnection, Get-PgConnection, ConvertFrom-PsqlOutput,
+    Invoke-Psql, Invoke-PgQuery, Invoke-PgScalar, Get-PgCount,
+    Get-PgSoftDeleteTables, Get-PgLiveCount, Reset-PgSchemaCache

--- a/test/nightly/Run-NightlyLocal.ps1
+++ b/test/nightly/Run-NightlyLocal.ps1
@@ -91,6 +91,9 @@ function Write-Result {
 $pgUser      = 'identity_atlas'
 $pgPassword  = 'identity_atlas_local'
 $pgDatabase  = 'identity_atlas'
+
+Import-Module (Join-Path $PSScriptRoot '..' 'lib' 'PgQuery.psm1') -Force
+Set-PgConnection -User $pgUser -Password $pgPassword -Database $pgDatabase
 $apiBaseUrl  = 'http://localhost:3001/api'
 $uiBaseUrl   = 'http://localhost:3001'
 $backendDir  = Join-Path $RepoRoot 'app/api'
@@ -471,70 +474,37 @@ if (-not $SkipIntegration) {
         }
     }
 
-    # ── Verify all expected postgres tables exist via psql ──────────
-    # We shell into the postgres container and run a single SELECT against
-    # pg_tables. PowerShell's `&` invocation can mangle docker compose's
-    # quoting on Windows, so we put the SQL in a file inside the container
-    # and invoke psql -f <file>. Simpler than escaping nested quotes.
+    # ── Verify all expected postgres relations exist ────────────────
+    # Query goes through test/lib/PgQuery.psm1, the single postgres transport for
+    # PowerShell (see nativePg.guard.test.js Tier 3). It replaces ~50 lines of
+    # inline psql + hand-rolled output filtering that used to live here.
     Write-Phase "Phase 4c: Verify Postgres Schema"
 
+    # information_schema.tables covers base tables AND views. pg_tables lists only
+    # base tables, so it reported GraphTags missing every night — since the v6
+    # context redesign that's a backward-compat VIEW over Contexts, not a table.
     $expectedTables = @('Systems', 'Resources', 'Principals', 'ResourceAssignments', 'ResourceRelationships',
                         'Identities', 'IdentityMembers', 'Contexts', 'GovernanceCatalogs', 'AssignmentPolicies',
                         'AssignmentRequests', 'CertificationDecisions', 'Crawlers', 'CrawlerAuditLog',
                         'CrawlerConfigs', 'CrawlerJobs', 'WorkerConfig', 'GraphSyncLog',
                         'GraphTags', 'GovernanceCategories', 'GraphRiskProfiles', 'GraphRiskClassifiers',
-                        'RiskScores', 'GraphResourceClusters', 'AccountLinkingConfig', 'AccountLinkingRuns',
+                        'RiskScores', 'AccountLinkingConfig', 'AccountLinkingRuns',
                         # Added by migration 009 (history) and 010 (secrets + risk v2)
                         '_history', 'Secrets', 'RiskProfiles', 'RiskClassifiers', 'ScoringRuns')
+    # GraphResourceClusters is deliberately absent: the v6 context redesign
+    # dropped it (clustering is a context-algorithm plugin now) with no
+    # compatibility view, so asserting on it failed every run.
     try {
-        # Pipe the SQL via stdin to avoid nested-quote hell in the
-        # PowerShell → cmd → docker → sh → psql chain on Windows. The -c flag
-        # with embedded single quotes inside double quotes breaks ~50% of the
-        # time depending on which shell layer strips them.
-        # Use dollar-quoting ($$public$$) instead of single quotes ('public')
-        # because PowerShell strips single quotes from strings piped through
-        # docker compose exec, causing psql to interpret 'public' as a column
-        # reference instead of a string literal. The SQL is in a single-quoted
-        # string so PowerShell won't try to expand $$ as a variable.
-        $env:MSYS_NO_PATHCONV = '1'
-        $sql = 'SELECT tablename FROM pg_tables WHERE schemaname=$$public$$ ORDER BY tablename'
-        $listOutput = $sql | & docker compose exec -T -e PGPASSWORD=$pgPassword postgres `
-            psql -U $pgUser -d $pgDatabase -A -t 2>&1
-        Remove-Item Env:MSYS_NO_PATHCONV -ErrorAction SilentlyContinue
-        # Coerce each line to a string before .Trim() — if `docker compose exec`
-        # itself errored we get ErrorRecord objects mixed in, and ErrorRecord
-        # doesn't have a Trim() method. Also filter out lines that look like
-        # psql error messages so they don't fake a non-empty result set.
-        $existingTables = @($listOutput |
-            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
-            ForEach-Object { [string]$_ } |
-            ForEach-Object { $_.Trim() } |
-            Where-Object { $_ -ne '' -and $_ -notmatch '^[\(\)]' -and $_ -notmatch '^(ERROR|LINE |DETAIL|HINT)' })
-
+        $existingTables = Invoke-PgQuery -Query @'
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'
+'@
         if ($existingTables.Count -eq 0) {
-            # Fallback: try the -c approach in case piping didn't work
-            Write-Host "  (pipe approach returned 0 tables — falling back to -c)" -ForegroundColor DarkGray
-            $env:MSYS_NO_PATHCONV = '1'
-            $listOutput = & docker compose exec -T -e PGPASSWORD=$pgPassword postgres `
-                psql -U $pgUser -d $pgDatabase -A -t `
-                -c 'SELECT tablename FROM pg_tables WHERE schemaname=$$public$$ ORDER BY tablename' 2>&1
-            Remove-Item Env:MSYS_NO_PATHCONV -ErrorAction SilentlyContinue
-            $existingTables = @($listOutput |
-                Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
-                ForEach-Object { [string]$_ } |
-                ForEach-Object { $_.Trim() } |
-                Where-Object { $_ -ne '' -and $_ -notmatch '^[\(\)]' -and $_ -notmatch '^(ERROR|LINE |DETAIL|HINT)' })
-        }
-
-        if ($existingTables.Count -eq 0) {
-            # Last resort: use the API's own admin status endpoint to confirm
-            # the database is at least reachable. Report a single failure
-            # rather than 25 table-not-found lines that obscure the real issue.
-            Write-Result 'Schema-Check' $false "psql returned no tables (docker exec may have failed — check docker-up.log)"
+            # Report one failure rather than 30 not-found lines that bury the cause.
+            Write-Result 'Schema-Check' $false 'postgres returned no relations (is the container up? check docker-up.log)'
         } else {
             foreach ($table in $expectedTables) {
                 $exists = $existingTables -contains $table
-                Write-Result "Table-$table" $exists $(if (-not $exists) { "Table not found in pg_tables" })
+                Write-Result "Table-$table" $exists $(if (-not $exists) { "Not found in information_schema.tables" })
             }
         }
     } catch {

--- a/test/run-docker-tests.ps1
+++ b/test/run-docker-tests.ps1
@@ -14,6 +14,10 @@ $cfg = Get-Content (Join-Path $PSScriptRoot 'test.config.json') -Raw | ConvertFr
 $apiBaseUrl = $cfg.api.baseUrl
 $uiBaseUrl  = $cfg.api.uiUrl
 
+Import-Module (Join-Path $PSScriptRoot 'lib' 'PgQuery.psm1') -Force
+Set-PgConnection -Service $cfg.postgres.service -User $cfg.postgres.user `
+                 -Password $cfg.postgres.password -Database $cfg.postgres.database
+
 $results = [ordered]@{}
 $totalPassed = 0
 $totalFailed = 0
@@ -228,21 +232,22 @@ if ($crawlerKey -and $datasetExists) {
 
 Write-Host "`n--- 5. Data Verification (SQL) ---" -ForegroundColor Yellow
 
-$connStr = "Server=$($cfg.sql.server),$($cfg.sql.port);Database=$($cfg.sql.database);User Id=$($cfg.sql.username);Password=$($cfg.sql.password);TrustServerCertificate=True"
-$CURRENT = "'9999-12-31 23:59:59.9999999'"
+# Postgres (v5). Identifiers are double-quoted because the migrations create them
+# as "PascalCase" — unquoted names fold to lowercase and don't resolve. There is
+# no ValidTo: v5 dropped temporal tables and hides removed entities with a
+# `deletedAt` tombstone instead, so "current rows" means `deletedAt IS NULL` on
+# the three soft-delete tables (Get-PgLiveCount applies it per table).
 
-function Get-SqlScalar {
-    param([string]$Query)
+# A query error must fail its own check, not the whole run — but it must never
+# read as a silent 0 either, which is how the v4 T-SQL here went unnoticed.
+function Measure-Check {
+    param([string]$Category, [string]$Name, [string]$Query, [int]$Min)
     try {
-        $conn = New-Object System.Data.SqlClient.SqlConnection($connStr)
-        $conn.Open()
-        $cmd = $conn.CreateCommand()
-        $cmd.CommandText = $Query
-        $cmd.CommandTimeout = 30
-        $result = $cmd.ExecuteScalar()
-        $conn.Close()
-        return $result
-    } catch { return $null }
+        $count = Get-PgCount -Query $Query
+        Test-Check $Category $Name ($count -ge $Min) "count=$count"
+    } catch {
+        Test-Check $Category $Name $false "query failed: $($_.Exception.Message)"
+    }
 }
 
 # Table existence
@@ -251,76 +256,116 @@ $expectedTables = @('Systems','Resources','Principals','ResourceAssignments','Re
     'AssignmentRequests','CertificationDecisions','Crawlers','CrawlerAuditLog')
 
 foreach ($table in $expectedTables) {
-    $exists = Get-SqlScalar "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '$table' AND TABLE_SCHEMA = 'dbo'"
-    Test-Check 'Schema' "Table exists: $table" ($exists -ge 1)
+    try {
+        $exists = Get-PgCount -Query "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = '$table' AND table_schema = 'public'"
+        Test-Check 'Schema' "Table exists: $table" ($exists -ge 1)
+    } catch {
+        Test-Check 'Schema' "Table exists: $table" $false "query failed: $($_.Exception.Message)"
+    }
 }
 
 # Row counts (after demo dataset ingest)
 $countChecks = @{
-    'Systems'                = @{ Min = 1;  Query = "SELECT COUNT(*) FROM dbo.Systems WHERE ValidTo = $CURRENT" }
-    'Principals'             = @{ Min = 5;  Query = "SELECT COUNT(*) FROM dbo.Principals WHERE ValidTo = $CURRENT" }
-    'Resources'              = @{ Min = 5;  Query = "SELECT COUNT(*) FROM dbo.Resources WHERE ValidTo = $CURRENT" }
-    'ResourceAssignments'    = @{ Min = 10; Query = "SELECT COUNT(*) FROM dbo.ResourceAssignments WHERE ValidTo = $CURRENT" }
-    'ResourceRelationships'  = @{ Min = 5;  Query = "SELECT COUNT(*) FROM dbo.ResourceRelationships WHERE ValidTo = $CURRENT" }
-    'Identities'             = @{ Min = 5;  Query = "SELECT COUNT(*) FROM dbo.Identities WHERE ValidTo = $CURRENT" }
-    'Contexts'               = @{ Min = 3;  Query = "SELECT COUNT(*) FROM dbo.Contexts WHERE ValidTo = $CURRENT" }
-    'GovernanceCatalogs'     = @{ Min = 1;  Query = "SELECT COUNT(*) FROM dbo.GovernanceCatalogs WHERE ValidTo = $CURRENT" }
+    'Systems'                = 1
+    'Principals'             = 5
+    'Resources'              = 5
+    'ResourceAssignments'    = 10
+    'ResourceRelationships'  = 5
+    'Identities'             = 5
+    'Contexts'               = 3
+    'GovernanceCatalogs'     = 1
 }
 
 foreach ($table in $countChecks.Keys | Sort-Object) {
-    $count = Get-SqlScalar $countChecks[$table].Query
-    $min = $countChecks[$table].Min
-    Test-Check 'DataCounts' "$table >= $min rows" ($count -ge $min) "actual=$count"
+    $min = $countChecks[$table]
+    try {
+        $count = Get-PgLiveCount -Table $table
+        Test-Check 'DataCounts' "$table >= $min rows" ($count -ge $min) "actual=$count"
+    } catch {
+        Test-Check 'DataCounts' "$table >= $min rows" $false "query failed: $($_.Exception.Message)"
+    }
 }
 
-# Referential integrity
-$orphanAssignRes = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments ra WHERE ra.ValidTo = $CURRENT AND NOT EXISTS (SELECT 1 FROM Resources r WHERE r.id = ra.resourceId AND r.ValidTo = $CURRENT)"
-Test-Check 'Integrity' 'Assignments -> Resources (no orphans)' ($orphanAssignRes -eq 0) "orphans=$orphanAssignRes"
+# Referential integrity — a live assignment must not point at a tombstoned or
+# missing row, so both sides of the check filter deletedAt.
+try {
+    $orphanAssignRes = Get-PgCount -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+WHERE ra."deletedAt" IS NULL
+  AND NOT EXISTS (SELECT 1 FROM "Resources" r WHERE r."id" = ra."resourceId" AND r."deletedAt" IS NULL)
+'@
+    Test-Check 'Integrity' 'Assignments -> Resources (no orphans)' ($orphanAssignRes -eq 0) "orphans=$orphanAssignRes"
+} catch {
+    Test-Check 'Integrity' 'Assignments -> Resources (no orphans)' $false "query failed: $($_.Exception.Message)"
+}
 
-$orphanAssignPrinc = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments ra WHERE ra.ValidTo = $CURRENT AND NOT EXISTS (SELECT 1 FROM Principals p WHERE p.id = ra.principalId AND p.ValidTo = $CURRENT)"
-Test-Check 'Integrity' 'Assignments -> Principals (no orphans)' ($orphanAssignPrinc -eq 0) "orphans=$orphanAssignPrinc"
+try {
+    $orphanAssignPrinc = Get-PgCount -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+WHERE ra."deletedAt" IS NULL
+  AND NOT EXISTS (SELECT 1 FROM "Principals" p WHERE p."id" = ra."principalId" AND p."deletedAt" IS NULL)
+'@
+    Test-Check 'Integrity' 'Assignments -> Principals (no orphans)' ($orphanAssignPrinc -eq 0) "orphans=$orphanAssignPrinc"
+} catch {
+    Test-Check 'Integrity' 'Assignments -> Principals (no orphans)' $false "query failed: $($_.Exception.Message)"
+}
 
 # Principal types
-$userCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE principalType = 'User' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has User principals' ($userCount -ge 10) "count=$userCount"
+Measure-Check 'BusinessLogic' 'Has User principals' -Min 10 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "principalType" = 'User' AND "deletedAt" IS NULL
+'@
 
-$spCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE principalType = 'ServicePrincipal' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has ServicePrincipal' ($spCount -ge 1) "count=$spCount"
+Measure-Check 'BusinessLogic' 'Has ServicePrincipal' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "principalType" = 'ServicePrincipal' AND "deletedAt" IS NULL
+'@
 
-$aiCount = Get-SqlScalar "SELECT COUNT(*) FROM Principals WHERE principalType = 'AIAgent' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has AIAgent' ($aiCount -ge 1) "count=$aiCount"
+Measure-Check 'BusinessLogic' 'Has AIAgent' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Principals" WHERE "principalType" = 'AIAgent' AND "deletedAt" IS NULL
+'@
 
 # Resource types
-$brCount = Get-SqlScalar "SELECT COUNT(*) FROM Resources WHERE resourceType = 'BusinessRole' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has BusinessRole resources' ($brCount -ge 2) "count=$brCount"
+Measure-Check 'BusinessLogic' 'Has BusinessRole resources' -Min 2 -Query @'
+SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'BusinessRole' AND "deletedAt" IS NULL
+'@
 
-$groupCount = Get-SqlScalar "SELECT COUNT(*) FROM Resources WHERE resourceType = 'Group' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has Group resources' ($groupCount -ge 3) "count=$groupCount"
+Measure-Check 'BusinessLogic' 'Has Group resources' -Min 3 -Query @'
+SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'Group' AND "deletedAt" IS NULL
+'@
 
-# Assignment types
-$govCount = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments WHERE assignmentType = 'Governed' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has Governed assignments' ($govCount -ge 5) "count=$govCount"
+# Governance is the `governed` flag on the assignment — never an assignmentType.
+# This asserted assignmentType = 'Governed' until #707: a retired value that
+# ingest now rejects outright, so the check could only ever have matched 0 rows.
+Measure-Check 'BusinessLogic' 'Has governed assignments' -Min 5 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" WHERE "governed" = true AND "deletedAt" IS NULL
+'@
 
-$ownerCount = Get-SqlScalar "SELECT COUNT(*) FROM ResourceAssignments WHERE assignmentType = 'Owner' AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has Owner assignments' ($ownerCount -ge 1) "count=$ownerCount"
+Measure-Check 'BusinessLogic' 'Has Eligible assignments' -Min 1 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" WHERE "assignmentType" = 'Eligible' AND "deletedAt" IS NULL
+'@
 
-# Context hierarchy
-$rootCtx = Get-SqlScalar "SELECT COUNT(*) FROM Contexts WHERE parentContextId IS NULL AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has root context (no parent)' ($rootCtx -ge 1) "count=$rootCtx"
+# NOTE: the old 'Has Owner assignments' check is deliberately gone rather than
+# ported. Ownership is no longer an assignmentType — it's a Direct assignment on
+# a GroupOwnership resource — and Generate-DemoDataset.ps1 emits no ownership at
+# all (its resources are Groups, EntraDirectoryRoles, EntraAppRoles and
+# BusinessRoles). There is nothing here to assert on; re-add this check together
+# with ownership in the generator, not before.
 
-$childCtx = Get-SqlScalar "SELECT COUNT(*) FROM Contexts WHERE parentContextId IS NOT NULL AND ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has child contexts (with parent)' ($childCtx -ge 3) "count=$childCtx"
+# Context hierarchy (Contexts has no soft-delete column)
+Measure-Check 'BusinessLogic' 'Has root context (no parent)' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Contexts" WHERE "parentContextId" IS NULL
+'@
+
+Measure-Check 'BusinessLogic' 'Has child contexts (with parent)' -Min 3 -Query @'
+SELECT COUNT(*) FROM "Contexts" WHERE "parentContextId" IS NOT NULL
+'@
 
 # Governance
-$catCount = Get-SqlScalar "SELECT COUNT(*) FROM GovernanceCatalogs WHERE ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has governance catalogs' ($catCount -ge 2) "count=$catCount"
+Measure-Check 'BusinessLogic' 'Has governance catalogs' -Min 2 -Query 'SELECT COUNT(*) FROM "GovernanceCatalogs"'
 
-$polCount = Get-SqlScalar "SELECT COUNT(*) FROM AssignmentPolicies WHERE ValidTo = $CURRENT"
-Test-Check 'BusinessLogic' 'Has assignment policies' ($polCount -ge 2) "count=$polCount"
+Measure-Check 'BusinessLogic' 'Has assignment policies' -Min 2 -Query 'SELECT COUNT(*) FROM "AssignmentPolicies"'
 
 # Crawler audit log
-$auditCount = Get-SqlScalar "SELECT COUNT(*) FROM CrawlerAuditLog"
-Test-Check 'BusinessLogic' 'Crawler audit log has entries' ($auditCount -ge 1) "count=$auditCount"
+Measure-Check 'BusinessLogic' 'Crawler audit log has entries' -Min 1 -Query 'SELECT COUNT(*) FROM "CrawlerAuditLog"'
 
 # ═══════════════════════════════════════════════════════════════════
 # 6. API DATA VERIFICATION (read-side)
@@ -400,7 +445,10 @@ try {
 
 Write-Host "`n--- 7. Worker Container ---" -ForegroundColor Yellow
 
-$workerLogs = (docker logs fortigigraph-worker-1 2>&1) -join "`n"
+# Ask compose for the service's logs rather than naming the container directly:
+# the project was renamed fortigigraph -> identityatlas, so the old hardcoded
+# `fortigigraph-worker-1` resolved to nothing and both checks below always failed.
+$workerLogs = (docker compose -f (Join-Path $repoRoot 'docker-compose.yml') logs worker 2>&1) -join "`n"
 Test-Check 'Worker' 'Module loaded successfully' ($workerLogs -like '*Module loaded successfully*')
 Test-Check 'Worker' 'Shows Identity Atlas branding' ($workerLogs -like '*Identity Atlas*')
 

--- a/test/test.config.json
+++ b/test/test.config.json
@@ -3,11 +3,10 @@
     "baseUrl": "http://localhost:3001/api",
     "uiUrl": "http://localhost:3001"
   },
-  "sql": {
-    "server": "localhost",
-    "port": 1433,
-    "database": "GraphData",
-    "username": "sa",
-    "password": "FortigiGraph_Local1!"
+  "postgres": {
+    "service": "postgres",
+    "user": "identity_atlas",
+    "password": "identity_atlas_local",
+    "database": "identity_atlas"
   }
 }

--- a/test/unit/PgQuery.Tests.ps1
+++ b/test/unit/PgQuery.Tests.ps1
@@ -195,4 +195,16 @@ Describe 'Set-PgConnection' {
         $c.User | Should -Be 'identity_atlas'
         Set-PgConnection -Database 'identity_atlas'   # restore
     }
+
+    It 'defaults to no compose file (plain `docker compose`)' {
+        (Get-PgConnection).ComposeFile | Should -BeNullOrEmpty
+    }
+
+    It 'accepts a compose file override' {
+        # CI starts its stack from docker-compose.ci.yml; a plain `docker compose`
+        # would resolve docker-compose.yml instead and miss the running services.
+        Set-PgConnection -ComposeFile 'docker-compose.ci.yml'
+        (Get-PgConnection).ComposeFile | Should -Be 'docker-compose.ci.yml'
+        Set-PgConnection -ComposeFile ''   # restore
+    }
 }

--- a/test/unit/PgQuery.Tests.ps1
+++ b/test/unit/PgQuery.Tests.ps1
@@ -1,0 +1,198 @@
+# Tests for test/lib/PgQuery.psm1 — the single way PowerShell reaches postgres.
+#
+# The transport (Invoke-Psql) is mocked so these run without Docker. The parsing
+# and error-surfacing logic is what actually matters here: the v4 scripts these
+# replaced swallowed psql failures into $null, which read as "0 rows" and let a
+# broken query masquerade as a passing check.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'lib' 'PgQuery.psm1') -Force
+}
+
+AfterAll {
+    Remove-Module PgQuery -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'ConvertFrom-PsqlOutput' {
+    It 'returns plain lines as rows' {
+        $r = ConvertFrom-PsqlOutput -Output @('alice', 'bob')
+        $r.Rows | Should -Be @('alice', 'bob')
+        $r.Errors | Should -BeNullOrEmpty
+    }
+
+    It 'trims whitespace and drops blank lines' {
+        $r = ConvertFrom-PsqlOutput -Output @('  alice  ', '', '   ', 'bob')
+        $r.Rows | Should -Be @('alice', 'bob')
+    }
+
+    It 'drops the (N rows) footer' {
+        $r = ConvertFrom-PsqlOutput -Output @('alice', '(1 row)')
+        $r.Rows | Should -Be @('alice')
+    }
+
+    It 'classifies ERROR/FATAL lines as errors, not data' {
+        $r = ConvertFrom-PsqlOutput -Output @('ERROR:  relation "Nope" does not exist')
+        $r.Rows | Should -BeNullOrEmpty
+        $r.Errors.Count | Should -Be 1
+    }
+
+    It 'drops psql diagnostic continuation lines' {
+        # LINE/DETAIL/HINT follow an ERROR; they are noise, never data.
+        $r = ConvertFrom-PsqlOutput -Output @('LINE 1: SELECT * FROM "Nope"', 'HINT:  check the name')
+        $r.Rows | Should -BeNullOrEmpty
+    }
+
+    It 'treats stderr ErrorRecords as errors even without an ERROR prefix' {
+        # `docker compose exec ... 2>&1` merges stderr in as ErrorRecord objects,
+        # which have no .Trim() — the docker daemon being down arrives this way.
+        $rec = [System.Management.Automation.ErrorRecord]::new(
+            [Exception]::new('cannot connect to the Docker daemon'), 'x', 'NotSpecified', $null)
+        $r = ConvertFrom-PsqlOutput -Output @($rec)
+        $r.Rows | Should -BeNullOrEmpty
+        $r.Errors.Count | Should -Be 1
+    }
+
+    It 'handles null and empty input' {
+        (ConvertFrom-PsqlOutput -Output $null).Rows | Should -BeNullOrEmpty
+        (ConvertFrom-PsqlOutput -Output @()).Rows | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-PgQuery' {
+    It 'returns rows on success' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('a', 'b'); ExitCode = 0 } }
+        # Assign, don't pipe: the function returns the array as one object so that
+        # a single row can't unwrap to a bare string (see PgQuery.psm1).
+        $rows = Invoke-PgQuery -Query 'SELECT 1'
+        $rows | Should -Be @('a', 'b')
+    }
+
+    It 'returns an array even for a single row' {
+        # PowerShell unwraps one-element arrays on return; callers rely on .Count.
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('only'); ExitCode = 0 } }
+        $rows = Invoke-PgQuery -Query 'SELECT 1'
+        $rows.Count | Should -Be 1
+    }
+
+    It 'returns an empty array for no rows' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @(); ExitCode = 0 } }
+        (Invoke-PgQuery -Query 'SELECT 1').Count | Should -Be 0
+    }
+
+    It 'throws when psql reports an error' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('ERROR:  boom'); ExitCode = 1 } }
+        { Invoke-PgQuery -Query 'SELECT 1' } | Should -Throw -ExpectedMessage '*boom*'
+    }
+
+    It 'throws on a non-zero exit even when nothing looks like an error line' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @(); ExitCode = 2 } }
+        { Invoke-PgQuery -Query 'SELECT 1' } | Should -Throw -ExpectedMessage '*exit code 2*'
+    }
+
+    It 'never reports an error as an empty result set' {
+        # The regression that made #707 invisible: failure must not look like 0 rows.
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('ERROR:  column "validto" does not exist'); ExitCode = 1 } }
+        { Invoke-PgQuery -Query 'SELECT 1' } | Should -Throw
+    }
+}
+
+Describe 'Invoke-PgScalar' {
+    It 'returns the first column of the first row' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('42|extra'); ExitCode = 0 } }
+        Invoke-PgScalar -Query 'SELECT 1' | Should -Be '42'
+    }
+
+    It 'returns $null when there are no rows' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @(); ExitCode = 0 } }
+        Invoke-PgScalar -Query 'SELECT 1' | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-PgCount' {
+    It 'parses a numeric count' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('27'); ExitCode = 0 } }
+        Get-PgCount -Query 'SELECT COUNT(*) FROM "Principals"' | Should -Be 27
+    }
+
+    It 'returns 0 for an empty result' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @(); ExitCode = 0 } }
+        Get-PgCount -Query 'SELECT COUNT(*) FROM "Principals"' | Should -Be 0
+    }
+
+    It 'throws on a non-numeric result rather than coercing to 0' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('banana'); ExitCode = 0 } }
+        { Get-PgCount -Query 'SELECT 1' } | Should -Throw -ExpectedMessage '*banana*'
+    }
+
+    It 'propagates a psql error instead of returning 0' {
+        Mock Invoke-Psql -ModuleName PgQuery { @{ Output = @('ERROR:  nope'); ExitCode = 1 } }
+        { Get-PgCount -Query 'SELECT 1' } | Should -Throw
+    }
+}
+
+Describe 'Get-PgLiveCount' {
+    BeforeEach {
+        Reset-PgSchemaCache
+    }
+
+    It 'filters out tombstoned rows on a soft-delete table' {
+        # The v4 `ValidTo = <sentinel>` predicate ports to `deletedAt IS NULL` —
+        # NOT to an unfiltered COUNT(*), which would count deleted rows.
+        $script:seen = $null
+        Mock Invoke-Psql -ModuleName PgQuery {
+            if ($Query -match 'information_schema') { return @{ Output = @('Principals', 'Resources', 'ResourceAssignments'); ExitCode = 0 } }
+            $script:seen = $Query
+            return @{ Output = @('5'); ExitCode = 0 }
+        }
+        Get-PgLiveCount -Table 'Principals' | Should -Be 5
+        $script:seen | Should -Match '"deletedAt" IS NULL'
+    }
+
+    It 'does not filter a table that has no deletedAt column' {
+        $script:seen = $null
+        Mock Invoke-Psql -ModuleName PgQuery {
+            if ($Query -match 'information_schema') { return @{ Output = @('Principals', 'Resources', 'ResourceAssignments'); ExitCode = 0 } }
+            $script:seen = $Query
+            return @{ Output = @('3'); ExitCode = 0 }
+        }
+        Get-PgLiveCount -Table 'Contexts' | Should -Be 3
+        $script:seen | Should -Not -Match 'deletedAt'
+    }
+
+    It 'derives the soft-delete list from the schema rather than a hard-coded list' {
+        # A later migration adding deletedAt elsewhere must be picked up for free.
+        Mock Invoke-Psql -ModuleName PgQuery {
+            if ($Query -match 'information_schema') { return @{ Output = @('Contexts'); ExitCode = 0 } }
+            return @{ Output = @('1'); ExitCode = 0 }
+        }
+        Get-PgSoftDeleteTables | Should -Be @('Contexts')
+    }
+
+    It 'caches the schema lookup instead of re-querying per table' {
+        Mock Invoke-Psql -ModuleName PgQuery {
+            if ($Query -match 'information_schema') { return @{ Output = @('Principals'); ExitCode = 0 } }
+            return @{ Output = @('1'); ExitCode = 0 }
+        }
+        Get-PgLiveCount -Table 'Principals' | Out-Null
+        Get-PgLiveCount -Table 'Resources' | Out-Null
+        Should -Invoke Invoke-Psql -ModuleName PgQuery -Times 1 -Exactly `
+            -ParameterFilter { $Query -match 'information_schema' }
+    }
+}
+
+Describe 'Set-PgConnection' {
+    It 'defaults to the docker-compose postgres credentials' {
+        $c = Get-PgConnection
+        $c.User | Should -Be 'identity_atlas'
+        $c.Database | Should -Be 'identity_atlas'
+        $c.Service | Should -Be 'postgres'
+    }
+
+    It 'overrides only the fields it is given' {
+        Set-PgConnection -Database 'other_db'
+        $c = Get-PgConnection
+        $c.Database | Should -Be 'other_db'
+        $c.User | Should -Be 'identity_atlas'
+        Set-PgConnection -Database 'identity_atlas'   # restore
+    }
+}

--- a/tools/crawlers/csv/ConfigWizard.jsx
+++ b/tools/crawlers/csv/ConfigWizard.jsx
@@ -193,7 +193,7 @@ export default function ConfigWizard({ onComplete, onCancel, initialConfig, isEd
               <label className="block text-sm font-medium text-gray-700 mb-1 dark:text-gray-200">System name</label>
               <input type="text" value={systemName} onChange={e => setSystemName(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-200 rounded text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
-              <p className="text-xs text-gray-500 mt-1 dark:text-gray-400">Recorded in <code className="dark:text-gray-300">dbo.Systems.displayName</code>.</p>
+              <p className="text-xs text-gray-500 mt-1 dark:text-gray-400">Recorded in <code className="dark:text-gray-300">Systems.displayName</code>.</p>
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1 dark:text-gray-200">System type</label>


### PR DESCRIPTION
Fixes #707.
Fixes #712.
Fixes #710.
Fixes #709.

Four commits with one theme: the v5 postgres port left SQL Server code behind in the places nothing looks, and no gate could see any of it.

This is a single pull request targeting `main` rather than a stack, so that each issue closes on merge. #712 and #710 build directly on the guard refactoring in #707 and cannot apply to `main` without it.

---

## 1. The PowerShell scripts still spoke v4 SQL Server (#707)

`Verify-DemoDataset.ps1` and `run-docker-tests.ps1` opened a `System.Data.SqlClient` connection, which does not exist on PowerShell 7, and filtered on the temporal `ValidTo` columns that v5 dropped. Neither could check anything against a v5 database.

They did not fail CI while broken, because no workflow ran them. That is the root cause, and it is why #663 and #690 could not have caught this: their guard scans `app/api/src`, while these scripts bypass the API and talk to the database directly.

- **`test/lib/PgQuery.psm1`** is now the single postgres transport for PowerShell, running psql inside the container through `docker compose exec`. It replaces three hand-rolled copies of that logic. A failed query throws rather than returning `$null`, so a broken check can no longer read as an empty result.
- **A third guard tier** rejects any `.ps1` or `.psm1` file that names a SQL Server client, the `dbo` schema, or the v4 temporal sentinel value.
- **Both scripts are ported**, and `Run-NightlyLocal.ps1` now uses the shared module, which removed roughly 50 lines of inline psql and output filtering.

Three things the port had to get right, which a mechanical translation would not:

**The issue's prescription was wrong.** It says to drop the `ValidTo` predicates. But `040_soft_delete.sql` replaced temporal tables with `deletedAt` tombstones, and states that live views filter `deletedAt IS NULL`. Dropping the predicate outright would have silently counted deleted leavers. The correct translation is `deletedAt IS NULL`, applied to the three soft-delete tables only and derived from the schema rather than a hand-maintained list.

**One check was flaky by construction.** `RowCount-Contexts` counted every context: 8 before the worker ran, and 9 afterwards, once the context algorithms emitted generated contexts. It now counts `variant='synced'`, which is stable.

**The `Owner` check had no valid translation.** Ownership is no longer an assignmentType, and the generator emits no ownership data at all, so I removed the check rather than rewrite it into something that passes vacuously. #713 records the gap.

Also fixed, all of which a mechanical port would have preserved: `accountEnabled = 0`, which is a type error against a postgres boolean; a `$null` fallback that could never run; a `GROUP BY` read through a scalar, returning the first group's size instead of the number of multi-account identities; checks for the `Governed` and `Owner` assignment types that ingest now rejects; the nightly schema check failing on `GraphTags`, now a compatibility view and so invisible to `pg_tables`, and on `GraphResourceClusters`, which the context redesign removed; and the worker checks looking for a container under the project's former name.

## 2. SQL Server dialect in JavaScript was unguarded (#712)

Tier 1 bans the shim's API surface, not the SQL written through it, so `db.query('SELECT TOP 0 * FROM dbo.Resources')` passed every gate. #690 argued that native pg makes leftover T-SQL fail loudly at author time, but that holds only where something executes the query. In at least one case nothing did: a `SELECT TOP 0` probe ran on every column-discovery request, threw every time, was silently swallowed, and had to be found by hand.

Tier 4 scans for `dbo.`, `SELECT TOP`, `ISNULL`, `GETDATE` and `GETUTCDATE`, `NEWID`, `@@ROWCOUNT` and `@@IDENTITY`, `sp_executesql`, `NOLOCK`, `CROSS` and `OUTER APPLY`, `NVARCHAR` and `DATETIME2`, `IIF` and `TRY_CAST`, and `LEN`.

The matching is case-sensitive, which is deliberate. SQL here is written in upper case while JavaScript is camelCase, so a case-insensitive `GETDATE` pattern also matches `.getDate()`, and every date-formatting helper in the tree would become an offender. The trade-off is that a lower-case `isnull(` would slip through; that has never appeared here, and a guard that reports false positives gets suppressed. Tests pin both directions, so adding a case-insensitive flag fails loudly rather than flooding the tree.

## 3. The `dbo` schema survived in live UI text (#710)

`ConfigWizard.jsx` rendered **"Recorded in `dbo.Systems.displayName`"** as the help text under the CSV wizard's System name field. That is live JSX, so it told users their input goes to a schema that does not exist. There was also a stale `dbo.WorkerConfig` comment in `authConfig.js`.

Nothing caught it, because Tier 4 scanned `app/api/src` and this string lives in `tools/crawlers`. The fix is therefore paired with the guard that stops it returning: **Tier 4 now also walks `app/ui/src` and `tools`**. Tiers 1 and 2 stay scoped to `app/api/src`, because they concern the API's connection pool rather than SQL Server text a reader might trust.

## 4. CI now runs the demo-dataset verification (#709)

`pr-integration.yml` already loads this exact data: its "Load demo data" step queues the demo crawler, which ingests `demo-company.json`. What was missing is verification depth. The existing check only confirms that at least one row arrived on four endpoints, which is why a two-generations-stale dataset still looked green. All 35 assertions now gate, in a step placed between the load and the clean-database step.

Two details that would otherwise have broken it: `PgQuery.psm1` needed a `ComposeFile` option, because a plain `docker compose` resolves `docker-compose.yml` while CI runs from `docker-compose.ci.yml`; and the CI stack's postgres password is `ci_test` rather than the local default.

---

## Verification

Against a live stack, rather than by inspection:

| | |
|---|---|
| Demo dataset (generate, ingest, verify) | **35 of 35** |
| Docker suite | **87 of 87** |
| PowerShell unit suite | **1627 passed, 0 failed** |
| API `src/db` vitest | **108 passed** |
| CSV wizard tests | **9 of 9** |

Every guard was confirmed not to be vacuous by planting a real offender and watching it fail:

- Tier 3, against a reintroduced `SqlClient`, `dbo.` or sentinel value in a `.ps1` file: caught.
- Tier 4, against `SELECT TOP 0 * FROM dbo.Resources WHERE ISNULL(x, 0) = 1` in `app/api/src`: all three patterns fired, which is the exact bug class described above.
- The widened Tier 4, against the same `dbo.` string replanted in `tools/crawlers/csv`: caught.

All probes were removed. The comment-stripping helper and the case-sensitivity rule are both pinned by tests, so neither scan can silently blank real code.

## Notes for review

- **A misleading comment is corrected rather than propagated.** `Run-NightlyLocal.ps1` claimed that single quotes do not survive `docker compose exec`, and used dollar-quoting (`$$public$$`) to work around it. Tested against a live database, they survive correctly on stdin; the hazard applies only to SQL passed with `-c`, where it crosses argv boundaries.
- **The guard deliberately does not ban the word `ValidTo`.** Omada legitimately carries `validFrom` and `validTo` fields in its own source records, so the scan matches the temporal sentinel value instead.
- **Residual sweep.** Executable code is now fully native postgres: no `mssql` or `tedious` dependency, no `SqlClient`, no `dbo.` in any query, and no live view, matview or index still filtering the retired `Governed` assignment type.

Follow-ups: #711 (the demo-dataset row counts, now narrowed after #708 fixed the rest), #713 (demo-dataset ownership) and #716 (`run-docker-tests.ps1` in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
