### PR TITLE
fix(ui,api): server-side sort for paginated list pages (#771)

### DIFF
--- a/app/api/contract-tests/resources.contract.test.js
+++ b/app/api/contract-tests/resources.contract.test.js
@@ -62,4 +62,24 @@ describe('GET /resources', () => {
     expect(res.body.data.every(r => r.resourceType !== 'BusinessRole')).toBe(true);
     expect(res.body.data.some(r => r.displayName === 'Joiner Package')).toBe(false);
   });
+
+  it('sorts the full result set server-side by the requested column + direction (H-14)', async () => {
+    // Descending by displayName across all four non-BusinessRole rows — proves
+    // the dynamic ORDER BY (buildOrderBy over the page CTE's output alias) runs
+    // against the real schema, not just the default ASC path.
+    const res = await agent.get(`/api/resources?systemId=${systemId}&sort=displayName&dir=desc`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.map(r => r.displayName))
+      .toEqual(['Sales App', 'Global Admin', 'Finance', 'Engineering']);
+
+    // A different allow-listed column must also execute (alias resolution).
+    const byType = await agent.get(`/api/resources?systemId=${systemId}&sort=resourceType&dir=asc`);
+    expect(byType.status).toBe(200);
+    expect(byType.body.data.length).toBe(4);
+
+    // An unknown/injection sort key falls back to the default order, not an error.
+    const bad = await agent.get(`/api/resources?systemId=${systemId}&sort=id;DROP&dir=desc`);
+    expect(bad.status).toBe(200);
+    expect(bad.body.data.length).toBe(4);
+  });
 });

--- a/app/api/src/lib/listSort.js
+++ b/app/api/src/lib/listSort.js
@@ -1,0 +1,24 @@
+// Safe ORDER BY builder for the paginated list endpoints (/api/users,
+// /api/resources, /api/identities).
+//
+// The list pages sort a *column*, not the current page: the UI sends
+// `?sort=<columnKey>&dir=<asc|desc>` and the server must order the full result
+// set before it paginates (audit H-14 — the old client-side sort only reordered
+// the 100 rows already on screen, so "top N" was wrong past page 1).
+//
+// Neither `sort` nor `dir` is ever interpolated into SQL: `sort` is looked up in
+// a static per-endpoint allowlist that maps a column key to an already-quoted
+// SQL column expression, and `dir` collapses to the literal `ASC`/`DESC`. An
+// unknown column key (or an injection attempt) falls back to a fixed default.
+//
+// @param {string|undefined} sort      column key from the query string
+// @param {string|undefined} dir       'asc' | 'desc' (case-insensitive)
+// @param {Record<string,string>} allowed  colKey -> quoted SQL column expression
+// @param {string} [fallback]          full ORDER BY expression when sort is unknown
+// @returns {string} e.g. `"displayName" DESC` — safe to interpolate into ORDER BY
+export function buildOrderBy(sort, dir, allowed, fallback = '"displayName" ASC') {
+  const col = allowed[sort];
+  if (!col) return fallback;
+  const direction = String(dir).toLowerCase() === 'desc' ? 'DESC' : 'ASC';
+  return `${col} ${direction}`;
+}

