### PR TITLE
feat(db): enforce Contexts-tree acyclicity at the database (#627)

### DIFF
--- a/.ci/migration-hashes.json
+++ b/.ci/migration-hashes.json
@@ -61,6 +61,7 @@
     "055_history_timeline_indexes.sql": "2e238c636f986982243a09b6f33ff84c29dcfb92f093fb3efddaf5536db1a72f",
     "056_component_versions.sql": "82359f4155eaa216dd8b98f89b9ff46db66031a7a8e1efcb2c114267f68593fc",
     "057_principal_relationships.sql": "124f72d04f718f615ac665f47b8500479c84db7d39969159d55afd95e0525717",
-    "058_rename_entra_app_role.sql": "b86da2c0c2b0fc2934affcab1298886b4e5d23644742b2c433abc08fc3d1c57f"
+    "058_rename_entra_app_role.sql": "b86da2c0c2b0fc2934affcab1298886b4e5d23644742b2c433abc08fc3d1c57f",
+    "059_context_acyclic_trigger.sql": "b5cd241b6a5df8deb5834f56e020ba8e0be6ca02f324d8054f0042b6fd2eccd7"
   }
 }

--- a/app/api/contract-tests/contextAcyclicTrigger.contract.test.js
+++ b/app/api/contract-tests/contextAcyclicTrigger.contract.test.js
@@ -1,0 +1,139 @@
+// Contract test — the Contexts-acyclicity constraint trigger against real PG16.
+//
+// Migration 059 adds a DEFERRABLE INITIALLY DEFERRED constraint trigger that
+// makes it impossible to COMMIT a cyclic parentContextId from ANY writer (#627).
+// These tests pin the three behaviours that matter:
+//   - a cycle that survives to commit aborts the transaction (check_violation);
+//   - an acyclic tree commits fine;
+//   - a batch-internal transient cycle that resolves before commit is allowed
+//     (that's the whole reason the trigger is deferred, not per-statement).
+
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import pg from 'pg';
+
+let pool;
+let systemId;
+
+const A = 'a0000000-0000-0000-0000-0000000c0701';
+const B = 'a0000000-0000-0000-0000-0000000c0702';
+const C = 'a0000000-0000-0000-0000-0000000c0703';
+
+async function ins(client, id, parent) {
+  await client.query(
+    `INSERT INTO "Contexts" (id, variant, "targetType", "contextType", "displayName", "scopeSystemId", "parentContextId")
+     VALUES ($1, 'synced', 'Principal', 'Department', $2, $3, $4)`,
+    [id, `ctx-${id.slice(-4)}`, systemId, parent],
+  );
+}
+
+beforeAll(async () => {
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'contract-acyclic-trigger') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+});
+
+afterEach(async () => {
+  await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);
+});
+
+afterAll(async () => {
+  await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool.end();
+});
+
+describe('Contexts acyclicity trigger (migration 059)', () => {
+  it('commits an acyclic chain A <- B <- C', async () => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await ins(client, A, null);
+      await ins(client, B, A);
+      await ins(client, C, B);
+      await expect(client.query('COMMIT')).resolves.toBeDefined();
+    } finally {
+      await client.query('ROLLBACK').catch(() => {});
+      client.release();
+    }
+  });
+
+  it('aborts the transaction when a 2-cycle A <-> B survives to commit', async () => {
+    const client = await pool.connect();
+    let err;
+    try {
+      await client.query('BEGIN');
+      await ins(client, A, null);
+      await ins(client, B, A);
+      await client.query(`UPDATE "Contexts" SET "parentContextId" = $2 WHERE id = $1`, [A, B]); // A -> B -> A
+      await client.query('COMMIT');
+    } catch (e) {
+      err = e;
+    } finally {
+      await client.query('ROLLBACK').catch(() => {});
+      client.release();
+    }
+    expect(err).toBeDefined();
+    expect(err.code).toBe('23514'); // check_violation raised by the trigger
+    // Nothing persisted — the whole transaction rolled back.
+    const { rows } = await pool.query(`SELECT COUNT(*)::int AS n FROM "Contexts" WHERE id = ANY($1)`, [[A, B]]);
+    expect(rows[0].n).toBe(0);
+  });
+
+  it('aborts on a 3-cycle P -> Q -> R -> P', async () => {
+    const [P, Q, R] = ['a0000000-0000-0000-0000-0000000c07f1', 'a0000000-0000-0000-0000-0000000c07f2', 'a0000000-0000-0000-0000-0000000c07f3'];
+    const client = await pool.connect();
+    let err;
+    try {
+      await client.query('BEGIN');
+      await ins(client, P, null);
+      await ins(client, Q, P);
+      await ins(client, R, Q);
+      await client.query(`UPDATE "Contexts" SET "parentContextId" = $2 WHERE id = $1`, [P, R]); // close the loop
+      await client.query('COMMIT');
+    } catch (e) {
+      err = e;
+    } finally {
+      await client.query('ROLLBACK').catch(() => {});
+      client.release();
+    }
+    expect(err?.code).toBe('23514');
+  });
+
+  it('allows a batch-internal transient cycle that is resolved before commit', async () => {
+    // Deferred-to-commit is the point: mid-transaction the tree briefly loops,
+    // but the pointer is fixed before commit, so the final state is acyclic.
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await ins(client, A, null);
+      await ins(client, B, A);
+      await client.query(`UPDATE "Contexts" SET "parentContextId" = $2 WHERE id = $1`, [A, B]); // transient A -> B -> A
+      await client.query(`UPDATE "Contexts" SET "parentContextId" = NULL WHERE id = $1`, [A]);  // resolve it
+      await expect(client.query('COMMIT')).resolves.toBeDefined();
+    } finally {
+      await client.query('ROLLBACK').catch(() => {});
+      client.release();
+    }
+    const { rows } = await pool.query(`SELECT "parentContextId" FROM "Contexts" WHERE id = $1`, [A]);
+    expect(rows[0].parentContextId).toBeNull();
+  });
+
+  it('rejects a direct self-loop A -> A at commit', async () => {
+    const client = await pool.connect();
+    let err;
+    try {
+      await client.query('BEGIN');
+      await ins(client, A, null);
+      await client.query(`UPDATE "Contexts" SET "parentContextId" = id WHERE id = $1`, [A]);
+      await client.query('COMMIT');
+    } catch (e) {
+      err = e;
+    } finally {
+      await client.query('ROLLBACK').catch(() => {});
+      client.release();
+    }
+    expect(err).toBeDefined(); // self-FK or the trigger — either way it must not commit
+  });
+});

