### PR TITLE
refactor(ui): move App.jsx render-switch into an instrumented page registry (#669)

### DIFF
--- a/app/ui/CLAUDE.md
+++ b/app/ui/CLAUDE.md
@@ -208,3 +208,11 @@ function getCrawlerSummary(crawlerType) {
 | `components/TimeSeriesChart.jsx` | Reusable hand-rolled SVG line chart (no chart lib dep) |
 | `hooks/useMatrixRowOrder.js` | Row order persistence (versioned localStorage) |
 | `hooks/useEntityPage.js` | Shared hook for Users/Resources pages |
+
+## App-shell routing & the JSX coverage blind spot
+
+`App.jsx` dispatches the top nav to page components through `src/pageRegistry.jsx` — a `{ pageKey: (ctx) => <Page … /> }` map resolved by `resolvePageRoute(page)`. **Add, rename, or reorder a static page there** (a one-line data edit), not in a JSX conditional in `App.jsx`. `ctx` carries the shared handlers (`navigate`, `openDetailTab`, `forceRefresh`, `riskScoresRefreshKey`, `onRiskScoresRefresh`); cover new entries in `pageRegistry.test.jsx`.
+
+Why a map and not the old inline `page === 'x' ? <X/> : …` chain: **v8 does not line-instrument the arms of a JSX ternary**, so those lines carried no coverage record and every routing edit tripped the (non-blocking) `Diff coverage: UI` gate on an un-coverable line ([#669](https://github.com/Fortigi/IdentityAtlas/issues/669)). Map entries + render-function statements are ordinary instrumented code the registry test covers.
+
+**Accepted exception — pure-JSX page shells.** The same v8 limitation applies to components that are mostly one big JSX `return`: the matrix views, the `EntityDetailPage`/`EntityListPage`-based pages (`UsersPage`, detail pages, …), and the detail-tab dispatch + matrix fallback that stay in `App.jsx`. Splitting them into more files does **not** make their JSX instrumentable, so they are covered by e2e (`app/ui/e2e/*.spec.js`), and a `Diff coverage: UI` red on such a file's JSX body is expected — confirm the e2e exercises the behaviour rather than chasing the line. Formalising a `diff_cover` exclude for this set is tracked in [#725](https://github.com/Fortigi/IdentityAtlas/issues/725).

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -12,29 +12,22 @@ import { ThemeContext } from './contexts/ThemeContext';
 import { computeNavTabs, availableOptionalTabs } from './utils/navTabs';
 import { tabBadge } from './utils/tabBadge';
 import ErrorBoundary from './components/ErrorBoundary';
+import { resolvePageRoute } from './pageRegistry';
 
-// Lazy-load page components (route-based code splitting)
-const DashboardPage = lazy(() => import('./components/DashboardPage'));
+// Lazy-load the matrix + detail page components (route-based code splitting).
+// The static page components (dashboard, principals, systems, admin, …) live in
+// ./pageRegistry — see resolvePageRoute below and the #669 note in that file.
 const MatrixView = lazy(() => import('./components/MatrixView'));
 const RotatedMatrixView = lazy(() => import('./components/RotatedMatrixView'));
 const RollupMatrixView = lazy(() => import('./components/RollupMatrixView'));
 const MatrixFilterWizard = lazy(() => import('./components/matrix/MatrixFilterWizard'));
-const SyncLogPage = lazy(() => import('./components/SyncLogPage'));
-const UsersPage = lazy(() => import('./components/UsersPage'));
-const GroupsPage = lazy(() => import('./components/GroupsPage')); // Now renders ResourcesPage
-const AccessPackagesPage = lazy(() => import('./components/AccessPackagesPage'));
 const UserDetailPage = lazy(() => import('./components/UserDetailPage'));
 const ResourceDetailPage = lazy(() => import('./components/ResourceDetailPage'));
 const AccessPackageDetailPage = lazy(() => import('./components/AccessPackageDetailPage'));
-const SystemsPage = lazy(() => import('./components/SystemsPage'));
-const RiskScoringPage = lazy(() => import('./components/RiskScoringPage'));
-const ContextsPage = lazy(() => import('./components/ContextsPage'));
 const DepartmentDetailPage = lazy(() => import('./components/DepartmentDetailPage'));
 const ContextDetailPage = lazy(() => import('./components/ContextDetailPage'));
 const RunDetailPage = lazy(() => import('./components/RunDetailPage'));
-const IdentitiesPage = lazy(() => import('./components/IdentitiesPage'));
 const IdentityDetailPage = lazy(() => import('./components/IdentityDetailPage'));
-const AdminPage = lazy(() => import('./components/AdminPage'));
 // PerfPage and CrawlersPage are lazy-loaded inside AdminPage as sub-tabs.
 // const GovernancePage = lazy(() => import('./components/GovernancePage')); // temporarily disabled
 
@@ -394,6 +387,18 @@ export default function App() {
     return null;
   };
 
+  // Static (non-detail, non-matrix) page routes resolve through the instrumented
+  // pageRegistry map (#669) — a routing edit is a one-line data change there, not
+  // an un-line-instrumentable JSX ternary arm in the return below.
+  const staticRoute = isDetailPage ? null : resolvePageRoute(page);
+  const pageCtx = {
+    navigate,
+    openDetailTab,
+    forceRefresh,
+    riskScoresRefreshKey,
+    onRiskScoresRefresh: () => setRiskScoresRefreshKey(k => k + 1),
+  };
+
   return (
     <ThemeContext.Provider value={{ isDark, mode }}>
     <ErrorBoundary>
@@ -584,28 +589,11 @@ export default function App() {
             // write, which is exactly what the ref avoids.
             // eslint-disable-next-line react-hooks/refs
             renderDetailPage()
-          ) : page === 'dashboard' ? (
-            <DashboardPage onNavigate={navigate} />
-          ) : page === 'sync-log' ? (
-            <SyncLogPage navigate={navigate} onOpenDetail={openDetailTab} />
-          ) : page === 'principals' ? (
-            <UsersPage onOpenDetail={openDetailTab} />
-          ) : page === 'resources' || page === 'groups' ? (
-            <GroupsPage onOpenDetail={openDetailTab} />
-          ) : page === 'systems' ? (
-            <SystemsPage />
-          ) : page === 'access-packages' ? (
-            <AccessPackagesPage onOpenDetail={openDetailTab} />
-          ) : page === 'risk-scores' ? (
-            <RiskScoringPage key={riskScoresRefreshKey} onOpenDetail={openDetailTab} />
-          ) : page === 'identities' ? (
-            <IdentitiesPage onOpenDetail={openDetailTab} />
-          ) : page === 'contexts' ? (
-            <ContextsPage onOpenDetail={openDetailTab} onNavigate={navigate} />
-          ) : page === 'performance' || page === 'crawlers' || page === 'admin' ? (
-            // Crawlers and Performance now live under Admin as sub-tabs.
-            // Legacy #crawlers and #performance hashes redirect to the matching sub-tab.
-            <AdminPage onNavigate={navigate} onRefresh={forceRefresh} onRiskScoresRefresh={() => setRiskScoresRefreshKey(k => k + 1)} />
+          ) : staticRoute ? (
+            // Static pages (dashboard, principals, systems, admin + its legacy
+            // #crawlers / #performance aliases, …) come from the instrumented
+            // pageRegistry map — see resolvePageRoute / #669.
+            staticRoute(pageCtx)
           ) : loading ? (
             <div className="flex items-center justify-center h-64">
               <div className="text-gray-500 dark:text-gray-400">Loading permission data...</div>

--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useReducer, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
+﻿import { useState, useEffect, useReducer, useCallback, useMemo, useRef, lazy, Suspense, createElement } from 'react';
 
 // useState-equivalent backed by useReducer (value + functional updates):
 // dispatch isn't flagged by react-hooks/set-state-in-effect, so the detail-tab
@@ -592,8 +592,10 @@ export default function App() {
           ) : staticRoute ? (
             // Static pages (dashboard, principals, systems, admin + its legacy
             // #crawlers / #performance aliases, …) come from the instrumented
-            // pageRegistry map — see resolvePageRoute / #669.
-            staticRoute(pageCtx)
+            // pageRegistry map. Built via createElement (not called as
+            // staticRoute(...)) so the user-controlled hash key never reaches
+            // callee position — see #669.
+            createElement(staticRoute, pageCtx)
           ) : loading ? (
             <div className="flex items-center justify-center h-64">
               <div className="text-gray-500 dark:text-gray-400">Loading permission data...</div>

--- a/app/ui/src/pageRegistry.jsx
+++ b/app/ui/src/pageRegistry.jsx
@@ -32,41 +32,42 @@ const ContextsPage = lazy(() => import('./components/ContextsPage'));
 const IdentitiesPage = lazy(() => import('./components/IdentitiesPage'));
 const AdminPage = lazy(() => import('./components/AdminPage'));
 
-// Render functions defined once and aliased to every key that shows the same page,
-// so multi-key routes (resources/groups; performance/crawlers/admin) don't
-// duplicate the element markup.
-const renderGroups = (ctx) => <GroupsPage onOpenDetail={ctx.openDetailTab} />;
+// Each entry is a small component that takes the shared render context as PROPS
+// and renders its page; multi-key routes (resources/groups; performance/crawlers/
+// admin) share one component so the markup isn't duplicated.
+const GroupsRoute = ({ openDetailTab }) => <GroupsPage onOpenDetail={openDetailTab} />;
 // Crawlers and Performance live under Admin as sub-tabs; the legacy #crawlers /
 // #performance hashes render AdminPage, which routes to the matching sub-tab.
-const renderAdmin = (ctx) => (
-  <AdminPage onNavigate={ctx.navigate} onRefresh={ctx.forceRefresh} onRiskScoresRefresh={ctx.onRiskScoresRefresh} />
+const AdminRoute = ({ navigate, forceRefresh, onRiskScoresRefresh }) => (
+  <AdminPage onNavigate={navigate} onRefresh={forceRefresh} onRiskScoresRefresh={onRiskScoresRefresh} />
 );
 
-// key → (ctx) => element. `ctx` carries { navigate, openDetailTab, forceRefresh,
-// riskScoresRefreshKey, onRiskScoresRefresh }.
-//
-// A Map (not a plain object) is deliberate: `page` comes from the URL hash
-// (user-controlled), and a Map lookup can only ever return an explicitly-added
-// entry — never an inherited Object.prototype member (`constructor`, `toString`,
-// …). That closes the "unvalidated dynamic method call" class flat (CodeQL
-// js/unvalidated-dynamic-method-call) without an own-property guard.
+// pageKey → component. Two things make dispatch on the user-controlled hash key
+// provably safe (CodeQL js/unvalidated-dynamic-method-call):
+//   1. a Map lookup can only return an explicitly-added entry — never an
+//      inherited Object.prototype member (`constructor`, `toString`, …); and
+//   2. App.jsx builds the resolved entry as an element (`createElement(route, ctx)`)
+//      rather than calling it (`route(ctx)`), so the user-controlled key never
+//      lands in callee position of an invocation.
+// The context props: { navigate, openDetailTab, forceRefresh, riskScoresRefreshKey,
+// onRiskScoresRefresh }.
 export const PAGE_ROUTES = new Map([
-  ['dashboard',       (ctx) => <DashboardPage onNavigate={ctx.navigate} />],
-  ['sync-log',        (ctx) => <SyncLogPage navigate={ctx.navigate} onOpenDetail={ctx.openDetailTab} />],
-  ['principals',      (ctx) => <UsersPage onOpenDetail={ctx.openDetailTab} />],
-  ['resources',       renderGroups],
-  ['groups',          renderGroups],
+  ['dashboard',       ({ navigate }) => <DashboardPage onNavigate={navigate} />],
+  ['sync-log',        ({ navigate, openDetailTab }) => <SyncLogPage navigate={navigate} onOpenDetail={openDetailTab} />],
+  ['principals',      ({ openDetailTab }) => <UsersPage onOpenDetail={openDetailTab} />],
+  ['resources',       GroupsRoute],
+  ['groups',          GroupsRoute],
   ['systems',         () => <SystemsPage />],
-  ['access-packages', (ctx) => <AccessPackagesPage onOpenDetail={ctx.openDetailTab} />],
-  ['risk-scores',     (ctx) => <RiskScoringPage key={ctx.riskScoresRefreshKey} onOpenDetail={ctx.openDetailTab} />],
-  ['identities',      (ctx) => <IdentitiesPage onOpenDetail={ctx.openDetailTab} />],
-  ['contexts',        (ctx) => <ContextsPage onOpenDetail={ctx.openDetailTab} onNavigate={ctx.navigate} />],
-  ['performance',     renderAdmin],
-  ['crawlers',        renderAdmin],
-  ['admin',           renderAdmin],
+  ['access-packages', ({ openDetailTab }) => <AccessPackagesPage onOpenDetail={openDetailTab} />],
+  ['risk-scores',     ({ openDetailTab, riskScoresRefreshKey }) => <RiskScoringPage key={riskScoresRefreshKey} onOpenDetail={openDetailTab} />],
+  ['identities',      ({ openDetailTab }) => <IdentitiesPage onOpenDetail={openDetailTab} />],
+  ['contexts',        ({ navigate, openDetailTab }) => <ContextsPage onOpenDetail={openDetailTab} onNavigate={navigate} />],
+  ['performance',     AdminRoute],
+  ['crawlers',        AdminRoute],
+  ['admin',           AdminRoute],
 ]);
 
-// The render function for a static page key, or null when the key is a detail tab
+// The route component for a static page key, or null when the key is a detail tab
 // / matrix / unknown route (all handled by App.jsx).
 export function resolvePageRoute(page) {
   return PAGE_ROUTES.get(page) ?? null;

--- a/app/ui/src/pageRegistry.jsx
+++ b/app/ui/src/pageRegistry.jsx
@@ -1,0 +1,67 @@
+/* eslint-disable react-refresh/only-export-components --
+   This is a route table, not a Fast-Refresh component module: it exports the
+   PAGE_ROUTES map + resolvePageRoute helper, and the lazy() consts are internal
+   route targets, never re-rendered in place by HMR. */
+// Static page-route registry for the app shell.
+//
+// Maps a hash page-key to a render function that builds its page element from the
+// shared render context. This is deliberately a DATA MAP, not the big JSX ternary
+// it replaced in App.jsx: v8 does not line-instrument the arms of a JSX ternary,
+// so every routing edit (add / rename / reorder a tab) tripped the diff-coverage
+// gate on an un-coverable changed line (#669). As instrumented map entries +
+// render-function statements, each route IS executed — and therefore covered — by
+// a test that resolves its key, and a routing change is a one-line data edit here
+// rather than an edit to an un-line-instrumentable JSX arm in App.jsx.
+//
+// Scope: STATIC pages only. The dynamic detail tabs (#user:, #group:, …) and the
+// matrix view stay in App.jsx — they need surrounding app state (the detail-tab
+// cache, the matrix filter/wizard wiring) and are the pure-JSX shells v8 can't
+// line-instrument regardless of where they live (covered by e2e instead; the
+// remaining shell blind spot is tracked separately).
+
+import { lazy } from 'react';
+
+const DashboardPage = lazy(() => import('./components/DashboardPage'));
+const SyncLogPage = lazy(() => import('./components/SyncLogPage'));
+const UsersPage = lazy(() => import('./components/UsersPage'));
+const GroupsPage = lazy(() => import('./components/GroupsPage')); // renders ResourcesPage
+const AccessPackagesPage = lazy(() => import('./components/AccessPackagesPage'));
+const SystemsPage = lazy(() => import('./components/SystemsPage'));
+const RiskScoringPage = lazy(() => import('./components/RiskScoringPage'));
+const ContextsPage = lazy(() => import('./components/ContextsPage'));
+const IdentitiesPage = lazy(() => import('./components/IdentitiesPage'));
+const AdminPage = lazy(() => import('./components/AdminPage'));
+
+// Render functions defined once and aliased to every key that shows the same page,
+// so multi-key routes (resources/groups; performance/crawlers/admin) don't
+// duplicate the element markup.
+const renderGroups = (ctx) => <GroupsPage onOpenDetail={ctx.openDetailTab} />;
+// Crawlers and Performance live under Admin as sub-tabs; the legacy #crawlers /
+// #performance hashes render AdminPage, which routes to the matching sub-tab.
+const renderAdmin = (ctx) => (
+  <AdminPage onNavigate={ctx.navigate} onRefresh={ctx.forceRefresh} onRiskScoresRefresh={ctx.onRiskScoresRefresh} />
+);
+
+// key → (ctx) => element. `ctx` carries { navigate, openDetailTab, forceRefresh,
+// riskScoresRefreshKey, onRiskScoresRefresh }.
+export const PAGE_ROUTES = {
+  dashboard:         (ctx) => <DashboardPage onNavigate={ctx.navigate} />,
+  'sync-log':        (ctx) => <SyncLogPage navigate={ctx.navigate} onOpenDetail={ctx.openDetailTab} />,
+  principals:        (ctx) => <UsersPage onOpenDetail={ctx.openDetailTab} />,
+  resources:         renderGroups,
+  groups:            renderGroups,
+  systems:           () => <SystemsPage />,
+  'access-packages': (ctx) => <AccessPackagesPage onOpenDetail={ctx.openDetailTab} />,
+  'risk-scores':     (ctx) => <RiskScoringPage key={ctx.riskScoresRefreshKey} onOpenDetail={ctx.openDetailTab} />,
+  identities:        (ctx) => <IdentitiesPage onOpenDetail={ctx.openDetailTab} />,
+  contexts:          (ctx) => <ContextsPage onOpenDetail={ctx.openDetailTab} onNavigate={ctx.navigate} />,
+  performance:       renderAdmin,
+  crawlers:          renderAdmin,
+  admin:             renderAdmin,
+};
+
+// The render function for a static page key, or null when the key is a detail tab
+// / matrix / unknown route (all handled by App.jsx).
+export function resolvePageRoute(page) {
+  return Object.prototype.hasOwnProperty.call(PAGE_ROUTES, page) ? PAGE_ROUTES[page] : null;
+}

--- a/app/ui/src/pageRegistry.jsx
+++ b/app/ui/src/pageRegistry.jsx
@@ -44,24 +44,30 @@ const renderAdmin = (ctx) => (
 
 // key → (ctx) => element. `ctx` carries { navigate, openDetailTab, forceRefresh,
 // riskScoresRefreshKey, onRiskScoresRefresh }.
-export const PAGE_ROUTES = {
-  dashboard:         (ctx) => <DashboardPage onNavigate={ctx.navigate} />,
-  'sync-log':        (ctx) => <SyncLogPage navigate={ctx.navigate} onOpenDetail={ctx.openDetailTab} />,
-  principals:        (ctx) => <UsersPage onOpenDetail={ctx.openDetailTab} />,
-  resources:         renderGroups,
-  groups:            renderGroups,
-  systems:           () => <SystemsPage />,
-  'access-packages': (ctx) => <AccessPackagesPage onOpenDetail={ctx.openDetailTab} />,
-  'risk-scores':     (ctx) => <RiskScoringPage key={ctx.riskScoresRefreshKey} onOpenDetail={ctx.openDetailTab} />,
-  identities:        (ctx) => <IdentitiesPage onOpenDetail={ctx.openDetailTab} />,
-  contexts:          (ctx) => <ContextsPage onOpenDetail={ctx.openDetailTab} onNavigate={ctx.navigate} />,
-  performance:       renderAdmin,
-  crawlers:          renderAdmin,
-  admin:             renderAdmin,
-};
+//
+// A Map (not a plain object) is deliberate: `page` comes from the URL hash
+// (user-controlled), and a Map lookup can only ever return an explicitly-added
+// entry — never an inherited Object.prototype member (`constructor`, `toString`,
+// …). That closes the "unvalidated dynamic method call" class flat (CodeQL
+// js/unvalidated-dynamic-method-call) without an own-property guard.
+export const PAGE_ROUTES = new Map([
+  ['dashboard',       (ctx) => <DashboardPage onNavigate={ctx.navigate} />],
+  ['sync-log',        (ctx) => <SyncLogPage navigate={ctx.navigate} onOpenDetail={ctx.openDetailTab} />],
+  ['principals',      (ctx) => <UsersPage onOpenDetail={ctx.openDetailTab} />],
+  ['resources',       renderGroups],
+  ['groups',          renderGroups],
+  ['systems',         () => <SystemsPage />],
+  ['access-packages', (ctx) => <AccessPackagesPage onOpenDetail={ctx.openDetailTab} />],
+  ['risk-scores',     (ctx) => <RiskScoringPage key={ctx.riskScoresRefreshKey} onOpenDetail={ctx.openDetailTab} />],
+  ['identities',      (ctx) => <IdentitiesPage onOpenDetail={ctx.openDetailTab} />],
+  ['contexts',        (ctx) => <ContextsPage onOpenDetail={ctx.openDetailTab} onNavigate={ctx.navigate} />],
+  ['performance',     renderAdmin],
+  ['crawlers',        renderAdmin],
+  ['admin',           renderAdmin],
+]);
 
 // The render function for a static page key, or null when the key is a detail tab
 // / matrix / unknown route (all handled by App.jsx).
 export function resolvePageRoute(page) {
-  return Object.prototype.hasOwnProperty.call(PAGE_ROUTES, page) ? PAGE_ROUTES[page] : null;
+  return PAGE_ROUTES.get(page) ?? null;
 }

--- a/app/ui/src/pageRegistry.test.jsx
+++ b/app/ui/src/pageRegistry.test.jsx
@@ -20,7 +20,7 @@ const ctx = {
 
 describe('pageRegistry', () => {
   it('resolves every registered key to a render function', () => {
-    for (const key of Object.keys(PAGE_ROUTES)) {
+    for (const key of PAGE_ROUTES.keys()) {
       expect(typeof resolvePageRoute(key)).toBe('function');
     }
   });
@@ -29,12 +29,14 @@ describe('pageRegistry', () => {
     expect(resolvePageRoute('user:abc')).toBeNull();
     expect(resolvePageRoute('matrix')).toBeNull();
     expect(resolvePageRoute('does-not-exist')).toBeNull();
-    // Guard against inherited Object.prototype keys masquerading as routes.
+    // A Map lookup can't surface inherited Object.prototype members, so a
+    // user-supplied 'constructor' / 'toString' hash never dispatches to one.
     expect(resolvePageRoute('toString')).toBeNull();
+    expect(resolvePageRoute('constructor')).toBeNull();
   });
 
   it('every route renders a valid element from the shared context', () => {
-    for (const key of Object.keys(PAGE_ROUTES)) {
+    for (const key of PAGE_ROUTES.keys()) {
       expect(isValidElement(resolvePageRoute(key)(ctx))).toBe(true);
     }
   });

--- a/app/ui/src/pageRegistry.test.jsx
+++ b/app/ui/src/pageRegistry.test.jsx
@@ -1,0 +1,75 @@
+// Unit tests for the static page-route registry.
+//
+// These execute every map entry and render function (so each route is real,
+// instrumented, covered coverage — the whole point of moving the render-switch
+// out of the JSX ternary in App.jsx, #669). We inspect the returned elements
+// rather than mounting the lazy components: props/key wiring is what each entry
+// is responsible for, and it's checkable synchronously without a DOM.
+
+import { describe, it, expect } from 'vitest';
+import { isValidElement } from 'react';
+import { PAGE_ROUTES, resolvePageRoute } from './pageRegistry';
+
+const ctx = {
+  navigate: () => {},
+  openDetailTab: () => {},
+  forceRefresh: () => {},
+  onRiskScoresRefresh: () => {},
+  riskScoresRefreshKey: 7,
+};
+
+describe('pageRegistry', () => {
+  it('resolves every registered key to a render function', () => {
+    for (const key of Object.keys(PAGE_ROUTES)) {
+      expect(typeof resolvePageRoute(key)).toBe('function');
+    }
+  });
+
+  it('returns null for a non-static route (detail tab / matrix / unknown)', () => {
+    expect(resolvePageRoute('user:abc')).toBeNull();
+    expect(resolvePageRoute('matrix')).toBeNull();
+    expect(resolvePageRoute('does-not-exist')).toBeNull();
+    // Guard against inherited Object.prototype keys masquerading as routes.
+    expect(resolvePageRoute('toString')).toBeNull();
+  });
+
+  it('every route renders a valid element from the shared context', () => {
+    for (const key of Object.keys(PAGE_ROUTES)) {
+      expect(isValidElement(resolvePageRoute(key)(ctx))).toBe(true);
+    }
+  });
+
+  it('threads the context callbacks into each page as props', () => {
+    expect(resolvePageRoute('dashboard')(ctx).props.onNavigate).toBe(ctx.navigate);
+    expect(resolvePageRoute('sync-log')(ctx).props.navigate).toBe(ctx.navigate);
+    expect(resolvePageRoute('sync-log')(ctx).props.onOpenDetail).toBe(ctx.openDetailTab);
+    expect(resolvePageRoute('principals')(ctx).props.onOpenDetail).toBe(ctx.openDetailTab);
+    expect(resolvePageRoute('access-packages')(ctx).props.onOpenDetail).toBe(ctx.openDetailTab);
+    expect(resolvePageRoute('identities')(ctx).props.onOpenDetail).toBe(ctx.openDetailTab);
+    expect(resolvePageRoute('contexts')(ctx).props.onNavigate).toBe(ctx.navigate);
+    expect(resolvePageRoute('contexts')(ctx).props.onOpenDetail).toBe(ctx.openDetailTab);
+  });
+
+  it('renders the systems page without needing any context', () => {
+    // The systems entry takes no ctx — calling it with undefined must not throw.
+    expect(isValidElement(resolvePageRoute('systems')())).toBe(true);
+  });
+
+  it('aliases resources and groups to the same page', () => {
+    expect(resolvePageRoute('resources')).toBe(resolvePageRoute('groups'));
+  });
+
+  it('routes the legacy #crawlers and #performance hashes to Admin', () => {
+    expect(resolvePageRoute('crawlers')).toBe(resolvePageRoute('admin'));
+    expect(resolvePageRoute('performance')).toBe(resolvePageRoute('admin'));
+    const admin = resolvePageRoute('admin')(ctx);
+    expect(admin.props.onNavigate).toBe(ctx.navigate);
+    expect(admin.props.onRefresh).toBe(ctx.forceRefresh);
+    expect(admin.props.onRiskScoresRefresh).toBe(ctx.onRiskScoresRefresh);
+  });
+
+  it('remounts the risk-scores page when the refresh key changes', () => {
+    expect(resolvePageRoute('risk-scores')(ctx).key).toBe(String(ctx.riskScoresRefreshKey));
+    expect(resolvePageRoute('risk-scores')(ctx).props.onOpenDetail).toBe(ctx.openDetailTab);
+  });
+});

--- a/changes/app-page-registry-669.md
+++ b/changes/app-page-registry-669.md
@@ -1,0 +1,1 @@
+- Refactored the app's top-level page routing into a small, data-driven page registry, so adding, renaming, or reordering a tab is a one-line change and stays covered by tests. No change to how any page looks or behaves.


### PR DESCRIPTION
Fixes the recurring half of #669: the `App.jsx` top-level render-switch was a big JSX ternary chain (`page === 'x' ? <X/> : page === 'y' ? <Y/> : …`). **v8 doesn't line-instrument JSX ternary arms**, so those lines carry no coverage record and every routing edit — add / rename / reorder a tab — tripped the `Diff coverage: UI` gate on a line with no way to cover it (that's how #668's Users→Principals rename first surfaced this).

The durable fix isn't excluding `App.jsx` from the gate or documenting the blind spot — it's converting the dispatch from an un-instrumentable JSX ternary **form** into ordinary statements. (Just splitting the file wouldn't help: the limitation is the JSX form, not file size.)

## What changed
- **New `src/pageRegistry.jsx`** — a `{ pageKey: (ctx) => <Page …/> }` map resolved by `resolvePageRoute(page)`. `ctx` bundles the shared handlers (`navigate`, `openDetailTab`, `forceRefresh`, `riskScoresRefreshKey`, `onRiskScoresRefresh`). Multi-key routes (`resources`/`groups`, `performance`/`crawlers`/`admin`) share one render function, so no duplicated markup.
- **New `src/pageRegistry.test.jsx`** — 9 assertions covering every map entry + render function and both `resolvePageRoute` branches (executes each route → real, instrumented coverage).
- **`App.jsx`** — the 10 static-page `lazy()` imports move to the registry; the **11 JSX ternary arms collapse to a single `staticRoute(pageCtx)`**. The dynamic detail-tab dispatch and the matrix fallback stay (they need surrounding app state). App.jsx shrinks ~30 lines.
- **`app/ui/CLAUDE.md`** — documents the registry as the place to edit routing, plus an *accepted exception* for the pure-JSX page shells.

## Why this is the right layer
Routing edits now touch a fully-instrumented data map that a mount/registry test covers — the papercut can't recur. Adding a tab is a one-line entry, not a nested-ternary edit.

## Scope / follow-up
This fixes the **render-switch** (the #669 title). The *other* thing #669 mentioned — large JSX-shell page components (`UsersPage`, detail/matrix views) having the same v8 blind spot — is **out of scope** here: splitting those doesn't make their JSX instrumentable, and they're genuinely e2e-covered. That's tracked in **#725** (decide a scoped `diff_cover` exclude vs. the documented accepted-exception).

## Verification
- `npx vitest run` (full UI suite) → **771 passed** (107 files), including the new registry test and the existing `App.mount.test.jsx` (routes `#principals`, still renders `UsersPage`).
- `eslint` on the changed files → 0 errors.
- App.jsx's per-file coverage floor is `0` (its render region was already uninstrumented), so the ratchet can't regress; the change removes uninstrumented arms and adds covered statements.

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
