### PR TITLE
fix(demo): seed department/team membership so the matrix scopes out of the box

### DIFF
--- a/changes/feature-demo-seed-context-members.md
+++ b/changes/feature-demo-seed-context-members.md
@@ -1,0 +1,1 @@
+- Demo data now includes department and team membership, so the access matrix can be scoped by department (e.g. Sales, Engineering) immediately after loading the demo dataset — previously the synced Department/Team contexts were created empty and had to be populated by running a context-algorithm plugin first.

--- a/test/demo-dataset/Generate-DemoDataset.ps1
+++ b/test/demo-dataset/Generate-DemoDataset.ps1
@@ -275,6 +275,37 @@ $identityMembers += @{
     accountEnabled = $true
 }
 
+# ─── Context Members (org membership) ────────────────────────────
+# Attach each principal to their department context (so a department scope in
+# the matrix resolves directly) and, for engineers, also to their team context.
+# Without these, the synced Department/Team contexts have zero members and the
+# access matrix cannot be scoped by department — the product's headline view.
+$deptCtxByName = @{
+    'Management'  = $ctxRoot
+    'Engineering' = $ctxEng
+    'Finance'     = $ctxFin
+    'Sales'       = $ctxSales
+    'Operations'  = $ctxOps
+}
+
+$contextMembers = @()
+$seenCtxMember = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($emp in $employees) {
+    $pGuid = New-DemoGuid "principal-$($emp.id)"
+    foreach ($cid in @($deptCtxByName[$emp.dept], $emp.ctx)) {
+        if ($cid -and $seenCtxMember.Add("$cid|$pGuid")) {
+            $contextMembers += @{ contextId = $cid; memberId = $pGuid; memberType = 'Principal'; addedBy = 'sync' }
+        }
+    }
+}
+
+# Departmented edge cases (contractor in Engineering, former employee in Sales)
+foreach ($ec in @(@{ c = $ctxEng; g = $guidContractor }, @{ c = $ctxSales; g = $guidDisabled })) {
+    if ($seenCtxMember.Add("$($ec.c)|$($ec.g)")) {
+        $contextMembers += @{ contextId = $ec.c; memberId = $ec.g; memberType = 'Principal'; addedBy = 'sync' }
+    }
+}
+
 # ─── Governance ───────────────────────────────────────────────────
 
 $catalogs = @(
@@ -310,6 +341,7 @@ $dataset = @{
             identities             = $identities.Count
             identityMembers        = $identityMembers.Count
             contexts               = $contexts.Count
+            contextMembers         = $contextMembers.Count
             governanceCatalogs     = $catalogs.Count
             assignmentPolicies     = $policies.Count
             certificationDecisions = $certifications.Count
@@ -317,6 +349,7 @@ $dataset = @{
     }
     systems                = $systems
     contexts               = $contexts
+    contextMembers         = $contextMembers
     principals             = $principals
     resources              = $resources
     resourceAssignments    = $assignments
@@ -340,6 +373,7 @@ Write-Host "  Relationships:        $($counts.resourceRelationships)"
 Write-Host "  Identities:           $($counts.identities)"
 Write-Host "  Identity Members:     $($counts.identityMembers)"
 Write-Host "  Contexts:             $($counts.contexts)"
+Write-Host "  Context Members:      $($counts.contextMembers)"
 Write-Host "  Governance Catalogs:  $($counts.governanceCatalogs)"
 Write-Host "  Assignment Policies:  $($counts.assignmentPolicies)"
 Write-Host "  Certifications:       $($counts.certificationDecisions)"

--- a/test/demo-dataset/Ingest-DemoDataset.ps1
+++ b/test/demo-dataset/Ingest-DemoDataset.ps1
@@ -75,7 +75,7 @@ Write-Host "API:     $ApiBaseUrl"
 Write-Host ""
 
 # 1. Systems (no systemId needed)
-Write-Host "[1/11] Systems ($($dataset.systems.Count))..." -ForegroundColor Cyan
+Write-Host "[1/12] Systems ($($dataset.systems.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/systems' -Records $dataset.systems -SyncMode 'delta'
 
 # Get system IDs (we assume 1=EntraID, 2=HR, 3=Omada based on insertion order)
@@ -84,43 +84,47 @@ $sysHR = 2
 $sysOmada = 3
 
 # 2. Contexts
-Write-Host "[2/11] Contexts ($($dataset.contexts.Count))..." -ForegroundColor Cyan
+Write-Host "[2/12] Contexts ($($dataset.contexts.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/contexts' -Records $dataset.contexts -SystemId $sysHR -SyncMode 'full'
 
 # 3. Principals
-Write-Host "[3/11] Principals ($($dataset.principals.Count))..." -ForegroundColor Cyan
+Write-Host "[3/12] Principals ($($dataset.principals.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/principals' -Records $dataset.principals -SystemId $sysEntraId -SyncMode 'full'
 
-# 4. Resources
-Write-Host "[4/11] Resources ($($dataset.resources.Count))..." -ForegroundColor Cyan
+# 4. Context Members (department / team membership — depends on Contexts + Principals)
+Write-Host "[4/12] Context Members ($($dataset.contextMembers.Count))..." -ForegroundColor Cyan
+Post-Ingest -Endpoint 'ingest/context-members' -Records $dataset.contextMembers -SystemId $sysHR -SyncMode 'full'
+
+# 5. Resources
+Write-Host "[5/12] Resources ($($dataset.resources.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/resources' -Records $dataset.resources -SystemId $sysEntraId -SyncMode 'full'
 
-# 5. Resource Assignments
-Write-Host "[5/11] Resource Assignments ($($dataset.resourceAssignments.Count))..." -ForegroundColor Cyan
+# 6. Resource Assignments
+Write-Host "[6/12] Resource Assignments ($($dataset.resourceAssignments.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/resource-assignments' -Records $dataset.resourceAssignments -SystemId $sysEntraId -SyncMode 'full'
 
-# 6. Resource Relationships
-Write-Host "[6/11] Resource Relationships ($($dataset.resourceRelationships.Count))..." -ForegroundColor Cyan
+# 7. Resource Relationships
+Write-Host "[7/12] Resource Relationships ($($dataset.resourceRelationships.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/resource-relationships' -Records $dataset.resourceRelationships -SystemId $sysEntraId -SyncMode 'full'
 
-# 7. Identities
-Write-Host "[7/11] Identities ($($dataset.identities.Count))..." -ForegroundColor Cyan
+# 8. Identities
+Write-Host "[8/12] Identities ($($dataset.identities.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/identities' -Records $dataset.identities -SystemId $sysHR -SyncMode 'full'
 
-# 8. Identity Members
-Write-Host "[8/11] Identity Members ($($dataset.identityMembers.Count))..." -ForegroundColor Cyan
+# 9. Identity Members
+Write-Host "[9/12] Identity Members ($($dataset.identityMembers.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/identity-members' -Records $dataset.identityMembers -SystemId $sysHR -SyncMode 'full'
 
-# 9. Governance Catalogs
-Write-Host "[9/11] Governance Catalogs ($($dataset.governanceCatalogs.Count))..." -ForegroundColor Cyan
+# 10. Governance Catalogs
+Write-Host "[10/12] Governance Catalogs ($($dataset.governanceCatalogs.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/governance/catalogs' -Records $dataset.governanceCatalogs -SystemId $sysOmada -SyncMode 'full'
 
-# 10. Assignment Policies
-Write-Host "[10/11] Assignment Policies ($($dataset.assignmentPolicies.Count))..." -ForegroundColor Cyan
+# 11. Assignment Policies
+Write-Host "[11/12] Assignment Policies ($($dataset.assignmentPolicies.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/governance/policies' -Records $dataset.assignmentPolicies -SystemId $sysOmada -SyncMode 'full'
 
-# 11. Certification Decisions
-Write-Host "[11/11] Certification Decisions ($($dataset.certificationDecisions.Count))..." -ForegroundColor Cyan
+# 12. Certification Decisions
+Write-Host "[12/12] Certification Decisions ($($dataset.certificationDecisions.Count))..." -ForegroundColor Cyan
 Post-Ingest -Endpoint 'ingest/governance/certifications' -Records $dataset.certificationDecisions -SystemId $sysOmada -SyncMode 'full'
 
 # Refresh views

--- a/test/unit/DemoDataset.Tests.ps1
+++ b/test/unit/DemoDataset.Tests.ps1
@@ -1,0 +1,118 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+<#
+.SYNOPSIS
+    Pester unit tests for the Fortigi Demo Corp synthetic dataset generator.
+
+.DESCRIPTION
+    Regenerates the dataset from Generate-DemoDataset.ps1 (demo-company.json is a
+    gitignored build artifact, so the test never relies on a stale copy) and
+    validates the ContextMembers section: referential integrity, member shape,
+    de-duplication, and that each department resolves — via the context tree — to
+    a non-empty set of members. Without ContextMembers the synced Department/Team
+    contexts are empty and the access matrix cannot be scoped by department, which
+    is the product's headline view; these tests guard that regression.
+
+.USAGE
+    Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser
+    Invoke-Pester -Path test/unit/DemoDataset.Tests.ps1 -Output Detailed
+#>
+
+BeforeAll {
+    $script:repoRoot    = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:genScript   = Join-Path $script:repoRoot 'test' 'demo-dataset' 'Generate-DemoDataset.ps1'
+    $script:datasetPath = Join-Path $script:repoRoot 'test' 'demo-dataset' 'demo-company.json'
+
+    # Regenerate deterministically so the assertions never depend on a stale artifact.
+    & $script:genScript | Out-Null
+    $script:data = Get-Content $script:datasetPath -Raw | ConvertFrom-Json
+
+    # Lookups
+    $script:ctxById      = @{}
+    $script:ctxIdByName  = @{}
+    foreach ($c in $script:data.contexts) {
+        $script:ctxById[$c.id]         = $c
+        $script:ctxIdByName[$c.displayName] = $c.id
+    }
+    $script:principalIds = @{}
+    foreach ($p in $script:data.principals) { $script:principalIds[$p.id] = $true }
+
+    # Parent -> children map, for walking a department down to its descendants.
+    $script:childrenOf = @{}
+    foreach ($c in $script:data.contexts) {
+        if ($c.parentContextId) {
+            if (-not $script:childrenOf.ContainsKey($c.parentContextId)) { $script:childrenOf[$c.parentContextId] = @() }
+            $script:childrenOf[$c.parentContextId] += $c.id
+        }
+    }
+    # Direct members per context.
+    $script:membersByCtx = @{}
+    foreach ($m in $script:data.contextMembers) {
+        if (-not $script:membersByCtx.ContainsKey($m.contextId)) { $script:membersByCtx[$m.contextId] = @() }
+        $script:membersByCtx[$m.contextId] += $m.memberId
+    }
+
+    # Resolve all distinct members of a context including every descendant context
+    # (mirrors how the matrix resolves a department scope via the context tree).
+    function Get-CtxMembersDeep {
+        param([string]$CtxId)
+        $acc   = @{}
+        $stack = [System.Collections.Generic.Stack[string]]::new()
+        $stack.Push($CtxId)
+        while ($stack.Count -gt 0) {
+            $id = $stack.Pop()
+            foreach ($mid in $script:membersByCtx[$id]) { $acc[$mid] = $true }
+            foreach ($ch  in $script:childrenOf[$id])   { $stack.Push($ch) }
+        }
+        return @($acc.Keys)
+    }
+
+    # Pre-compute validation collections + department counts for the It blocks.
+    $script:badCtxRefs   = @($script:data.contextMembers | Where-Object { -not $script:ctxById.ContainsKey($_.contextId) })
+    $script:badPrincRefs = @($script:data.contextMembers | Where-Object { -not $script:principalIds.ContainsKey($_.memberId) })
+    $script:badShape     = @($script:data.contextMembers | Where-Object { $_.memberType -ne 'Principal' -or $_.addedBy -ne 'sync' })
+    $script:pairs        = @($script:data.contextMembers | ForEach-Object { "$($_.contextId)|$($_.memberId)" })
+    $script:deepCount    = @{}
+    foreach ($name in @('Engineering', 'Finance', 'Sales', 'Operations')) {
+        $script:deepCount[$name] = @(Get-CtxMembersDeep -CtxId $script:ctxIdByName[$name]).Count
+    }
+    $script:platformCount = @(Get-CtxMembersDeep -CtxId $script:ctxIdByName['Platform Team']).Count
+}
+
+Describe 'Demo dataset — context membership' {
+
+    It 'includes a non-empty contextMembers section' {
+        @($script:data.contextMembers).Count | Should -BeGreaterThan 0
+    }
+
+    It 'every context member references an existing context' {
+        $script:badCtxRefs.Count | Should -Be 0
+    }
+
+    It 'every context member references an existing principal' {
+        $script:badPrincRefs.Count | Should -Be 0
+    }
+
+    It 'every context member is a sync-added Principal member' {
+        $script:badShape.Count | Should -Be 0
+    }
+
+    It 'has no duplicate (context, member) pairs' {
+        ($script:pairs | Sort-Object -Unique).Count | Should -Be $script:pairs.Count
+    }
+
+    It 'resolves the Sales department to its 5 members' {
+        $script:deepCount['Sales'] | Should -Be 5
+    }
+
+    It 'resolves the Engineering department to include its team members' {
+        # Engineering direct members plus Platform/Security team members via the tree.
+        $script:deepCount['Engineering'] | Should -BeGreaterOrEqual 9
+        $script:platformCount | Should -BeGreaterThan 0
+    }
+
+    It 'gives every department at least one member' {
+        foreach ($name in @('Engineering', 'Finance', 'Sales', 'Operations')) {
+            $script:deepCount[$name] | Should -BeGreaterThan 0
+        }
+    }
+}


### PR DESCRIPTION
## What

Makes the demo dataset **self-contained**: loading it now populates department and team membership, so the access matrix can be scoped by department (Sales, Engineering, …) immediately — no manual plugin run required.

## Why (the bug)

The demo dataset declared synced **Department/Team contexts but never emitted any `ContextMembers`**. On a fresh seed every department was empty, so the matrix — the product's headline view — couldn't be scoped by department until an admin ran the `department-from-principal` context plugin by hand. That also produced a *second*, parallel set of department contexts, leaving confusing duplicates.

This was found while standing up the public demo (issue #705): out of the box the seeded matrix showed no departments.

## The fix (at the source)

The generator already tracks each employee's leaf org context (`$emp.ctx`), so the data was there — it just wasn't emitted.

- **`Generate-DemoDataset.ps1`** — emit a `contextMembers` array: each principal linked to their **department** context (so a department scope resolves directly) and, for engineers, also to their **team** context. Includes the departmented edge cases (contractor, former employee). De-duplicated.
- **`Ingest-DemoDataset.ps1`** — ingest them via the existing **`/ingest/context-members`** endpoint (new step 4/12, after Contexts + Principals).

This is deterministic, needs **no plugin run**, and works regardless of auth mode (same crawler-key ingest path as every other entity). It populates the *existing* synced contexts, so it also removes the need for the plugin-created duplicate departments.

`demo-company.json` is a gitignored build artifact — the crawler regenerates it at runtime from the generator, so a fresh image build picks this up automatically.

## Tests

- **`test/unit/DemoDataset.Tests.ps1`** (Pester, 8 tests, passing locally): regenerates the dataset and asserts ContextMembers referential integrity (every member → an existing context + principal), member shape (`Principal` / `sync`), de-duplication, and that each department resolves via the context tree to a non-empty set — **Sales = 5**, Engineering includes its Platform/Security team members.

## Verification

- Pester suite green locally (8/8).
- Endpoint + record schema confirmed against `app/api/src/ingest/validation.js` (`context-members`).
- Separately confirmed this session that populating `ContextMembers` makes `POST /api/matrix/preview` scoped to Sales return 5 subjects (same table this ingest writes to).
- Full end-to-end on a running stack will occur naturally on merge → `:edge` rebuild → demo reseed (the pre-snapshot step for the demo environment).

## Scope / follow-ups

Deliberately **not** in this PR (separate concerns, tracked for #705):
- **Risk-scoring in the seed** — risk scoring is deterministic and already auto-runs post-crawl, but only if an active `RiskClassifiers` row exists, and there's no default one. Seeding a fixed classifier is a separate, instance-wide config decision.
- Rewriting the stale SQL-Server-era `Verify-DemoDataset.ps1`.
- Org-chart (manager-hierarchy) and other generated context views remain a "run the plugin" feature.