--- a/app/api/contract-tests/contexts.contract.test.js
+++ b/app/api/contract-tests/contexts.contract.test.js
@@ -89,13 +89,22 @@ describe('contexts tree CTE — happy path', () => {
 });
 
 describe('contexts tree CTE — cyclic parentContextId', () => {
-  // Build A→B→A: insert acyclic, then close the loop with a direct UPDATE,
-  // mimicking corrupt data that arrives via the ingest / plugin write paths
-  // (which, unlike PATCH /contexts/:id, do not guard against cycles).
+  // Build A→B→A, mimicking corrupt data that predates migration 059's trigger or
+  // arrives via a bypassing writer. The trigger blocks committing a cycle through
+  // a normal write, so close the loop with triggers off for this connection only
+  // (session_replication_role, reset in finally so it never leaks). The read-side
+  // CYCLE guards still have to survive such a cycle — that's what these tests pin.
   async function makeCycle() {
     const a = await insertContext({ name: 'Cycle A' });
     const b = await insertContext({ parent: a, name: 'Cycle B' });
-    await pool.query(`UPDATE "Contexts" SET "parentContextId" = $1 WHERE id = $2`, [b, a]);
+    const c = await pool.connect();
+    try {
+      await c.query(`SET session_replication_role = replica`);
+      await c.query(`UPDATE "Contexts" SET "parentContextId" = $1 WHERE id = $2`, [b, a]);
+    } finally {
+      await c.query(`SET session_replication_role = origin`).catch(() => {});
+      c.release();
+    }
     return { a, b };
   }
 

--- a/app/api/contract-tests/cycleGuard.contract.test.js
+++ b/app/api/contract-tests/cycleGuard.contract.test.js
@@ -46,13 +46,33 @@ beforeEach(async () => {
   await pool.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);
   // clean chain
   await ins(A, null); await ins(B, A); await ins(C, B);
-  // 2-cycle: insert acyclic, then close the loop with an UPDATE
+  // 2-cycle + 3-cycle. These are "pre-existing corruption": migration 059's
+  // trigger blocks committing a cycle through a normal write, so seed the
+  // loop-closing UPDATEs with triggers off for this connection only. That's
+  // exactly the scenario these defenses exist for — a cycle that predates the
+  // trigger or arrives via a bypassing writer. session_replication_role is
+  // session-scoped and reset in finally, so it never leaks to other connections.
   await ins(X, null); await ins(Y, X);
-  await pool.query(`UPDATE "Contexts" SET "parentContextId" = $1 WHERE id = $2`, [Y, X]);
-  // 3-cycle
   await ins(P, null); await ins(Q, P); await ins(R, Q);
-  await pool.query(`UPDATE "Contexts" SET "parentContextId" = $1 WHERE id = $2`, [R, P]);
+  await withTriggersOff(async (c) => {
+    await c.query(`UPDATE "Contexts" SET "parentContextId" = $1 WHERE id = $2`, [Y, X]); // close 2-cycle
+    await c.query(`UPDATE "Contexts" SET "parentContextId" = $1 WHERE id = $2`, [R, P]); // close 3-cycle
+  });
 });
+
+// Run `fn(client)` with user triggers disabled on that client's session, so a
+// test can seed a genuinely cyclic tree that the migration-059 trigger would
+// otherwise reject. Always reset + release, so no other connection is affected.
+async function withTriggersOff(fn) {
+  const c = await pool.connect();
+  try {
+    await c.query(`SET session_replication_role = replica`);
+    await fn(c);
+  } finally {
+    await c.query(`SET session_replication_role = origin`).catch(() => {});
+    c.release();
+  }
+}
 
 afterAll(async () => {
   await pool?.query(`DELETE FROM "Contexts" WHERE "scopeSystemId" = $1`, [systemId]);

--- a/app/api/contract-tests/runnerCycle.contract.test.js
+++ b/app/api/contract-tests/runnerCycle.contract.test.js
@@ -1,0 +1,103 @@
+// Contract test — the context-plugin runner reconciles a cyclic plugin batch
+// without persisting a cycle (#627, gap #1).
+//
+// The silent breakCycles-after-reconcile repair was removed. Two things now keep
+// the tree acyclic: linkContextParents skips a loop-closing parent link
+// (wouldCreateCycle), and migration 059's deferred trigger is the backstop. This
+// registers a throwaway plugin that emits an A<->B parent loop, runs it through
+// enqueueRun against real PG, and asserts the persisted tree is acyclic and the
+// run succeeded — i.e. the skip handled the loop and no cycle reached commit. If
+// the skip were removed, both links would be written and the trigger would abort
+// the run (status 'failed'), so this test is load-bearing for the skip.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { randomUUID } from 'crypto';
+import pg from 'pg';
+
+const PLUGIN_NAME = 'contract-cyclic-627';
+
+let enqueueRun;
+let REGISTERED_PLUGINS;
+let pool;
+let systemId;
+
+const CYCLIC_PLUGIN = {
+  name: PLUGIN_NAME,
+  displayName: 'Cyclic Test (627)',
+  targetType: 'Principal',
+  async run() {
+    // A -> B and B -> A: a genuine batch-internal 2-cycle in the parent structure.
+    return {
+      contexts: [
+        { externalId: 'A', displayName: 'Ctx A', parentExternalId: 'B' },
+        { externalId: 'B', displayName: 'Ctx B', parentExternalId: 'A' },
+      ],
+      members: [],
+    };
+  },
+};
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = process.env.CONTRACT_DB_URL;
+  ({ enqueueRun } = await import('../src/contexts/plugins/runner.js'));
+  ({ REGISTERED_PLUGINS } = await import('../src/contexts/plugins/registry.js'));
+  REGISTERED_PLUGINS.push(CYCLIC_PLUGIN);
+  pool = new pg.Pool({ connectionString: process.env.CONTRACT_DB_URL });
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType","displayName") VALUES ('test','cyclic-627') RETURNING id`,
+  );
+  systemId = sys.rows[0].id;
+});
+
+afterAll(async () => {
+  await cleanup();
+  await pool.query(`DELETE FROM "Systems" WHERE id = $1`, [systemId]);
+  const i = REGISTERED_PLUGINS.findIndex((p) => p.name === PLUGIN_NAME);
+  if (i >= 0) REGISTERED_PLUGINS.splice(i, 1);
+  await pool.end();
+});
+
+beforeEach(cleanup);
+
+async function cleanup() {
+  await pool.query(`DELETE FROM "Contexts" WHERE "sourceAlgorithmId" IN (SELECT id FROM "ContextAlgorithms" WHERE name = $1)`, [PLUGIN_NAME]);
+  await pool.query(`DELETE FROM "ContextAlgorithms" WHERE name = $1`, [PLUGIN_NAME]);
+}
+
+async function seedAlgorithm() {
+  await pool.query(
+    `INSERT INTO "ContextAlgorithms" ("id", "name", "displayName", "targetType")
+     VALUES ($1, $2, 'Cyclic Test', 'Principal')`,
+    [randomUUID(), PLUGIN_NAME],
+  );
+}
+
+describe('runner — cyclic plugin batch (#627)', () => {
+  it('reconciles an A<->B parent loop into an acyclic tree with no persisted cycle', async () => {
+    await seedAlgorithm();
+    const runId = await enqueueRun(PLUGIN_NAME, { scopeSystemId: systemId }, 'contract-test', { awaitCompletion: true });
+
+    const { rows } = await pool.query(
+      `SELECT id, "parentContextId" FROM "Contexts"
+        WHERE "sourceAlgorithmId" IN (SELECT id FROM "ContextAlgorithms" WHERE name = $1)`,
+      [PLUGIN_NAME],
+    );
+    expect(rows).toHaveLength(2);
+
+    // The loop-closing link was skipped, so at most one of the two carries a parent.
+    expect(rows.filter((r) => r.parentContextId !== null).length).toBeLessThanOrEqual(1);
+
+    // No node is its own ancestor — walk each parent chain to a root, never revisiting.
+    const parentOf = new Map(rows.map((r) => [r.id, r.parentContextId]));
+    for (const start of parentOf.keys()) {
+      const seen = new Set();
+      let cur = start;
+      while (cur != null && !seen.has(cur)) { seen.add(cur); cur = parentOf.get(cur) ?? null; }
+      expect(cur).toBeNull(); // reached a root → acyclic (a cycle would leave cur non-null)
+    }
+
+    // The skip handled the loop up front, so the run succeeded (trigger never fired).
+    const run = await pool.query(`SELECT status FROM "ContextAlgorithmRuns" WHERE id = $1`, [runId]);
+    expect(run.rows[0].status).toBe('succeeded');
+  });
+});

