### PR TITLE
refactor(api): de-duplicate matrix + resource route helpers (audit Q3-Q5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ __pycache__/
 
 # PowerShell mutation testing reports (PSMutant)
 reports/
+report/

--- a/app/api/src/routes/matrix/data.coverage.test.js
+++ b/app/api/src/routes/matrix/data.coverage.test.js
@@ -51,7 +51,11 @@ vi.mock('../../perf/sqlTimer.js', () => ({
 let parseFilterImpl = () => baseFilter();
 let buildSubqueriesImpl = async () => baseBuilt();
 let scopeCountsImpl = async () => ({ subjectCount: 5, subjectTotal: 10, resourceCount: 3, resourceTotal: 8 });
-vi.mock('./shared.js', () => ({
+// Spread the real module so runBound/collectResources (pure helpers over the
+// mocked timedQuery + built) are exercised for real; override only the three
+// entry points the tests drive.
+vi.mock('./shared.js', async (importActual) => ({
+  ...(await importActual()),
   parseFilter: (...a) => parseFilterImpl(...a),
   buildSubqueries: (...a) => buildSubqueriesImpl(...a),
   scopeCounts: (...a) => scopeCountsImpl(...a),

--- a/app/api/src/routes/matrix/data.js
+++ b/app/api/src/routes/matrix/data.js
@@ -9,7 +9,7 @@ import { Router } from 'express';
 import * as db from '../../db/connection.js';
 import { timedQuery } from '../../perf/sqlTimer.js';
 import { createParams } from '../../db/sqlParams.js';
-import { buildIdentityJoinExprs, buildRoleSubjectJoinExprs, buildApMemberExprs, mergeGroupTotals, resourceMeta } from '../../db/matrixHelpers.js';
+import { buildIdentityJoinExprs, buildRoleSubjectJoinExprs, buildApMemberExprs, mergeGroupTotals } from '../../db/matrixHelpers.js';
 import { resolveAttrExpr } from '../../matrix/attrExpr.js';
 import { buildInheritedFlatRows, buildInheritedRollupCounts, buildInheritedContextCounts, buildInheritedFoldCounts } from '../../matrix/inheritedAccess.js';
 import {
@@ -20,7 +20,7 @@ import {
 } from '../../matrix/contextRollup.js';
 import { buildAttrCutCellsSql, buildAttrCutNodesSql, tupleToNode } from '../../matrix/attributeCut.js';
 import { buildRollupSql, buildRollupRolesSql, buildRolesAsRowsSql, buildGroupTotalsSql, buildRolesDrillSql } from '../../matrix/rollupBuilders.js';
-import { parseFilter, buildSubqueries, scopeCounts } from './shared.js';
+import { parseFilter, buildSubqueries, scopeCounts, runBound, collectResources } from './shared.js';
 import { GROUP_PRINCIPAL_TYPE } from '../../lib/principalTypes.js';
 
 const router = Router();
@@ -101,26 +101,23 @@ async function handleAttributeFold(res, ctx) {
 
   // cells: subject + resource fragments + the collapse keys, all bound through
   // one params array (rendered fresh per query so the $N line up).
-  const cp = createParams();
-  const cellsSubjectSql = built.subject(cp.bind).sql;
-  const cellsResourceSql = built.resource(cp.bind).sql;
-  const cellRows = (await timedQuery(p, `matrix-attrcut-cells[${rowType}]`, res, buildAttrCutCellsSql({
-    attrExprs, collapsedParams: collapsedKeys.map(k => cp.bind(k)), subjectJoin,
-    subjectIdExpr: memberIdExpr, subjectIdForFilter,
-    subjectSql: cellsSubjectSql, resourceSql: cellsResourceSql,
-  }), cp.params)).rows;
+  const cellRows = (await runBound(p, `matrix-attrcut-cells[${rowType}]`, res, built,
+    ({ subjectSql, resourceSql, bind }) => buildAttrCutCellsSql({
+      attrExprs, collapsedParams: collapsedKeys.map(k => bind(k)), subjectJoin,
+      subjectIdExpr: memberIdExpr, subjectIdForFilter,
+      subjectSql, resourceSql,
+    }))).rows;
 
-  const np = createParams();
-  const nodesSubjectSql = built.subject(np.bind).sql;
-  const nodeRows = (await timedQuery(p, `matrix-attrcut-nodes[${rowType}]`, res, buildAttrCutNodesSql({
-    attrExprs, collapsedParams: collapsedKeys.map(k => np.bind(k)),
-    subjectTable: rowType === 'identity' ? 'Identities' : 'Principals',
-    subjectAlias,
-    subjectIdExpr: rowType === 'identity' ? 'i.id' : 'u.id',
-    subjectIdForFilter: rowType === 'identity' ? 'i.id' : 'u.id',
-    subjectSql: nodesSubjectSql,
-    excludeGroups: rowType !== 'identity',
-  }), np.params)).rows;
+  const nodeRows = (await runBound(p, `matrix-attrcut-nodes[${rowType}]`, res, built,
+    ({ subjectSql, bind }) => buildAttrCutNodesSql({
+      attrExprs, collapsedParams: collapsedKeys.map(k => bind(k)),
+      subjectTable: rowType === 'identity' ? 'Identities' : 'Principals',
+      subjectAlias,
+      subjectIdExpr: rowType === 'identity' ? 'i.id' : 'u.id',
+      subjectIdForFilter: rowType === 'identity' ? 'i.id' : 'u.id',
+      subjectSql,
+      excludeGroups: rowType !== 'identity',
+    }), { resource: false })).rows;
 
   // Fold inherited (effective) access into the layered attribute fold. Holder
   // tuple keys match the fold's visible key, so they reuse existing columns.
@@ -134,12 +131,8 @@ async function handleAttributeFold(res, ctx) {
     .map(r => tupleToNode(r.groupValue, r.total, r.childCount))
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
-  const resMap = new Map();
-  for (const row of cellRows) {
-    if (!row.resourceId || resMap.has(row.resourceId)) continue;
-    resMap.set(row.resourceId, resourceMeta(row));
-  }
-  for (const r of inhFold.resources) if (!resMap.has(r.resourceId)) resMap.set(r.resourceId, r);
+  const resMap = collectResources(new Map(), cellRows);
+  collectResources(resMap, inhFold.resources, r => r);
 
   const counts = await scopeCounts(p, res, rowType, built);
   // Always show one header row per chosen attribute (folded groups occupy
@@ -190,7 +183,7 @@ async function inheritedLayerFold(ctx, nodeIds, cells, resMap) {
     catch (err) { built.warnings.push('inherited context fold failed: ' + err.message); }
   }
   const inhTotByNode = new Map((inhCtx?.groupTotals || []).map(t => [t.groupValue, t.total]));
-  for (const r of (inhCtx?.resources || [])) if (!resMap.has(r.resourceId)) resMap.set(r.resourceId, r);
+  collectResources(resMap, inhCtx?.resources, r => r);
   const cellNodeIds = new Set([...cells.map(c => c.groupValue), ...(inhCtx?.groupValues || [])]);
   return { inhTotByNode, cellNodeIds, counts: inhCtx?.counts || [] };
 }
@@ -220,29 +213,21 @@ async function handleContextLayered(res, ctx) {
 
   const { join: idJoin, subjectId: cutSubjectId } = buildIdentityJoinExprs(rowType);
 
-  const lp = createParams();
-  const layerSubjectSql = built.subject(lp.bind).sql;
-  const layerResourceSql = built.resource(lp.bind).sql;
-  const layerCells = (await timedQuery(p, `matrix-ctx-layered[${rowType}]`, res, buildContextRollupSql({
-    values: cutValues, identityJoin: idJoin, subjectId: cutSubjectId, subjectScope: cutSubjectId,
-    subjectSql: layerSubjectSql, resourceSql: layerResourceSql,
-  }), lp.params)).rows;
+  const layerCells = (await runBound(p, `matrix-ctx-layered[${rowType}]`, res, built,
+    ({ subjectSql, resourceSql }) => buildContextRollupSql({
+      values: cutValues, identityJoin: idJoin, subjectId: cutSubjectId, subjectScope: cutSubjectId,
+      subjectSql, resourceSql,
+    }))).rows;
 
-  const layerResMap = new Map();
-  for (const row of layerCells) {
-    if (!row.resourceId || layerResMap.has(row.resourceId)) continue;
-    layerResMap.set(row.resourceId, resourceMeta(row));
-  }
+  const layerResMap = collectResources(new Map(), layerCells);
 
   // SCOPED member counts for the header (direct / total), so they match the
   // assignment-scoped cells and member drill rather than raw org size.
-  const scp = createParams();
-  const scSubjectSql = built.subject(scp.bind).sql;
-  const scResourceSql = built.resource(scp.bind).sql;
-  const scMap = new Map((await timedQuery(p, `matrix-ctx-scoped-members[${rowType}]`, res, buildContextScopedMemberCountsSql({
-    values: cutValues, identityJoin: idJoin, subjectId: cutSubjectId, subjectScope: cutSubjectId,
-    subjectSql: scSubjectSql, resourceSql: scResourceSql,
-  }), scp.params)).rows.map(r => [r.groupValue, { total: r.total, direct: r.direct }]));
+  const scMap = new Map((await runBound(p, `matrix-ctx-scoped-members[${rowType}]`, res, built,
+    ({ subjectSql, resourceSql }) => buildContextScopedMemberCountsSql({
+      values: cutValues, identityJoin: idJoin, subjectId: cutSubjectId, subjectScope: cutSubjectId,
+      subjectSql, resourceSql,
+    }))).rows.map(r => [r.groupValue, { total: r.total, direct: r.direct }]));
 
   // Fold inherited (effective) access into the org-rollup cells; hides org
   // branches with no in-scope assignments (a column only shows if some resource
@@ -302,22 +287,22 @@ async function handleContextZoom(res, ctx) {
   // context condition) into its subjects + the business role each holds.
   if (filter.drill) {
     const { join: brSubjectJoin, id: brId, name: brName, type: brType } = buildRoleSubjectJoinExprs(rowType);
-    const dp = createParams();
-    const members = (await timedQuery(p, `matrix-ctx-rows-drill[${rowType}]`, res, buildRolesDrillSql({
-      subjectJoin: brSubjectJoin, subjectIdExpr: brId,
-      subjectNameExpr: brName,
-      subjectTypeExpr: brType,
-      subjectIdForFilter: brId, subjectSql: built.subject(dp.bind).sql,
-    }), dp.params)).rows;
+    const members = (await runBound(p, `matrix-ctx-rows-drill[${rowType}]`, res, built,
+      ({ subjectSql }) => buildRolesDrillSql({
+        subjectJoin: brSubjectJoin, subjectIdExpr: brId,
+        subjectNameExpr: brName,
+        subjectTypeExpr: brType,
+        subjectIdForFilter: brId, subjectSql,
+      }), { resource: false })).rows;
     return res.json({ rollup: 'context', rollupKind: 'context', rollupContent: 'roles-only', drill: { members } });
   }
 
   // Shared: per-node subject totals (% denominator), node metadata, breadcrumb.
-  const tp = createParams();
-  const ctxTotals = (await timedQuery(p, `matrix-ctx-totals[${rowType}]`, res, buildContextTotalsSql({
-    values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
-    subjectSql: built.subject(tp.bind).sql,
-  }), tp.params)).rows.map(r => ({ groupValue: r.groupValue, total: r.total }));
+  const ctxTotals = (await runBound(p, `matrix-ctx-totals[${rowType}]`, res, built,
+    ({ subjectSql }) => buildContextTotalsSql({
+      values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
+      subjectSql,
+    }), { resource: false })).rows.map(r => ({ groupValue: r.groupValue, total: r.total }));
 
   const nodeRows = (await timedQuery(p, 'matrix-ctx-nodes', res, buildContextNodesSql(frontier), [])).rows;
   const nodeMeta = new Map(nodeRows.map(n => [n.id, { id: n.id, displayName: n.displayName, parent: n.parent, total: n.total, directMembers: n.directMembers, childCount: n.childCount }]));
@@ -349,11 +334,11 @@ async function handleContextZoomRoles(res, ctx, z) {
   const { built, rowType, p } = ctx;
   const { values, identityJoin, ctxSubjectId, shared } = z;
 
-  const rrp = createParams();
-  const roleRowsRes = (await timedQuery(p, `matrix-ctx-roles-rows[${rowType}]`, res, buildContextRolesAsRowsSql({
-    values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
-    subjectSql: built.subject(rrp.bind).sql,
-  }), rrp.params)).rows;
+  const roleRowsRes = (await runBound(p, `matrix-ctx-roles-rows[${rowType}]`, res, built,
+    ({ subjectSql }) => buildContextRolesAsRowsSql({
+      values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
+      subjectSql,
+    }), { resource: false })).rows;
   const roleMap = new Map();
   for (const r of roleRowsRes) {
     if (!r.roleId) continue;
@@ -374,13 +359,11 @@ async function contextZoomBusinessRoles(res, ctx, z) {
   const { values, identityJoin, ctxSubjectId } = z;
   const roleCounts = [];
   try {
-    const bp = createParams();
-    const brSubjectSql = built.subject(bp.bind).sql;
-    const brResourceSql = built.resource(bp.bind).sql;
-    const brRows = (await timedQuery(p, `matrix-ctx-roles[${rowType}]`, res, buildContextRolesSql({
-      values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
-      subjectSql: brSubjectSql, resourceSql: brResourceSql,
-    }), bp.params)).rows;
+    const brRows = (await runBound(p, `matrix-ctx-roles[${rowType}]`, res, built,
+      ({ subjectSql, resourceSql }) => buildContextRolesSql({
+        values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
+        subjectSql, resourceSql,
+      }))).rows;
     const roleMap = new Map();
     for (const r of brRows) {
       if (!r.roleId) continue;
@@ -397,23 +380,13 @@ async function handleContextZoomResources(res, ctx, z) {
   const { filter, built, rowType, includeInherited, p } = ctx;
   const { values, identityJoin, ctxSubjectId, frontier, ctxTotals, shared } = z;
 
-  const czp = createParams();
-  const czSubjectSql = built.subject(czp.bind).sql;
-  const czResourceSql = built.resource(czp.bind).sql;
-  const cellRows = (await timedQuery(p, `matrix-ctx-rollup[${rowType}]`, res, buildContextRollupSql({
-    values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
-    subjectSql: czSubjectSql, resourceSql: czResourceSql,
-  }), czp.params)).rows;
+  const cellRows = (await runBound(p, `matrix-ctx-rollup[${rowType}]`, res, built,
+    ({ subjectSql, resourceSql }) => buildContextRollupSql({
+      values, identityJoin, subjectId: ctxSubjectId, subjectScope: ctxSubjectId,
+      subjectSql, resourceSql,
+    }))).rows;
 
-  const resMap = new Map();
-  for (const row of cellRows) {
-    if (!row.resourceId || resMap.has(row.resourceId)) continue;
-    resMap.set(row.resourceId, {
-      resourceId: row.resourceId, resourceDisplayName: row.resourceDisplayName,
-      resourceType: row.resourceType, resourceDescription: row.resourceDescription,
-      systemId: row.systemId, systemName: row.systemName,
-    });
-  }
+  const resMap = collectResources(new Map(), cellRows);
 
   // Fold inherited (effective) access into the org-rollup cells (zoom view).
   // The frontier columns already exist, so we only add resources + counts.
@@ -422,7 +395,7 @@ async function handleContextZoomResources(res, ctx, z) {
     try { inhCtx2 = await buildInheritedContextCounts(p, built, rowType, frontier); }
     catch (err) { built.warnings.push('inherited context fold failed: ' + err.message); }
   }
-  for (const r of (inhCtx2?.resources || [])) if (!resMap.has(r.resourceId)) resMap.set(r.resourceId, r);
+  collectResources(resMap, inhCtx2?.resources, r => r);
 
   let businessRoles = [];
   let roleCounts = [];
@@ -462,13 +435,13 @@ async function handleRollup(res, ctx) {
   // Per-group subject denominator for the "% of subjects" metric. Returned
   // in every roll-up response so the frontend can switch count↔percent
   // without a re-query.
-  const gtp = createParams();
-  const groupTotals = (await timedQuery(p, `matrix-rollup-totals[${rowType}]`, res, buildGroupTotalsSql({
-    attrExpr: resolved.attrExpr,
-    subjectTable: rowType === 'identity' ? 'Identities' : 'Principals',
-    subjectAlias,
-    subjectSql: built.subject(gtp.bind).sql,
-  }), gtp.params)).rows.map(r => ({ groupValue: r.groupValue, total: r.total }));
+  const groupTotals = (await runBound(p, `matrix-rollup-totals[${rowType}]`, res, built,
+    ({ subjectSql }) => buildGroupTotalsSql({
+      attrExpr: resolved.attrExpr,
+      subjectTable: rowType === 'identity' ? 'Identities' : 'Principals',
+      subjectAlias,
+      subjectSql,
+    }), { resource: false })).rows.map(r => ({ groupValue: r.groupValue, total: r.total }));
 
   if (filter.rollupContent === 'roles-only') return handleRollupRoles(res, ctx, resolved, groupTotals);
   return handleRollupResources(res, ctx, resolved, groupTotals);
@@ -485,26 +458,26 @@ async function handleRollupRoles(res, ctx, resolved, groupTotals) {
   // subject attribute condition the frontend added, so subjectSql carries
   // the constraint. Returns a compact { members } payload only.
   if (filter.drill) {
-    const rdp = createParams();
-    const members = (await timedQuery(p, `matrix-rollup-rows-drill[${rowType}]`, res, buildRolesDrillSql({
-      subjectJoin: brSubjectJoin,
-      subjectIdExpr: brSubjectId,
-      subjectNameExpr: brSubjectName,
-      subjectTypeExpr: brSubjectType,
-      subjectIdForFilter: brSubjectId,
-      subjectSql: built.subject(rdp.bind).sql,
-    }), rdp.params)).rows;
+    const members = (await runBound(p, `matrix-rollup-rows-drill[${rowType}]`, res, built,
+      ({ subjectSql }) => buildRolesDrillSql({
+        subjectJoin: brSubjectJoin,
+        subjectIdExpr: brSubjectId,
+        subjectNameExpr: brSubjectName,
+        subjectTypeExpr: brSubjectType,
+        subjectIdForFilter: brSubjectId,
+        subjectSql,
+      }), { resource: false })).rows;
     return res.json({ rollup: filter.rollup, rollupContent: 'roles-only', drill: { members } });
   }
 
-  const rrp2 = createParams();
-  const rolesResult = (await timedQuery(p, `matrix-rollup-rows[${rowType}]`, res, buildRolesAsRowsSql({
-    attrExpr: resolved.attrExpr,
-    subjectJoin: brSubjectJoin,
-    subjectIdExpr: brSubjectId,
-    subjectIdForFilter: brSubjectId,
-    subjectSql: built.subject(rrp2.bind).sql,
-  }), rrp2.params)).rows;
+  const rolesResult = (await runBound(p, `matrix-rollup-rows[${rowType}]`, res, built,
+    ({ subjectSql }) => buildRolesAsRowsSql({
+      attrExpr: resolved.attrExpr,
+      subjectJoin: brSubjectJoin,
+      subjectIdExpr: brSubjectId,
+      subjectIdForFilter: brSubjectId,
+      subjectSql,
+    }), { resource: false })).rows;
 
   const counts = await scopeCounts(p, res, rowType, built);
   const roleMap = new Map();
@@ -534,34 +507,19 @@ async function handleRollupRoles(res, ctx, resolved, groupTotals) {
 async function handleRollupResources(res, ctx, resolved, groupTotals) {
   const { filter, built, rowType, subjectJoin, memberIdExpr, subjectIdForFilter, includeInherited, p } = ctx;
 
-  const rup = createParams();
-  const ruSubjectSql = built.subject(rup.bind).sql;
-  const ruResourceSql = built.resource(rup.bind).sql;
-  const rollupResult = await timedQuery(p, `matrix-rollup[${rowType}]`, res, buildRollupSql({
-    attrExpr: resolved.attrExpr,
-    subjectJoin,
-    subjectIdExpr: memberIdExpr,
-    subjectIdForFilter,
-    subjectSql: ruSubjectSql,
-    resourceSql: ruResourceSql,
-  }), rup.params);
+  const rollupResult = await runBound(p, `matrix-rollup[${rowType}]`, res, built,
+    ({ subjectSql, resourceSql }) => buildRollupSql({
+      attrExpr: resolved.attrExpr,
+      subjectJoin,
+      subjectIdExpr: memberIdExpr,
+      subjectIdForFilter,
+      subjectSql,
+      resourceSql,
+    }));
 
   const counts = await scopeCounts(p, res, rowType, built);
-  const resMap = new Map();
-  const groupSet = new Set();
-  for (const row of rollupResult.rows) {
-    if (!resMap.has(row.resourceId)) {
-      resMap.set(row.resourceId, {
-        resourceId: row.resourceId,
-        resourceDisplayName: row.resourceDisplayName,
-        resourceType: row.resourceType,
-        resourceDescription: row.resourceDescription,
-        systemId: row.systemId,
-        systemName: row.systemName,
-      });
-    }
-    groupSet.add(row.groupValue);
-  }
+  const resMap = collectResources(new Map(), rollupResult.rows);
+  const groupSet = new Set(rollupResult.rows.map(r => r.groupValue));
 
   // Fold inherited (effective) access into the count cells (Phase 2). The
   // declared rollup above is empty for scope-node scopes; the engine yields
@@ -572,7 +530,7 @@ async function handleRollupResources(res, ctx, resolved, groupTotals) {
     try {
       const inh = await buildInheritedRollupCounts(p, built, rowType, filter.rollup, built.principalCols);
       if (inh) {
-        for (const r of inh.resources) if (!resMap.has(r.resourceId)) resMap.set(r.resourceId, r);
+        collectResources(resMap, inh.resources, r => r);
         for (const gv of inh.groupValues) groupSet.add(gv);
         inhCounts = inh.counts;
         inhGroupTotals = inh.groupTotals;
@@ -588,12 +546,10 @@ async function handleRollupResources(res, ctx, resolved, groupTotals) {
   if (filter.rollupContent !== 'resources-only') {
     try {
       const { memberId: brMemberId, join: brJoin } = buildApMemberExprs(rowType);
-      const brp = createParams();
-      const brRolesSubjectSql = built.subject(brp.bind).sql;
-      const brRolesResourceSql = built.resource(brp.bind).sql;
-      const brRows = (await timedQuery(p, 'matrix-rollup-roles', res, buildRollupRolesSql({
-        brMemberId, brJoin, subjectSql: brRolesSubjectSql, resourceSql: brRolesResourceSql,
-      }), brp.params)).rows;
+      const brRows = (await runBound(p, 'matrix-rollup-roles', res, built,
+        ({ subjectSql, resourceSql }) => buildRollupRolesSql({
+          brMemberId, brJoin, subjectSql, resourceSql,
+        }))).rows;
       const roleMap = new Map();
       for (const r of brRows) {
         if (!r.roleId) continue;

--- a/app/api/src/routes/matrix/shared.js
+++ b/app/api/src/routes/matrix/shared.js
@@ -9,6 +9,7 @@ import { timedQuery } from '../../perf/sqlTimer.js';
 import { createParams } from '../../db/sqlParams.js';
 import { getPrincipalColumns, getResourceColumns } from '../../db/columnCache.js';
 import { buildEntitySubquery, collectContextIds } from '../../matrix/filterSql.js';
+import { resourceMeta } from '../../db/matrixHelpers.js';
 import { GROUP_PRINCIPAL_TYPE } from '../../lib/principalTypes.js';
 
 export const ROW_TYPES = new Set(['principal', 'identity']);
@@ -246,6 +247,34 @@ export async function buildSubqueries(filter) {
 export async function runCount(p, label, res, sql, params) {
   const result = await timedQuery(p, label, res, sql, params);
   return result.rows[0]?.c ?? 0;
+}
+
+// Most matrix sub-queries share one shape: allocate a fresh positional-param
+// array (pg can't reuse params across queries), render the subject filter
+// subquery — and, unless { resource:false }, the resource one — into the SQL via
+// `bind`, time the query, and return the pg result. runBound captures that
+// boilerplate; `render({ subjectSql, resourceSql, bind })` returns the finished
+// SQL string. Pass { resource:false } for subject-only queries so no resource
+// params are bound (which would desync pg's positional-parameter count). Binding
+// order is subject, then resource, then whatever the render binds — matching the
+// hand-written call sites this replaces.
+export async function runBound(p, label, res, built, render, { resource = true } = {}) {
+  const { params, bind } = createParams();
+  const subjectSql = built.subject(bind).sql;
+  const resourceSql = resource ? built.resource(bind).sql : '';
+  return timedQuery(p, label, res, render({ subjectSql, resourceSql, bind }), params);
+}
+
+// De-dupe resource rows/objects into `map` keyed by resourceId (first occurrence
+// wins), mirroring the resource-map build repeated across the roll-up handlers.
+// Raw query rows go through resourceMeta by default; pass an identity mapper
+// (r => r) to merge already-shaped resource objects (the inherited-access lists).
+export function collectResources(map, rows, toMeta = resourceMeta) {
+  for (const row of rows || []) {
+    if (!row?.resourceId || map.has(row.resourceId)) continue;
+    map.set(row.resourceId, toMeta(row));
+  }
+  return map;
 }
 
 export function subjectScopeClauses(rowType, subjectSql) {

--- a/app/api/src/routes/matrix/shared.test.js
+++ b/app/api/src/routes/matrix/shared.test.js
@@ -16,7 +16,7 @@ vi.mock('../../matrix/filterSql.js', () => ({ buildEntitySubquery: (...a) => bui
 
 const {
   parseFilter, normaliseBlock, subjectScopeClauses, normaliseSortAttributes,
-  buildSubqueries, runCount, scopeCounts,
+  buildSubqueries, runCount, scopeCounts, runBound, collectResources,
 } = await import('./shared.js');
 const { createParams } = await import('../../db/sqlParams.js');
 
@@ -147,5 +147,59 @@ describe('scopeCounts', () => {
     // The resource-count query has no IN clause when the resource fragment is null.
     const resourceCountSql = timedQ.mock.calls.find(c => c[1] === 'matrix-data-resource-count')[3];
     expect(resourceCountSql).not.toContain('WHERE id IN');
+  });
+});
+
+describe('runBound', () => {
+  it('binds subject then resource then render params, runs the rendered SQL, returns the result', async () => {
+    timedQ.mockResolvedValueOnce({ rows: [{ x: 1 }] });
+    const built = {
+      subject: (bind) => ({ sql: `SUBJ(${bind('s')})` }),
+      resource: (bind) => ({ sql: `RES(${bind('r')})` }),
+    };
+    const out = await runBound({}, 'lbl', {}, built,
+      ({ subjectSql, resourceSql, bind }) => `SELECT ${subjectSql} ${resourceSql} ${bind('extra')}`);
+    expect(out).toEqual({ rows: [{ x: 1 }] });
+    const [, label, , sql, params] = timedQ.mock.calls[0];
+    expect(label).toBe('lbl');
+    expect(sql).toBe('SELECT SUBJ($1) RES($2) $3');   // subject $1, resource $2, render $3
+    expect(params).toEqual(['s', 'r', 'extra']);
+  });
+
+  it('skips the resource fragment (binds no resource params) when { resource:false }', async () => {
+    timedQ.mockResolvedValueOnce({ rows: [] });
+    const resource = vi.fn();
+    const built = { subject: (bind) => ({ sql: `SUBJ(${bind('s')})` }), resource };
+    await runBound({}, 'lbl', {}, built,
+      ({ subjectSql, resourceSql }) => `Q ${subjectSql} [${resourceSql}]`, { resource: false });
+    expect(resource).not.toHaveBeenCalled();
+    const [, , , sql, params] = timedQ.mock.calls[0];
+    expect(sql).toBe('Q SUBJ($1) []');   // resourceSql defaults to '' — no resource params
+    expect(params).toEqual(['s']);
+  });
+});
+
+describe('collectResources', () => {
+  it('maps rows through resourceMeta, keeps the first per resourceId, skips falsy ids', () => {
+    const rows = [
+      { resourceId: 'a', resourceDisplayName: 'A', resourceType: 'Group', resourceDescription: 'd', systemId: 1, systemName: 'S' },
+      { resourceId: 'a', resourceDisplayName: 'A-dup' },   // duplicate id ignored
+      { resourceId: null, resourceDisplayName: 'skip' },   // falsy id skipped
+    ];
+    const map = collectResources(new Map(), rows);
+    expect([...map.keys()]).toEqual(['a']);
+    expect(map.get('a')).toEqual({
+      resourceId: 'a', resourceDisplayName: 'A', resourceType: 'Group',
+      resourceDescription: 'd', systemId: 1, systemName: 'S',
+    });
+  });
+
+  it('accepts an identity mapper to merge shaped objects and tolerates null rows', () => {
+    const map = new Map([['a', { resourceId: 'a' }]]);
+    const obj = { resourceId: 'b', foo: 1 };
+    collectResources(map, [obj, { resourceId: 'a', foo: 2 }], r => r);  // 'a' present → kept
+    collectResources(map, null, r => r);                                 // null rows → no-op
+    expect(map.get('b')).toBe(obj);                     // identity mapper stores as-is
+    expect(map.get('a')).toEqual({ resourceId: 'a' });  // existing 'a' not overwritten
   });
 });

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -4,13 +4,12 @@ import { createParams } from '../db/sqlParams.js';
 import { parseJsonbColumn } from '../lib/jsonb.js';
 import { buildOrderBy } from '../lib/listSort.js';
 import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
-import { ensureTagTables, buildFilterWhere } from './tags.js';
+import { ensureTagTables, buildFilterWhere, parseTags } from './tags.js';
+import { UUID_RE, cleanRow, getPermissionTable } from './details/shared.js';
 import { isMissingSchema } from '../db/schemaErrors.js';
 
 const router = Router();
 const useSql = process.env.USE_SQL === 'true';
-const UUID_RE = /^[0-9a-f-]{36}$/i;
-const SYSTEM_COLS = new Set(['SysStartTime', 'SysEndTime']);
 
 // Columns the Groups/Resources page lets you sort by (its TABLE_COLUMNS keys).
 // Values are the page CTE's output aliases — safe to interpolate; see
@@ -24,27 +23,6 @@ const RESOURCE_SORTS = {
 let db = null;
 if (useSql) {
   db = await import('../db/connection.js');
-}
-
-function cleanRow(row) {
-  const clean = {};
-  for (const [key, value] of Object.entries(row)) {
-    if (!SYSTEM_COLS.has(key)) clean[key] = value;
-  }
-  return clean;
-}
-
-// Helper: parse tag string from SQL into array. Tag IDs are UUID strings (v6).
-function parseTags(tagString) {
-  if (!tagString) return [];
-  return tagString.split('|').map(t => {
-    const parts = t.split(':');
-    return { id: parts[0], name: parts[1], color: parts[2] };
-  });
-}
-
-async function getPermissionTable(_pool) {
-  return '"vw_ResourceUserPermissionAssignments"';
 }
 
 // ─── GET /api/resources ─────────────────────────────────────────

--- a/app/api/src/routes/resources.test.js
+++ b/app/api/src/routes/resources.test.js
@@ -29,10 +29,16 @@ vi.mock('../db/columnCache.js', () => ({
   getResourceColumns: async () => [{ name: 'displayName' }, { name: 'resourceType' }],
   getResourceColumnValues: vi.fn(),
 }));
-vi.mock('./tags.js', () => ({
-  ensureTagTables: async () => {},
-  buildFilterWhere: () => '',
-}));
+// parseTags is a pure helper re-exported from ./tags/shared.js — use the real
+// one so the tag-parsing assertion reflects production behaviour.
+vi.mock('./tags.js', async () => {
+  const { parseTags } = await vi.importActual('./tags/shared.js');
+  return {
+    ensureTagTables: async () => {},
+    buildFilterWhere: () => '',
+    parseTags,
+  };
+});
 
 const { default: router } = await import('./resources.js');
 const app = mountRouter(router);

--- a/app/api/src/routes/tags.js
+++ b/app/api/src/routes/tags.js
@@ -20,5 +20,5 @@ const router = Router();
 router.use(crudRouter);
 router.use(entitiesRouter);
 
-export { ensureTagTables, buildFilterWhere, ENTITY_TO_TARGET, UUID_RE } from './tags/shared.js';
+export { ensureTagTables, buildFilterWhere, ENTITY_TO_TARGET, UUID_RE, parseTags } from './tags/shared.js';
 export default router;

--- a/app/api/src/routes/tags/entities.js
+++ b/app/api/src/routes/tags/entities.js
@@ -11,7 +11,7 @@ import { getResourceColumns as getResourceCols, getPrincipalOrUserColumns, getPr
 import { createParams } from '../../db/sqlParams.js';
 import { parseJsonbColumn } from '../../lib/jsonb.js';
 import { buildOrderBy } from '../../lib/listSort.js';
-import { useSql, db, ensureTagTables, buildFilterWhere, UUID_RE } from './shared.js';
+import { useSql, db, ensureTagTables, buildFilterWhere, UUID_RE, parseTags } from './shared.js';
 
 const router = Router();
 
@@ -23,16 +23,6 @@ const USER_SORTS = {
   department: '"department"',
   jobTitle: '"jobTitle"',
 };
-
-// ─── Helper: parse tag string from SQL into array ─────────────────
-// Tag IDs are UUID strings (v6) — do not parseInt.
-function parseTags(tagString) {
-  if (!tagString) return [];
-  return tagString.split('|').map(t => {
-    const parts = t.split(':');
-    return { id: parts[0], name: parts[1], color: parts[2] };
-  });
-}
 
 // ─── GET /api/user-columns-page ──────────────────────────────────
 // Column discovery for the Users page (distinct values from GraphUsers)

--- a/app/api/src/routes/tags/shared.js
+++ b/app/api/src/routes/tags/shared.js
@@ -21,6 +21,18 @@ export async function ensureTagTables(_pool) { tablesReady = true; }
 export const ENTITY_TO_TARGET = { user: 'Principal', group: 'Resource', resource: 'Resource', identity: 'Identity' };
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Parse the pipe-delimited tag string emitted by the entity-list SQL
+// (`id:name:color|id:name:color…`) into an array of tag objects. Tag IDs are
+// UUID strings (v6). Empty/absent input yields []. Shared by tags/entities.js
+// and resources.js (via the ./tags.js barrel).
+export function parseTags(tagString) {
+  if (!tagString) return [];
+  return tagString.split('|').map(t => {
+    const parts = t.split(':');
+    return { id: parts[0], name: parts[1], color: parts[2] };
+  });
+}
+
 // Build parameterized WHERE clause from filters object.
 //
 // Two kinds of filter keys are accepted:

--- a/changes/route-helper-dedup.md
+++ b/changes/route-helper-dedup.md
@@ -1,0 +1,1 @@
+- Internal code cleanup: consolidated duplicated Node API route helpers flagged by the June 2026 maintenance audit — the matrix query handlers now share a single bind-and-run query helper and a resource-map accumulator instead of ~20 copy-pasted blocks, and the resource-list endpoint reuses the shared row/tag helpers. No change to behaviour or API responses.


### PR DESCRIPTION
Consolidates the three tightly-coupled route-helper duplications the June 2026 maintenance audit tracked as Q3/Q4/Q5. They all touch overlapping handler code (the matrix query handlers and the resource-list endpoint), so splitting them into separate PRs would self-conflict on merge — they're done together here as one behaviour-preserving cleanup.

### What changed

**Q3 — `runBound()` generalises `runCount` (Closes #791).**
The ~14 copy-pasted "allocate a fresh `createParams()` → render the subject/resource subqueries via `bind` → `timedQuery` → `.rows`" blocks across `matrix/data.js` now go through one `runBound(p, label, res, built, render, { resource })` helper in `matrix/shared.js`. Subject-only queries pass `{ resource:false }` so no resource params are bound (keeping pg's positional-param count in sync). Bind order (subject → resource → render) is preserved exactly.

**Q4 — reuse the shared row/tag helpers in `resources.js` (Closes #792).**
`resources.js` no longer keeps its own drifted copies of `cleanRow` / `UUID_RE` / `getPermissionTable` — it imports the canonical ones from `details/shared.js`. `parseTags` (previously duplicated byte-for-byte in `resources.js` and `tags/entities.js`) is promoted into `tags/shared.js`, re-exported through the `tags.js` barrel, and consumed by both.

**Q5 — `collectResources()` for the resource-map build loops (Closes #793).**
The ~8 "de-dupe rows into a `resourceId → meta` map" loops (two of which had re-inlined the shape, i.e. drifted) now call one `collectResources(map, rows, toMeta)` helper built on the existing `resourceMeta()`. Raw rows map through `resourceMeta` by default; the inherited-access merges pass an identity mapper.

No API responses or SQL change — the emitted SQL and params are identical.

### Tests
- New unit tests for `runBound` (both-fragment + `{resource:false}` paths, param order) and `collectResources` (resourceMeta mapping, first-wins de-dupe, falsy-id skip, identity mapper, null rows).
- `data.coverage.test.js` / `resources.test.js` mocks updated to expose the new/moved helpers (spread the real module; use the real `parseTags`).

### Verification (local)
ESLint · full API unit suite (1976) · aggregate + per-file coverage ratchets · cyclomatic + cognitive + file-length ratchets · jscpd (114 = base 114) · matrix-data / resources / shared **contract tests** against real Postgres 16.

Closes #791
Closes #792
Closes #793
