### PR TITLE
feat(support): honest support routing — report-first, best-effort + SLAs on the guide

### DIFF
--- a/app/ui/src/components/DashboardPage.jsx
+++ b/app/ui/src/components/DashboardPage.jsx
@@ -24,7 +24,6 @@ const DashboardTrendsTab = lazy(() => import('./DashboardTrendsTab'));
 
 const GITHUB_BASE = 'https://github.com/Fortigi/IdentityAtlas';
 const WEBSITE_URL = 'https://identityatlas.io';
-const SUPPORT_EMAIL = 'support@identityatlas.io';
 
 function changesUrl(v) {
   if (v) {
@@ -288,21 +287,17 @@ function FooterCards({ version }) {
           </div>
           <h3 className="text-sm font-bold text-gray-900 dark:text-white">Need support?</h3>
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">Email us a question, or report it on the tracker so others can follow along:</p>
-        <a
-          href={`mailto:${SUPPORT_EMAIL}`}
-          className="inline-block text-sm text-lime-700 hover:text-lime-800 font-medium hover:underline break-all"
-        >
-          {SUPPORT_EMAIL}
-        </a>
         <a
           href={docsUrl(v, '/contributing/report-an-issue/')}
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-2 text-sm text-gray-700 dark:text-gray-300 hover:text-lime-700 hover:underline flex items-center gap-2"
+          className="inline-flex items-center gap-2 text-sm text-lime-700 hover:text-lime-800 font-medium hover:underline"
         >
           <span>→</span>Report an issue or feature request
         </a>
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          Bugs and feature requests go on the public tracker so others can follow along. Community support is best effort — the guide explains how, and how to get an SLA or priority work if you need it.
+        </p>
       </div>
     </div>
   );

--- a/app/ui/src/components/DashboardPage.mount.test.jsx
+++ b/app/ui/src/components/DashboardPage.mount.test.jsx
@@ -78,6 +78,11 @@ describe('DashboardPage (mounted)', () => {
       'href',
       'https://fortigi.github.io/IdentityAtlas/edge/contributing/report-an-issue/',
     );
+
+    // The support email was intentionally removed from the dashboard — support
+    // now routes through the report-an-issue guide (which covers SLAs), not a
+    // mailto on the solution home page.
+    expect(screen.queryByText(/support@identityatlas\.io/i)).toBeNull();
   });
 
   it('navigates when a populated stat card is clicked', async () => {

--- a/changes/feature-support-routing.md
+++ b/changes/feature-support-routing.md
@@ -1,0 +1,3 @@
+- The dashboard's **Need support?** card now leads with **Report an issue or feature request** (linking to the support guide) and no longer shows a support email — bugs and feature requests go through the public tracker.
+- The support guide now states plainly that community support is **best effort**, and adds a section on requesting an **SLA or priority feature development** for organisations that need more, with a contact address.
+- Added a **Support** link to the website footer so visitors can find how to get help.

--- a/docs/contributing/report-an-issue.md
+++ b/docs/contributing/report-an-issue.md
@@ -7,6 +7,14 @@ Everything happens on our **issue tracker** on GitHub. An "issue" is just a
 message with a title and a description. Creating one is free; you only need a
 GitHub account (also free).
 
+!!! info "How support works here"
+    Identity Atlas is free and open source. Bugs and feature requests are handled
+    **best effort**, in the open on the tracker — there's no ticket queue and no
+    guaranteed response time. We read everything and prioritise what helps the most
+    people. If best effort isn't enough for your organisation, see
+    [Need guaranteed support or priority features?](#need-guaranteed-support-or-priority-features)
+    at the bottom of this page.
+
 !!! tip "In a hurry?"
     Jump straight to **[Open a new issue :material-open-in-new:](https://github.com/Fortigi/IdentityAtlas/issues/new/choose){ target=_blank rel=noopener }** and pick *Bug report* or *Feature request*.
 
@@ -65,3 +73,17 @@ fix — sometimes there's an easier route to what you need.
   [release notes](https://github.com/Fortigi/IdentityAtlas/blob/main/CHANGES.md){ target=_blank rel=noopener }.
 
 Want to help fix it yourself? See **[Contribute a change](contribute.md)**.
+
+## Need guaranteed support or priority features?
+
+We'll be honest: the community tracker above is **best effort**. There's no
+service-level agreement, and no promise of when — or whether — a given bug or
+feature gets picked up.
+
+If that isn't enough for your organisation, we offer paid options for both:
+
+- **Support with an SLA** — guaranteed response times and hands-on help.
+- **Priority feature development** — sponsor a feature you need and have it built
+  and maintained on a committed timeline.
+
+Tell us what you need at **[support@identityatlas.io](mailto:support@identityatlas.io)**.

--- a/docs/ui/dashboard.md
+++ b/docs/ui/dashboard.md
@@ -57,7 +57,8 @@ a coloured dot (green = active, amber = needs attention, grey = not configured):
 
 The bottom row has three cards: **Resources** (website, documentation, GitHub,
 license, releases), **Version** (the running version, with a "What is new" link to
-the changelog), and **Need support?** (a support email). A banner appears above
+the changelog), and **Need support?** (a link to [report a bug or request a
+feature](../contributing/report-an-issue.md)). A banner appears above
 everything if your `docker-compose.prod.yml` is outdated, with the command to
 re-download it.
 

--- a/site/index.html
+++ b/site/index.html
@@ -580,6 +580,7 @@
         <div class="ft-col">
           <h4>Resources</h4>
           <a href="https://fortigi.github.io/IdentityAtlas" target="_blank" rel="noopener">Documentation ↗</a>
+          <a href="https://fortigi.github.io/IdentityAtlas/stable/contributing/report-an-issue/" target="_blank" rel="noopener">Support ↗</a>
           <a href="https://github.com/Fortigi/IdentityAtlas" target="_blank" rel="noopener">Source on GitHub ↗</a>
           <a href="https://fortigi.github.io/IdentityAtlas/stable/history/" target="_blank" rel="noopener">Project history ↗</a>
           <a href="https://github.com/Fortigi/IdentityAtlas/blob/main/LICENSE" target="_blank" rel="noopener">MIT License ↗</a>


### PR DESCRIPTION
## What

Reworks how support is presented, per feedback that the dashboard's "Need support?" card wasn't good enough: lead with reporting, be honest that community support is **best effort**, and route people who need more (SLAs, priority features) to a contact — without putting the support email on the product's home page.

## Changes

**Dashboard "Need support?" card** (`DashboardPage.jsx`)
- **Report an issue or feature request** is now the primary, top option (linking to the support guide).
- The **support email is removed** from the solution home page.
- Adds a short line setting expectations: community support is best effort; the guide covers how, and how to get an SLA / priority work.

**Support guide** (`docs/contributing/report-an-issue.md`)
- Adds an up-front note that Identity Atlas is free/open-source and bugs + feature requests are handled **best effort** on the tracker — no queue, no guaranteed response time.
- Adds a **"Need guaranteed support or priority features?"** section: honest that the tracker has no SLA, and offers paid **support with an SLA** and **priority/sponsored feature development** (for both bugs and features), with **support@identityatlas.io**. This is the only place the email now lives.

**Marketing site** (`site/index.html`)
- Adds a **Support ↗** link (to the guide) in the footer Resources column, since visitors may look on identityatlas.io first.

**Docs** (`docs/ui/dashboard.md`) — updated the dashboard description to match (support card links to the guide, no email).

## Tests

- `DashboardPage.mount.test.jsx`: still asserts the Report link + its href, and now also asserts the support email is **not** rendered on the dashboard. 8/8 pass locally.

## Notes

- Site + docs deploy on merge (docs via mike `/stable/`, site to the self-hosted nginx). The footer Support link points at `…/stable/contributing/report-an-issue/`.
- Local ESLint couldn't run (a dev dep, `eslint-plugin-sonarjs`, isn't installed in this checkout) — CI lint will cover it; the only lint-relevant change was removing the now-unused `SUPPORT_EMAIL` constant, verified gone.