--- a/app/api/src/contexts/cycleGuard.js
+++ b/app/api/src/contexts/cycleGuard.js
@@ -1,11 +1,19 @@
 // Guards against cyclic parentContextId chains in the Contexts tree.
 //
 // The Contexts self-FK (`Contexts_parentContextId_fkey`) is not deferrable and
-// only rejects a self-loop (A → A), never a multi-hop cycle (A → B → A). Read
-// queries defend against cycles at query time with SQL `CYCLE` clauses, but the
-// three write paths — the UI reparent (PATCH /contexts/:id), the ingest upsert,
-// and the plugin runner — could still PERSIST a cycle. These helpers close that
-// gap at the source.
+// only rejects a self-loop (A → A), never a multi-hop cycle (A → B → A). The
+// source-of-truth guarantee now lives in the database: migration 059's DEFERRABLE
+// INITIALLY DEFERRED constraint trigger rejects any cycle at COMMIT, from every
+// writer (#627). These two helpers are the app-layer complements to it:
+//   - wouldCreateCycle(): a fast PROACTIVE check so the UI reparent (PATCH
+//     /contexts/:id) and the plugin runner can pre-empt a cycle with a friendly
+//     error / a skipped link, instead of hitting an opaque transaction abort.
+//   - breakCycles(): a one-time / defensive CLEANUP that NULLs the offending
+//     parent of any node already on a cycle — for data that predates the trigger
+//     (the migration runs this once) or arrived via a trigger-disabled path. It's
+//     a no-op on a trigger-protected tree.
+// Read queries additionally defend at query time with SQL `CYCLE` clauses, so a
+// stray cycle can never hang them.
 //
 // `db` is anything exposing `query(text, params) -> { rows }` — the shared pool
 // or a transaction client both work.