--- a/app/api/src/lib/listSort.test.js
+++ b/app/api/src/lib/listSort.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildOrderBy } from './listSort.js';
+
+const ALLOWED = {
+  displayName: '"displayName"',
+  accountCount: '"accountCount"',
+  department: '"department"',
+};
+
+describe('buildOrderBy', () => {
+  it('maps an allowed column + asc/desc to a safe ORDER BY expression', () => {
+    expect(buildOrderBy('accountCount', 'asc', ALLOWED)).toBe('"accountCount" ASC');
+    expect(buildOrderBy('accountCount', 'desc', ALLOWED)).toBe('"accountCount" DESC');
+  });
+
+  it('treats the direction case-insensitively and defaults unknown directions to ASC', () => {
+    expect(buildOrderBy('department', 'DESC', ALLOWED)).toBe('"department" DESC');
+    expect(buildOrderBy('department', 'Desc', ALLOWED)).toBe('"department" DESC');
+    expect(buildOrderBy('department', 'sideways', ALLOWED)).toBe('"department" ASC');
+    expect(buildOrderBy('department', undefined, ALLOWED)).toBe('"department" ASC');
+  });
+
+  it('falls back to the default when the sort column is unknown, missing, or an injection attempt', () => {
+    expect(buildOrderBy(undefined, 'asc', ALLOWED)).toBe('"displayName" ASC');
+    expect(buildOrderBy('nope', 'desc', ALLOWED)).toBe('"displayName" ASC');
+    // An injection attempt is not a key in the allowlist, so it never reaches SQL.
+    expect(buildOrderBy('id; DROP TABLE "Principals"; --', 'desc', ALLOWED))
+      .toBe('"displayName" ASC');
+  });
+
+  it('honours a caller-supplied fallback expression', () => {
+    expect(buildOrderBy('unknown', 'asc', ALLOWED, '"accountCount" DESC'))
+      .toBe('"accountCount" DESC');
+  });
+
+  it('never lets a column outside the allowlist through even with a valid-looking name', () => {
+    // "password" is a real-ish column name but not allow-listed → fallback.
+    expect(buildOrderBy('password', 'asc', ALLOWED)).toBe('"displayName" ASC');
+  });
+});

--- a/app/api/src/routes/identities/list.js
+++ b/app/api/src/routes/identities/list.js
@@ -9,9 +9,23 @@ import { Router } from 'express';
 import { timedQuery } from '../../perf/sqlTimer.js';
 import { createParams } from '../../db/sqlParams.js';
 import { isMissingSchema } from '../../db/schemaErrors.js';
+import { buildOrderBy } from '../../lib/listSort.js';
 import { useSql, db, hasTable } from './shared.js';
 
 const router = Router();
