### PR TITLE
feat(site): live-demo splash page at /demo + links from the site

### DIFF
--- a/changes/feature-demo-splash-page.md
+++ b/changes/feature-demo-splash-page.md
@@ -1,0 +1,2 @@
+- Added a "Live demo" splash page to the marketing website (at `/demo`) that welcomes visitors to the public hosted demo, explains it runs on synthetic data, warns that the environment resets regularly and is shared/unauthenticated, cautions against uploading real data, and links out to the live demo — with a short "try this once you're in" guide.
+- Linked the marketing site to the live demo: a "Live demo" nav item, a "Try the live demo" primary button in the hero and closing call-to-action, and a zero-install demo callout in the "How to start" section.

--- a/site/assets/base.css
+++ b/site/assets/base.css
@@ -1,0 +1,89 @@
+/* ─────────────────────────────────────────────────────────────
+   Identity Atlas — shared site foundation
+   Brand tokens (mirrors app/ui + mkdocs docs), base reset and buttons.
+   Linked by both the marketing homepage and the /demo splash page so the
+   design system lives in one place. Page-specific CSS stays inline per page.
+   Interactive = blue-600 / blue-400 · Brand accent = lime
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --blue-400: #60a5fa; --blue-500: #3b82f6; --blue-600: #2563eb; --blue-700: #1d4ed8;
+  --lime-300: #bef264; --lime-400: #a3e635; --lime-500: #84cc16; --lime-600: #65a30d; --lime-700: #4d7c0f;
+
+  --bg:        #fafafa;
+  --bg-elev:   #ffffff;
+  --bg-soft:   #f5f5f5;
+  --border:    #e5e7eb;
+  --border-strong: #d1d5db;
+  --fg:        #111827;
+  --fg-muted:  #4b5563;
+  --fg-subtle: #6b7280;
+  --accent:      var(--blue-600);
+  --accent-hover:var(--blue-700);
+  --brand:       var(--lime-700);   /* readable green on light */
+  --brand-solid: var(--lime-600);
+  --shadow: 0 1px 2px rgba(16,24,40,.04), 0 8px 24px -12px rgba(16,24,40,.18);
+  --shadow-lg: 0 4px 12px rgba(16,24,40,.06), 0 24px 48px -24px rgba(16,24,40,.28);
+  --radius: 16px;
+  --maxw: 1120px;
+}
+html.dark {
+  --bg:        #0d1117;
+  --bg-elev:   #161b22;
+  --bg-soft:   #1c2430;
+  --border:    #2b3444;
+  --border-strong: #3a4557;
+  --fg:        #f3f4f6;
+  --fg-muted:  #b6c0cf;
+  --fg-subtle: #8a94a6;
+  --accent:      var(--blue-400);
+  --accent-hover:#93c5fd;
+  --brand:       var(--lime-300);
+  --brand-solid: var(--lime-400);
+  --shadow: 0 1px 2px rgba(0,0,0,.4), 0 12px 28px -14px rgba(0,0,0,.6);
+  --shadow-lg: 0 8px 20px rgba(0,0,0,.4), 0 30px 60px -24px rgba(0,0,0,.7);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  transition: background-color .3s ease, color .3s ease;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-hover); }
+h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
+p { margin: 0; }
+img { max-width: 100%; height: auto; display: block; } /* height:auto preserves aspect ratio when CSS overrides width */
+::selection { background: var(--lime-300); color: #14210a; }
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
+
+.wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+.eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: .8rem; font-weight: 650; letter-spacing: .04em; text-transform: uppercase;
+  color: var(--brand);
+}
+.eyebrow::before { content:""; width: 22px; height: 2px; background: var(--brand-solid); border-radius: 2px; }
+
+/* ── Buttons ───────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: .95rem; font-weight: 600; line-height: 1;
+  padding: 12px 20px; border-radius: 10px; cursor: pointer;
+  border: 1px solid transparent; transition: transform .12s ease, background-color .2s ease, border-color .2s ease, color .2s ease;
+  white-space: nowrap;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { background: var(--accent-hover); color: #fff; }
+html.dark .btn-primary { color: #0b1220; }
+.btn-ghost { background: transparent; color: var(--fg); border-color: var(--border-strong); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="en" data-theme="auto">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Live demo — Identity Atlas</title>
+  <meta name="description" content="Try Identity Atlas right now — a public, no-login demo loaded with a synthetic dataset. Explore the access matrix, see how each permission was granted and review identity risk. No install, no tenant." />
+  <link rel="icon" type="image/png" href="../assets/favicon.png" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Live demo — Identity Atlas" />
+  <meta property="og:description" content="A public, no-login demo of Identity Atlas, loaded with synthetic data. Click around and explore the access matrix — nothing to install." />
+  <meta property="og:image" content="../assets/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <!-- Set theme before paint to avoid flash (shared with the main site) -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('ia-theme') || 'auto';
+        var dark = t === 'dark' || (t === 'auto' && matchMedia('(prefers-color-scheme: dark)').matches);
+        document.documentElement.setAttribute('data-theme', t);
+        document.documentElement.classList.toggle('dark', dark);
+      } catch (e) {}
+    })();
+  </script>
+
+  <style>
+    /* Identity Atlas — brand tokens (mirrors site/index.html) */
+    :root {
+      --blue-400: #60a5fa; --blue-500: #3b82f6; --blue-600: #2563eb; --blue-700: #1d4ed8;
+      --lime-300: #bef264; --lime-400: #a3e635; --lime-500: #84cc16; --lime-600: #65a30d; --lime-700: #4d7c0f;
+      --bg: #fafafa; --bg-elev: #ffffff; --bg-soft: #f5f5f5;
+      --border: #e5e7eb; --border-strong: #d1d5db;
+      --fg: #111827; --fg-muted: #4b5563; --fg-subtle: #6b7280;
+      --accent: var(--blue-600); --accent-hover: var(--blue-700);
+      --brand: var(--lime-700); --brand-solid: var(--lime-600);
+      --amber-bg: #fffbeb; --amber-border: #fcd34d; --amber-fg: #92400e;
+      --shadow: 0 1px 2px rgba(16,24,40,.04), 0 8px 24px -12px rgba(16,24,40,.18);
+      --shadow-lg: 0 4px 12px rgba(16,24,40,.06), 0 24px 48px -24px rgba(16,24,40,.28);
+      --radius: 16px; --maxw: 880px;
+    }
+    html.dark {
+      --bg: #0d1117; --bg-elev: #161b22; --bg-soft: #1c2430;
+      --border: #2b3444; --border-strong: #3a4557;
+      --fg: #f3f4f6; --fg-muted: #b6c0cf; --fg-subtle: #8a94a6;
+      --accent: var(--blue-400); --accent-hover: #93c5fd;
+      --brand: var(--lime-300); --brand-solid: var(--lime-400);
+      --amber-bg: #2a2213; --amber-border: #5c4813; --amber-fg: #fbbf24;
+      --shadow: 0 1px 2px rgba(0,0,0,.4), 0 12px 28px -14px rgba(0,0,0,.6);
+      --shadow-lg: 0 8px 20px rgba(0,0,0,.4), 0 30px 60px -24px rgba(0,0,0,.7);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+    body {
+      margin: 0; min-height: 100vh;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg); color: var(--fg); line-height: 1.6;
+      -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { color: var(--accent-hover); }
+    h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
+    p { margin: 0; }
+    img { max-width: 100%; height: auto; display: block; }
+    ::selection { background: var(--lime-300); color: #14210a; }
+    :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
+
+    .wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    .eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: .8rem; font-weight: 650; letter-spacing: .04em; text-transform: uppercase; color: var(--brand);
+    }
+    .eyebrow::before { content:""; width: 22px; height: 2px; background: var(--brand-solid); border-radius: 2px; }
+
+    /* buttons */
+    .btn {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: .98rem; font-weight: 600; line-height: 1;
+      padding: 14px 24px; border-radius: 10px; cursor: pointer;
+      border: 1px solid transparent; transition: transform .12s ease, background-color .2s ease, border-color .2s ease, color .2s ease;
+      white-space: nowrap;
+    }
+    .btn:active { transform: translateY(1px); }
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent-hover); color: #fff; }
+    html.dark .btn-primary { color: #0b1220; }
+    .btn-ghost { background: transparent; color: var(--fg); border-color: var(--border-strong); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* nav */
+    header.nav { border-bottom: 1px solid var(--border); }
+    .nav-inner { display: flex; align-items: center; gap: 16px; height: 66px; }
+    .brand { display: flex; align-items: center; gap: 10px; font-weight: 750; font-size: 1.15rem; letter-spacing: -0.02em; color: var(--fg); }
+    .brand:hover { color: var(--fg); }
+    .brand img { width: 30px; height: 30px; }
+    .brand .b-atlas { color: var(--brand); }
+    .nav-right { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+    .nlink { color: var(--fg-muted); font-weight: 550; font-size: .93rem; padding: 8px 12px; border-radius: 8px; }
+    .nlink:hover { color: var(--fg); background: var(--bg-soft); }
+
+    /* layout */
+    main { padding: 64px 0 80px; }
+    .hero { text-align: center; max-width: 680px; margin: 0 auto 44px; }
+    .hero .eyebrow { justify-content: center; }
+    .hero h1 { font-size: clamp(2.2rem, 5vw, 3.2rem); font-weight: 800; margin-top: 16px; }
+    .hero h1 .g { color: var(--brand); }
+    .hero .lede { margin-top: 20px; font-size: clamp(1.05rem, 1.8vw, 1.2rem); color: var(--fg-muted); }
+
+    .cta-row { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-top: 30px; }
+    .live-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--lime-400); box-shadow: 0 0 0 0 rgba(163,230,53,.7); }
+    @media (prefers-reduced-motion: no-preference) { .live-dot { animation: pulse 2s infinite; } }
+    @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(163,230,53,.6); } 70% { box-shadow: 0 0 0 8px rgba(163,230,53,0); } 100% { box-shadow: 0 0 0 0 rgba(163,230,53,0); } }
+
+    /* terms card */
+    .card {
+      background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 30px; box-shadow: var(--shadow);
+    }
+    .card h2 { font-size: 1.3rem; font-weight: 750; }
+    .terms { list-style: none; margin: 22px 0 0; padding: 0; display: grid; gap: 18px; }
+    .terms li { display: flex; gap: 14px; align-items: flex-start; }
+    .terms .ic {
+      flex: none; width: 38px; height: 38px; border-radius: 10px; display: grid; place-items: center;
+      background: color-mix(in srgb, var(--lime-600) 16%, transparent); color: var(--brand);
+    }
+    .terms .ic svg { width: 20px; height: 20px; }
+    .terms strong { display: block; font-size: 1.02rem; color: var(--fg); }
+    .terms span { color: var(--fg-muted); font-size: .96rem; }
+
+    .warn {
+      margin-top: 22px; display: flex; gap: 12px; align-items: flex-start;
+      background: var(--amber-bg); border: 1px solid var(--amber-border); border-radius: 12px; padding: 16px 18px;
+    }
+    .warn svg { flex: none; width: 20px; height: 20px; color: var(--amber-fg); margin-top: 2px; }
+    .warn p { color: var(--amber-fg); font-size: .95rem; }
+    .warn strong { font-weight: 700; }
+
+    .explore { margin-top: 26px; }
+    .explore .kicker { color: var(--brand); font-weight: 700; font-size: .85rem; letter-spacing: .03em; text-transform: uppercase; margin-bottom: 12px; }
+    .explore ol { margin: 0; padding-left: 20px; color: var(--fg-muted); display: grid; gap: 8px; font-size: .97rem; }
+    .explore ol strong { color: var(--fg); }
+
+    .enter { text-align: center; margin-top: 40px; }
+    .enter .sub { margin-top: 14px; font-size: .9rem; color: var(--fg-subtle); }
+
+    footer.ft { border-top: 1px solid var(--border); padding: 26px 0; color: var(--fg-subtle); font-size: .9rem; }
+    .ft-inner { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+    .ft a { color: var(--fg-muted); }
+
+    @media (max-width: 560px) { .cta-row .btn { width: 100%; justify-content: center; } }
+  </style>
+</head>
+<body>
+  <header class="nav">
+    <div class="wrap nav-inner">
+      <a class="brand" href="/" aria-label="Identity Atlas home">
+        <img src="../assets/mark.png" alt="" width="30" height="30" />
+        <span>Identity<span class="b-atlas"> Atlas</span></span>
+      </a>
+      <div class="nav-right">
+        <a class="nlink" href="/#how">How to run it</a>
+        <a class="nlink" href="https://fortigi.github.io/IdentityAtlas" target="_blank" rel="noopener">Docs ↗</a>
+        <a class="nlink" href="https://github.com/Fortigi/IdentityAtlas" target="_blank" rel="noopener">GitHub ↗</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <div class="wrap">
+      <section class="hero">
+        <span class="eyebrow">Live demo</span>
+        <h1>Take Identity Atlas for a <span class="g">spin.</span></h1>
+        <p class="lede">
+          A public, no-login demo loaded with a synthetic dataset. Click around, open the access matrix
+          and see for yourself how Identity Atlas makes sense of authorization data — nothing to install,
+          no tenant to connect.
+        </p>
+      </section>
+
+      <div class="card">
+        <h2>Before you go in</h2>
+        <ul class="terms">
+          <li>
+            <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.7 9.7 0 0 0-6.7 2.7L3 8"/><path d="M3 3v5h5"/></svg></span>
+            <span><strong>It resets regularly</strong>This environment is restored to a clean state on a regular basis. Anything you change, add or upload can be wiped at any time — treat everything here as temporary.</span>
+          </li>
+          <li>
+            <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+            <span><strong>It's shared and open</strong>There is no sign-in — everyone uses the same instance. Other visitors may see, change or remove anything you do while you're in there.</span>
+          </li>
+          <li>
+            <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M9 13h6M9 17h6"/></svg></span>
+            <span><strong>The data is made up</strong>Everything you see belongs to a fictional company ("Fortigi Demo Corp"). There are no real people, accounts or credentials in here.</span>
+          </li>
+        </ul>
+
+        <div class="warn" role="note">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/><path d="M12 9v4M12 17h.01"/></svg>
+          <p><strong>Don't upload anything real.</strong> The demo lets you import files, but do so entirely at your own risk. Never upload personal, confidential or production data — we take no responsibility for anything you put into this environment.</p>
+        </div>
+
+        <div class="explore">
+          <div class="kicker">Once you're in, try this</div>
+          <ol>
+            <li>Open the <strong>access matrix</strong> and scope it to the <strong>Sales</strong> department.</li>
+            <li>Pick a person and see <strong>how each permission was granted</strong> — directly, through a group, or via a business role.</li>
+            <li>Look at an identity's <strong>risk</strong> and how it was built up.</li>
+            <li>Browse <strong>systems, resources and identities</strong> to see the whole picture in one place.</li>
+          </ol>
+        </div>
+      </div>
+
+      <div class="enter">
+        <div class="cta-row">
+          <a class="btn btn-primary" href="https://demo1.identityatlas.io" target="_blank" rel="noopener">
+            <span class="live-dot" aria-hidden="true"></span>
+            Enter the live demo →
+          </a>
+          <a class="btn btn-ghost" href="/#how">Prefer to run it yourself?</a>
+        </div>
+        <p class="sub">Opens in a new tab · demo1.identityatlas.io</p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="ft">
+    <div class="wrap ft-inner">
+      <span>© <span id="year">2026</span> Maatschap Fortigi · Identity Atlas · MIT-licensed open source.</span>
+      <span><a href="/">← Back to identityatlas.io</a></span>
+    </div>
+  </footer>
+
+  <script>
+    try { document.getElementById('year').textContent = new Date().getFullYear(); } catch (e) {}
+  </script>
+</body>
+</html>

--- a/site/demo/index.html
+++ b/site/demo/index.html
@@ -25,69 +25,16 @@
     })();
   </script>
 