--- a/app/api/src/contexts/plugins/runner.js
+++ b/app/api/src/contexts/plugins/runner.js
@@ -20,23 +20,16 @@
 import * as db from '../../db/connection.js';
 import { randomUUID } from 'crypto';
 import { getPlugin } from './registry.js';
-import { breakCycles, wouldCreateCycle } from '../cycleGuard.js';
-
-// Repair any parentContextId cycle a plugin's parent structure introduced, and
-// log if anything was broken. Kept as a module-level helper so the reconcile
-// routine that calls it stays within its complexity budget.
-async function repairPluginCycles(client, pluginName) {
-  const n = await breakCycles(client);
-  if (n) console.warn(`[context-plugin] ${pluginName}: broke ${n} cyclic parentContextId link(s)`);
-}
+import { wouldCreateCycle } from '../cycleGuard.js';
 
 // Second pass of reconcile: set parent pointers now that every target row exists.
 // Skips analyst-reparented nodes and unresolved parents, and — via wouldCreateCycle
 // — any link that would close a loop against the tree written so far this pass
 // (client sees the in-transaction rows), leaving that node a root rather than
-// writing-then-NULLing it. Extracted from reconcile to keep it under the
-// complexity ceiling; repairPluginCycles stays as the net for a batch-internal
-// cycle prevention can't see pre-persist.
+// writing it. Extracted from reconcile to keep it under the complexity ceiling.
+// Migration 059's deferred trigger is the backstop: a cycle that somehow survived
+// to commit aborts the run's transaction (surfaced as a failed run) rather than
+// being silently NULLed by a post-hoc repair (#627).
 async function linkContextParents(client, contexts, newByExternalId, reparentedIds, pluginName) {
   for (const node of contexts) {
     if (!node.externalId || !node.parentExternalId) continue;
@@ -309,10 +302,10 @@ async function reconcile(plugin, algorithmId, runId, params, result, instanceKey
     // 3b) Second pass: set parent pointers now that every target row exists.
     await linkContextParents(client, result.contexts, newByExternalId, reparentedIds, plugin.name);
 
-    // Fix-at-source: if the plugin's parentExternalId structure formed a loop,
-    // repair the stored tree now — before the member-count roll-up below
-    // recurses it — by NULLing the offending parent link(s).
-    await repairPluginCycles(client, plugin.name);
+    // Acyclicity is handled up front by linkContextParents (it skips a loop-closing
+    // link, leaving the node a root) and guaranteed by migration 059's deferred
+    // trigger at commit; the member-count roll-up below is itself CYCLE-guarded, so
+    // it can't hang. No post-hoc repair needed (#627).
 
     // 4) Remove contexts that previously belonged to this (algorithm, scope)
     //    but are no longer in the plugin's output.

--- a/app/api/src/db/migrations/059_context_acyclic_trigger.sql
+++ b/app/api/src/db/migrations/059_context_acyclic_trigger.sql
@@ -1,0 +1,86 @@
+-- Identity Atlas — enforce Contexts-tree acyclicity at the database (#627).
+--
+-- The Contexts self-FK ("Contexts_parentContextId_fkey") only rejects a 1-hop
+-- self-loop (A -> A), never a multi-hop cycle (A -> B -> A). Until now the
+-- invariant "the Contexts tree is acyclic" lived only in application code:
+-- wouldCreateCycle() on the UI reparent, and breakCycles() run after ingest /
+-- plugin batches. That has two problems this migration fixes at the source:
+--   1. every raw-SQL / migration / future writer bypasses the JS guards; and
+--   2. breakCycles "repaired" a cycle by SILENTLY NULLing an edge — trading a
+--      detectable error for undetectable corruption.
+--
+-- Move the invariant to the layer that owns the data: a DEFERRABLE INITIALLY
+-- DEFERRED constraint trigger checked at COMMIT. Deferring to commit lets a bulk
+-- set-based batch build up the full tree (a batch-internal transient cycle that
+-- resolves before commit is fine) while making it impossible for ANY writer to
+-- COMMIT a real cycle. A cyclic write now fails loudly (the transaction aborts
+-- with a check_violation) instead of being silently rewritten.
+
+-- 1. One-time cleanup. A constraint trigger validates only NEW writes, never
+--    pre-existing rows, so any cycle already stored (written before this trigger)
+--    would sit undetected until a later touch failed unexpectedly. NULL the
+--    parent of every node currently on a cycle so the tree is acyclic first.
+WITH RECURSIVE walk AS (
+    SELECT id, "parentContextId" AS cur, ARRAY[id] AS path
+      FROM "Contexts" WHERE "parentContextId" IS NOT NULL
+    UNION ALL
+    SELECT w.id, c."parentContextId", w.path || c.id
+      FROM walk w
+      JOIN "Contexts" c ON c.id = w.cur
+     WHERE c.id <> ALL(w.path)          -- stop the step that would revisit
+)
+UPDATE "Contexts" t
+   SET "parentContextId" = NULL
+ WHERE t.id IN (
+     SELECT w.id FROM walk w
+      JOIN "Contexts" c ON c.id = w.cur
+     WHERE c."parentContextId" = w.id
+ );
+
+-- 2. The check: is NEW.id currently on a cycle? Walk UP from NEW.id over the LIVE
+--    table and see whether the chain returns to NEW.id.
+--
+--    Crucially this re-reads the row's CURRENT parent rather than trusting
+--    NEW."parentContextId": a DEFERRED FOR EACH ROW trigger captures a STALE NEW
+--    for every intermediate update, but by commit the table already holds the
+--    final state — so a transaction that briefly loops the tree and then fixes it
+--    must pass. Re-reading is what makes that work; using the captured NEW value
+--    would reject a transient-then-resolved cycle. The CYCLE clause flags the row
+--    that closes a loop and stops recursion, so it terminates on any input.
+CREATE OR REPLACE FUNCTION "fn_Contexts_reject_cycle"() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    on_cycle boolean;
+BEGIN
+    SELECT EXISTS (
+        WITH RECURSIVE chain AS (
+            SELECT id, "parentContextId"
+              FROM "Contexts" WHERE id = NEW.id
+            UNION ALL
+            SELECT c.id, c."parentContextId"
+              FROM "Contexts" c
+              JOIN chain ch ON c.id = ch."parentContextId"
+        ) CYCLE id SET is_cycle USING path
+        SELECT 1 FROM chain WHERE id = NEW.id AND is_cycle
+    ) INTO on_cycle;
+
+    IF on_cycle THEN
+        RAISE EXCEPTION
+            'Context % is on a parentContextId cycle — the Contexts tree must stay acyclic',
+            NEW.id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- 3. Deferred constraint trigger. FOR EACH ROW, but checked at COMMIT because it
+--    is DEFERRABLE INITIALLY DEFERRED — so a transaction that passes through a
+--    cyclic intermediate state but resolves it before commit is allowed, while a
+--    cycle that survives to commit aborts the whole transaction.
+DROP TRIGGER IF EXISTS "trg_Contexts_reject_cycle" ON "Contexts";
+CREATE CONSTRAINT TRIGGER "trg_Contexts_reject_cycle"
+    AFTER INSERT OR UPDATE ON "Contexts"
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION "fn_Contexts_reject_cycle"();

--- a/app/api/src/routes/ingest.coverage.test.js
+++ b/app/api/src/routes/ingest.coverage.test.js
@@ -142,6 +142,30 @@ describe('ingest handler — single batch', () => {
     expect(normalized[0].governanceResource).toBe(true);
   });
 
+  it('returns 422 when a contexts batch would create a parentContextId cycle (#627)', async () => {
+    // The Contexts acyclicity trigger (migration 059) aborts the ingest() commit
+    // with a check_violation; the handler surfaces it as a 422 naming the context
+    // rather than an opaque 500.
+    mockIngest.mockRejectedValueOnce(Object.assign(
+      new Error('Context abc is on a parentContextId cycle — the Contexts tree must stay acyclic'),
+      { code: '23514' },
+    ));
+    const res = await request(app).post('/ingest/contexts').send({
+      records: [{ displayName: 'X', variant: 'synced', targetType: 'Principal', contextType: 'Department' }],
+      systemId: 1, syncMode: 'delta',
+    });
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatch(/cycle/i);
+    expect(res.body.message).toMatch(/parentContextId cycle/i);
+  });
+
+  it('still returns 500 for a non-cycle ingest failure', async () => {
+    mockIngest.mockRejectedValueOnce(Object.assign(new Error('relation missing'), { code: '42P01' }));
+    const res = await request(app).post('/ingest/principals').send(goodPrincipal);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/ingest failed/i);
+  });
+
   it('returns systemIds after a systems ingest', async () => {
     mockIngest.mockResolvedValue({ inserted: 1, updated: 0, deleted: 0 });
     mockQueryOne.mockResolvedValue({ id: 42 });
@@ -247,7 +271,11 @@ describe('POST /ingest/sync-log', () => {
   });
 });
 
-// ── POST /ingest/contexts — parent-cycle repair (A3) ─────────────────────────
+// ── POST /ingest/contexts — DB-enforced acyclicity (#627) ────────────────────
+// The old silent breakCycles-after-ingest repair is gone; a cyclic contexts
+// batch now aborts its own commit (migration-059 trigger) and is surfaced as a
+// 422 (see the 422 test in "single batch" above). A clean batch must not issue
+// the old repair UPDATE.
 const CYCLE_REPAIR_RE = /UPDATE\s+"Contexts"[\s\S]*"parentContextId"\s*=\s*NULL/i;
 const goodContext = {
   records: [{ displayName: 'Dept', variant: 'synced', targetType: 'Identity', contextType: 'Department' }],
@@ -255,36 +283,12 @@ const goodContext = {
   syncMode: 'full',
 };
 
-describe('POST /ingest/contexts — parent-cycle repair', () => {
-  it('runs breakCycles after a contexts batch that wrote rows', async () => {
+describe('POST /ingest/contexts — DB-enforced acyclicity', () => {
+  it('ingests a clean contexts batch with no app-side cycle repair', async () => {
     mockIngest.mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0 });
-    const res = await request(app).post('/ingest/contexts').send(goodContext);
-    expect(res.status).toBe(201);
-    expect(mockQuery.mock.calls.some(([sql]) => CYCLE_REPAIR_RE.test(sql))).toBe(true);
-  });
-
-  it('does NOT run the cycle repair for a non-contexts entity', async () => {
-    mockIngest.mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0 });
-    const res = await request(app).post('/ingest/principals').send(goodPrincipal);
-    expect(res.status).toBe(201);
-    expect(mockQuery.mock.calls.some(([sql]) => CYCLE_REPAIR_RE.test(sql))).toBe(false);
-  });
-
-  it('skips the repair when the batch wrote no rows', async () => {
-    mockIngest.mockResolvedValueOnce({ inserted: 0, updated: 0, deleted: 0 });
     const res = await request(app).post('/ingest/contexts').send(goodContext);
     expect(res.status).toBe(201);
     expect(mockQuery.mock.calls.some(([sql]) => CYCLE_REPAIR_RE.test(sql))).toBe(false);
-  });
-
-  it('a breakCycles failure is non-fatal (still 201)', async () => {
-    mockIngest.mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0 });
-    mockQuery.mockImplementation((sql) =>
-      CYCLE_REPAIR_RE.test(sql)
-        ? Promise.reject(new Error('boom'))
-        : Promise.resolve({ rows: [], rowCount: 0 }));
-    const res = await request(app).post('/ingest/contexts').send(goodContext);
-    expect(res.status).toBe(201);
   });
 });
 

--- a/app/api/src/routes/ingest/handlers.js
+++ b/app/api/src/routes/ingest/handlers.js
@@ -15,7 +15,7 @@ import { crawlerHasSystemAccess, crawlerHasPermission } from '../../middleware/c
 import { normalizePresenceQuery, lookupCrawlerPresence } from '../../ingest/crawlerPresence.js';
 import {
   applyIngestDefaults, recoverSystemPrefix, buildScope, conflictFilterFor, discoverCoreColumns,
-  handleSessionPath, applyDeleteByIds, lookupSystemIds, writeAuditLog,
+  handleSessionPath, applyDeleteByIds, lookupSystemIds, writeAuditLog, ingestErrorResponse,
 } from './helpers.js';
 
 const router = Router();
@@ -101,13 +101,9 @@ function createIngestHandler(entityType) {
       console.error(`Ingest error (${entityType}):`, err.message);
       await writeSyncLog(null, `API-${entityType}`, tableName, startTime,
                          body.records?.length || 0, 0, 0, 0, err.message).catch(() => {});
-      // A parentContextId cycle is rejected at COMMIT by the Contexts acyclicity
-      // trigger (migration 059). Surface it as a clear 422 (the batch's source
-      // tree is malformed — the caller's to fix) rather than an opaque 500.
-      if (err.code === '23514' && /parentContextId cycle/i.test(err.message || '')) {
-        return res.status(422).json({ error: 'Context hierarchy would create a cycle', message: err.message });
-      }
-      return res.status(500).json({ error: 'Ingest failed', message: err.message });
+      // 422 for a context-cycle rejection (migration 059's trigger), else 500.
+      const errRes = ingestErrorResponse(err);
+      return res.status(errRes.status).json(errRes.body);
     }
   };
 }

