### PR TITLE
fix(demo): emit group ownership in the demo dataset (#713)

### DIFF
--- a/changes/demo-ownership-data-713.md
+++ b/changes/demo-ownership-data-713.md
@@ -1,0 +1,1 @@
+- The demo dataset now includes group ownership — a few groups (Engineering, Finance, the Tier-0 admin group) have designated owners — so the matrix's owner badges and the ownership views have real demo data to show.

--- a/docs/architecture/demo-dataset.md
+++ b/docs/architecture/demo-dataset.md
@@ -112,6 +112,9 @@ AU-Netherlands
 | BR-Engineering-Tools | BusinessRole | Omada | Dev tools access package |
 | BR-Finance-Systems | BusinessRole | Omada | Financial systems access |
 | BR-Admin-Privileged | BusinessRole | Omada | Privileged admin access |
+| SG-Engineering | GroupOwnership | EntraID | Owners of the Engineering group (a GroupOwnership resource is named after the group it owns) |
+| SG-Finance | GroupOwnership | EntraID | Owners of the Finance group |
+| SG-Admin-Tier0 | GroupOwnership | EntraID | Owners of the Tier-0 admin group |
 
 ### Assignments (Who Has What)
 
@@ -128,6 +131,7 @@ AU-Netherlands
 | Every employee except the intern (21) | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
 | Engineering employees except the intern (8) | BR-Engineering-Tools | Direct (`governed=true`) | Via business role |
 | E0029 (SysAdmin) | BR-Admin-Privileged | Eligible | PIM-eligible, not active |
+| E0010 → SG-Engineering; E0012 → SG-Finance; E0002 + E0029 → SG-Admin-Tier0 | GroupOwnership | Direct | Ownership is a Direct assignment on a synthetic GroupOwnership resource, never an `Owner` type |
 
 ### Resource Relationships
 
@@ -142,6 +146,9 @@ AU-Netherlands
 | BR-Admin-Privileged | SG-Admin-Tier0 | Contains | |
 | BR-Admin-Privileged | SG-PAM-Users | Contains | |
 | SG-Engineering | SG-AllEmployees | GrantsAccessTo | Nested group |
+| SG-Engineering | SG-Engineering (ownership) | HasOwnership | Group → its GroupOwnership resource |
+| SG-Finance | SG-Finance (ownership) | HasOwnership | |
+| SG-Admin-Tier0 | SG-Admin-Tier0 (ownership) | HasOwnership | |
 
 ### Governance
 
@@ -181,9 +188,9 @@ The dataset is a single JSON file that maps directly to the Ingest API endpoints
     "entityCounts": {
       "systems": 3,
       "principals": 28,
-      "resources": 14,
-      "resourceAssignments": 69,
-      "resourceRelationships": 9,
+      "resources": 17,
+      "resourceAssignments": 73,
+      "resourceRelationships": 12,
       "identities": 23,
       "identityMembers": 24,
       "contexts": 8,
@@ -220,9 +227,9 @@ Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssig
 |---|---|---|
 | Systems | 3 | Entra ID + HR + Omada |
 | Principals | 28 | 24 `User` (22 employees + 1 disabled + 1 Omada account for the multi-system employee) + 1 `ExternalUser` (contractor) + 1 `ServicePrincipal` + 1 `AIAgent` + 1 `SharedMailbox` |
-| Resources | 14 | 6 groups + 2 directory roles + 2 app roles + 4 business roles |
-| ResourceAssignments | 69 | 68 `Direct` + 1 `Eligible`; 29 of them carry `governed=true` |
-| ResourceRelationships | 9 | 8 Contains + 1 GrantsAccessTo |
+| Resources | 17 | 6 groups + 2 directory roles + 2 app roles + 4 business roles + 3 group-ownership |
+| ResourceAssignments | 73 | 72 `Direct` + 1 `Eligible`; 29 of them carry `governed=true` (4 of the `Direct` are group-ownership) |
+| ResourceRelationships | 12 | 8 Contains + 1 GrantsAccessTo + 3 HasOwnership |
 | Identities | 23 | 22 employees + 1 disabled |
 | IdentityMembers | 24 | 23 primary + 1 secondary (the multi-system employee's Omada account) |
 | Contexts | 8 | 1 root + 4 departments + 2 teams + 1 admin unit — all `variant='synced'` |
@@ -258,6 +265,7 @@ Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssig
 | AI agent (AI-001) has `principalType='AIAgent'` | True |
 | Disabled account (E0041) has `accountEnabled=0` | True |
 | Intern (E0031) has 0 resource assignments | True |
+| Group ownership exists — `GroupOwnership` resources with `Direct` owner assignments | True |
 | BR-Employee-Base contains SG-AllEmployees (relationship) | True |
 | BR-Admin-Privileged is in catalog "Privileged Access" | True |
 | Engineering context has parent = "Fortigi Demo Corp" | True |
@@ -268,7 +276,7 @@ Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssig
 
 | Check | How |
 |---|---|
-| Resources page shows 14 resources (excluding BusinessRoles) | Count rows, filter by non-BusinessRole |
+| Resources page shows 13 resources (excluding BusinessRoles) | Count rows, filter by non-BusinessRole (6 groups + 2 directory roles + 2 app roles + 3 group-ownership) |
 | Business Roles page shows 4 business roles | Count rows |
 | Users page shows 28 principals | Count visible or total indicator |
 | Matrix shows data (not "0 users x 0 resources") | Assert text not present |

--- a/test/demo-dataset/Generate-DemoDataset.ps1
+++ b/test/demo-dataset/Generate-DemoDataset.ps1
@@ -234,6 +234,34 @@ $relationships = @(
     @{ parentResourceId = $resEng;     childResourceId = $resAllEmp;  relationshipType = 'GrantsAccessTo' }
 )
 
+# ─── Group Ownership ──────────────────────────────────────────────
+# v5 models ownership as a Direct assignment on a synthetic GroupOwnership
+# resource (named after the owned group), linked to the group by a HasOwnership
+# relationship — mirroring ConvertTo-EntraGroupOwnership in the Entra crawler.
+# Without this the dataset has no ownership at all, leaving the matrix's
+# owner-badge rules (docs/architecture/matrix.md) without demo coverage (#713).
+$ownedGroups = @(
+    @{ groupId = $resEng;        name = 'SG-Engineering'; owners = @('E0010') }
+    @{ groupId = $resFin;        name = 'SG-Finance';     owners = @('E0012') }
+    @{ groupId = $resAdminTier0; name = 'SG-Admin-Tier0'; owners = @('E0002', 'E0029') }
+)
+foreach ($og in $ownedGroups) {
+    $ownId = New-DemoGuid "res-ownership-$($og.name)"
+    $resources += @{
+        id                 = $ownId
+        displayName        = $og.name
+        resourceType       = 'GroupOwnership'
+        systemId           = $sysEntraId
+        enabled            = $true
+        externalId         = "entraid-ownership:$($og.groupId)"
+        extendedAttributes = @{ ownedResourceId = $og.groupId }
+    }
+    $relationships += @{ parentResourceId = $og.groupId; childResourceId = $ownId; relationshipType = 'HasOwnership' }
+    foreach ($ownerId in $og.owners) {
+        $assignments += @{ resourceId = $ownId; principalId = (New-DemoGuid "principal-$ownerId"); assignmentType = 'Direct'; resourceType = 'GroupOwnership' }
+    }
+}
+
 # ─── Identities & IdentityMembers ────────────────────────────────
 
 $identities = @()

--- a/test/demo-dataset/Verify-DemoDataset.ps1
+++ b/test/demo-dataset/Verify-DemoDataset.ps1
@@ -191,6 +191,18 @@ Assert-Count 'Has-Eligible-Assignments' -Min 1 -Query @'
 SELECT COUNT(*) FROM "ResourceAssignments" WHERE "assignmentType" = 'Eligible' AND "deletedAt" IS NULL
 '@
 
+# Ownership: a Direct assignment on a synthetic GroupOwnership resource, not the
+# retired 'Owner' assignmentType (#713).
+Assert-Count 'Has-GroupOwnership-Resources' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'GroupOwnership' AND "deletedAt" IS NULL
+'@
+
+Assert-Count 'Has-Owner-Assignments' -Min 1 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+JOIN "Resources" r ON r."id" = ra."resourceId"
+WHERE r."resourceType" = 'GroupOwnership' AND ra."deletedAt" IS NULL
+'@
+
 # Relationship types (ResourceRelationships has no soft-delete column)
 Assert-Count 'Contains-Relationships' -Min 8 -Query @'
 SELECT COUNT(*) FROM "ResourceRelationships" WHERE "relationshipType" = 'Contains'
@@ -198,6 +210,10 @@ SELECT COUNT(*) FROM "ResourceRelationships" WHERE "relationshipType" = 'Contain
 
 Assert-Count 'GrantsAccessTo-Relationships' -Min 1 -Query @'
 SELECT COUNT(*) FROM "ResourceRelationships" WHERE "relationshipType" = 'GrantsAccessTo'
+'@
+
+Assert-Count 'HasOwnership-Relationships' -Min 1 -Query @'
+SELECT COUNT(*) FROM "ResourceRelationships" WHERE "relationshipType" = 'HasOwnership'
 '@
 
 # Context hierarchy

--- a/test/run-docker-tests.ps1
+++ b/test/run-docker-tests.ps1
@@ -343,12 +343,18 @@ Measure-Check 'BusinessLogic' 'Has Eligible assignments' -Min 1 -Query @'
 SELECT COUNT(*) FROM "ResourceAssignments" WHERE "assignmentType" = 'Eligible' AND "deletedAt" IS NULL
 '@
 
-# NOTE: the old 'Has Owner assignments' check is deliberately gone rather than
-# ported. Ownership is no longer an assignmentType — it's a Direct assignment on
-# a GroupOwnership resource — and Generate-DemoDataset.ps1 emits no ownership at
-# all (its resources are Groups, EntraDirectoryRoles, EntraAppRoles and
-# BusinessRoles). There is nothing here to assert on; re-add this check together
-# with ownership in the generator, not before.
+# Ownership is a Direct assignment on a synthetic GroupOwnership resource, not the
+# retired 'Owner' assignmentType. Restored (#713) now that Generate-DemoDataset.ps1
+# emits ownership — the v5 replacement for the old 'Has Owner assignments' check.
+Measure-Check 'BusinessLogic' 'Has GroupOwnership resources' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'GroupOwnership' AND "deletedAt" IS NULL
+'@
+
+Measure-Check 'BusinessLogic' 'Has owner assignments' -Min 1 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+JOIN "Resources" r ON r."id" = ra."resourceId"
+WHERE r."resourceType" = 'GroupOwnership' AND ra."deletedAt" IS NULL
+'@
 
 # Context hierarchy (Contexts has no soft-delete column)
 Measure-Check 'BusinessLogic' 'Has root context (no parent)' -Min 1 -Query @'

--- a/test/unit/DemoDataset.Tests.ps1
+++ b/test/unit/DemoDataset.Tests.ps1
@@ -146,3 +146,47 @@ Describe 'Demo dataset — zero-assignment edge case (#717)' {
         @($script:data.resourceAssignments | Where-Object { $_.principalId -eq $eng.id }).Count | Should -BeGreaterThan 0
     }
 }
+
+Describe 'Demo dataset — group ownership (#713)' {
+
+    BeforeAll {
+        # v5 ownership: a Direct assignment on a synthetic GroupOwnership resource
+        # (named after the owned group), linked by a HasOwnership relationship —
+        # never the retired 'Owner' assignmentType.
+        $script:ownershipResources = @($script:data.resources             | Where-Object { $_.resourceType   -eq 'GroupOwnership' })
+        $script:ownershipRels      = @($script:data.resourceRelationships  | Where-Object { $_.relationshipType -eq 'HasOwnership' })
+        $script:ownerAssignments   = @($script:data.resourceAssignments    | Where-Object { $_.resourceType   -eq 'GroupOwnership' })
+        $script:resById            = @{}
+        foreach ($r in $script:data.resources)  { $script:resById[$r.id]  = $r }
+        $script:principalIdSet     = @{}
+        foreach ($p in $script:data.principals) { $script:principalIdSet[$p.id] = $true }
+    }
+
+    It 'emits a GroupOwnership resource per owned group, tagged with the owned group' {
+        $script:ownershipResources.Count | Should -BeGreaterThan 0
+        foreach ($o in $script:ownershipResources) {
+            $o.extendedAttributes.ownedResourceId | Should -Not -BeNullOrEmpty
+            $script:resById.ContainsKey($o.extendedAttributes.ownedResourceId) | Should -BeTrue
+        }
+    }
+
+    It 'links each ownership resource to its group via a HasOwnership relationship' {
+        $script:ownershipRels.Count | Should -Be $script:ownershipResources.Count
+        foreach ($rel in $script:ownershipRels) {
+            $script:resById.ContainsKey($rel.parentResourceId) | Should -BeTrue   # the owned group
+            $script:resById[$rel.childResourceId].resourceType | Should -Be 'GroupOwnership'
+        }
+    }
+
+    It 'models each owner as a Direct assignment on the GroupOwnership resource' {
+        $script:ownerAssignments.Count | Should -BeGreaterThan 0
+        foreach ($a in $script:ownerAssignments) {
+            $a.assignmentType | Should -Be 'Direct'
+            $script:principalIdSet.ContainsKey($a.principalId) | Should -BeTrue
+        }
+    }
+
+    It 'never emits the retired Owner assignmentType' {
+        @($script:data.resourceAssignments | Where-Object { $_.assignmentType -eq 'Owner' }).Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
## The gap

`Generate-DemoDataset.ps1` emitted **no ownership at all** (its 14 resources were Groups, EntraDirectoryRoles, EntraAppRoles, BusinessRoles). So the v5 owner model had zero demo coverage, and the old `Has Owner assignments` check — removed in #707 because `Owner` is a retired assignmentType — had nothing to be restored against (`resourceType='GroupOwnership'` would have asserted `0 >= 1`).

## Fix

Add ownership the v5 way, mirroring `ConvertTo-EntraGroupOwnership` in the Entra crawler:
- a synthetic **`GroupOwnership`** resource per owned group (named after the group, `extendedAttributes.ownedResourceId` → the group),
- a **`HasOwnership`** relationship (group → ownership resource),
- a **`Direct`** owner assignment per owner (`resourceType='GroupOwnership'`) — never the retired `Owner` type.

Three groups get owners: **SG-Engineering** (E0010), **SG-Finance** (E0012), **SG-Admin-Tier0** (E0002 + E0029) → **3** resources, **3** relationships, **4** assignments. This finally gives the matrix's owner-badge rules (`docs/architecture/matrix.md`) real demo data.

## Verified

Regenerated & measured: **17** resources (3 GroupOwnership), **3** HasOwnership relationships, **4** owner assignments, **73** total assignments (72 Direct + 1 Eligible), 29 governed. The ownership resource shape matches the crawler exactly.

**Pester: 16 passed** (8 context + 4 zero-assignment + **4 new ownership** — GroupOwnership resource per group, HasOwnership links, Direct owner assignments, and a guard that the retired `Owner` type never appears).

## Checks restored / added

- **`run-docker-tests.ps1`** — restored the check at its `NOTE:` marker (the v5 replacement for the old `Has Owner assignments`).
- **`Verify-DemoDataset.ps1`** (the integration-job script) — added `Has-GroupOwnership-Resources`, `Has-Owner-Assignments`, `HasOwnership-Relationships` (min-based).

## Docs reconciled

`demo-dataset.md`: Resources `14 → 17`, ResourceAssignments `69 → 73` (`68 → 72 Direct`), ResourceRelationships `9 → 12` (+3 HasOwnership); resource/assignment/relationship tables gain ownership rows; a validation entry added; and a pre-existing Resources-page count corrected (`14 → 13` non-BusinessRole).

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)
