### PR TITLE
docs(api): fix perf-endpoint reference + complete & enforce the OpenAPI spec

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,1 +1,39 @@
 extends: ["spectral:oas"]
+
+# The bare `spectral:oas` ruleset lets a thin spec pass trivially — most
+# documentation-quality rules ship at `warn`, so `spectral lint` exits 0 even
+# when operations lack operationIds, descriptions, or reference undeclared tags.
+# Elevate the documentation-completeness rules to `error` so CI actually blocks
+# regressions, and add one house rule the OAS ruleset doesn't cover.
+rules:
+  # Every operation must be uniquely and safely addressable (codegen/tooling).
+  operation-operationId: error
+  operation-operationId-unique: error
+  operation-operationId-valid-in-url: error
+
+  # Every operation must be documented and correctly categorised.
+  operation-description: error
+  operation-tag-defined: error
+  operation-tags: error
+
+  # A success response must always be described.
+  operation-success-response: error
+
+  # API-level metadata must be present (contact block + description).
+  info-contact: error
+  info-description: error
+
+  # Catch common authoring mistakes as errors rather than warnings.
+  no-$ref-siblings: error
+  duplicated-entry-in-enum: error
+  typed-enum: error
+
+  # House rule: every operation carries a non-empty summary.
+  operation-summary:
+    description: Every operation must have a non-empty summary.
+    message: "Operation must have a summary."
+    given: "$.paths[*][get,put,post,delete,patch,options,head]"
+    severity: error
+    then:
+      field: summary
+      function: truthy