--- a/app/api/src/routes/ingest/handlers.js
+++ b/app/api/src/routes/ingest/handlers.js
@@ -15,7 +15,7 @@ import { crawlerHasSystemAccess, crawlerHasPermission } from '../../middleware/c
 import { normalizePresenceQuery, lookupCrawlerPresence } from '../../ingest/crawlerPresence.js';
 import {
   applyIngestDefaults, recoverSystemPrefix, buildScope, conflictFilterFor, discoverCoreColumns,
-  handleSessionPath, applyDeleteByIds, lookupSystemIds, writeAuditLog, repairContextCyclesAfterIngest,
+  handleSessionPath, applyDeleteByIds, lookupSystemIds, writeAuditLog,
 } from './helpers.js';
 
 const router = Router();
@@ -76,7 +76,10 @@ function createIngestHandler(entityType) {
       const delErr = await applyDeleteByIds(body, tableName, result);
       if (delErr) return res.status(delErr.status).json(delErr.body);
 
-      await repairContextCyclesAfterIngest(entityType, result);
+      // Context-tree acyclicity is enforced at the database (migration 059's
+      // deferred trigger) — a cyclic batch aborts the ingest() commit above and is
+      // handled in catch. The old post-ingest breakCycles repair is gone: it
+      // silently NULLed an edge instead of surfacing the malformed input.
 
       await writeSyncLog(null, `API-${entityType}`, tableName, startTime,
                          body.records.length, result.inserted, result.updated, result.deleted, null);
@@ -98,6 +101,12 @@ function createIngestHandler(entityType) {
       console.error(`Ingest error (${entityType}):`, err.message);
       await writeSyncLog(null, `API-${entityType}`, tableName, startTime,
                          body.records?.length || 0, 0, 0, 0, err.message).catch(() => {});
+      // A parentContextId cycle is rejected at COMMIT by the Contexts acyclicity
+      // trigger (migration 059). Surface it as a clear 422 (the batch's source
+      // tree is malformed — the caller's to fix) rather than an opaque 500.
+      if (err.code === '23514' && /parentContextId cycle/i.test(err.message || '')) {
+        return res.status(422).json({ error: 'Context hierarchy would create a cycle', message: err.message });
+      }
       return res.status(500).json({ error: 'Ingest failed', message: err.message });
     }
   };

