### PR TITLE
ci: correct the measured job durations in the pr-integration header

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -3,10 +3,23 @@
 # Builds the complete stack (postgres + web + worker), then exercises every
 # nightly test scenario so main stays stable.
 #
-# Three parallel jobs:
-#   1. integration  — core + secret-dependent tests (~20 min)
-#   2. e2e          — Playwright browser tests (~15 min)
-#   3. load-soak    — 1.5M-row load test + 15-min soak test (~50 min)
+# Three parallel jobs. The durations below are measured across recent successful
+# runs rather than estimated; the previous figures (20 / 15 / 50 min) overstated
+# every job, which makes it hard to judge what re-running the suite costs.
+#   1. integration  — core + secret-dependent tests (~5 min)
+#   2. e2e          — Playwright browser tests (~5 min)
+#   3. load-soak    — 1.5M-row load test (~7 min) + 15-min soak test (~22 min)
+#
+# Note: load-soak currently finishes in ~8 min, not ~22, because the soak test
+# does not actually run. It takes a memory baseline from GET /admin/container-stats
+# and skips — recording a PASS — when that is unavailable, which is always: #213
+# removed the endpoint and the Docker socket mount it needed, because mounting
+# docker.sock into the web container was a host-takeover primitive. So a step
+# named "Soak test (15 min)" completes in 0 min and goes green. #721 tracks it.
+#
+# ~22 min is what this job should cost once the soak works again. Do NOT get
+# there by restoring the endpoint or the socket mount — that re-opens the hole
+# #213 closed. See #721 for the alternatives.
 #
 # Secret-dependent tests (Entra ID crawler, LLM risk scoring) skip gracefully
 # when GitHub Actions secrets are not configured. Set them in repo Settings →


### PR DESCRIPTION
Corrects the job durations in `pr-integration.yml`'s header comment, and documents a bug found while checking them.

## The stale figures

The header claimed 20, 15 and 50 minutes for the three parallel jobs. Measured across recent successful runs, none is close:

| Job | Header claimed | Actual (min / max / avg) |
|---|---|---|
| Load & Soak Tests | ~50 min | 7.5 / 9.2 / **8.2** |
| Integration Tests | ~20 min | 1.8 / 9.1 / **5.1** |
| Playwright E2E | ~15 min | 4.2 / 5.3 / **4.8** |

These numbers are what someone reads when deciding whether a re-run or a force-push is expensive. Overstating them by three to six times discourages re-runs that actually cost a few minutes. I got this wrong myself: I delayed rewording a commit on the belief that Load & Soak was a 50-minute job.

## Why load-soak is documented as ~22 min, not the ~8 it takes today

The 8 minutes is a symptom, not the truth. The soak test does not run. It takes a memory baseline from `GET /admin/container-stats` and skips — recording a **pass** — when that is unavailable, which is always:

```
Test: Load test (1.5M rows)      6.7 min  success
Test: Soak test (15 min)         0   min  success   <-- never runs
```

```
=== Soak Test (15 min) ===
    SKIP  /admin/container-stats unavailable — skipping soak test
    PASS  Soak/InitialMemory  skipped: container stats unavailable
```

That endpoint was removed by #213, together with the Docker socket mount it needed, because mounting `docker.sock` into the web container was a host-takeover primitive. Verified against a running stack: with a valid API key it returns 404, the same as a route that never existed. #213 missed two consumers under `test/nightly/` — this soak, and `Run-NightlyLocal.ps1` Phase 4f6, which has been failing every night since.

Recording ~8 here would make the missing 15 minutes look intended and hide the bug permanently, so the header states **~22 min** (7 load + 15 soak) as the figure to expect once the soak works — with an explicit warning **not** to reach it by restoring the endpoint or the socket mount. #721 tracks the fix and its options.

## Notes

- **No changelog fragment.** The gate in `pr.yml` scopes "code" to `app/api/src/*.{js,sql}`, `app/*.mjs`, `app/ui/src/*.{js,jsx}`, `tools/*.ps1` and `setup/docker/*.ps1`. A workflow comment does not match, so the gate reports "No product code changed", and the change has no user-facing effect.
- The YAML was re-parsed after the edit to confirm all six jobs still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