+  <link rel="stylesheet" href="../assets/base.css" />
+
   <style>
-    /* Identity Atlas — brand tokens (mirrors site/index.html) */
-    :root {
-      --blue-400: #60a5fa; --blue-500: #3b82f6; --blue-600: #2563eb; --blue-700: #1d4ed8;
-      --lime-300: #bef264; --lime-400: #a3e635; --lime-500: #84cc16; --lime-600: #65a30d; --lime-700: #4d7c0f;
-      --bg: #fafafa; --bg-elev: #ffffff; --bg-soft: #f5f5f5;
-      --border: #e5e7eb; --border-strong: #d1d5db;
-      --fg: #111827; --fg-muted: #4b5563; --fg-subtle: #6b7280;
-      --accent: var(--blue-600); --accent-hover: var(--blue-700);
-      --brand: var(--lime-700); --brand-solid: var(--lime-600);
-      --amber-bg: #fffbeb; --amber-border: #fcd34d; --amber-fg: #92400e;
-      --shadow: 0 1px 2px rgba(16,24,40,.04), 0 8px 24px -12px rgba(16,24,40,.18);
-      --shadow-lg: 0 4px 12px rgba(16,24,40,.06), 0 24px 48px -24px rgba(16,24,40,.28);
-      --radius: 16px; --maxw: 880px;
-    }
-    html.dark {
-      --bg: #0d1117; --bg-elev: #161b22; --bg-soft: #1c2430;
-      --border: #2b3444; --border-strong: #3a4557;
-      --fg: #f3f4f6; --fg-muted: #b6c0cf; --fg-subtle: #8a94a6;
-      --accent: var(--blue-400); --accent-hover: #93c5fd;
-      --brand: var(--lime-300); --brand-solid: var(--lime-400);
-      --amber-bg: #2a2213; --amber-border: #5c4813; --amber-fg: #fbbf24;
-      --shadow: 0 1px 2px rgba(0,0,0,.4), 0 12px 28px -14px rgba(0,0,0,.6);
-      --shadow-lg: 0 8px 20px rgba(0,0,0,.4), 0 30px 60px -24px rgba(0,0,0,.7);
-    }
-    * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; }
-    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
-    body {
-      margin: 0; min-height: 100vh;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: var(--bg); color: var(--fg); line-height: 1.6;
-      -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
-    }
-    a { color: var(--accent); text-decoration: none; }
-    a:hover { color: var(--accent-hover); }
-    h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
-    p { margin: 0; }
-    img { max-width: 100%; height: auto; display: block; }
-    ::selection { background: var(--lime-300); color: #14210a; }
-    :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
-
-    .wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
-    .eyebrow {
-      display: inline-flex; align-items: center; gap: 8px;
-      font-size: .8rem; font-weight: 650; letter-spacing: .04em; text-transform: uppercase; color: var(--brand);
-    }
-    .eyebrow::before { content:""; width: 22px; height: 2px; background: var(--brand-solid); border-radius: 2px; }
-
-    /* buttons */
-    .btn {
-      display: inline-flex; align-items: center; gap: 8px;
-      font-size: .98rem; font-weight: 600; line-height: 1;
-      padding: 14px 24px; border-radius: 10px; cursor: pointer;
-      border: 1px solid transparent; transition: transform .12s ease, background-color .2s ease, border-color .2s ease, color .2s ease;
-      white-space: nowrap;
-    }
-    .btn:active { transform: translateY(1px); }
-    .btn-primary { background: var(--accent); color: #fff; }
-    .btn-primary:hover { background: var(--accent-hover); color: #fff; }
-    html.dark .btn-primary { color: #0b1220; }
-    .btn-ghost { background: transparent; color: var(--fg); border-color: var(--border-strong); }
-    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    /* Page-specific styles. Shared brand tokens, base reset, .wrap/.eyebrow
+       and buttons come from ../assets/base.css (linked above); the rules
+       below add the splash page's own tokens and overrides. */
+    :root { --amber-bg: #fffbeb; --amber-border: #fcd34d; --amber-fg: #92400e; --maxw: 880px; }
+    html.dark { --amber-bg: #2a2213; --amber-border: #5c4813; --amber-fg: #fbbf24; }
+    body { min-height: 100vh; }
+    .btn { font-size: .98rem; padding: 14px 24px; }  /* slightly larger CTA on the splash */
 
     /* nav */
     header.nav { border-bottom: 1px solid var(--border); }

--- a/site/index.html
+++ b/site/index.html
@@ -330,6 +330,7 @@
         <a class="nlink" href="#what">What</a>
         <a class="nlink" href="#how">How to start</a>
         <a class="nlink" href="#trust">Trust</a>
+        <a class="nlink" href="/demo/">Live demo</a>
         <a class="nlink" href="https://fortigi.github.io/IdentityAtlas" target="_blank" rel="noopener">Docs ↗</a>
         <div class="nav-cta">
           <a class="icon-btn" href="https://github.com/Fortigi/IdentityAtlas" target="_blank" rel="noopener" aria-label="View source on GitHub" title="GitHub">
@@ -363,8 +364,8 @@
             understand access, identify risks and make informed decisions.
           </p>
           <div class="hero-cta">
-            <a class="btn btn-primary" href="#how">Get started</a>
-            <a class="btn btn-ghost" href="https://fortigi.github.io/IdentityAtlas" target="_blank" rel="noopener">Read the docs</a>
+            <a class="btn btn-primary" href="/demo/">Try the live demo</a>
+            <a class="btn btn-ghost" href="#how">Get started</a>
           </div>
           <p class="hero-note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"/></svg>
@@ -506,6 +507,7 @@
           <span class="eyebrow">How to start</span>
           <h2>Pick a release channel. Pick a way to run it.</h2>
           <p>Identity Atlas is delivered as a self-contained stack. Evaluate it in minutes, run it wherever you run containers or deploy it directly into your own Azure subscription.</p>
+          <p style="margin-top:16px;">Just want to look around first? <a href="/demo/"><strong>Try the hosted live demo ↗</strong></a> — no login and nothing to install.</p>
         </div>
 
         <div class="channels">
@@ -626,9 +628,9 @@
       <div class="wrap">
         <div class="reveal">
           <h2>Make sense of the whole haystack.</h2>
-          <p>Start the Docker stack with demo data in under a minute — no tenant required — and explore the access matrix yourself.</p>
+          <p>Try the hosted demo right now — no login, no install — or start the Docker stack with demo data in under a minute and explore the access matrix yourself.</p>
           <div class="hero-cta">
-            <a class="btn btn-primary" href="#how">Get started</a>
+            <a class="btn btn-primary" href="/demo/">Try the live demo</a>
             <a class="btn btn-ghost" href="https://github.com/Fortigi/IdentityAtlas" target="_blank" rel="noopener">
               <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M12 .5A11.5 11.5 0 0 0 .5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.88-1.36-3.88-1.36-.53-1.35-1.29-1.71-1.29-1.71-1.05-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.72 1.27 3.38.97.11-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.19-3.08-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.8 1.18 1.83 1.18 3.08 0 4.41-2.69 5.38-5.25 5.66.42.36.8 1.08.8 2.18v3.24c0 .31.21.68.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>
               Star on GitHub

--- a/site/index.html
+++ b/site/index.html
@@ -29,97 +29,15 @@
     })();
   </script>
 
+  <link rel="stylesheet" href="assets/base.css" />
+
   <style>
-    /* ─────────────────────────────────────────────────────────────
-       Identity Atlas — brand tokens (mirrors app/ui + mkdocs docs)
-       Interactive = blue-600 / blue-400 · Brand accent = lime
-       ───────────────────────────────────────────────────────────── */
-    :root {
-      --blue-400: #60a5fa; --blue-500: #3b82f6; --blue-600: #2563eb; --blue-700: #1d4ed8;
-      --lime-300: #bef264; --lime-400: #a3e635; --lime-500: #84cc16; --lime-600: #65a30d; --lime-700: #4d7c0f;
-
-      --bg:        #fafafa;
-      --bg-elev:   #ffffff;
-      --bg-soft:   #f5f5f5;
-      --border:    #e5e7eb;
-      --border-strong: #d1d5db;
-      --fg:        #111827;
-      --fg-muted:  #4b5563;
-      --fg-subtle: #6b7280;
-      --accent:      var(--blue-600);
-      --accent-hover:var(--blue-700);
-      --brand:       var(--lime-700);   /* readable green on light */
-      --brand-solid: var(--lime-600);
-      --shadow: 0 1px 2px rgba(16,24,40,.04), 0 8px 24px -12px rgba(16,24,40,.18);
-      --shadow-lg: 0 4px 12px rgba(16,24,40,.06), 0 24px 48px -24px rgba(16,24,40,.28);
-      --radius: 16px;
-      --maxw: 1120px;
-    }
-    html.dark {
-      --bg:        #0d1117;
-      --bg-elev:   #161b22;
-      --bg-soft:   #1c2430;
-      --border:    #2b3444;
-      --border-strong: #3a4557;
-      --fg:        #f3f4f6;
-      --fg-muted:  #b6c0cf;
-      --fg-subtle: #8a94a6;
-      --accent:      var(--blue-400);
-      --accent-hover:#93c5fd;
-      --brand:       var(--lime-300);
-      --brand-solid: var(--lime-400);
-      --shadow: 0 1px 2px rgba(0,0,0,.4), 0 12px 28px -14px rgba(0,0,0,.6);
-      --shadow-lg: 0 8px 20px rgba(0,0,0,.4), 0 30px 60px -24px rgba(0,0,0,.7);
-    }
-
-    * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; }
-    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: var(--bg);
-      color: var(--fg);
-      line-height: 1.6;
-      -webkit-font-smoothing: antialiased;
-      text-rendering: optimizeLegibility;
-      transition: background-color .3s ease, color .3s ease;
-    }
-    a { color: var(--accent); text-decoration: none; }
-    a:hover { color: var(--accent-hover); }
-    h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0; }
-    p { margin: 0; }
-    img { max-width: 100%; height: auto; display: block; } /* height:auto preserves aspect ratio when CSS overrides width */
-    ::selection { background: var(--lime-300); color: #14210a; }
-
-    :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
-
-    .wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
-    .eyebrow {
-      display: inline-flex; align-items: center; gap: 8px;
-      font-size: .8rem; font-weight: 650; letter-spacing: .04em; text-transform: uppercase;
-      color: var(--brand);
-    }
-    .eyebrow::before { content:""; width: 22px; height: 2px; background: var(--brand-solid); border-radius: 2px; }
+    /* Page-specific styles. Shared brand tokens, base reset, .wrap/.eyebrow
+       and buttons live in assets/base.css (linked above). */
 
     /* skip link */
     .skip { position: absolute; left: -999px; top: 8px; background: var(--accent); color:#fff; padding: 8px 14px; border-radius: 8px; z-index: 200; }
     .skip:focus { left: 12px; }
-
-    /* ── Buttons ───────────────────────────────────────────── */
-    .btn {
-      display: inline-flex; align-items: center; gap: 8px;
-      font-size: .95rem; font-weight: 600; line-height: 1;
-      padding: 12px 20px; border-radius: 10px; cursor: pointer;
-      border: 1px solid transparent; transition: transform .12s ease, background-color .2s ease, border-color .2s ease, color .2s ease;
-      white-space: nowrap;
-    }
-    .btn:active { transform: translateY(1px); }
-    .btn-primary { background: var(--accent); color: #fff; }
-    .btn-primary:hover { background: var(--accent-hover); color: #fff; }
-    html.dark .btn-primary { color: #0b1220; }
-    .btn-ghost { background: transparent; color: var(--fg); border-color: var(--border-strong); }
-    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
 
     /* ── Nav ───────────────────────────────────────────────── */
     header.nav {

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://identityatlas.io/demo/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## What

Adds a **Live demo** splash/terms page to the marketing site at `/demo`, and links the main site to it. This is the on-site landing page in front of the public hosted demo at **demo1.identityatlas.io** (issue #705, step 3).

## Why

The public demo is live and unauthenticated. Visitors need a welcome page that sets expectations and warnings before they click through — and the marketing site needs to actually point at the demo.

## Changes

- **New `site/demo/index.html`** — a self-contained welcome page (reuses the site's brand tokens, light/dark, responsive):
  - Hero: "Take Identity Atlas for a spin." — a public, no-login demo on synthetic data.
  - **Terms & warnings:** resets regularly (treat everything as temporary), shared & unauthenticated (others may change what you do), data is fictional ("Fortigi Demo Corp"), and a prominent **"don't upload anything real"** caution (at your own risk, no responsibility taken).
  - A short **"once you're in, try this"** guide (open the matrix → scope to Sales → see how access was granted → check identity risk).
  - Primary CTA **"Enter the live demo →"** → `https://demo1.identityatlas.io` (new tab).
- **`site/index.html`** — links to the demo from four spots: a "Live demo" nav item, a "Try the live demo" primary button in the hero and the closing CTA band, and a zero-install callout in "How to start".
- **`site/sitemap.xml`** — adds `/demo/`.

## Notes

- The reset warning says "resets regularly / can be wiped at any time" rather than "every night" on purpose — the daily hypervisor-snapshot schedule (issue #705, step 4) isn't set up yet, so this is honest now and stays true once daily restore is on.
- Production is self-hosted (SK2 nginx serving identityatlas.io), so this is already deployed there via the usual sync; this PR gets it into the repo.

## Verification

- `demo1.identityatlas.io`: DNS + valid Let's Encrypt cert, app + `/api/version` return 200.
- `https://www.identityatlas.io/demo/` → 200 with correct content; apex `identityatlas.io/demo/` → 301 → www (per the #706 canonical redirect). Homepage unregressed.
- Light + dark screenshots render clean and on-brand; no console errors.
