### PR TITLE
fix(ui): run scoring from the Risk Scoring page; remove dead cluster code (#766)

### DIFF
--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -1,10 +1,12 @@
 ﻿import { useState, useEffect, useReducer, useCallback } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
+import { useCanManageCrawlers } from '@ui/auth/usePermissions';
+import { useDialog } from '@ui/components/dialogContext';
 import { TIER_STYLES } from '@ui/utils/tierStyles';
 
 // Human-readable noun for the current risk-scoring view, used in the search
 // field's placeholder and its accessible label.
-const VIEW_SEARCH_NOUNS = { clusters: 'clusters', groups: 'resources', users: 'users', 'business-roles': 'business roles', contexts: 'contexts', identities: 'identities' };
+const VIEW_SEARCH_NOUNS = { groups: 'resources', users: 'users', 'business-roles': 'business roles', contexts: 'contexts', identities: 'identities' };
 const viewSearchNoun = (view) => VIEW_SEARCH_NOUNS[view] || view;
 
 function TierBadge({ tier }) {
@@ -188,290 +190,13 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
   );
 }
 
-// ─── Cluster Detail Panel ───────────────────────────────────────────
-
-function ClusterDetail({ cluster, authFetch, onClose, onOpenDetail, onRefresh }) {
-  const [detail, setDetail] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [ownerSearch, setOwnerSearch] = useState('');
-  const [ownerResults, setOwnerResults] = useState([]);
-  const [showOwnerSearch, setShowOwnerSearch] = useState(false);
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      try {
-        const res = await authFetch(`/api/risk-scores/clusters/${encodeURIComponent(cluster.id)}`);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const json = await res.json();
-        if (!cancelled) setDetail(json);
-      } catch (err) {
-        console.error('Failed to load cluster detail:', err);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [authFetch, cluster.id]);
-
-  // Clear results when the query is too short — during render on the
-  // transition, so the debounce effect body holds no synchronous setState.
-  const ownerTooShort = !ownerSearch || ownerSearch.length < 2;
-  const [seenOwnerTooShort, setSeenOwnerTooShort] = useState(ownerTooShort);
-  if (ownerTooShort !== seenOwnerTooShort) {
-    setSeenOwnerTooShort(ownerTooShort);
-    if (ownerTooShort) setOwnerResults([]);
-  }
-  // Search users for owner assignment
-  useEffect(() => {
-    if (ownerTooShort) return undefined;
-    const timer = setTimeout(async () => {
-      try {
-        const res = await authFetch(`/api/risk-scores/users?search=${encodeURIComponent(ownerSearch)}&limit=8`);
-        if (res.ok) {
-          const json = await res.json();
-          setOwnerResults(json.data || []);
-        }
-      } catch { }
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [authFetch, ownerSearch, ownerTooShort]);
-
-  const handleAssignOwner = async (user) => {
-    setSaving(true);
-    try {
-      const res = await authFetch(`/api/risk-scores/clusters/${encodeURIComponent(cluster.id)}/owner`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: user.id, displayName: user.displayName, assignedBy: 'UI' }),
-      });
-      if (res.ok) {
-        setShowOwnerSearch(false);
-        setOwnerSearch('');
-        onRefresh?.();
-      }
-    } catch (err) {
-      console.error('Failed to assign owner:', err);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleRemoveOwner = async () => {
-    setSaving(true);
-    try {
-      const res = await authFetch(`/api/risk-scores/clusters/${encodeURIComponent(cluster.id)}/owner`, {
-        method: 'DELETE',
-      });
-      if (res.ok) onRefresh?.();
-    } catch (err) {
-      console.error('Failed to remove owner:', err);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const c = detail?.cluster || cluster;
-  const members = detail?.members || [];
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center pt-16 bg-black/30" onClick={onClose}>
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-        {/* Header */}
-        <div className="sticky top-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4 flex items-center justify-between">
-          <div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{c.displayName}</h3>
-            <div className="flex items-center gap-2 mt-0.5">
-              <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                c.clusterType === 'classifier' ? 'bg-blue-50 text-blue-700 dark:text-blue-300' : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
-              }`}>{c.clusterType}</span>
-              {c.sourceClassifierCategory && (
-                <span className="text-xs text-gray-600 dark:text-gray-500">{c.sourceClassifierCategory}</span>
-              )}
-              <span className="text-xs text-gray-600 dark:text-gray-500">{c.memberCount} member{c.memberCount !== 1 ? 's' : ''}</span>
-            </div>
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="text-right">
-              <div className="text-2xl font-bold text-gray-800 dark:text-gray-200">{c.aggregateRiskScore}</div>
-              <TierBadge tier={c.riskTier} />
-            </div>
-            <button onClick={onClose} className="text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 p-1">
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-            </button>
-          </div>
-        </div>
-
-        <div className="px-6 py-4 space-y-5">
-          {/* Score summary */}
-          <div className="grid grid-cols-3 gap-3">
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
-              <div className="text-lg font-bold text-gray-800 dark:text-gray-200">{c.aggregateRiskScore}</div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400">Aggregate</div>
-            </div>
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
-              <div className="text-lg font-bold text-gray-800 dark:text-gray-200">{c.maxMemberRiskScore}</div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400">Max</div>
-            </div>
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-center">
-              <div className="text-lg font-bold text-gray-800 dark:text-gray-200">{c.avgMemberRiskScore}</div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400">Avg</div>
-            </div>
-          </div>
-
-          {/* Tier distribution */}
-          {c.tierDistribution && Object.keys(c.tierDistribution).length > 0 && (
-            <div className="flex gap-2 flex-wrap">
-              {['Critical', 'High', 'Medium', 'Low', 'Minimal'].map(t => {
-                const count = c.tierDistribution[t];
-                if (!count) return null;
-                const s = TIER_STYLES[t];
-                return (
-                  <span key={t} className={`${s.bg} ${s.text} text-xs px-2 py-0.5 rounded-full border ${s.border}`}>
-                    {count} {t}
-                  </span>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Owner */}
-          <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
-            <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Owner / Responsible</h4>
-            {c.ownerDisplayName ? (
-              <div className="flex items-center justify-between">
-                <div>
-                  <button
-                    onClick={() => c.ownerUserId && onOpenDetail?.('user', c.ownerUserId, c.ownerDisplayName)}
-                    className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                  >
-                    {c.ownerDisplayName}
-                  </button>
-                  {c.ownerAssignedAt && (
-                    <span className="text-[10px] text-gray-600 dark:text-gray-500 ml-2">
-                      assigned {new Date(c.ownerAssignedAt).toLocaleDateString()}
-                    </span>
-                  )}
-                </div>
-                <button
-                  onClick={handleRemoveOwner}
-                  disabled={saving}
-                  className="text-xs text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 border border-red-200 dark:border-red-700 rounded px-2 py-0.5 hover:bg-red-50 dark:bg-red-900/30 disabled:opacity-40"
-                >
-                  Remove
-                </button>
-              </div>
-            ) : (
-              <div>
-                {!showOwnerSearch ? (
-                  <button
-                    onClick={() => setShowOwnerSearch(true)}
-                    className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 border border-blue-200 rounded px-2 py-1 hover:bg-blue-50"
-                  >
-                    Assign Owner
-                  </button>
-                ) : (
-                  <div className="space-y-2">
-                    <input
-                      type="text"
-                      value={ownerSearch}
-                      onChange={e => setOwnerSearch(e.target.value)}
-                      aria-label="Search users by name"
-                      placeholder="Search users by name..."
-                      className="w-full text-sm border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 placeholder-gray-400"
-                      autoFocus
-                    />
-                    {ownerResults.length > 0 && (
-                      <div className="border border-gray-200 dark:border-gray-700 rounded-lg max-h-40 overflow-y-auto">
-                        {ownerResults.map(u => (
-                          <button
-                            key={u.id}
-                            onClick={() => handleAssignOwner(u)}
-                            disabled={saving}
-                            className="w-full text-left px-3 py-1.5 text-sm hover:bg-blue-50 border-b border-gray-100 dark:border-gray-700 last:border-0 disabled:opacity-40"
-                          >
-                            {u.displayName}
-                            {u.jobTitle && <span className="text-xs text-gray-600 dark:text-gray-500 ml-2">{u.jobTitle}</span>}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                    <button
-                      onClick={() => { setShowOwnerSearch(false); setOwnerSearch(''); }}
-                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Match patterns */}
-          {c.matchPatterns && c.matchPatterns.length > 0 && (
-            <div>
-              <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Match Patterns</h4>
-              <div className="flex gap-1.5 flex-wrap">
-                {c.matchPatterns.map((p, i) => (
-                  <span key={i} className="text-[10px] font-mono bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-1.5 py-0.5 rounded">
-                    {p}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Members */}
-          <div>
-            <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">
-              Members ({members.length})
-            </h4>
-            {loading ? (
-              <div className="text-xs text-gray-600 dark:text-gray-500 py-2">Loading members...</div>
-            ) : (
-              <div className="space-y-1 max-h-[300px] overflow-y-auto">
-                {members.map(m => (
-                  <div key={`${m.resourceType}-${m.resourceId}`} className="flex items-center justify-between py-1.5 px-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <button
-                        onClick={() => onOpenDetail?.('group', m.resourceId, m.resourceName)}
-                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline truncate"
-                      >
-                        {m.resourceName}
-                      </button>
-                      {m.isNonProduction && (
-                        <span className="text-[9px] font-medium bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-1 py-0.5 rounded shrink-0">NON-PROD</span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0 ml-2">
-                      <ScoreBar score={m.resourceRiskScore || 0} />
-                      <TierBadge tier={m.resourceRiskTier} />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* Scored timestamp */}
-          {c.scoredAt && (
-            <div className="text-xs text-gray-600 dark:text-gray-500 pt-2 border-t border-gray-100 dark:border-gray-700">
-              Scored at: {new Date(c.scoredAt).toLocaleString()}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 // ─── Main Risk Scoring Page ──────────────────────────────────────────
 
 export default function RiskScoringPage({ onOpenDetail }) {
   const { authFetch } = useAuth();
+  const dialog = useDialog();
+  const canRun = useCanManageCrawlers();
+  const [running, setRunning] = useState(false);
   const [summary, setSummary] = useState(null);
   // loading/error/entityLoading are flipped synchronously inside the fetch
   // effects; reducer dispatches keep that clear of set-state-in-effect.
@@ -484,10 +209,6 @@ export default function RiskScoringPage({ onOpenDetail }) {
   const [entityData, setEntityData] = useState({ data: [], total: 0 });
   const [entityLoading, setEntityLoading] = useReducer((_, v) => v, false);
   const [page, setPage] = useState(0);
-  const [clusterData, setClusterData] = useState({ available: false, data: [], total: 0 });
-  const [clusterSummary, setClusterSummary] = useState(null);
-  const [selectedCluster, setSelectedCluster] = useState(null);
-  const [clusterSort] = useState({ key: 'score', dir: 'desc' });
   const PAGE_SIZE = 25;
 
   // Fetch summary
@@ -528,59 +249,28 @@ export default function RiskScoringPage({ onOpenDetail }) {
       .finally(() => setEntityLoading(false));
   }, [authFetch, view, page, tierFilter, search, overridesOnly]);
 
-  // Fetch clusters (paginated, server-side)
-  const fetchClusters = useCallback(async () => {
+  // Kick off a scoring run from this page (mirrors Admin → Risk Scoring's "Run
+  // now"). Gated on admin.crawlers — the button only renders for `canRun`, and
+  // the endpoint enforces the same permission server-side. Refreshes the summary
+  // a few seconds later so early results appear without a manual reload.
+  const runScoring = useCallback(async () => {
+    setRunning(true);
     try {
-      const params = new URLSearchParams({
-        limit: String(PAGE_SIZE),
-        offset: String(page * PAGE_SIZE),
+      const r = await authFetch('/api/risk-scoring/runs', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
       });
-      if (tierFilter) params.set('tier', tierFilter);
-      if (search) params.set('search', search);
-      // Build sort param: "score" (default desc) or "score-asc"
-      const sortParam = clusterSort.dir === 'asc' && !['name', 'type', 'owner'].includes(clusterSort.key)
-        ? `${clusterSort.key}-asc`
-        : clusterSort.dir === 'desc' && ['name', 'type', 'owner'].includes(clusterSort.key)
-        ? `${clusterSort.key}-desc`
-        : clusterSort.key;
-      params.set('sort', sortParam);
-      const res = await authFetch(`/api/risk-scores/clusters?${params}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
-      setClusterData(json);
-    } catch (err) {
-      console.error('Failed to fetch clusters:', err);
-      setClusterData({ available: false, data: [], total: 0 });
+      if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `HTTP ${r.status}`);
+      dialog.toast('Risk scoring started — follow progress in the Logs tab.', { variant: 'success' });
+      setTimeout(() => fetchSummary(), 4000);
+    } catch (e) {
+      dialog.alert(e.message || 'Failed to start risk scoring');
     } finally {
+      setRunning(false);
     }
-  }, [authFetch, page, tierFilter, search, clusterSort]);
-
-  // Fetch cluster summary
-  const fetchClusterSummary = useCallback(async () => {
-    try {
-      const res = await authFetch('/api/risk-scores/cluster-summary');
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
-      setClusterSummary(json);
-    } catch (err) {
-      console.error('Failed to fetch cluster summary:', err);
-    }
-  }, [authFetch]);
-
-
-  // Refresh clusters list after owner change
-  const handleClusterRefresh = useCallback(() => {
-    fetchClusters();
-    fetchClusterSummary();
-    setSelectedCluster(null);
-  }, [fetchClusters, fetchClusterSummary]);
+  }, [authFetch, dialog, fetchSummary]);
 
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
-  // Resource clusters moved to the Contexts tab (Phase 7 of the redesign).
-  // The old /api/risk-scores/clusters* routes no longer exist.
-  useEffect(() => {
-    if (view !== 'clusters') fetchEntities();
-  }, [view, fetchEntities]);
+  useEffect(() => { fetchEntities(); }, [view, fetchEntities]);
   // Reset to the first page when the filters change — during render via a
   // composite-signature compare, so no synchronous setState lives in an effect.
   const pageFilterSig = `${view}|${tierFilter}|${search}|${overridesOnly}`;