--- a/app/api/src/routes/ingest/helpers.js
+++ b/app/api/src/routes/ingest/helpers.js
@@ -166,3 +166,15 @@ export function writeAuditLog(req, body) {
 // constraint trigger, #627), so the old reactive breakCycles-after-ingest repair
 // was removed: a cyclic contexts batch now aborts its own ingest() commit and is
 // surfaced as a 422 by the handler, instead of being silently NULLed here.
+
+// Map an ingest failure to an HTTP response. A parentContextId cycle is rejected
+// at COMMIT by the Contexts acyclicity trigger (migration 059) — surface it as a
+// clear 422 (a malformed source tree, the caller's to fix) rather than an opaque
+// 500. Extracted from the handler's catch so the handler stays under the cognitive
+// complexity ceiling.
+export function ingestErrorResponse(err) {
+  if (err.code === '23514' && /parentContextId cycle/i.test(err.message || '')) {
+    return { status: 422, body: { error: 'Context hierarchy would create a cycle', message: err.message } };
+  }
+  return { status: 500, body: { error: 'Ingest failed', message: err.message } };
+}

--- a/app/api/src/routes/ingest/helpers.js
+++ b/app/api/src/routes/ingest/helpers.js
@@ -9,7 +9,6 @@
 import * as db from '../../db/connection.js';
 import { SOFT_DELETE_TABLES } from '../../ingest/engine.js';
 import { startSession, continueSession, endSession, hasSession } from '../../ingest/sessions.js';
-import { breakCycles } from '../../contexts/cycleGuard.js';
 
 export function applyIngestDefaults(entityType, body) {
   if (!Array.isArray(body.records)) body.records = [];
@@ -163,18 +162,7 @@ export function writeAuditLog(req, body) {
   ).catch(() => {});
 }
 
-// Contexts self-reference via parentContextId; a mis-parented synced tree can
-// persist a cycle. True prevention isn't feasible for a set-based bulk upsert (a
-// batch-internal A->B->A loop is invisible pre-persist), so repair reactively per
-// contexts batch — don't wait for the end-of-sync refresh-views call, which a
-// delta/partial crawl may never make. No-op on a clean tree. Extracted from the
-// handler so the generic ingest path stays under the complexity ceiling.
-export async function repairContextCyclesAfterIngest(entityType, result) {
-  if (entityType !== 'contexts' || (result.inserted + result.updated) <= 0) return;
-  try {
-    const broken = await breakCycles(db);
-    if (broken) console.warn(`Ingest contexts: broke ${broken} cyclic parentContextId link(s)`);
-  } catch (cycErr) {
-    console.warn('Ingest contexts cycle repair failed (non-fatal):', cycErr.message);
-  }
-}
+// Context-tree acyclicity is enforced at the database (migration 059's deferred
+// constraint trigger, #627), so the old reactive breakCycles-after-ingest repair
+// was removed: a cyclic contexts batch now aborts its own ingest() commit and is
+// surfaced as a 422 by the handler, instead of being silently NULLed here.

--- a/app/api/src/routes/ingest/matrixViews.js
+++ b/app/api/src/routes/ingest/matrixViews.js
@@ -42,11 +42,11 @@ router.post('/ingest/refresh-views', async (req, res) => {
       console.warn('lastSyncDateTime update failed (non-fatal):', tsErr.message);
     }
 
-    // Fix-at-source: a crawler can emit a mis-parented context tree (or an IGA
-    // export with a loop), persisting a cyclic parentContextId. The roll-up
-    // below is CYCLE-guarded so it won't hang, but a stored cycle would still
-    // leave totalMemberCount undefined for the looped subtree — so repair the
-    // stored state first (NULL the offending parent link, logged).
+    // Defensive: migration 059's trigger prevents new cycles, but breakCycles
+    // here still cleans any cycle that predates the trigger (or arrived via a
+    // trigger-disabled path) so the CYCLE-guarded roll-up below computes a
+    // complete totalMemberCount for every subtree. A no-op on a trigger-protected
+    // tree (#627).
     try {
       const broken = await breakCycles(db);
       if (broken) console.warn(`Context cycle guard: broke ${broken} cyclic parentContextId link(s) after ingest`);

--- a/changes/context-cycle-db-enforcement-627.md
+++ b/changes/context-cycle-db-enforcement-627.md
@@ -1,0 +1,1 @@
+- The Contexts hierarchy (departments, org units, tags) is now guaranteed acyclic at the database level: any change that would create a parent-child loop is rejected outright, so a mis-configured source tree surfaces as a clear error instead of being silently altered. Bulk imports that briefly build an intermediate state and resolve it before finishing are unaffected.


### PR DESCRIPTION
**Draft — delivered in slices on this branch.** Implements the architecturally sound resolution of #627: move the "the Contexts tree is acyclic" invariant from scattered application code to the layer that owns the data — a **deferred DB constraint trigger** — and replace silent repair with fail-loud.

### Why (the decision)

Acyclicity is an invariant of the *data*, so it belongs in the *database*, not in every JS write path. Today it's enforced only in application code (`wouldCreateCycle` on the UI reparent; `breakCycles` repair after ingest/plugin batches). That has two flaws #627 names:
1. every raw-SQL / migration / future writer **bypasses** the JS guards (gap #3); and
2. `breakCycles` "repairs" a cycle by **silently NULLing an edge** — trading a detectable error for undetectable corruption.

A **`DEFERRABLE INITIALLY DEFERRED`** constraint trigger checked at COMMIT resolves the only real objection to DB enforcement (a bulk set-based batch can't validate pre-persist): the batch builds the full tree, and the invariant is checked once at commit. A cycle that survives to commit now **aborts the transaction** (fail loud) instead of being silently rewritten.

### Slices

- [x] **DB trigger (migration 059)** + one-time cleanup of any pre-existing cycle. The trigger re-reads the row's *live* parent (not the captured, possibly-stale `NEW`) so a transient-then-resolved batch passes.
- [x] **Trigger contract test** — commits acyclic; aborts 2/3-cycle + self-loop; allows transient-then-resolved (real PG16).
- [x] **Fix the two affected contract tests** — `cycleGuard` / `contexts` now seed their *pre-existing-cycle* fixtures with triggers off for that connection (`session_replication_role`, reset in `finally`).
- [ ] **Ingest** — catch the trigger's `check_violation` and surface which context looped; drop the now-redundant silent `breakCycles` from the ingest path (+ delta contract test, #627 gap #2).
- [ ] **Plugin runner** — same: let a batch-internal cycle abort + report instead of silently repairing; keep `wouldCreateCycle` as the proactive skip (+ runner contract test, #627 gap #1).
- [ ] **Reconcile `breakCycles`** to its remaining role (one-time / defensive cleanup) + docs.

### Semantics change to review

A crawler/plugin batch carrying a cyclic source tree will now **fail loudly** instead of self-healing. That's the *correct* behavior (bad source data becomes visible), but it's the product call worth a look — hence draft.

Contract tests green so far: 15 (trigger + the two reconciled fixtures). Keeps #627's read-side `CYCLE` guards as the last-resort net for any cycle that predates the trigger.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)
