### PR TITLE
fix(demo): make Zara Intern (E0031) a genuine zero-assignment principal (#717)

### DIFF
--- a/changes/demo-intern-zero-assignments-717.md
+++ b/changes/demo-intern-zero-assignments-717.md
@@ -1,0 +1,1 @@
+- The demo dataset now includes a principal with no access at all — Zara Intern (a new hire not yet provisioned) — so the matrix and other views have a genuine zero-assignment employee to exercise, matching what the documentation described.

--- a/docs/architecture/demo-dataset.md
+++ b/docs/architecture/demo-dataset.md
@@ -64,7 +64,7 @@ graph TB
 | Multi-system identity | E0020 Hassan Ibrahim | Has accounts in both EntraID and Omada; identity correlation links them |
 | Shared mailbox | SM-001 info@fortigidemo.com | `principalType: SharedMailbox`; owned by E0027 |
 | Manager in different dept | E0014 Ursula Visser | Reports to COO but manages Operations — tests cross-dept context |
-| Intern | E0031 Intern | Lowest-privilege employee. Not a zero-assignment case: assignments are granted by `department`, so the intern still gets the 4 Engineering ones. The dataset has no principal with zero assignments — see issue #717 |
+| Employee with no assignments | E0031 Zara Intern | A new hire not yet provisioned: flagged `noAccess` in the generator, so she is excluded from every department group and business-role grant. She still exists as a principal and appears in the Engineering context, but holds **zero** resource assignments — the deliberate zero-assignment edge case |
 
 ### Systems
 
@@ -117,16 +117,16 @@ AU-Netherlands
 
 | Principal | Resource | Type | Notes |
 |---|---|---|---|
-| All 22 employees | SG-AllEmployees | Direct | |
-| Every Engineering employee (10) | SG-Engineering | Direct | By `department`, so it includes the CTO (E0002) and the intern (E0031) |
+| Every employee except the intern (21) | SG-AllEmployees | Direct | E0031 is the deliberate zero-assignment case — see Edge Cases |
+| Engineering employees except the intern (8) | SG-Engineering | Direct | By `department` (includes the CTO E0002); the unprovisioned intern E0031 is excluded |
 | Every Finance employee (4) | SG-Finance | Direct | By `department` |
 | E0029, E0030 (SysAdmins) | SG-VPN-Access | Direct | |
 | E0002 (CTO) | SG-Admin-Tier0 | Direct | CTO is a member of the critical Tier-0 admin group |
 | E0029 (SysAdmin) | SG-Admin-Tier0 | Direct | Member of high-risk group |
 | SVC-001 (Deploy Pipeline) | SG-Admin-Tier0 | Direct | Service principal in admin group |
 | E0002 (CTO) | Global Administrator | Direct | Directory role assignment |
-| All 22 employees | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
-| Every Engineering employee (10) | BR-Engineering-Tools | Direct (`governed=true`) | Via business role |
+| Every employee except the intern (21) | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
+| Engineering employees except the intern (8) | BR-Engineering-Tools | Direct (`governed=true`) | Via business role |
 | E0029 (SysAdmin) | BR-Admin-Privileged | Eligible | PIM-eligible, not active |
 
 ### Resource Relationships
@@ -182,7 +182,7 @@ The dataset is a single JSON file that maps directly to the Ingest API endpoints
       "systems": 3,
       "principals": 28,
       "resources": 14,
-      "resourceAssignments": 73,
+      "resourceAssignments": 69,
       "resourceRelationships": 9,
       "identities": 23,
       "identityMembers": 24,
@@ -221,7 +221,7 @@ Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssig
 | Systems | 3 | Entra ID + HR + Omada |
 | Principals | 28 | 24 `User` (22 employees + 1 disabled + 1 Omada account for the multi-system employee) + 1 `ExternalUser` (contractor) + 1 `ServicePrincipal` + 1 `AIAgent` + 1 `SharedMailbox` |
 | Resources | 14 | 6 groups + 2 directory roles + 2 app roles + 4 business roles |
-| ResourceAssignments | 73 | 72 `Direct` + 1 `Eligible`; 31 of them carry `governed=true` |
+| ResourceAssignments | 69 | 68 `Direct` + 1 `Eligible`; 29 of them carry `governed=true` |
 | ResourceRelationships | 9 | 8 Contains + 1 GrantsAccessTo |
 | Identities | 23 | 22 employees + 1 disabled |
 | IdentityMembers | 24 | 23 primary + 1 secondary (the multi-system employee's Omada account) |

--- a/test/demo-dataset/Generate-DemoDataset.ps1
+++ b/test/demo-dataset/Generate-DemoDataset.ps1
@@ -88,7 +88,11 @@ $employees = @(
     @{ id = 'E0028'; name = 'Stefan Tanaka';     title = 'Account Executive';   dept = 'Sales';       manager = 'E0013'; ctx = $ctxSales }
     @{ id = 'E0029'; name = 'Victor Wang';       title = 'SysAdmin';            dept = 'Operations';  manager = 'E0014'; ctx = $ctxOps }
     @{ id = 'E0030'; name = 'Wendy Xu';          title = 'SysAdmin';            dept = 'Operations';  manager = 'E0014'; ctx = $ctxOps }
-    @{ id = 'E0031'; name = 'Zara Intern';       title = 'Intern';              dept = 'Engineering'; manager = 'E0010'; ctx = $ctxEng }
+    # Zara Intern is the deliberate "principal with zero resource assignments"
+    # edge case (a new hire not yet provisioned): noAccess excludes her from every
+    # group / business-role grant loop below, while she still exists as a principal
+    # and appears in her department context. See docs/architecture/demo-dataset.md.
+    @{ id = 'E0031'; name = 'Zara Intern';       title = 'Intern';              dept = 'Engineering'; manager = 'E0010'; ctx = $ctxEng; noAccess = $true }
 )
 
 $principals = @()
@@ -168,20 +172,25 @@ $resources = @(
 
 $assignments = @()
 
+# Employees who receive access grants — everyone except the noAccess edge case(s)
+# (Zara Intern), so the dataset always contains a principal with zero resource
+# assignments for the matrix's zero-assignment path to exercise.
+$provisionedEmployees = @($employees | Where-Object { -not $_.noAccess })
+
 # All employees -> SG-AllEmployees (Direct)
-foreach ($emp in $employees) {
+foreach ($emp in $provisionedEmployees) {
     $pGuid = New-DemoGuid "principal-$($emp.id)"
     $assignments += @{ resourceId = $resAllEmp; principalId = $pGuid; assignmentType = 'Direct' }
 }
 
 # Engineering employees -> SG-Engineering
-foreach ($emp in ($employees | Where-Object { $_.dept -eq 'Engineering' })) {
+foreach ($emp in ($provisionedEmployees | Where-Object { $_.dept -eq 'Engineering' })) {
     $pGuid = New-DemoGuid "principal-$($emp.id)"
     $assignments += @{ resourceId = $resEng; principalId = $pGuid; assignmentType = 'Direct' }
 }
 
 # Finance employees -> SG-Finance
-foreach ($emp in ($employees | Where-Object { $_.dept -eq 'Finance' })) {
+foreach ($emp in ($provisionedEmployees | Where-Object { $_.dept -eq 'Finance' })) {
     $pGuid = New-DemoGuid "principal-$($emp.id)"
     $assignments += @{ resourceId = $resFin; principalId = $pGuid; assignmentType = 'Direct' }
 }
@@ -199,11 +208,11 @@ $assignments += @{ resourceId = $resAdminTier0; principalId = $guidSvcPrinc; ass
 $assignments += @{ resourceId = $resGlobalAdmin; principalId = (New-DemoGuid 'principal-E0002'); assignmentType = 'Direct' }
 
 # Governed business-role memberships: Direct assignments flagged governed=true
-foreach ($emp in $employees) {
+foreach ($emp in $provisionedEmployees) {
     $pGuid = New-DemoGuid "principal-$($emp.id)"
     $assignments += @{ resourceId = $resBRBase; principalId = $pGuid; assignmentType = 'Direct'; governed = $true }
 }
-foreach ($emp in ($employees | Where-Object { $_.dept -eq 'Engineering' })) {
+foreach ($emp in ($provisionedEmployees | Where-Object { $_.dept -eq 'Engineering' })) {
     $pGuid = New-DemoGuid "principal-$($emp.id)"
     $assignments += @{ resourceId = $resBREng; principalId = $pGuid; assignmentType = 'Direct'; governed = $true }
 }

--- a/test/unit/DemoDataset.Tests.ps1
+++ b/test/unit/DemoDataset.Tests.ps1
@@ -116,3 +116,33 @@ Describe 'Demo dataset — context membership' {
         }
     }
 }
+
+Describe 'Demo dataset — zero-assignment edge case (#717)' {
+
+    BeforeAll {
+        # Zara Intern (E0031) is the deliberate "employee with no assignments" edge
+        # case documented in docs/architecture/demo-dataset.md — a new hire not yet
+        # provisioned. She must exist and be in the org, but hold zero access.
+        $script:intern = $script:data.principals | Where-Object { $_.employeeId -eq 'E0031' }
+        $script:internAssignments = @($script:data.resourceAssignments | Where-Object { $_.principalId -eq $script:intern.id })
+        $script:internContexts    = @($script:data.contextMembers    | Where-Object { $_.memberId   -eq $script:intern.id })
+    }
+
+    It 'includes Zara Intern (E0031) as a principal' {
+        $script:intern | Should -Not -BeNullOrEmpty
+        $script:intern.displayName | Should -Be 'Zara Intern'
+    }
+
+    It 'gives the intern zero resource assignments (the documented edge case)' {
+        $script:internAssignments.Count | Should -Be 0
+    }
+
+    It 'still places the intern in her department context (present in the org, just unprovisioned)' {
+        $script:internContexts.Count | Should -BeGreaterThan 0
+    }
+
+    It 'keeps other engineers provisioned — the exclusion is scoped to the intern' {
+        $eng = $script:data.principals | Where-Object { $_.employeeId -eq 'E0010' }
+        @($script:data.resourceAssignments | Where-Object { $_.principalId -eq $eng.id }).Count | Should -BeGreaterThan 0
+    }
+}


### PR DESCRIPTION
## The bug

`docs/architecture/demo-dataset.md` advertised **E0031 Intern** as the deliberate *"employee with no assignments"* edge case, but the generator grants access **by department**, so the intern actually received **4** assignments (SG-AllEmployees, SG-Engineering, BR-Employee-Base, BR-Engineering-Tools). The dataset had **no** zero-assignment employee, and the docs contradicted themselves (one row said "not a zero-assignment case — see #717", another asserted "Intern has 0 assignments — True").

## Fix

Flag the intern `noAccess` and route the department group + business-role grant loops through a `$provisionedEmployees` set that excludes `noAccess` employees. She stays a **principal** and a member of her **Engineering context** (present in the org, just unprovisioned), but now holds **zero** resource assignments — the intended edge case that exercises the matrix's zero-assignment path.

The identity and context-member loops still include her, so she appears in the org chart and department scope with no access.

## Verified

Regenerated and measured:
- E0031: principal ✅, **0** resource assignments (was 4) ✅, still 1 context membership ✅
- Control (E0010): still 4 assignments ✅

**Pester: 12 passed** (8 existing + 4 new in `DemoDataset.Tests.ps1` — intern exists, 0 assignments, still in her context, other engineers stay provisioned).

## Docs reconciled to the new output

- Edge-case row rewritten (E0031 is now the zero-assignment case).
- Grant table: SG-AllEmployees / BR-Employee-Base `22 → 21`; SG-Engineering / BR-Engineering-Tools `→ 8` (intern excluded; the pre-existing "(10)" overcount corrected to the real 8).
- Counts: `ResourceAssignments 73 → 69` (`72 → 68 Direct`, `31 → 29 governed`).

`Verify-DemoDataset.ps1` needs no change — its assignment checks are min-based (`governed ≥ 10` → 29 ✓, `eligible ≥ 1` → 1 ✓). The two generator copies stay in sync automatically: the `app/api/bundled-scripts/` copy is a git-ignored build artifact regenerated from this source.

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