@@ -616,8 +306,19 @@ export default function RiskScoringPage({ onOpenDetail }) {
         <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg p-6 text-center">
           <h3 className="text-amber-800 dark:text-amber-300 font-semibold text-lg">Risk Scores Not Yet Computed</h3>
           <p className="text-amber-700 dark:text-amber-400 text-sm mt-2">
-            Run the risk scoring engine from <span className="font-semibold">Admin&nbsp;→&nbsp;Risk&nbsp;Scoring</span> to compute scores.
+            {canRun
+              ? 'Run the risk scoring engine to compute a score for every identity and resource.'
+              : <>Run the risk scoring engine from <span className="font-semibold">Admin&nbsp;→&nbsp;Risk&nbsp;Scoring</span> to compute scores.</>}
           </p>
+          {canRun && (
+            <button
+              onClick={runScoring}
+              disabled={running}
+              className="mt-4 px-4 py-2 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {running ? 'Starting…' : 'Run scoring now'}
+            </button>
+          )}
           <p className="text-amber-600 dark:text-amber-400 text-xs mt-3">
             Scores are persisted as columns on Principals and Resources. The UI reads them directly.
           </p>
@@ -628,7 +329,7 @@ export default function RiskScoringPage({ onOpenDetail }) {
 
   const s = summary?.summary;
   const tiers = ['Critical', 'High', 'Medium', 'Low', 'Minimal', 'None'];
-  const activeTotal = view === 'clusters' ? (clusterData.total || 0) : (entityData.total || 0);
+  const activeTotal = entityData.total || 0;
   const totalPages = Math.ceil(activeTotal / PAGE_SIZE);
   const totalOverrides = (s?.groupOverrides || 0) + (s?.userOverrides || 0)
     + (s?.businessRoleOverrides || 0) + (s?.contextOverrides || 0) + (s?.identityOverrides || 0);
@@ -645,11 +346,11 @@ export default function RiskScoringPage({ onOpenDetail }) {
   return (
     <div className="max-w-7xl mx-auto space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-4">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Identity Risk Scores</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-            Persisted risk scores computed by the risk scoring engine (run from <span className="font-medium text-gray-700 dark:text-gray-200">Admin&nbsp;→&nbsp;Risk&nbsp;Scoring</span>)
+            Persisted risk scores computed by the risk scoring engine
             {totalOverrides > 0 && (
               <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">
                 ({totalOverrides} analyst override{totalOverrides !== 1 ? 's' : ''})
@@ -657,11 +358,22 @@ export default function RiskScoringPage({ onOpenDetail }) {
             )}
           </p>
         </div>
-        {summary?.scoredAt && (
-          <span className="text-xs text-gray-600 dark:text-gray-500">
-            Last scored: {new Date(summary.scoredAt).toLocaleString()}
-          </span>
-        )}
+        <div className="flex items-center gap-3 shrink-0">
+          {summary?.scoredAt && (
+            <span className="text-xs text-gray-600 dark:text-gray-500">
+              Last scored: {new Date(summary.scoredAt).toLocaleString()}
+            </span>
+          )}
+          {canRun && (
+            <button
+              onClick={runScoring}
+              disabled={running}
+              className="px-3 py-1.5 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {running ? 'Starting…' : 'Run scoring now'}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Summary Cards */}
@@ -672,42 +384,13 @@ export default function RiskScoringPage({ onOpenDetail }) {
         if (s.totalBusinessRoles > 0) distCharts.push({ label: 'Business Roles', byTier: s.businessRolesByTier, total: s.totalBusinessRoles });
         if (s.totalContexts > 0) distCharts.push({ label: 'Contexts', byTier: s.contextsByTier, total: s.totalContexts });
         if (s.totalIdentities > 0) distCharts.push({ label: 'Identities', byTier: s.identitiesByTier, total: s.totalIdentities });
-        const hasCluster = clusterSummary?.available;
-        const colCount = distCharts.length + (hasCluster ? 1 : 0);
+        const colCount = distCharts.length;
         const gridCols = colCount <= 2 ? 'grid-cols-2' : colCount <= 3 ? 'grid-cols-3' : colCount <= 4 ? 'grid-cols-4' : 'grid-cols-5';
         return (
           <div className={`grid gap-4 ${gridCols}`}>
             {distCharts.map(c => (
               <DistributionChart key={c.label} label={c.label} byTier={c.byTier} total={c.total} />
             ))}
-            {hasCluster && (
-              <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">Resource Clusters</h3>
-                <p className="text-xs text-gray-600 dark:text-gray-500 mb-3">{clusterSummary.total} clusters</p>
-                <div className="space-y-2">
-                  {['Critical', 'High', 'Medium', 'Low', 'Minimal'].map(tier => {
-                    const count = clusterSummary.byTier?.[tier] || 0;
-                    if (count === 0) return null;
-                    const pct = clusterSummary.total > 0 ? (count / clusterSummary.total) * 100 : 0;
-                    const st = TIER_STYLES[tier];
-                    return (
-                      <div key={tier} className="flex items-center gap-2">
-                        <span className={`w-16 text-xs font-medium ${st.text}`}>{tier}</span>
-                        <div className="flex-1 h-5 bg-gray-50 dark:bg-gray-700/50 rounded overflow-hidden">
-                          <div className={`h-full ${st.dot} rounded`} style={{ width: `${pct}%` }} />
-                        </div>
-                        <span className="w-8 text-xs text-gray-500 dark:text-gray-400 text-right">{count}</span>
-                      </div>
-                    );
-                  })}
-                </div>
-                {clusterSummary.unowned > 0 && (
-                  <p className="text-[10px] text-amber-600 dark:text-amber-400 mt-2">
-                    {clusterSummary.unowned} cluster{clusterSummary.unowned !== 1 ? 's' : ''} without owner
-                  </p>
-                )}
-              </div>
-            )}
           </div>
         );
       })()}
@@ -821,17 +504,15 @@ export default function RiskScoringPage({ onOpenDetail }) {
           </div>
 
           <div className="flex items-center gap-3">
-            {view !== 'clusters' && (
-              <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={overridesOnly}
-                  onChange={e => setOverridesOnly(e.target.checked)}
-                  className="rounded border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white w-3.5 h-3.5"
-                />
-                Overrides only
-              </label>
-            )}
+            <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={overridesOnly}
+                onChange={e => setOverridesOnly(e.target.checked)}
+                className="rounded border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white w-3.5 h-3.5"
+              />
+              Overrides only
+            </label>
 
             <select
               aria-label="Filter by risk tier"
@@ -879,16 +560,6 @@ export default function RiskScoringPage({ onOpenDetail }) {
           </div>
         )}
       </div>
-
-      {selectedCluster && (
-        <ClusterDetail
-          cluster={selectedCluster}
-          authFetch={authFetch}
-          onClose={() => setSelectedCluster(null)}
-          onOpenDetail={onOpenDetail}
-          onRefresh={handleClusterRefresh}
-        />
-      )}
     </div>
   );
 }

--- a/app/ui/src/components/RiskScoringPage.jsx
+++ b/app/ui/src/components/RiskScoringPage.jsx
@@ -190,6 +190,18 @@ function EntityTable({ entities, entityType, onOpenDetail }) {
   );
 }
 
+// Kick-off button for a scoring run. Renders nothing without the admin.crawlers
+// permission — kept as its own component so the page body doesn't carry the
+// canRun/running conditionals inline (keeps its cognitive complexity in check).
+function RunScoringButton({ canRun, running, onRun, className }) {
+  if (!canRun) return null;
+  return (
+    <button type="button" onClick={onRun} disabled={running} className={className}>
+      {running ? 'Starting…' : 'Run scoring now'}
+    </button>
+  );
+}
+
 // ─── Main Risk Scoring Page ──────────────────────────────────────────
 
 export default function RiskScoringPage({ onOpenDetail }) {
@@ -306,19 +318,14 @@ export default function RiskScoringPage({ onOpenDetail }) {
         <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg p-6 text-center">
           <h3 className="text-amber-800 dark:text-amber-300 font-semibold text-lg">Risk Scores Not Yet Computed</h3>
           <p className="text-amber-700 dark:text-amber-400 text-sm mt-2">
-            {canRun
-              ? 'Run the risk scoring engine to compute a score for every identity and resource.'
-              : <>Run the risk scoring engine from <span className="font-semibold">Admin&nbsp;→&nbsp;Risk&nbsp;Scoring</span> to compute scores.</>}
+            Run the risk scoring engine to compute a score for every identity and resource. It can also be configured and run from <span className="font-semibold">Admin&nbsp;→&nbsp;Risk&nbsp;Scoring</span>.
           </p>
-          {canRun && (
-            <button
-              onClick={runScoring}
-              disabled={running}
-              className="mt-4 px-4 py-2 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
-            >
-              {running ? 'Starting…' : 'Run scoring now'}
-            </button>
-          )}
+          <RunScoringButton
+            canRun={canRun}
+            running={running}
+            onRun={runScoring}
+            className="mt-4 px-4 py-2 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+          />
           <p className="text-amber-600 dark:text-amber-400 text-xs mt-3">
             Scores are persisted as columns on Principals and Resources. The UI reads them directly.
           </p>
@@ -364,15 +371,12 @@ export default function RiskScoringPage({ onOpenDetail }) {
               Last scored: {new Date(summary.scoredAt).toLocaleString()}
             </span>
           )}
-          {canRun && (
-            <button
-              onClick={runScoring}
-              disabled={running}
-              className="px-3 py-1.5 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
-            >
-              {running ? 'Starting…' : 'Run scoring now'}
-            </button>
-          )}
+          <RunScoringButton
+            canRun={canRun}
+            running={running}
+            onRun={runScoring}
+            className="px-3 py-1.5 rounded text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+          />
         </div>
       </div>
 

--- a/app/ui/src/components/RiskScoringPage.mount.test.jsx
+++ b/app/ui/src/components/RiskScoringPage.mount.test.jsx
@@ -82,7 +82,6 @@ const groupsList = {
 
 function routes(overrides = {}) {
   return makeAuthFetch({
-    '/api/risk-scores/cluster-summary': { available: false },
     '/api/risk-scores/users': usersList,
     '/api/risk-scores/groups': groupsList,
     '/api/risk-scores/business-roles': {
@@ -258,6 +257,38 @@ describe('RiskScoringPage (mounted)', () => {
     await user.click(screen.getByRole('button', { name: 'Contexts' }));
     expect(await screen.findByText('Sales Team')).toBeInTheDocument();
     expect(screen.getByText('Carol Manager')).toBeInTheDocument();
+  });
+
+  it('starts a scoring run from the page and toasts on success (admin.crawlers)', async () => {
+    const authFetch = routes({ '/api/risk-scoring/runs': { runId: 'r1' } });
+    renderWithProviders(h(RiskScoringPage, { onOpenDetail: () => {} }), { auth: { authFetch } });
+    await screen.findByText('Identity Risk Scores');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Run scoring now/i }));
+
+    await waitFor(() => {
+      const posted = authFetch.mock.calls.find(c => String(c[0]).includes('/api/risk-scoring/runs'));
+      expect(posted).toBeTruthy();
+      expect(posted[1]?.method).toBe('POST');
+    });
+    expect(await screen.findByText(/Risk scoring started/i)).toBeInTheDocument();
+  });
+
+  it('offers "Run scoring now" from the not-computed empty state', async () => {
+    renderWithProviders(h(RiskScoringPage), {
+      auth: { authFetch: routes({ '/api/risk-scores': { available: false } }) },
+    });
+    expect(await screen.findByText('Risk Scores Not Yet Computed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Run scoring now/i })).toBeInTheDocument();
+  });
+
+  it('hides the run button for users without the admin.crawlers permission', async () => {
+    renderWithProviders(h(RiskScoringPage, { onOpenDetail: () => {} }), {
+      auth: { authFetch: routes(), hasWildcard: false, permissions: new Set() },
+    });
+    await screen.findByText('Identity Risk Scores');
+    expect(screen.queryByRole('button', { name: /Run scoring now/i })).toBeNull();
   });
 
   it('renders entity-type-specific columns for the identities view', async () => {

--- a/changes/risk-scoring-page-cleanup.md
+++ b/changes/risk-scoring-page-cleanup.md
@@ -1,0 +1,2 @@
+- The Risk Scoring page now has a "Run scoring now" button (for users who can manage crawlers) in both its header and its "not yet computed" empty state, so you can kick off a scoring run without leaving for Admin → Risk Scoring.
+- Removed the dead resource-cluster panel and its broken data fetches from the Risk Scoring page — resource clusters moved to the Contexts tab, and the old cluster endpoints no longer exist. A "View clusters →" link to the Contexts tab remains.


### PR DESCRIPTION
Closes #766 (UX audit **H-07** — "Risk Scoring can't be created/run from its own page; dead cluster code").

## Two parts

**1. Run from the page.** You could only start a scoring run from Admin → Risk Scoring. Added a **"Run scoring now"** button to the Risk Scoring page — in the header and in the "not yet computed" empty state — that POSTs `/api/risk-scoring/runs`, toasts on success, and refreshes the summary a few seconds later. It's gated on `admin.crawlers` (via `useCanManageCrawlers`), the same permission the endpoint enforces server-side, so it only renders for users who can actually run it. The empty state falls back to the old "run from Admin → Risk Scoring" hint for everyone else.

**2. Remove the dead cluster path.** Resource clustering moved to the Contexts tab (a generated context tree) and the `/api/risk-scores/clusters*` endpoints were dropped — but `RiskScoringPage` still carried a whole `ClusterDetail` panel, `fetchClusters`/`fetchClusterSummary`, cluster state, and a "Resource Clusters" summary card, all calling routes that no longer exist. `ClusterDetail` was never even reachable (`selectedCluster` was never set). Removed all of it (**894 → 543 lines**). The working **"View clusters →"** link to the Contexts tab stays.

## Tests
`RiskScoringPage.mount.test.jsx` gains: the run button starts a run (asserts the POST + method) and toasts; the empty state offers it; and it's hidden for a user without `admin.crawlers`. Existing tests all still pass (dropped the now-dead `cluster-summary` mock). eslint clean; per-file coverage ratchet OK (removing the dead, untested cluster code raised the file's coverage); no net-new jscpd clone.

**Note on live validation:** the run/empty-state affordances and the permission gate are exercised by the mount tests (mocking the run endpoint and toggling the permission); the dead code removed was unreachable, so there's nothing to drive live.