+
+// Columns the Identities page lets you sort by (its TABLE_COLUMNS keys), plus
+// two legacy keys (confidence/linkedAt) other callers pass. Values are the page
+// CTE's output aliases — safe to interpolate; see lib/listSort.js.
+const IDENTITY_SORTS = {
+  displayName: '"displayName"',
+  primaryAccountUpn: '"primaryAccountUpn"',
+  accountCount: '"accountCount"',
+  department: '"department"',
+  jobTitle: '"jobTitle"',
+  confidence: '"linkConfidence"',
+  linkedAt: '"linkedAt"',
+};
 
 function parseTagString(tagString) {
   if (!tagString) return [];
@@ -32,7 +46,7 @@ router.get('/identities', async (req, res) => {
       return res.json({ available: false, data: [], total: 0, summary: null });
     }
 
-    const { search, minAccounts, confidence, hrAnchored, orphanStatus, sort, limit, offset } = req.query;
+    const { search, minAccounts, confidence, hrAnchored, orphanStatus, sort, dir, limit, offset } = req.query;
     const pageLimit = Math.min(parseInt(limit) || 50, 500);
     const pageOffset = parseInt(offset) || 0;
 
@@ -137,15 +151,9 @@ router.get('/identities', async (req, res) => {
           AND _it."name" = ${bind(identityTagFilter)} AND _it."entityType" = 'identity'`;
     }
 
-    // Sort
-    const ALLOWED_SORTS = {
-      'accountCount': '"accountCount" DESC',
-      'confidence': '"linkConfidence" DESC',
-      'displayName': '"displayName" ASC',
-      'department': 'department ASC',
-      'linkedAt': '"linkedAt" DESC',
-    };
-    const orderBy = ALLOWED_SORTS[sort] || '"displayName" ASC';
+    // Sort the whole result set server-side (audit H-14), column + direction
+    // from the query; unknown columns fall back to displayName ASC.
+    const orderBy = buildOrderBy(sort, dir, IDENTITY_SORTS);
 
     // Page first, then resolve tags only for the page rows; count only on page 1.
     // (Same export-pagination fix as /api/users — the per-row tag subquery used to

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { timedQuery } from '../perf/sqlTimer.js';
 import { createParams } from '../db/sqlParams.js';
 import { parseJsonbColumn } from '../lib/jsonb.js';
+import { buildOrderBy } from '../lib/listSort.js';
 import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
 import { ensureTagTables, buildFilterWhere } from './tags.js';
 import { isMissingSchema } from '../db/schemaErrors.js';
@@ -10,6 +11,15 @@ const router = Router();
 const useSql = process.env.USE_SQL === 'true';
 const UUID_RE = /^[0-9a-f-]{36}$/i;
 const SYSTEM_COLS = new Set(['SysStartTime', 'SysEndTime']);
+
+// Columns the Groups/Resources page lets you sort by (its TABLE_COLUMNS keys).
+// Values are the page CTE's output aliases — safe to interpolate; see
+// lib/listSort.js.
+const RESOURCE_SORTS = {
+  displayName: '"displayName"',
+  resourceType: '"resourceType"',
+  description: '"description"',
+};
 
 let db = null;
 if (useSql) {
@@ -128,6 +138,10 @@ router.get('/resources', async (req, res) => {
     // params before binding the page window so the COUNT query isn't handed the
     // LIMIT/OFFSET values it never references.
     const countParams = [...params];
+    // Sort the whole result set server-side (audit H-14) so "top N" is correct
+    // past page 1; the same expression orders the page window and the outer
+    // tag-resolving select, both over the page CTE's output aliases.
+    const orderBy = buildOrderBy(req.query.sort, req.query.dir, RESOURCE_SORTS);
     const baseSql = `
       WITH page AS (
         SELECT r.id, r."displayName", r."description", r."resourceType", r."governanceResource",
@@ -139,7 +153,7 @@ router.get('/resources', async (req, res) => {
           FROM "Resources" r
           ${resourceTagJoin}
          WHERE ${where}
-         ORDER BY r."displayName"
+         ORDER BY ${orderBy}
          LIMIT ${bind(limit)} OFFSET ${bind(offset)}
       )
       SELECT page.*,
@@ -149,7 +163,7 @@ router.get('/resources', async (req, res) => {
                WHERE ta."entityId" = UPPER(page.id::text)
              ) AS "tagString"
         FROM page
-       ORDER BY page."displayName"`;
+       ORDER BY ${orderBy}`;
     const dataResult = await db.query(baseSql, params);
 
     const data = dataResult.rows.map(row => {

--- a/app/api/src/routes/tags/entities.js
+++ b/app/api/src/routes/tags/entities.js
@@ -10,9 +10,19 @@ import { Router } from 'express';
 import { getResourceColumns as getResourceCols, getPrincipalOrUserColumns, getPrincipalOrUserColumnValues, getResourceColumnValues } from '../../db/columnCache.js';
 import { createParams } from '../../db/sqlParams.js';
 import { parseJsonbColumn } from '../../lib/jsonb.js';
+import { buildOrderBy } from '../../lib/listSort.js';
 import { useSql, db, ensureTagTables, buildFilterWhere, UUID_RE } from './shared.js';
 
 const router = Router();
+
+// Columns the Users page lets you sort by (its TABLE_COLUMNS keys). Values are
+// the page CTE's output aliases — safe to interpolate; see lib/listSort.js.
+const USER_SORTS = {
+  displayName: '"displayName"',
+  userPrincipalName: '"userPrincipalName"',
+  department: '"department"',
+  jobTitle: '"jobTitle"',
+};
 
 // ─── Helper: parse tag string from SQL into array ─────────────────
 // Tag IDs are UUID strings (v6) — do not parseInt.
@@ -166,6 +176,10 @@ router.get('/users', async (req, res) => {
     // from page 1 and then pages by row count, so re-counting the whole table on
     // every page was pure waste.
     const countParams = [...params]; // filter params only — snapshot before LIMIT/OFFSET
+    // Sort the whole result set server-side (audit H-14) so "top N" is correct
+    // past page 1; the same expression orders the page window and the outer
+    // tag-resolving select, both over the page CTE's output aliases.
+    const orderBy = buildOrderBy(req.query.sort, req.query.dir, USER_SORTS);
     const baseSql = `
       WITH page AS (
         SELECT u.id, u."displayName", u."email" AS "userPrincipalName",
@@ -177,7 +191,7 @@ router.get('/users', async (req, res) => {
           FROM "Principals" u
           ${userTagJoin}
          WHERE ${where}
-         ORDER BY u."displayName"
+         ORDER BY ${orderBy}
          LIMIT ${bind(limit)} OFFSET ${bind(offset)}
       )
       SELECT page.*,
@@ -187,7 +201,7 @@ router.get('/users', async (req, res) => {
                WHERE ta."entityId" = UPPER(page.id::text)
              ) AS "tagString"
         FROM page
-       ORDER BY page."displayName"`;
+       ORDER BY ${orderBy}`;
     const dataResult = await db.query(baseSql, params);
 
     const data = dataResult.rows.map(r => {

--- a/app/ui/src/hooks/useEntityPage.js
+++ b/app/ui/src/hooks/useEntityPage.js
@@ -74,7 +74,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
 
   // Reset page & selection when filters change — during render via a
   // value-signature compare, so no synchronous setState lives in an effect.
-  const filterResetSig = JSON.stringify({ debouncedSearch, activeFilters, baseFilters, includeDeleted });
+  const filterResetSig = JSON.stringify({ debouncedSearch, activeFilters, baseFilters, includeDeleted, sortCol, sortDir });
   const [seenFilterResetSig, setSeenFilterResetSig] = useState(filterResetSig);
   if (filterResetSig !== seenFilterResetSig) {
     setSeenFilterResetSig(filterResetSig);
@@ -124,6 +124,9 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
     if (debouncedSearch) params.set('search', debouncedSearch);
     if (filtersObj) params.set('filters', JSON.stringify(filtersObj));
     if (includeDeleted) params.set('includeDeleted', 'true');
+    // Sort is applied server-side over the full result set — a column header
+    // sorts every match, not just the rows already on this page (audit H-14).
+    if (sortCol) { params.set('sort', sortCol); params.set('dir', sortDir); }
     return authFetch(`${listEndpoint}?${params}`)
       .then((res) => {
         if (!res.ok) throw new Error(`Request failed (${res.status})`);
@@ -147,7 +150,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
         if (version === fetchVersion.current) setError(err);
       })
       .finally(() => { if (version === fetchVersion.current) setLoading(false); });
-  }, [page, debouncedSearch, filtersObj, authFetch, listEndpoint, includeDeleted, entityType]);
+  }, [page, debouncedSearch, filtersObj, authFetch, listEndpoint, includeDeleted, entityType, sortCol, sortDir]);
 
   useEffect(() => { fetchItems(); }, [fetchItems]);
 
@@ -178,15 +181,10 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
     }
   };
 
-  const sortedItems = useMemo(() => {
-    if (!sortCol) return items;
-    return [...items].sort((a, b) => {
-      const av = (a[sortCol] ?? '').toString().toLowerCase();
-      const bv = (b[sortCol] ?? '').toString().toLowerCase();
-      const cmp = av.localeCompare(bv);
-      return sortDir === 'asc' ? cmp : -cmp;
-    });
-  }, [items, sortCol, sortDir]);
+  // The server returns the page already ordered by sortCol/sortDir across the
+  // full result set, so the rendered rows are just `items` in that order. (The
+  // old client-side re-sort only reordered the current page — audit H-14.)
+  const sortedItems = items;
 
   // Filter helpers
   const addFilter = useCallback((field, value) => {

--- a/app/ui/src/hooks/useEntityPage.test.jsx
+++ b/app/ui/src/hooks/useEntityPage.test.jsx
@@ -204,18 +204,44 @@ describe('useEntityPage', () => {
     expect(result.current.selected.size).toBe(0);
   });
 
-  it('toggleSort cycles direction and sortedItems reflects the sort', async () => {
-    const { result } = setup();
+  it('toggleSort pushes sort+dir to the server and renders rows in the returned order', async () => {
+    const { af, result } = setup();
     await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Without a sort column, no sort/dir params are sent.
+    expect(lastListUrl(af)).not.toContain('sort=');
 
     act(() => result.current.toggleSort('displayName'));
     expect(result.current.sortCol).toBe('displayName');
     expect(result.current.sortDir).toBe('asc');
-    expect(result.current.sortedItems.map((i) => i.id)).toEqual(['2', '1']); // alice < Bob
+    await waitFor(() => {
+      const url = lastListUrl(af);
+      expect(url).toContain('sort=displayName');
+      expect(url).toContain('dir=asc');
+    });
 
     act(() => result.current.toggleSort('displayName'));
     expect(result.current.sortDir).toBe('desc');
-    expect(result.current.sortedItems.map((i) => i.id)).toEqual(['1', '2']);
+    await waitFor(() => expect(lastListUrl(af)).toContain('dir=desc'));
+
+    // Rows are shown in the order the server returned them — no client re-sort.
+    expect(result.current.sortedItems).toBe(result.current.items);
+  });
+
+  it('resets to the first page when the sort changes', async () => {
+    const { af, result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.setPage(2));
+    await waitFor(() => expect(lastListUrl(af)).toContain('offset=200'));
+
+    act(() => result.current.toggleSort('displayName'));
+    await waitFor(() => {
+      const url = lastListUrl(af);
+      expect(url).toContain('sort=displayName');
+      expect(url).toContain('offset=0');
+    });
+    expect(result.current.page).toBe(0);
   });
 
   it('getFilterFields and getOptionsForField derive from available columns', async () => {

--- a/changes/server-side-list-sort.md
+++ b/changes/server-side-list-sort.md
@@ -1,0 +1,2 @@
+- Fixed list-page sorting (Users, Groups, Identities): clicking a column header now sorts the entire result set on the server, not just the rows on the current page — so the ordering (and "top of the list") is correct across every page instead of silently reshuffling only the 100 rows on screen.
+- Changing the sort now returns you to the first page of the newly ordered results.


### PR DESCRIPTION
Closes #771 (UX audit **H-14** — "List-page sort silently sorts only the current page over server pagination").

## The bug
The Users, Groups, and Identities list pages sorted **client-side**: `useEntityPage` re-ordered only the ~100 rows already on the current page. So "top of the list" was wrong the moment you paged — page 2 was sorted independently of page 1, and a numeric column (Identities' *Accounts*) was compared as a string.

## The fix
Push the sort to the server so it spans the **full result set** before pagination.

- **New `lib/listSort.js` → `buildOrderBy(sort, dir, allowed, fallback?)`** — maps a column key to an already-quoted SQL expression from a **static per-endpoint allowlist** and collapses `dir` to the literal `ASC`/`DESC`. Neither value is ever interpolated raw, so an unknown key or an injection attempt just falls back to `"displayName" ASC`.
- **All three list endpoints** now order by `buildOrderBy(...)` over the page CTE's output aliases (both the page window and the outer tag-resolving select): `/api/users` (`tags/entities.js`), `/api/resources` (`resources.js`), `/api/identities` (`identities/list.js` — replaced its bespoke compound-key `ALLOWED_SORTS`, keeping the same columns + the two the UI could already click).
- **`useEntityPage`** sends `?sort=<col>&dir=<asc|desc>`, refetches on sort change, resets to page 1, and renders the server order (the client re-sort is gone).

## Tests
- `lib/listSort.test.js` — unit-covers every branch (asc/desc, case-insensitive dir, unknown/missing/injection key → fallback, custom fallback).
- `useEntityPage.test.jsx` — rewrote the old "client re-sort" test: asserts the fetch carries `sort`/`dir`, that changing sort resets to page 0, and that rows mirror the server order.
- `resources.contract.test.js` — proves the dynamic `ORDER BY` (incl. a non-default column and an injection-key fallback) runs against real PostgreSQL.

All API (1965) + UI (798) units green; both contract tests green on real Postgres; eslint clean; per-file coverage ratchet OK (`useEntityPage.js` 78→80); no net-new jscpd clone.

**Note on live validation:** the running stack has no seeded multi-page dataset, so cross-page ordering is exercised by the contract test (real PG, full set) rather than a live click-through.