--- a/app/api/CLAUDE.md
+++ b/app/api/CLAUDE.md
@@ -69,6 +69,10 @@ Migration files are numbered sequentially (`001_core_schema.sql`, `002_governanc
 | `middleware/auth.js` | Entra ID JWT validation (v1+v2 tokens) |
 | `middleware/perfMetrics.js` | Request timing + Server-Timing headers |
 
+## OpenAPI spec & drift guard
+
+`src/openapi.yaml` documents the public API surface; `.spectral.yaml` lints its syntax (the `Lint: OpenAPI spec` PR gate). Separately, `routes/openapi.drift.test.js` classifies every router module under `routes/` as **documented** (at least one of its routes appears in `openapi.yaml`) or **undocumented** (read/internal APIs, listed in an explicit allowlist inside that test). A **new router module that is neither documented nor allowlisted fails the completeness test.** So when you add a router: either document its routes in `openapi.yaml`, or add the file to the undocumented allowlist in `openapi.drift.test.js` — otherwise the suite goes red.
+
 ## Crawler Job System
 
 Crawler types and their config schemas are auto-discovered from `tools/crawlers/*/crawler.json` manifests at startup. See `tools/crawlers/CLAUDE.md` for the manifest schema.

--- a/app/api/src/openapi.yaml
+++ b/app/api/src/openapi.yaml
@@ -31,6 +31,8 @@ tags:
     description: Crawler self-service (API key rotation, identity)
   - name: Admin
     description: Crawler management (requires Entra ID auth)
+  - name: Effective Access
+    description: On-demand effective-access resolution — computed per request, never stored
 
 paths:
   # ─── Ingest Endpoints ──────────────────────────────────────────
@@ -38,6 +40,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest systems
+      operationId: ingestSystems
       description: Upsert system records. Systems don't require a systemId in the envelope.
       requestBody:
         required: true
@@ -63,6 +66,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest principals
+      operationId: ingestPrincipals
       description: Upsert principal records (users, service principals, etc.). Scope by principalType for full sync deletes.
       requestBody:
         required: true
@@ -80,6 +84,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest resources
+      operationId: ingestResources
       description: Upsert resource records (groups, roles, apps, business roles). Scope by resourceType.
       requestBody:
         required: true
@@ -95,6 +100,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest resource assignments
+      operationId: ingestResourceAssignments
       description: Upsert assignments (who has access to what). Composite key (resourceId, principalId, assignmentType). Scope by assignmentType.
       requestBody:
         required: true
@@ -110,6 +116,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest resource relationships
+      operationId: ingestResourceRelationships
       description: Upsert resource-to-resource links (Contains, GrantsAccessTo). Scope by relationshipType.
       requestBody:
         required: true
@@ -125,6 +132,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest identities
+      operationId: ingestIdentities
       description: Upsert real-person identity records.
       requestBody:
         required: true
@@ -140,6 +148,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest identity members
+      operationId: ingestIdentityMembers
       description: Upsert identity-to-principal links.
       requestBody:
         required: true
@@ -155,6 +164,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest contexts
+      operationId: ingestContexts
       description: Upsert organizational contexts (departments, OUs, classifications). Scope by contextType.
       requestBody:
         required: true
@@ -170,6 +180,8 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest governance catalogs
+      operationId: ingestGovernanceCatalogs
+      description: Upsert governance catalogs (access-package catalogs / IGA sources).
       requestBody:
         required: true
         content:
@@ -184,6 +196,8 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest assignment policies
+      operationId: ingestAssignmentPolicies
+      description: Upsert assignment policies (approval and settings for business-role assignment).
       requestBody:
         required: true
         content:
@@ -198,6 +212,8 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest assignment requests
+      operationId: ingestAssignmentRequests
+      description: Upsert assignment requests (access requests and their state).
       requestBody:
         required: true
         content:
@@ -212,6 +228,8 @@ paths:
     post:
       tags: [Ingest]
       summary: Ingest certification decisions
+      operationId: ingestCertificationDecisions
+      description: Upsert certification decisions (access-review outcomes).
       requestBody:
         required: true
         content:
@@ -226,6 +244,7 @@ paths:
     post:
       tags: [Ingest]
       summary: Refresh materialized views
+      operationId: refreshMaterializedViews
       description: Triggers a refresh of cached SQL views. Requires refreshViews permission.
       responses:
         '200':
@@ -238,6 +257,7 @@ paths:
     get:
       tags: [Crawlers]
       summary: Get own identity
+      operationId: getOwnCrawlerIdentity
       description: Returns the authenticated crawler's metadata.
       responses:
         '200':
@@ -251,6 +271,7 @@ paths:
     post:
       tags: [Crawlers]
       summary: Rotate own API key
+      operationId: rotateOwnApiKey
       description: Generates a new key and immediately invalidates the current one.
       responses:
         '200':
@@ -265,6 +286,8 @@ paths:
     get:
       tags: [Admin]
       summary: List all crawlers
+      operationId: listCrawlers
+      description: List all registered crawlers (Entra ID auth required).
       security:
         - EntraIdBearer: []
       responses:
@@ -273,6 +296,8 @@ paths:
     post:
       tags: [Admin]
       summary: Register a new crawler
+      operationId: registerCrawler
+      description: Register a new crawler and return its one-time API key.
       security:
         - EntraIdBearer: []
       requestBody:
@@ -289,6 +314,8 @@ paths:
     patch:
       tags: [Admin]
       summary: Update crawler
+      operationId: updateCrawler
+      description: Update a crawler's metadata, permissions, or system scope.
       security:
         - EntraIdBearer: []
       parameters:
@@ -303,6 +330,8 @@ paths:
     delete:
       tags: [Admin]
       summary: Disable crawler
+      operationId: disableCrawler
+      description: Disable a crawler (soft delete; its API key stops working).
       security:
         - EntraIdBearer: []
       parameters:
@@ -319,6 +348,8 @@ paths:
     post:
       tags: [Admin]
       summary: Admin-initiated key reset
+      operationId: resetCrawlerKey
+      description: Admin-initiated API-key reset; returns a new one-time key.
       security:
         - EntraIdBearer: []
       parameters:
@@ -335,6 +366,8 @@ paths:
     get:
       tags: [Admin]
       summary: Get crawler audit log
+      operationId: getCrawlerAuditLog
+      description: Return the crawler's paginated audit log.
       security:
         - EntraIdBearer: []
       parameters:
@@ -361,6 +394,7 @@ paths:
     get:
       tags: [Effective Access]
       summary: Effective access of one principal on one resource
+      operationId: resolveEffectiveAccess
       description: >
         Resolves whether a principal effectively holds a resource — direct grants plus grants
         reached via (transitive) group membership — returning the effect and the reachability
@@ -389,6 +423,7 @@ paths:
     get:
       tags: [Effective Access]
       summary: Effective capabilities a principal holds at a resource/node
+      operationId: getResourceEffectiveAccess
       description: >
         Down-expansion: includes capabilities inherited from ancestor nodes via the Contains
         hierarchy, computed on demand and never stored. One row per capability.
@@ -416,6 +451,7 @@ paths:
     get:
       tags: [Effective Access]
       summary: Effective capabilities a principal holds at a given node
+      operationId: getPrincipalEffectiveAccess
       description: >
         Principal-centric form of the node down-expansion; includes inherited capabilities.
       security:

--- a/changes/docs-openapi-hygiene.md
+++ b/changes/docs-openapi-hygiene.md
@@ -1,0 +1,3 @@
+- Corrected the Performance Metrics API reference: the endpoint is `GET /api/perf/slow` (was documented as `/api/perf/slowest`, which 404s), and documented the previously-missing `POST /api/perf/toggle`.
+- Completed the OpenAPI spec: every operation now has a unique `operationId` and a description, and the `Effective Access` tag is declared.
+- Strengthened OpenAPI linting so incomplete spec changes fail CI (operationId, description, tags, and success-response rules are now enforced as errors instead of silently warning).

--- a/docs/api/entities.md
+++ b/docs/api/entities.md
@@ -669,9 +669,10 @@ Performance monitoring is opt-in. Enable by setting `PERF_METRICS_ENABLED=true`.
 |---|---|---|
 | `/api/perf` | `GET` | Aggregated endpoint summaries — P50, P95, P99 latency per route |
 | `/api/perf/recent` | `GET` | Last N requests with per-SQL-query timing breakdowns |
-| `/api/perf/slowest` | `GET` | Slowest N requests (by total duration) |
+| `/api/perf/slow` | `GET` | Slowest N requests (by total duration) |
 | `/api/perf/export` | `GET` | Download full ring buffer as JSON for offline analysis |
-| `/api/perf/clear` | `POST` | Clear the ring buffer (admin use) |
+| `/api/perf/clear` | `POST` | Clear the ring buffer (admin only) |
+| `/api/perf/toggle` | `POST` | Enable/disable the collector at runtime (admin only) |
 
 The ring buffer holds 1000 entries. When disabled (`PERF_METRICS_ENABLED` is unset or `false`), no overhead is incurred — the middleware is a no-op.
 


### PR DESCRIPTION
Fixes the two open **Documentation** issues from the June 2026 audit backlog.

## `Closes #802` — perf endpoint reference
`docs/api/entities.md` listed `GET /api/perf/slowest`, which 404s — the real route is `GET /api/perf/slow`. Corrected it and documented the previously-omitted `POST /api/perf/toggle` (both `/clear` and `/toggle` are admin-only).

## `Closes #803` — OpenAPI spec was passing linting trivially
The bare `spectral:oas` ruleset ships its documentation rules at `warn`, so `spectral lint` exited 0 despite the spec having **0 operationIds**, 10 operations with no description, and an `Effective Access` tag used by 3 operations but never declared. Baseline: **37 warnings, 0 errors**.

- **Completed the spec:** unique `operationId` on all 24 operations, descriptions on the 10 that lacked one, `Effective Access` tag declared.
- **Enforced it:** `.spectral.yaml` now elevates the completeness rules (operationId + uniqueness + url-safety, description, tags, tag-defined, success-response, and a house `operation-summary` rule) to `error`, so an incomplete spec change now fails CI instead of warning silently.

Verified locally: `spectral lint app/api/src/openapi.yaml` → **0 errors**. The `openapi.drift.test.js` suite still passes (5/5) — no paths changed, so the documented-router surface is unchanged.

Docs/spec/CI-config only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #802
Closes #803
