### PR TITLE
fix(ui): surface enabled optional tabs (Risk Scores, Identities) (#770)

### DIFF
--- a/app/ui/src/App.jsx
+++ b/app/ui/src/App.jsx
@@ -140,7 +140,7 @@ export default function App() {
   }, []);
 
   // Re-fetch features whenever the user navigates — picks up runtime toggle changes
-  // from the admin Risk Scoring sub-tab so the optional Risk Scores / Identities / Org Chart
+  // from the admin Risk Scoring sub-tab so the feature-gated Risk Scores / Identities
   // tabs appear or disappear without a hard reload.
   useEffect(() => {
     fetch('/api/features').then(r => r.json()).then(d => setFeatures(d)).catch(() => {});

--- a/app/ui/src/utils/navTabs.js
+++ b/app/ui/src/utils/navTabs.js
@@ -3,8 +3,14 @@
 //
 // Tab flags:
 //   feature   — only shown when that feature flag is enabled server-side.
+//               Enabling the feature (an admin action) IS the opt-in, so the tab
+//               surfaces automatically when it's on — it is NOT also `optional`
+//               (audit H-13: Risk Scores / Identities used to stay hidden behind
+//               a second per-user toggle even after the feature was turned on).
 //   optional  — hidden by default; the user opts in via Settings → tabs, which
-//               adds the tab key to their `visibleTabs` preference.
+//               adds the tab key to their `visibleTabs` preference. Reserved for
+//               always-available views that just declutter the nav (never combine
+//               with `feature`).
 //
 // Systems and Sync Log are optional: most users live in the Matrix / Principals /
 // Contexts surfaces, so these admin-leaning views are off by default and can be
@@ -17,8 +23,8 @@ export const ALL_NAV_TABS = [
   { key: 'resources',        label: 'Resources' },
   { key: 'systems',          label: 'Systems',      optional: true },
   { key: 'access-packages',  label: 'Business Roles' },
-  { key: 'risk-scores',      label: 'Risk Scores',  feature: 'riskScoring',    optional: true },
-  { key: 'identities',       label: 'Identities',   feature: 'accountLinking', optional: true },
+  { key: 'risk-scores',      label: 'Risk Scores',  feature: 'riskScoring' },
+  { key: 'identities',       label: 'Identities',   feature: 'accountLinking' },
   { key: 'contexts',         label: 'Contexts' },
   { key: 'sync-log',         label: 'Logs',         optional: true },
   { key: 'admin',            label: 'Admin' },

--- a/app/ui/src/utils/navTabs.test.js
+++ b/app/ui/src/utils/navTabs.test.js
@@ -34,6 +34,24 @@ describe('navTabs', () => {
     expect(optional).toEqual(expect.arrayContaining(['systems', 'sync-log']));
   });
 
+  it('surfaces feature tabs (Risk Scores / Identities) as soon as their feature is on, with no second opt-in (H-13)', () => {
+    // Feature enabled server-side but the user has never touched their tab prefs
+    // (empty visibleTabs) — the tabs must still show. This was the bug: they were
+    // also `optional`, so they stayed hidden behind a per-user toggle.
+    const shown = keys(computeNavTabs({ features: ENABLE_ALL_FEATURES, visibleTabs: [], canSeeAdmin: true }));
+    expect(shown).toContain('risk-scores');
+    expect(shown).toContain('identities');
+  });
+
+  it('does not list feature tabs as toggleable optional tabs (the feature flag is the control)', () => {
+    const optional = keys(availableOptionalTabs(ENABLE_ALL_FEATURES));
+    expect(optional).not.toContain('risk-scores');
+    expect(optional).not.toContain('identities');
+    for (const tab of ALL_NAV_TABS) {
+      expect(tab.optional && tab.feature, `${tab.key} must not be both feature-gated and optional`).toBeFalsy();
+    }
+  });
+
   it('keeps non-optional tabs visible regardless of preferences', () => {
     const shown = keys(computeNavTabs({ features: ENABLE_ALL_FEATURES, visibleTabs: [], canSeeAdmin: true }));
     expect(shown).toEqual(expect.arrayContaining(['dashboard', 'matrix', 'principals', 'resources', 'access-packages', 'contexts']));

--- a/changes/surface-feature-tabs.md
+++ b/changes/surface-feature-tabs.md
@@ -1,0 +1,1 @@
+- The Risk Scores and Identities tabs now appear in the top navigation as soon as their feature is enabled, instead of staying hidden behind a second per-user "show this tab" toggle. Turning the feature on is all that's needed; the redundant toggle for these two tabs is gone (Systems and Logs remain opt-in as before).


### PR DESCRIPTION
Closes #770 (UX audit **H-13** — "Optional tabs (Risk Scores, Identities) hidden by default even when the feature is enabled").

## The bug
The Risk Scores and Identities tabs were **both** feature-gated **and** `optional`. So enabling the feature server-side — a deliberate admin action — wasn't enough: the tab stayed hidden until the user *also* opted in via Settings → tabs (which adds the key to their `visibleTabs` preference). Two gates for one intent; a freshly-enabled feature looked broken because its tab never appeared.

## The fix
A feature-gated tab is surfaced by turning its feature on — that IS the opt-in — so it should show by default. Dropped `optional` from `risk-scores` and `identities`; now `computeNavTabs` shows them whenever their feature flag is on and hides them when it's off, with no second per-user toggle. `optional` is now reserved for always-available declutter tabs (Systems, Logs), which keep their opt-in behaviour unchanged.

Also removed the two tabs from `availableOptionalTabs` (so the Settings → tabs list no longer offers a toggle that wouldn't do anything), and corrected a stale App.jsx comment.

## Tests
`navTabs.test.js` gains: feature tabs show with an empty `visibleTabs` (the exact bug scenario), they're not listed as toggleable optional tabs, and an invariant that no tab is ever both `feature`-gated and `optional`. Existing coverage (feature-off hides them; Systems/Logs still opt-in) still passes. `navTabs.js` at 100% lines; all 799 UI unit tests green; no net-new jscpd clone.
