### PR TITLE
fix(demo): correct Verify-DemoDataset row counts for group ownership (#713)

### DIFF
--- a/changes/verify-demo-rowcounts-713.md
+++ b/changes/verify-demo-rowcounts-713.md
@@ -1,0 +1,1 @@
+- Corrected the demo-dataset verification's expected resource and relationship counts to include the group-ownership data added in the previous release, so the integration check passes against the current demo dataset.

--- a/test/demo-dataset/Verify-DemoDataset.ps1
+++ b/test/demo-dataset/Verify-DemoDataset.ps1
@@ -84,9 +84,9 @@ Write-Host "`n--- Row Counts ---" -ForegroundColor Yellow
 $counts = @{
     'Systems'                = @{ Min = 3;  Max = 3 }
     'Principals'             = @{ Min = 27; Max = 30 }  # 22 employees + edge cases + omada account
-    'Resources'              = @{ Min = 14; Max = 14 }
+    'Resources'              = @{ Min = 17; Max = 17 }  # 6 groups + 2 dir roles + 2 app roles + 4 business roles + 3 group-ownership (#713)
     'ResourceAssignments'    = @{ Min = 50; Max = 120 }
-    'ResourceRelationships'  = @{ Min = 9;  Max = 9 }
+    'ResourceRelationships'  = @{ Min = 12; Max = 12 }  # 8 Contains + 1 GrantsAccessTo + 3 HasOwnership (#713)
     'Identities'             = @{ Min = 20; Max = 25 }
     'IdentityMembers'        = @{ Min = 20; Max = 40 }
     'GovernanceCatalogs'     = @{ Min = 2;  Max = 2 }


### PR DESCRIPTION
Follow-up to #713 (PR #745). That change added **3 GroupOwnership resources** (14→17) and **3 HasOwnership relationships** (9→12) to the demo dataset — and updated the docs + added ownership checks — but missed the **exact-count `RowCount` table** in `test/demo-dataset/Verify-DemoDataset.ps1`:

```
'Resources'             = @{ Min = 14; Max = 14 }
'ResourceRelationships' = @{ Min = 9;  Max = 9 }
```

It stayed hidden because #745 touched only `test/` + `docs/`, so the **Integration Tests** job (gated on `app/api/src` changes) **skipped** and never re-ran the verify script. The next `app/api/src` PR to run it fails with:

```
FAIL  RowCount-Resources              Got 17 (expected 14-14)
FAIL  RowCount-ResourceRelationships  Got 12 (expected 9-9)
```

Fix: bump the two exact counts to **17 / 12** (with a comment breaking down the composition). `ResourceAssignments` is already a range (50–120), so 73 passes.

This unblocks the integration job on `main` for every `app/api/src` PR (it currently surfaced on the #627 draft #746).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
