### PR TITLE
docs: correct demo-dataset.md to match what the generator produces (#711)

### DIFF
--- a/changes/fix-demo-dataset-doc-counts.md
+++ b/changes/fix-demo-dataset-doc-counts.md
@@ -1,0 +1,2 @@
+- Corrected the demo dataset documentation, which described a company and a set of records that didn't match what the dataset actually contains — wrong row counts throughout, three admin units where only one exists, and an "employee with no assignments" edge case that isn't in the data.
+- The documentation now explains how to count the records correctly, so readers don't get different numbers than the page shows.

--- a/docs/architecture/demo-dataset.md
+++ b/docs/architecture/demo-dataset.md
@@ -6,7 +6,7 @@ A purpose-built synthetic dataset for testing every feature of Identity Atlas. F
 
 ## The Company: Fortigi Demo Corp
 
-A mid-size technology consultancy with 50 employees across 4 departments. Small enough to reason about, large enough to exercise all features.
+A mid-size technology consultancy with 22 employees across 4 departments. Small enough to reason about, large enough to exercise all features.
 
 ### Org Chart
 
@@ -64,7 +64,7 @@ graph TB
 | Multi-system identity | E0020 Hassan Ibrahim | Has accounts in both EntraID and Omada; identity correlation links them |
 | Shared mailbox | SM-001 info@fortigidemo.com | `principalType: SharedMailbox`; owned by E0027 |
 | Manager in different dept | E0014 Ursula Visser | Reports to COO but manages Operations — tests cross-dept context |
-| Employee with no assignments | E0031 Intern | Principal exists but has zero resource assignments |
+| Intern | E0031 Intern | Lowest-privilege employee. Not a zero-assignment case: assignments are granted by `department`, so the intern still gets the 4 Engineering ones. The dataset has no principal with zero assignments — see issue #717 |
 
 ### Systems
 
@@ -92,8 +92,6 @@ Fortigi Demo Corp
 
 ```
 AU-Netherlands
-AU-Germany
-AU-Contractors
 ```
 
 ### Resources
@@ -119,16 +117,16 @@ AU-Contractors
 
 | Principal | Resource | Type | Notes |
 |---|---|---|---|
-| All 30 employees | SG-AllEmployees | Direct | |
-| E0010-E0024 (Engineering) | SG-Engineering | Direct | |
-| E0025-E0026 (Finance) | SG-Finance | Direct | |
+| All 22 employees | SG-AllEmployees | Direct | |
+| Every Engineering employee (10) | SG-Engineering | Direct | By `department`, so it includes the CTO (E0002) and the intern (E0031) |
+| Every Finance employee (4) | SG-Finance | Direct | By `department` |
 | E0029, E0030 (SysAdmins) | SG-VPN-Access | Direct | |
 | E0002 (CTO) | SG-Admin-Tier0 | Direct | CTO is a member of the critical Tier-0 admin group |
 | E0029 (SysAdmin) | SG-Admin-Tier0 | Direct | Member of high-risk group |
 | SVC-001 (Deploy Pipeline) | SG-Admin-Tier0 | Direct | Service principal in admin group |
 | E0002 (CTO) | Global Administrator | Direct | Directory role assignment |
-| All 30 employees | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
-| E0010-E0024 | BR-Engineering-Tools | Direct (`governed=true`) | Via business role |
+| All 22 employees | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
+| Every Engineering employee (10) | BR-Engineering-Tools | Direct (`governed=true`) | Via business role |
 | E0029 (SysAdmin) | BR-Admin-Privileged | Eligible | PIM-eligible, not active |
 
 ### Resource Relationships
@@ -182,12 +180,12 @@ The dataset is a single JSON file that maps directly to the Ingest API endpoints
     "description": "Synthetic dataset for E2E testing",
     "entityCounts": {
       "systems": 3,
-      "principals": 35,
+      "principals": 28,
       "resources": 14,
-      "resourceAssignments": 85,
+      "resourceAssignments": 73,
       "resourceRelationships": 9,
-      "identities": 32,
-      "identityMembers": 34,
+      "identities": 23,
+      "identityMembers": 24,
       "contexts": 8,
       "governanceCatalogs": 2,
       "assignmentPolicies": 3,
@@ -212,23 +210,28 @@ The dataset is a single JSON file that maps directly to the Ingest API endpoints
 
 ## Verification Tests
 
-After ingesting the demo dataset, the nightly runner executes these verification checks. Every check has an expected value derived from the dataset definition above.
+After ingesting the demo dataset, `test/demo-dataset/Verify-DemoDataset.ps1` executes these verification checks — it runs on every PR, in the `integration` job of `pr-integration.yml`. Every check has an expected value derived from the dataset definition above.
 
 ### Table Row Counts
 
-| Table | Expected | Query |
+Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssignments`. Those three tables soft-delete (`040_soft_delete.sql`): a removed entity is kept as a tombstone rather than dropped, so an unfiltered `COUNT(*)` also counts leavers and deleted resources. The other tables have no lifecycle column and are counted as-is.
+
+| Table | Expected | Composition |
 |---|---|---|
-| Systems | 3 | `SELECT COUNT(*) FROM Systems` |
-| Principals | 35 | Includes: 30 employees + 1 contractor + 1 disabled + 1 SP + 1 AI + 1 shared mailbox |
+| Systems | 3 | Entra ID + HR + Omada |
+| Principals | 28 | 24 `User` (22 employees + 1 disabled + 1 Omada account for the multi-system employee) + 1 `ExternalUser` (contractor) + 1 `ServicePrincipal` + 1 `AIAgent` + 1 `SharedMailbox` |
 | Resources | 14 | 6 groups + 2 directory roles + 2 app roles + 4 business roles |
-| ResourceAssignments | ~85 | Direct + Eligible (governed assignments carry `governed=true`) |
+| ResourceAssignments | 73 | 72 `Direct` + 1 `Eligible`; 31 of them carry `governed=true` |
 | ResourceRelationships | 9 | 8 Contains + 1 GrantsAccessTo |
-| Identities | 32 | 30 active employees + 1 disabled + 1 multi-system |
-| IdentityMembers | 34 | 32 primary links + 2 secondary (multi-system) |
-| Contexts | 8 | 1 root + 4 departments + 2 teams + 1 admin unit |
+| Identities | 23 | 22 employees + 1 disabled |
+| IdentityMembers | 24 | 23 primary + 1 secondary (the multi-system employee's Omada account) |
+| Contexts | 8 | 1 root + 4 departments + 2 teams + 1 admin unit — all `variant='synced'` |
 | GovernanceCatalogs | 2 | Employee + Privileged |
 | AssignmentPolicies | 3 | Auto-assign + Manager approval + Dual approval |
 | CertificationDecisions | 2 | 1 approve + 1 deny |
+
+!!! note "Counting Contexts"
+    Filter on `variant='synced'` to get the 8 above. A bare `SELECT COUNT(*) FROM "Contexts"` returns more: the API creates `manual` Tag roots at bootstrap, and the context-algorithm plugins emit `generated` contexts once the worker runs. Only the `synced` ones come from this dataset.
 
 ### Relationship Integrity
 
@@ -267,7 +270,7 @@ After ingesting the demo dataset, the nightly runner executes these verification
 |---|---|
 | Resources page shows 14 resources (excluding BusinessRoles) | Count rows, filter by non-BusinessRole |
 | Business Roles page shows 4 business roles | Count rows |
-| Users page shows 35 principals | Count visible or total indicator |
+| Users page shows 28 principals | Count visible or total indicator |
 | Matrix shows data (not "0 users x 0 resources") | Assert text not present |
 | Click CTO user → detail page opens | Navigate, check heading |
 | CTO detail shows "Global Administrator" in memberships | Assert membership listed |


### PR DESCRIPTION
Fixes #711.

This targets `main` directly. It changes documentation only and does not depend on #714, so it will close its issue on merge.

## The problem

Every row count on the page was wrong, and the errors were large:

| Table | The page said | Actual |
|---|---|---|
| Principals | 35 | **28** |
| ResourceAssignments | ~85 | **73** |
| Identities | 32 | **23** |
| IdentityMembers | 34 | **24** |

The page also opened by describing a company with "50 employees", when the dataset contains 22. The same wrong figures were repeated in the assignment table, in the `entityCounts` JSON block, and in the UI checklist.

#708 corrected this page's T-SQL examples and its references to retired assignment types. The counts were not part of that change.

## How the numbers were verified

Two independent sources agree exactly: the summary that `Generate-DemoDataset.ps1` prints, and a live run of generate, ingest and measure against a real database.

```
Systems: 3   Principals: 28   Resources: 14   Assignments: 73
Relationships: 9   Identities: 23   Identity Members: 24   Contexts: 8
Governance Catalogs: 2   Assignment Policies: 3   Certifications: 2
```

The 28 principals are 24 of type `User` (22 employees, 1 disabled account, and 1 Omada account belonging to the multi-system employee), plus one each of `ExternalUser`, `ServicePrincipal`, `AIAgent` and `SharedMailbox`.

## Other corrections

- The page listed three admin units: `AU-Netherlands`, `AU-Germany` and `AU-Contractors`. Only `AU-Netherlands` exists.
- The assignment table described Engineering and Finance membership as employee-ID ranges, such as `E0010-E0024`. The generator grants those assignments by `department`, so the ranges were both inaccurate and misleading: they omitted the CTO (E0002) and the intern (E0031), who do receive the assignments.
- The page listed "Employee with no assignments — E0031 Intern" as a deliberate edge case. That is not true. E0031 has four assignments, and the dataset contains no principal with zero assignments at all. The page now says so, and I raised #717 so that the missing edge case is recorded rather than quietly dropped.

## Two counting notes added

Both come from mistakes I made while verifying the numbers, so a reader is likely to hit them too.

- Contexts must be counted with `variant='synced'`. A plain `COUNT(*)` returns more, because the API creates manual Tag roots at start-up and the context algorithms add generated contexts once the worker runs. The count read 8 before the worker started and 9 afterwards. Without this note, a reader comparing the page's "8" against a live database would conclude the page was wrong. #714 had to apply the same filter to stop its verification check being flaky.
- `Principals`, `Resources` and `ResourceAssignments` must be counted with `deletedAt IS NULL`. v5 soft-deletes those three tables (`040_soft_delete.sql`), so an unfiltered `COUNT(*)` also counts tombstoned rows.

## What I did not change

The org chart, the edge-case table and the individual employee IDs are accurate. I checked them against the ingested data: E0031, E0027, E0014 and E0028 all exist, and the 22 employees are numbered E0001-E0005, E0010-E0014 and E0020-E0031. I left those sections alone.

I also corrected a mistake of my own. I had written the three systems as "Entra ID, Omada and Azure RM" from memory. They are EntraID, HR and Omada. The page was already correct and my edit introduced the error. I found it by querying the database before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
