### PR TITLE
fix(ui): shared EmptyState with a next action on list pages (#760)

### DIFF
--- a/app/ui/src/components/EntityListPage.jsx
+++ b/app/ui/src/components/EntityListPage.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
 import useEntityPage from '@ui/hooks/useEntityPage';
 import FilterBar from './FilterBar';
+import EmptyState from './EmptyState';
 import { TAG_COLORS, tagPillStyle } from '@ui/utils/colors';
 import { useIsDark } from '@ui/contexts/ThemeContext';
 
@@ -301,9 +302,21 @@ function EntityListTable({ ep, label, tableColumns, renderEntityCell, renderData
           </button>
         </div>
       ) : ep.items.length === 0 ? (
-        <div className="text-center text-gray-500 dark:text-gray-400 py-12">
-          {ep.hasAnyFilter ? `No ${label} match the current filters.` : `No ${label} found.`}
-        </div>
+        ep.hasAnyFilter ? (
+          <EmptyState
+            title={`No ${label} match your filters`}
+            hint="Adjust your search or filters — or clear them to see everything."
+            actionLabel="Clear filters"
+            onAction={ep.clearAllFilters}
+          />
+        ) : (
+          <EmptyState
+            title={`No ${label} yet`}
+            hint={`${label.charAt(0).toUpperCase()}${label.slice(1)} are imported by a crawler. Add one to connect a source (Entra ID, CSV, …) and import data.`}
+            actionLabel="Add a crawler →"
+            onAction={() => { window.location.hash = 'admin?sub=crawlers'; }}
+          />
+        )
       ) : (
         <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
           <table className="w-full text-sm">

--- a/app/ui/src/components/EntityListPage.mount.test.jsx
+++ b/app/ui/src/components/EntityListPage.mount.test.jsx
@@ -109,15 +109,45 @@ describe('EntityListPage error state (audit H6)', () => {
 
     renderPage(af);
 
-    // A failed load surfaces a distinct error panel — NOT the "No users found"
-    // empty state it used to be indistinguishable from.
+    // A failed load surfaces a distinct error panel — NOT the empty state it
+    // used to be indistinguishable from.
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent(/Couldn.t load users/i);
-    expect(screen.queryByText('No users found.')).not.toBeInTheDocument();
+    expect(screen.queryByText(/No users (yet|match)/i)).not.toBeInTheDocument();
 
     // Retry re-fetches; the second response succeeds and the row renders.
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
     expect(await screen.findByText('Bob')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('EntityListPage empty state (audit H-12 / #760)', () => {
+  const emptyRoutes = () => makeAuthFetch((url) => {
+    const s = String(url);
+    if (s.includes(COLUMNS)) return [];
+    if (s.includes('/api/tags')) return [];
+    if (s.includes(LIST)) return { data: [], total: 0 };
+    return undefined;
+  });
+
+  it('shows an onboarding EmptyState with a next action when nothing has been imported', async () => {
+    renderPage(emptyRoutes());
+    // The shared EmptyState (not a bare "No users found." dead-end) with a real action.
+    expect(await screen.findByText('No users yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add a crawler/i })).toBeInTheDocument();
+  });
+
+  it('switches to a filter-aware EmptyState with "Clear filters" when a search matches nothing', async () => {
+    renderPage(emptyRoutes());
+    await screen.findByText('No users yet');
+
+    // Typing a search flips hasAnyFilter → the message and action change.
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'zzz' } });
+    expect(await screen.findByText('No users match your filters')).toBeInTheDocument();
+
+    // Clearing filters returns to the unfiltered onboarding state.
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(await screen.findByText('No users yet')).toBeInTheDocument();
   });
 });

--- a/app/ui/src/components/EntityListPage.mount.test.jsx
+++ b/app/ui/src/components/EntityListPage.mount.test.jsx
@@ -131,11 +131,13 @@ describe('EntityListPage empty state (audit H-12 / #760)', () => {
     return undefined;
   });
 
-  it('shows an onboarding EmptyState with a next action when nothing has been imported', async () => {
+  it('shows an onboarding EmptyState whose next action navigates to Admin → Crawlers', async () => {
+    window.location.hash = '';
     renderPage(emptyRoutes());
     // The shared EmptyState (not a bare "No users found." dead-end) with a real action.
     expect(await screen.findByText('No users yet')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Add a crawler/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Add a crawler/i }));
+    expect(window.location.hash).toContain('admin?sub=crawlers');
   });
 
   it('switches to a filter-aware EmptyState with "Clear filters" when a search matches nothing', async () => {

--- a/changes/list-page-emptystate.md
+++ b/changes/list-page-emptystate.md
@@ -1,0 +1,1 @@
+- Empty list pages (Users, Resources, Identities) now show the shared onboarding panel with a clear next step — "Add a crawler" when nothing has been imported yet, or "Clear filters" when a search or filter matches nothing — instead of a bare "No X found." dead-end.


### PR DESCRIPTION
Closes #760 (Maintenance audit **L1** · UX audit **H-12** — "List pages don't use the shared `EmptyState`").

## The problem
The Users / Resources / Identities list pages (all backed by `EntityListPage`) dead-ended on a bare line of text — `No users found.` — with no guidance and no next step. `EmptyState` (the shared onboarding panel already used by Systems and the rotated matrix) existed but these lists never adopted it.

## The fix
`EntityListPage`'s empty branch now renders `EmptyState` with a real next action, and distinguishes the two empty cases:

- **Nothing imported yet** → "No {label} yet" + a hint that a crawler imports them + an **"Add a crawler →"** button (navigates to Admin → Crawlers, mirroring `SystemsPage`'s exact pattern).
- **A search/filter matched nothing** → "No {label} match your filters" + **"Clear filters"** (calls the page's `clearAllFilters`).

One change in the shared scaffold fixes all three EntityListPage-backed lists at once. (Systems and the matrix already used `EmptyState`; other bespoke lists can follow if they still dead-end.)

## Tests
`EntityListPage.mount.test.jsx` gains: the onboarding EmptyState + "Add a crawler" action render when the list is empty; typing a search flips it to the filter-aware message + "Clear filters", and clearing returns to the onboarding state. Updated the H6 error-state test's assertion for the new empty-state text. All 799 UI unit tests green; eslint clean; per-file coverage ratchet OK; no net-new jscpd clone. Independent of the other open PRs (none touch `EntityListPage.jsx`).
