### PR TITLE
feat(demo): extend the demo dataset to carry Capture-the-Flag flags 1-12 (#705)

### DIFF
--- a/changes/feature-demo-ctf-dataset.md
+++ b/changes/feature-demo-ctf-dataset.md
@@ -1,0 +1,9 @@
+- Expanded the demo dataset from 3 systems to 5: alongside Entra ID and HR, the demo now ships an IGA system, an SAP ERP system and an Azure (AzureRM) system, with accounts correlated across all of them.
+- Renamed the demo's governance system from "Omada" to a vendor-neutral "IGA" — a business role is the same concept whether it comes from Omada, midPoint or SailPoint, and the demo shouldn't imply one vendor. (The Omada crawler itself is unchanged.)
+- Added a Marketing department and four new people to the demo company, including Piet Jansen — the deliberately worst-case identity, with role-inherited access, a never-expiring password and consent to a risky app.
+- Added a Sales business role, an ad-hoc role candidate, and an over-privileged cross-department group, so the demo now shows a realistic role-mining picture: what a role grants, what it should probably grant, and what it should not.
+- Demo accounts now carry a password-expiry attribute, so you can filter the matrix for accounts whose password never expires.
+- Added two third-party apps to the demo with OAuth consent grants — one risky, one clean — so the Risky Consent view has something to find.
+- Azure demo resources are region-tagged (US and EU), so you can ask who has access in a given region.
+- The demo dataset now resolves real system ids from the API instead of assuming they are 1, 2 and 3 — previously it could attach demo data to the wrong system on any database that had already seen another crawler.
+- Demo data is now loaded per system, so re-loading it can no longer make one system's sync remove another system's data.

--- a/docs/architecture/demo-dataset.md
+++ b/docs/architecture/demo-dataset.md
@@ -1,5 +1,8 @@
 # Demo Dataset & End-to-End Validation
 
+!!! danger "This whole page is a spoiler"
+    It documents the dataset in full — including the records that exist only to be the wrong answer. If you want to play [Capture the Flag](../demo/capture-the-flag.md), go there instead and don't read on. (The answer key itself is collapsed further down, but the tables above it give plenty away.)
+
 A purpose-built synthetic dataset for testing every feature of Identity Atlas. Fully controlled — every record, relationship, and edge case is intentional, so tests can assert on exact values.
 
 It also backs the **public demo environment** and hides the **Capture-the-Flag** scenarios from issue #705 — see [Capture-the-Flag scenarios](#capture-the-flag-scenarios) below. That is why several records exist purely as distractors: a flag is only interesting if a plausible wrong answer sits next to the right one.

--- a/docs/architecture/demo-dataset.md
+++ b/docs/architecture/demo-dataset.md
@@ -2,11 +2,32 @@
 
 A purpose-built synthetic dataset for testing every feature of Identity Atlas. Fully controlled — every record, relationship, and edge case is intentional, so tests can assert on exact values.
 
+It also backs the **public demo environment** and hides the **Capture-the-Flag** scenarios from issue #705 — see [Capture-the-Flag scenarios](#capture-the-flag-scenarios) below. That is why several records exist purely as distractors: a flag is only interesting if a plausible wrong answer sits next to the right one.
+
+## How it's generated
+
+`test/demo-dataset/Generate-DemoDataset.ps1` is a thin orchestrator. Each domain lives in its own file under `parts/`, dot-sourced in order and appending into one shared state object via record builders (`Add-DemoResource`, `Add-DemoAssignment`, …), so the shape of each record is defined once:
+
+| Part | Owns |
+|---|---|
+| `DemoState.ps1` | `New-DemoGuid`, the state accumulator, the record builders |
+| `DemoOrg.ps1` | Systems, the context tree, people, identities |
+| `DemoEntraBase.ps1` | Entra groups / directory roles / app roles / group ownership |
+| `DemoGovernance.ps1` | IGA catalogs, business roles, policies, certifications |
+| `DemoSalesScenario.ps1` | The Sales role-mining scenario (flags 1–7) |
+| `DemoConsent.ps1` | OAuth consent + shadow IT (flags 11–12) |
+| `DemoSap.ps1` | The SAP ERP system (flag 8) |
+| `DemoAzure.ps1` | The AzureRM system (flag 10) |
+
+GUIDs are a pure function of a seed string (`New-DemoGuid`), so any part can reference another part's record without an ordering contract, and the whole dataset is byte-stable across runs.
+
+> **`demo-company.json` is a build artifact, not a source file.** It is gitignored — always regenerate rather than relying on a copy on disk.
+
 ---
 
 ## The Company: Fortigi Demo Corp
 
-A mid-size technology consultancy with 22 employees across 4 departments. Small enough to reason about, large enough to exercise all features.
+A mid-size technology consultancy with 26 employees across 6 departments. Small enough to reason about, large enough to exercise all features.
 
 ### Org Chart
 
@@ -43,12 +64,19 @@ graph TB
         CSO --> SM["Paul Quinn<br/>Sales Manager<br/>E0013"]
         SM --> SR1["Rachel Smith<br/>Account Exec<br/>E0027"]
         SM --> SR2["Stefan Tanaka<br/>Account Exec<br/>E0028"]
+        SM --> SR3["Piet Jansen<br/>Account Exec<br/>E0032"]
+        SM --> SR4["Sanne Vermeer<br/>Sales Dev Rep<br/>E0033"]
     end
 
     subgraph Operations
         COO --> OM["Ursula Visser<br/>Ops Manager<br/>E0014"]
         OM --> OPS1["Victor Wang<br/>SysAdmin<br/>E0029"]
         OM --> OPS2["Wendy Xu<br/>SysAdmin<br/>E0030"]
+        OM --> OPS3["Tom Bakker<br/>Logistics Coord<br/>E0034"]
+    end
+
+    subgraph Marketing
+        CEO --> MK1["Nadia Haddad<br/>Marketing Specialist<br/>E0035"]
     end
 ```
 
@@ -61,18 +89,27 @@ graph TB
 | Disabled account | E0041 Alex Former | `accountEnabled: false`; left the company; should still show in history |
 | Service principal | SVC-001 Deploy Pipeline | Non-human; `principalType: ServicePrincipal`; member of admin groups |
 | AI agent | AI-001 Copilot Assistant | `principalType: AIAgent`; member of data access groups |
-| Multi-system identity | E0020 Hassan Ibrahim | Has accounts in both EntraID and Omada; identity correlation links them |
+| Multi-system identity | E0020 Hassan Ibrahim | Has accounts in EntraID, the IGA system and SAP; identity correlation links them |
 | Shared mailbox | SM-001 info@fortigidemo.com | `principalType: SharedMailbox`; owned by E0027 |
 | Manager in different dept | E0014 Ursula Visser | Reports to COO but manages Operations — tests cross-dept context |
 | Employee with no assignments | E0031 Zara Intern | A new hire not yet provisioned: flagged `noAccess` in the generator, so she is excluded from every department group and business-role grant. She still exists as a principal and appears in the Engineering context, but holds **zero** resource assignments — the deliberate zero-assignment edge case |
+| Never-revoked role after a transfer | E0034 Tom Bakker | Moved from Sales to Operations but kept his `BR-Sales` assignment — the "nobody cleaned it up" case |
+| Worst-case identity | E0032 Piet Jansen | Role-inherited CRM access, a never-expiring password, and consent to a risky app. Deliberately threads through flags 4, 9, 11 and 12 |
+| Provisioning gap | Everyone | `BR-Employee-Base` **Contains** `FortigiGraph-App`, but nobody holds an effective assignment on it — so it renders as a gap under the matrix's Gaps toggle rather than as access. Deliberate; do not "fix" it |
 
 ### Systems
 
 | System | Type | Content |
 |---|---|---|
-| Fortigi Demo EntraID | `EntraID` | Principals (users, SPs, AI agents), groups, directory roles |
-| Fortigi Demo HR | `HR` | Identities, org units (HR department tree), employment |
-| Fortigi Demo Omada | `Omada` | Business roles, governed assignments, certifications |
+| Fortigi Demo EntraID | `EntraID` | Principals (users, SPs, AI agents), groups, directory roles, app consent |
+| Fortigi Demo HR | `HR` | Identities, the department context tree, employment |
+| Fortigi Demo IGA | `IGA` | Business roles, governed assignments, certifications |
+| Fortigi Demo SAP ERP | `SAP` | SAP accounts + roles, correlated to identities |
+| Fortigi Demo Azure | `AzureRM` | Azure scope tree + RBAC role assignments, region-tagged |
+
+> **Why `IGA` and not `Omada`.** A business role is the same concept whether it comes from Omada, midPoint or SailPoint, so the demo names the source generically — the CTF is identical in every case (issue #705, Rob's review). This is demo data only; the real Omada crawler under `tools/crawlers/omada/` is a separate thing and is unaffected.
+
+> **System ids are placeholders.** `Systems.id` is a `SERIAL`, so the ids the database hands out are only 1..N on a pristine database. The generator emits placeholders plus a `metadata.systemKeys` index; `Ingest-DemoDataset.ps1` posts Systems first, reads the real ids back from the API response, and remaps every reference before posting anything else. Rows are then posted **per system**, because a full sync reconciles against the envelope's `systemId`.
 
 ### Context Trees (Independent)
 
@@ -106,21 +143,35 @@ AU-Netherlands
 | SG-PAM-Users | Group | EntraID | PAM access |
 | Global Administrator | EntraDirectoryRole | EntraID | Entra directory role |
 | SharePoint Admin | EntraDirectoryRole | EntraID | Entra directory role |
-| IdentityAtlas-App | AppRole | EntraID | App role for this product |
+| FortigiGraph-App | AppRole | EntraID | App role for this product. (Name predates the Identity Atlas rename; the generator still emits `FortigiGraph-App`.) |
 | SAP-Finance-Role | AppRole | EntraID | SAP financial access |
-| BR-Employee-Base | BusinessRole | Omada | Base employee access package |
-| BR-Engineering-Tools | BusinessRole | Omada | Dev tools access package |
-| BR-Finance-Systems | BusinessRole | Omada | Financial systems access |
-| BR-Admin-Privileged | BusinessRole | Omada | Privileged admin access |
+| BR-Employee-Base | BusinessRole | IGA | Base employee access package |
+| BR-Engineering-Tools | BusinessRole | IGA | Dev tools access package |
+| BR-Finance-Systems | BusinessRole | IGA | Financial systems access |
+| BR-Admin-Privileged | BusinessRole | IGA | Privileged admin access |
+| BR-Sales | BusinessRole | IGA | Sales role — Contains SG-Sales + SG-CRM-Users |
 | SG-Engineering | GroupOwnership | EntraID | Owners of the Engineering group (a GroupOwnership resource is named after the group it owns) |
 | SG-Finance | GroupOwnership | EntraID | Owners of the Finance group |
 | SG-Admin-Tier0 | GroupOwnership | EntraID | Owners of the Tier-0 admin group |
+| SG-Sales | Group | EntraID | Sales department group — granted **by** BR-Sales |
+| SG-CRM-Users | Group | EntraID | CRM access — granted **by** BR-Sales (flag 4) |
+| SG-Sales-SharePoint | Group | EntraID | Ad-hoc grant held directly by 5 of 6 Sales — the role candidate (flag 6) |
+| SG-Finance-Reports | Group | EntraID | Sensitive cross-department finance access — the over-privileged trap (flag 7) |
+| FileSync Pro | Application | EntraID | Third-party app, unverified publisher — the risky one |
+| Files.ReadWrite.All | DelegatedPermission | EntraID | The risky consent scope (flags 11–12) |
+| Contoso Timesheets | Application | EntraID | Approved app, verified publisher — the control |
+| User.Read | DelegatedPermission | EntraID | Low-risk scope on the control app |
+| SAP_FI_ACCOUNTANT / SAP_SD_SALES / SAP_MM_VIEWER / SAP_BASIS_ADMIN | SAPRole | SAP ERP | SAP role per module |
+| Fortigi Demo Tenant | AzureScope | AzureRM | Azure scope-tree root |
+| rg-prod-eastus / rg-prod-westeurope | AzureResourceGroup | AzureRM | Region-tagged (`azureLocation`) resource groups |
+| stprodeastus01 / stprodweu01 | AzureResource | AzureRM | Storage accounts under each RG |
+| `<Role> @ <scope>` (×4) | AzureRoleAssignment | AzureRM | The synthetic "role at scope" capability RBAC hangs off (flag 10) |
 
 ### Assignments (Who Has What)
 
 | Principal | Resource | Type | Notes |
 |---|---|---|---|
-| Every employee except the intern (21) | SG-AllEmployees | Direct | E0031 is the deliberate zero-assignment case — see Edge Cases |
+| Every employee except the intern (25) | SG-AllEmployees | Direct | E0031 is the deliberate zero-assignment case — see Edge Cases |
 | Engineering employees except the intern (8) | SG-Engineering | Direct | By `department` (includes the CTO E0002); the unprovisioned intern E0031 is excluded |
 | Every Finance employee (4) | SG-Finance | Direct | By `department` |
 | E0029, E0030 (SysAdmins) | SG-VPN-Access | Direct | |
@@ -128,23 +179,36 @@ AU-Netherlands
 | E0029 (SysAdmin) | SG-Admin-Tier0 | Direct | Member of high-risk group |
 | SVC-001 (Deploy Pipeline) | SG-Admin-Tier0 | Direct | Service principal in admin group |
 | E0002 (CTO) | Global Administrator | Direct | Directory role assignment |
-| Every employee except the intern (21) | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
+| Every employee except the intern (25) | BR-Employee-Base | Direct (`governed=true`) | Via business role — governance is the `governed` flag, not an assignment type |
 | Engineering employees except the intern (8) | BR-Engineering-Tools | Direct (`governed=true`) | Via business role |
 | E0029 (SysAdmin) | BR-Admin-Privileged | Eligible | PIM-eligible, not active |
 | E0010 → SG-Engineering; E0012 → SG-Finance; E0002 + E0029 → SG-Admin-Tier0 | GroupOwnership | Direct | Ownership is a Direct assignment on a synthetic GroupOwnership resource, never an `Owner` type |
+| The 6 Sales members **+ E0034 Tom Bakker + E0035 Nadia Haddad** | BR-Sales | Direct (`governed=true`) | The two outsiders are flag 3's answer — a role assignment that survived a transfer / a project |
+| Everyone holding BR-Sales (8) | SG-Sales, SG-CRM-Users | Indirect | The materialised role-derived access. The `Contains` edge supplies the *why*; this row is the access itself |
+| 5 of the 6 Sales members (not E0033) | SG-Sales-SharePoint | Direct | Ad-hoc — the role candidate (flag 6). Held by most, not all, which is what keeps it out of flag 2's shared set |
+| E0013, E0027, E0028, E0032 + all 4 Finance | SG-Finance-Reports | Direct | The over-privileged trap (flag 7) |
+| E0032, E0027, E0020, E0030, E0025 | Files.ReadWrite.All | Direct | OAuth consent (flag 11). Migration 045 rewrote `OAuth2Grant` → `Direct`, so consent is a Direct assignment |
+| E0029, E0021, E0022, E0024 | User.Read | Direct | Consent to the clean control app — E0029 is flag 12's trap |
+| 10 SAP accounts | SAP roles | Direct | Skewed Finance 4 / Sales 3 / Ops 2 / Eng 1 (flag 8) |
+| E0029 + SVC-001 → eastus; E0030 → eastus storage; E0020, E0010, E0029 → westeurope | AzureRoleAssignment | Direct | Flag 10. E0029 spans both regions on purpose |
 
 ### Resource Relationships
 
 | Parent | Child | Type | Notes |
 |---|---|---|---|
 | BR-Employee-Base | SG-AllEmployees | Contains | Business role grants group |
-| BR-Employee-Base | IdentityAtlas-App | Contains | Business role grants app role |
+| BR-Employee-Base | FortigiGraph-App | Contains | Business role grants app role — deliberately with no effective assignment, so it renders as a provisioning gap |
 | BR-Engineering-Tools | SG-Engineering | Contains | |
 | BR-Engineering-Tools | SG-VPN-Access | Contains | |
 | BR-Finance-Systems | SG-Finance | Contains | |
 | BR-Finance-Systems | SAP-Finance-Role | Contains | |
 | BR-Admin-Privileged | SG-Admin-Tier0 | Contains | |
 | BR-Admin-Privileged | SG-PAM-Users | Contains | |
+| BR-Sales | SG-Sales | Contains | Business role grants the Sales group |
+| BR-Sales | SG-CRM-Users | Contains | Business role grants CRM — this edge is flag 4's answer |
+| FileSync Pro | Files.ReadWrite.All | DelegatesScope | App → the scope consented to it |
+| Contoso Timesheets | User.Read | DelegatesScope | The control app |
+| Fortigi Demo Tenant → rg-prod-eastus / rg-prod-westeurope → their storage accounts | Contains | Contains | The Azure scope tree (4 edges) |
 | SG-Engineering | SG-AllEmployees | GrantsAccessTo | Nested group |
 | SG-Engineering | SG-Engineering (ownership) | HasOwnership | Group → its GroupOwnership resource |
 | SG-Finance | SG-Finance (ownership) | HasOwnership | |
@@ -154,22 +218,81 @@ AU-Netherlands
 
 | Entity | Data |
 |---|---|
-| Catalog: "Employee Access" | Contains BR-Employee-Base, BR-Engineering-Tools, BR-Finance-Systems |
+| Catalog: "Employee Access" | Contains BR-Employee-Base, BR-Engineering-Tools, BR-Finance-Systems, BR-Sales |
 | Catalog: "Privileged Access" | Contains BR-Admin-Privileged |
 | Policy: "Auto-assign all employees" | On BR-Employee-Base, scope: all, auto-approve |
 | Policy: "Manager approval" | On BR-Engineering-Tools, requires manager approval |
 | Policy: "Dual approval" | On BR-Admin-Privileged, requires manager + security team |
+| Policy: "Sales role — manager approval" | On BR-Sales, requires manager approval |
 | Certification: Q1 2026 Review | Reviewed E0029's access to BR-Admin-Privileged — decision: Approve |
 | Certification: Q1 2026 Review | Reviewed E0041's access to BR-Employee-Base — decision: Deny (left company) |
+| Certification: Q1 2026 Review | Reviewed E0013's access to SG-Finance-Reports — decision: Approve, "Sales Manager needs pipeline revenue reporting; approved for this role only". This is the evidence for flag 7's *why* |
 
 ### Identity Correlation
 
 | Identity | Principals | Correlation |
 |---|---|---|
-| Anna Bakker (ID-001) | E0001 (EntraID), E0001-omada (Omada) | employeeId match |
-| Hassan Ibrahim (ID-020) | E0020 (EntraID), E0020-omada (Omada) | employeeId match |
+| Hassan Ibrahim (E0020) | E0020 (EntraID), E0020-iga (IGA), HIBRAHIM (SAP) | employeeId match — the three-system case |
+| Clara Dijkstra (E0003) | E0003 (EntraID), CDIJKSTRA (SAP) | employeeId match |
 | Yuki Zhao (Contractor) | E0040 (EntraID) | No identity — external, uncorrelated |
 | Deploy Pipeline | SVC-001 (EntraID) | No identity — non-human |
+
+**SAP accounts carry no department and no friendly name** — just an SAP user id like `CDIJKSTRA`. That is what a real ERP account list looks like, and it is what makes flag 8 hard from a raw export: the only route from an SAP account to a department is through the identity. Ten employees have one, skewed Finance 4 / Sales 3 / Operations 2 / Engineering 1.
+
+---
+
+## Capture-the-Flag scenarios
+
+The dataset carries the twelve CTF scenarios from [issue #705](https://github.com/Fortigi/IdentityAtlas/issues/705). The design principle: **every flag must be hard from a raw export and easy in Identity Atlas.** Answers are asserted in two places, so a dataset change can never silently move one:
+
+* **`test/unit/DemoDataset.Tests.ps1`** — over the generated JSON.
+* **`test/demo-dataset/Verify-DemoDataset.ps1`** — over the ingested database (the `CTF*` checks).
+
+!!! warning "Player-facing page is [Capture the Flag](../demo/capture-the-flag.md)"
+    That page publishes the **questions and hints only**. This page is the engineering reference and spells out the answers. If you intend to play, stop here.
+
+??? danger "Spoilers — the answer key"
+
+    | # | Question | Answer | Where it's answered |
+    |---|---|---|---|
+    | 1 | How many identities does Sales have? | **6** active | Sales scope resolves to 7 — the 7th (Alex Former) is disabled |
+    | 2 | How many assignments do all Sales users share? | **5** | ⚠️ no shared-by-all statistic exists yet — data-complete, product gap |
+    | 3 | Which two users outside Sales share that set? | **Tom Bakker, Nadia Haddad** | ⚠️ same gap as flag 2 |
+    | 4 | Why does Piet have the CRM permission? | Inherited via **BR-Sales** | Matrix cell: `Indirect` badge + access-package overlay |
+    | 5 | Which shared assignments are role-based? | **SG-Sales, SG-CRM-Users** | Matrix Governed / Non-governed toggle |
+    | 6 | Which assignment could be added to the role? | **SG-Sales-SharePoint** | Non-governed toggle on the Sales scope |
+    | 7 | Which looks addable but should NOT be? | **SG-Finance-Reports** — sensitive, cross-department, only the manager is certified for it | Same toggle; the certification + description supply the *why* |
+    | 8 | Which department has the most SAP users? | **Finance** (4, vs Sales 3) | Identity correlation — SAP accounts carry no department |
+    | 9 | Which accounts have never-expiring passwords? | **5** | Matrix filter on `ext.passwordNeverExpires` |
+    | 10 | Who has access to a resource in Azure US? | **Victor Wang, Wendy Xu, Deploy Pipeline** | Resource filter on `ext.azureLocation = eastus` |
+    | 11 | Who consented to `Files.ReadWrite.All`? | **5** users | `risky-consent` plugin → "Risky Consent — High" → Direct Members |
+    | 12 | Who consented to a *risky* app **and** has a never-expiring password? | **Piet Jansen, Wendy Xu** | One matrix: resource filter on the risky-consent context + subject filter on `ext.passwordNeverExpires` |
+
+### Why the distractors matter
+
+A flag is only hard because a plausible wrong answer sits next to the right one. That is why several records exist purely to be wrong.
+
+??? danger "Spoilers — the traps"
+
+    | Flag | The trap |
+    |---|---|
+    | 1 | A disabled Sales leaver makes the naive count 7 instead of 6 |
+    | 6 vs 7 | Both are ad-hoc direct grants held by most of Sales. Only the risk + the department boundary separate the candidate from the trap |
+    | 8 | Sales (3) is close enough to Finance (4) that you have to count |
+    | 10 | `rg-prod-westeurope` sits next to `rg-prod-eastus`, and Victor Wang holds roles in **both** — so "whoever isn't in westeurope" is not a shortcut |
+    | 12 | Victor Wang has a never-expiring password **and** consented to an app — but a clean one. Ignore the "risky" half and you get 3 instead of 2 |
+
+### Determinism (issue #705, risk R1)
+
+Flags 11–12 need "FileSync Pro is risky" to be true on every run. **No LLM is involved:** the `risky-consent` context plugin classifies permissions from a curated map (`riskyConsentRiskMap.js`), and `Files.ReadWrite.All` is in its `HIGH_RISK` set. FileSync Pro's publisher is `Default Directory` — unverified — so the plugin's offline heuristic also files it under "Risky App Consent — Suspicious" with no threat-feed call needed. Contoso Timesheets is the control: `User.Read` classifies Low, its publisher is verified, and four consenters keep it above the low-prevalence threshold.
+
+The plugin is **not** run by seeding — trigger it explicitly (`POST /api/context-plugins/risky-consent/run`) or from Admin → Plugins.
+
+### Role-derived access is materialised
+
+Holding `BR-Sales` does **not** by itself give anyone `SG-CRM-Users`. The matrix matview (migration 049) derives *managed-by-role* from `Contains` + holding the role, but only for cells that already exist; a `Contains` child with no effective assignment renders as a provisioning **gap**, not as access.
+
+So role-derived access is emitted as explicit `Indirect` assignments **and** a `Contains` edge. The assignment is the access; the edge is the *why*. Drop either and flag 4 has no answer. See `docs/architecture/matrix.md`.
 
 ---
 
@@ -183,20 +306,24 @@ The dataset is a single JSON file that maps directly to the Ingest API endpoints
 {
   "metadata": {
     "company": "Fortigi Demo Corp",
-    "version": "1.0",
-    "description": "Synthetic dataset for E2E testing",
+    "version": "2.0",
+    "description": "Synthetic dataset for E2E testing and the public demo (issue #705)",
+    "systemKeys": [
+      { "key": "entra", "systemType": "EntraID", "tenantId": "demo-tenant-001" }
+    ],
     "entityCounts": {
-      "systems": 3,
-      "principals": 28,
-      "resources": 17,
-      "resourceAssignments": 73,
-      "resourceRelationships": 12,
-      "identities": 23,
-      "identityMembers": 24,
-      "contexts": 8,
+      "systems": 5,
+      "principals": 45,
+      "resources": 39,
+      "resourceAssignments": 143,
+      "resourceRelationships": 20,
+      "identities": 27,
+      "identityMembers": 38,
+      "contexts": 9,
+      "contextMembers": 35,
       "governanceCatalogs": 2,
-      "assignmentPolicies": 3,
-      "certificationDecisions": 2
+      "assignmentPolicies": 4,
+      "certificationDecisions": 3
     }
   },
   "systems": [ ... ],
@@ -225,20 +352,22 @@ Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssig
 
 | Table | Expected | Composition |
 |---|---|---|
-| Systems | 3 | Entra ID + HR + Omada |
-| Principals | 28 | 24 `User` (22 employees + 1 disabled + 1 Omada account for the multi-system employee) + 1 `ExternalUser` (contractor) + 1 `ServicePrincipal` + 1 `AIAgent` + 1 `SharedMailbox` |
-| Resources | 17 | 6 groups + 2 directory roles + 2 app roles + 4 business roles + 3 group-ownership |
-| ResourceAssignments | 73 | 72 `Direct` + 1 `Eligible`; 29 of them carry `governed=true` (4 of the `Direct` are group-ownership) |
-| ResourceRelationships | 12 | 8 Contains + 1 GrantsAccessTo + 3 HasOwnership |
-| Identities | 23 | 22 employees + 1 disabled |
-| IdentityMembers | 24 | 23 primary + 1 secondary (the multi-system employee's Omada account) |
-| Contexts | 8 | 1 root + 4 departments + 2 teams + 1 admin unit — all `variant='synced'` |
+| Systems | 5 | Entra ID + HR + IGA + SAP ERP + AzureRM |
+| Principals | 45 | 26 employees + 1 disabled + 1 contractor + 1 `ServicePrincipal` + 1 `AIAgent` + 1 `SharedMailbox` + 1 IGA account + 10 SAP accounts + 3 app service principals |
+| Resources | 39 | Entra 10 + group-ownership 3 + business roles 5 + Sales 4 + consent 4 + SAP 4 + Azure 9 |
+| ResourceAssignments | 143 | `Direct` + `Indirect` (role-derived) + 1 `Eligible`; the `governed=true` ones are the business-role memberships |
+| ResourceRelationships | 20 | 14 Contains + 1 GrantsAccessTo + 3 HasOwnership + 2 DelegatesScope |
+| Identities | 27 | 26 employees + 1 disabled |
+| IdentityMembers | 38 | 27 Entra + 1 IGA + 10 SAP |
+| Contexts | 9 | 1 root + 5 departments + 2 teams + 1 admin unit — all `variant='synced'` |
 | GovernanceCatalogs | 2 | Employee + Privileged |
-| AssignmentPolicies | 3 | Auto-assign + Manager approval + Dual approval |
-| CertificationDecisions | 2 | 1 approve + 1 deny |
+| AssignmentPolicies | 4 | Auto-assign + Manager approval + Dual approval + Sales |
+| CertificationDecisions | 3 | 2 approve + 1 deny |
+
+These are **exact**, because the generator is deterministic. If one fails after a dataset change, that is the point: regenerate, confirm the new number is intended, and update it in the same PR.
 
 !!! note "Counting Contexts"
-    Filter on `variant='synced'` to get the 8 above. A bare `SELECT COUNT(*) FROM "Contexts"` returns more: the API creates `manual` Tag roots at bootstrap, and the context-algorithm plugins emit `generated` contexts once the worker runs. Only the `synced` ones come from this dataset.
+    Filter on `variant='synced'` to get the 9 above. A bare `SELECT COUNT(*) FROM "Contexts"` returns more: the API creates `manual` Tag roots at bootstrap, and the context-algorithm plugins emit `generated` contexts once the worker runs (the `risky-consent` plugin adds two). Only the `synced` ones come from this dataset.
 
 ### Relationship Integrity
 
@@ -270,15 +399,25 @@ Counted with `deletedAt IS NULL` on `Principals`, `Resources` and `ResourceAssig
 | BR-Admin-Privileged is in catalog "Privileged Access" | True |
 | Engineering context has parent = "Fortigi Demo Corp" | True |
 | Platform Team context has parent = "Engineering" | True |
-| Anna Bakker's identity links to 2 principals (EntraID + Omada) | True |
+| At least one identity links to 2+ principals across systems | True |
+| Sales resolves to 6 active identities, 7 including the leaver (flag 1) | True |
+| Piet has `Indirect` (not `Direct`) on SG-CRM-Users (flag 4) | True |
+| SG-Sales-SharePoint is NOT a `Contains` child of BR-Sales (flag 6) | True |
+| SG-Finance-Reports is held across 2+ departments (flag 7) | True |
+| SAP accounts carry no `department` (flag 8) | True |
+| 5 principals have `ext.passwordNeverExpires='true'` (flag 9) | True |
+| 3 principals hold an `eastus` Azure role (flag 10) | True |
+| 5 principals consented to `Files.ReadWrite.All` (flag 11) | True |
+| 2 principals are risky-consenters with never-expiring passwords, and the "any consent" trap is wider at 3 (flag 12) | True |
+| Every `DelegatedPermission`'s `clientSpId` resolves to a Principal | True |
 
 ### UI Verification (Playwright)
 
 | Check | How |
 |---|---|
-| Resources page shows 13 resources (excluding BusinessRoles) | Count rows, filter by non-BusinessRole (6 groups + 2 directory roles + 2 app roles + 3 group-ownership) |
-| Business Roles page shows 4 business roles | Count rows |
-| Users page shows 28 principals | Count visible or total indicator |
+| Resources page shows 34 resources (excluding BusinessRoles) | Count rows, filter by non-BusinessRole |
+| Business Roles page shows 5 business roles | Count rows |
+| Users page shows 45 principals | Count visible or total indicator |
 | Matrix shows data (not "0 users x 0 resources") | Assert text not present |
 | Click CTO user → detail page opens | Navigate, check heading |
 | CTO detail shows "Global Administrator" in memberships | Assert membership listed |

--- a/docs/demo/capture-the-flag.md
+++ b/docs/demo/capture-the-flag.md
@@ -1,0 +1,152 @@
+# Capture the Flag
+
+Twelve questions hidden in the demo data.
+
+Every one of them is **painful to answer from a raw export** — a CSV out of Entra, an SAP account list, an Azure RBAC dump — and **straightforward once the same data is in Identity Atlas**. That is the whole point. The data isn't secret. The insight is the product.
+
+You don't need an IAM background to start. The tracks build up: the first questions are a guided tour of one screen, the last ones ask you to combine three signals that live in three different places.
+
+---
+
+## House rules
+
+- **Honour system.** There are no accounts and no tracking. Nothing stops you reading the answers — they're in this open-source repo. But if you look them up, you've only cheated yourself out of the thing that makes this worth doing.
+- **Hints are free; answers cost you the flag.** Every question below has a hint telling you roughly where to look. Use them as much as you like. Looking up the actual answer scores nothing for that flag.
+- **The demo resets every night.** Anything you change is wiped. Feel free to click, filter and break things.
+- **The data is 100% synthetic.** Fortigi Demo Corp is not a real company, and none of these people exist.
+
+!!! danger "Where not to look"
+    [Demo Dataset](../architecture/demo-dataset.md) is the engineering reference for this dataset and it **contains the full answer key**. If you want to actually play, don't open it until you're done.
+
+## How to enter
+
+Email your twelve answers to **[flag@identityatlas.io](mailto:flag@identityatlas.io)**.
+
+Score **90% or better (11 of 12)** and you get an invitation to the next Fortigi borrel. 🍻
+
+## Before you start
+
+Two things worth knowing, so you don't hunt for something that isn't switched on:
+
+1. **Run the Risky Consent plugin** — Admin → Plugins → *Risky Consent* → Run. Track 3 needs it. It groups the OAuth grants by how dangerous they are; without a run, there's nothing to scope to.
+2. **The access matrix is the main screen.** If you've never used it: it's a grid of subjects (people) against resources (what they can get at). You choose who's in the grid with a filter, and each cell tells you *how* that person holds that access — not just that they do.
+
+---
+
+## Track 1 — Access matrix & roles
+
+Meet the Sales department. Seven questions, one screen, rising difficulty. This track teaches you to read the matrix: how to scope it, how to tell *direct* access from access someone gets *through a role*, and how to spot the difference between a good role-mining idea and a bad one.
+
+### Flag 1 — Sales headcount *(Starter)*
+
+> **How many identities does the Sales department have?**
+
+!!! tip "Hint"
+    Scope the matrix (or the Identities list) to the Sales department. Then count carefully — the first number the screen gives you is not necessarily the number the question is asking for.
+
+### Flag 2 — The shared core *(Starter)*
+
+> **How many resource assignments do all Sales users share?**
+
+That is: how many resources does *every single member* of Sales have, without exception?
+
+!!! tip "Hint"
+    Scope the matrix to Sales and look down the columns for the resources where nobody is missing a cell. There is no one-click "shared by all" statistic yet — you're reading the grid by eye. (If that annoys you, good: it's a gap we know about.)
+
+### Flag 3 — The outsiders *(Intermediate)*
+
+> **Which two users *outside* Sales also have that exact shared set?**
+
+!!! tip "Hint"
+    Widen the scope past Sales and look for the same pattern of cells. Ask yourself how someone who doesn't work in Sales could end up looking exactly like someone who does.
+
+### Flag 4 — Why does Piet have this? *(Intermediate)*
+
+> **Piet Jansen can get into the CRM. What is the most likely reason?**
+
+!!! tip "Hint"
+    Find Piet's cell for the CRM group and look at what the badge is telling you. The matrix records *how* access is held, not just that it is — and it can show you where it came from.
+
+### Flag 5 — Role or not? *(Intermediate)*
+
+> **Of the assignments all Sales users share, which ones are granted by a role rather than held directly?**
+
+!!! tip "Hint"
+    The matrix can show you only governed access, or only non-governed. Flipping between the two answers this question faster than reading badges one by one.
+
+### Flag 6 — The role candidate *(Advanced)*
+
+> **Which resource assignment could probably be added to the Sales role?**
+
+Role mining in one question: the Sales business role grants a certain set. Somewhere there's a group that *should* arguably be in it but isn't.
+
+!!! tip "Hint"
+    Look for something almost every Sales member has, but that the role doesn't grant them. "Almost" is doing real work in that sentence.
+
+### Flag 7 — The trap *(Pro)*
+
+> **Which resource assignment *looks* like it could be added to the role, but should not be — and why?**
+
+Two things fit flag 6's pattern. Only one of them is a good idea.
+
+!!! tip "Hint"
+    Compare the two candidates: who else holds it, what it actually gives access to, and whether anyone ever signed off on it. One of them isn't Sales' to have. We want the resource **and** the reason.
+
+---
+
+## Track 2 — Cloud & accounts
+
+Now leave Entra. This track is about the questions that get hard when a person has accounts in more than one system, and no two systems agree on what to call them.
+
+### Flag 8 — SAP by department *(Intermediate)*
+
+> **Which department has the most users in SAP ERP?**
+
+!!! tip "Hint"
+    Go and look at an SAP account. It won't tell you which department its owner is in — a real ERP account list never does. Something else in Identity Atlas already knows who that account belongs to.
+
+### Flag 9 — Passwords that never expire *(Intermediate)*
+
+> **Which accounts have passwords set to never expire?**
+
+!!! tip "Hint"
+    It isn't a column on the users list. But the crawler did bring the attribute along, and the matrix filter wizard can build a filter on attributes like that one — look for the ones prefixed `ext.`.
+
+### Flag 10 — Azure US *(Intermediate)*
+
+> **Which users have access to a resource in Azure US?**
+
+!!! tip "Hint"
+    Azure resources carry their region. Filter the resource side of the matrix on it rather than the people side. Careful: at least one person has access in more than one region, so "everyone who isn't in Europe" will not get you there.
+
+---
+
+## Track 3 — Apps & consent
+
+Shadow IT. Somebody in Fortigi Demo Corp clicked "Accept" on a third-party app, and nobody reviewed it. These two are the payoff: questions a security team genuinely asks and genuinely struggles to answer.
+
+### Flag 11 — Who consented? *(Advanced)*
+
+> **Which users have consented to `Files.ReadWrite.All`?**
+
+That permission lets an app read and write every file the user can reach.
+
+!!! tip "Hint"
+    Run the Risky Consent plugin if you haven't. It sorts the consent grants by how dangerous the permission is. Once you've found the grant itself, the question becomes "who holds this?" — which is the thing the product is best at.
+
+### Flag 12 — The worst of both *(Pro)*
+
+> **Which users consented to a *risky* app **and** have a never-expiring password?**
+
+An account whose password never rotates, which has also handed a third-party app broad access to its files. That's the combination you'd want to know about on a Monday morning.
+
+!!! tip "Hint"
+    This is flags 9 and 11 on one screen: filter the resource side to the risky grants, and the subject side to the never-expiring accounts. Read the answer off the cells, not off the row count. And note the word *risky* is load-bearing — plenty of people have consented to something.
+
+---
+
+## When you're done
+
+Send your twelve answers to **[flag@identityatlas.io](mailto:flag@identityatlas.io)**.
+
+If you got stuck on one and want to know how it was *meant* to be found, that's a good sign — tell us which one. Half the reason this exists is to find out which questions Identity Atlas doesn't yet answer as well as it should.

--- a/docs/demo/capture-the-flag.md
+++ b/docs/demo/capture-the-flag.md
@@ -28,8 +28,20 @@ Score **90% or better (11 of 12)** and you get an invitation to the next Fortigi
 
 Two things worth knowing, so you don't hunt for something that isn't switched on:
 
-1. **Run the Risky Consent plugin** — Admin → Plugins → *Risky Consent* → Run. Track 3 needs it. It groups the OAuth grants by how dangerous they are; without a run, there's nothing to scope to.
-2. **The access matrix is the main screen.** If you've never used it: it's a grid of subjects (people) against resources (what they can get at). You choose who's in the grid with a filter, and each cell tells you *how* that person holds that access — not just that they do.
+**1. Track 3 needs the Risky Consent plugin to have run.** It sorts the OAuth consent grants by how dangerous the permission is, into groups you can then scope a matrix to.
+
+First check whether it's already done — on most demo environments it is. Go to **Contexts** and look in the left-hand **Trees** pane for a group called **RiskyConsent (Resource)**. If **Risky Consent — High** is listed, you're set; skip to Track 1.
+
+If it isn't there, run it:
+
+> **Contexts** → **+ New** (top of the Trees pane) → **Run a plugin** → **Next ▸** → pick **Risky Consent** (under the *Resource* heading) → **Next ▸** → **Next ▸** (the defaults are correct — leave the form alone) → **Create tree**
+
+A preview runs by itself on the last step; the button that commits it says **Create tree**, not "Run".
+
+!!! note "Admin → Plugins won't help you here"
+    That tab lists context plugin trees that already exist, so it can re-run one — but it can't start the first run. New trees are only created from **Contexts → + New**.
+
+**2. The access matrix is the main screen.** If you've never used it: it's a grid of subjects (people) against resources (what they can get at). You choose who's in the grid with a filter, and each cell tells you *how* that person holds that access — not just that they do.
 
 ---
 
@@ -132,7 +144,7 @@ Shadow IT. Somebody in Fortigi Demo Corp clicked "Accept" on a third-party app, 
 That permission lets an app read and write every file the user can reach.
 
 !!! tip "Hint"
-    Run the Risky Consent plugin if you haven't. It sorts the consent grants by how dangerous the permission is. Once you've found the grant itself, the question becomes "who holds this?" — which is the thing the product is best at.
+    The **Risky Consent — High** context (see *Before you start*) groups the dangerous consent grants for you. The permission itself is a resource — so once you've found it, the question turns into "who holds this resource?", which is exactly what the matrix is for.
 
 ### Flag 12 — The worst of both *(Pro)*
 
@@ -150,3 +162,42 @@ An account whose password never rotates, which has also handed a third-party app
 Send your twelve answers to **[flag@identityatlas.io](mailto:flag@identityatlas.io)**.
 
 If you got stuck on one and want to know how it was *meant* to be found, that's a good sign — tell us which one. Half the reason this exists is to find out which questions Identity Atlas doesn't yet answer as well as it should.
+
+---
+
+## Answer key
+
+Don't open this until you've had a go. Opening it scores you nothing — but marking your own paper afterwards is the point of the exercise, so it lives here rather than somewhere you'd have to go asking for it.
+
+These are checked by CI on every change to the demo data, so they can't quietly drift out of date.
+
+??? danger "Spoilers — the answers to all twelve"
+
+    **Track 1 — Access matrix & roles**
+
+    | # | Answer |
+    |---|---|
+    | **1** | **6** — David El-Amin, Paul Quinn, Rachel Smith, Stefan Tanaka, Piet Jansen, Sanne Vermeer. The Sales scope shows **7**: Alex Former is a leaver whose account is disabled. |
+    | **2** | **5** — `SG-AllEmployees`, `BR-Employee-Base`, `BR-Sales`, `SG-Sales`, `SG-CRM-Users`. |
+    | **3** | **Tom Bakker** (Operations) and **Nadia Haddad** (Marketing). Both hold `BR-Sales`: Tom transferred out of Sales and it was never revoked, Nadia has it for a joint campaign. |
+    | **4** | He **inherits it through the `BR-Sales` business role** — it's a role-derived (`Indirect`) grant, not a direct one. He has no direct assignment on `SG-CRM-Users` at all. |
+    | **5** | **`SG-Sales` and `SG-CRM-Users`** — the two the role grants. `SG-AllEmployees` is held directly by everyone in the company; `BR-Employee-Base` and `BR-Sales` are roles themselves, not access granted *by* a role. |
+    | **6** | **`SG-Sales-SharePoint`** — held as a direct, ad-hoc grant by 5 of the 6 Sales members, and not part of `BR-Sales`. The obvious mining candidate. |
+    | **7** | **`SG-Finance-Reports`** — and the reason matters as much as the name. It fits the same shape (4 of 6 Sales hold it directly), but it's **sensitive cross-department finance access**: Finance holds it legitimately, and of the Sales side only the **Sales Manager (Paul Quinn)** was ever certified for it — the certification says "approved for this role only". Folding it into `BR-Sales` would hand every rep the company's revenue and margin data. A least-privilege violation, not a role candidate. |
+
+    **Track 2 — Cloud & accounts**
+
+    | # | Answer |
+    |---|---|
+    | **8** | **Finance**, with 4 SAP accounts. Sales has 3, Operations 2, Engineering 1 — close enough that guessing doesn't work. |
+    | **9** | **5 accounts**: Deploy Pipeline (service principal), info@fortigidemo.com (shared mailbox), Victor Wang, Wendy Xu and Piet Jansen. |
+    | **10** | **Victor Wang, Wendy Xu and Deploy Pipeline** — the holders of a role on an `eastus` resource. Victor also holds one in `westeurope`, so he's in the answer either way. |
+
+    **Track 3 — Apps & consent**
+
+    | # | Answer |
+    |---|---|
+    | **11** | **5 users**: Piet Jansen, Rachel Smith, Hassan Ibrahim, Wendy Xu and Niels Olsen. |
+    | **12** | **Piet Jansen and Wendy Xu.** The trap is **Victor Wang** — he has a never-expiring password *and* has consented to an app, but that app is Contoso Timesheets: verified publisher, `User.Read` only. Answer "consented to anything + never-expiring password" and you get 3. |
+
+    **Piet Jansen** is the thread: role-inherited access (4), a never-expiring password (9), risky consent (11) and both at once (12). If your answers to those four don't all feature him, one of them is wrong.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,8 @@ nav:
           - Omada Data Model Reference: architecture/omada-crawler-datamodel.md
           - Building a Crawler: sync/building-a-crawler.md
           - Custom Connector (Push API): sync/custom-connector.md
+      - Try It:
+          - Capture the Flag: demo/capture-the-flag.md
       - Using Identity Atlas:
           - Role Mining UI: ui/overview.md
           - Dashboard: ui/dashboard.md

--- a/test/demo-dataset/Generate-DemoDataset.ps1
+++ b/test/demo-dataset/Generate-DemoDataset.ps1
@@ -1,416 +1,122 @@
 <#
 .SYNOPSIS
-    Generates the Fortigi Demo Corp synthetic dataset for E2E testing.
+    Generates the Fortigi Demo Corp synthetic dataset.
 
 .DESCRIPTION
-    Creates demo-company.json with deterministic GUIDs for all entities.
-    The dataset exercises every feature: org hierarchy, multi-system identities,
-    business roles, governed assignments, edge cases (contractors, disabled accounts,
-    service principals, AI agents).
+    Emits demo-company.json with deterministic GUIDs for every entity: same
+    input, same output, every run. The dataset backs both the E2E suite and the
+    public demo environment, and it hides the Capture-the-Flag scenarios from
+    issue #705.
+
+    This file is a thin orchestrator. Each domain lives in its own part under
+    parts/, dot-sourced below and appended into one shared state object:
+
+      DemoState.ps1          — New-DemoGuid, the state accumulator, record builders
+      DemoOrg.ps1            — systems, context tree, people, identities
+      DemoEntraBase.ps1      — Entra groups / directory roles / app roles / ownership
+      DemoGovernance.ps1     — IGA catalogs, business roles, policies, certifications
+      DemoSalesScenario.ps1  — the Sales role-mining scenario (flags 1-7)
+      DemoConsent.ps1        — OAuth consent + shadow IT (flags 11-12)
+      DemoSap.ps1            — the SAP ERP system (flag 8)
+      DemoAzure.ps1          — the AzureRM system (flag 10)
 
 .EXAMPLE
     .\Generate-DemoDataset.ps1
-    Generates _Test/DemoDataset/demo-company.json
+    Writes demo-company.json next to this script (gitignored — it is a build
+    artifact, always regenerate rather than relying on a committed copy).
 #>
 
 [CmdletBinding()]
-Param()
-
-$outputPath = Join-Path $PSScriptRoot 'demo-company.json'
-
-# Deterministic GUID from a seed string (same input always produces same GUID)
-function New-DemoGuid {
-    param([string]$Seed)
-    $md5 = [System.Security.Cryptography.MD5]::Create()
-    $bytes = $md5.ComputeHash([System.Text.Encoding]::UTF8.GetBytes("fortigi-demo:$Seed"))
-    return [Guid]::new($bytes).ToString()
-}
-
-# ─── Systems ──────────────────────────────────────────────────────
-
-$systems = @(
-    @{ systemType = 'EntraID'; displayName = 'Fortigi Demo EntraID'; tenantId = 'demo-tenant-001'; enabled = $true; syncEnabled = $true }
-    @{ systemType = 'HR';      displayName = 'Fortigi Demo HR';      tenantId = 'demo-hr-001';     enabled = $true; syncEnabled = $true }
-    @{ systemType = 'Omada';   displayName = 'Fortigi Demo Omada';   tenantId = 'demo-omada-001';  enabled = $true; syncEnabled = $true }
+Param(
+    [string]$OutputPath = ''
 )
 
-# System IDs are auto-assigned by SQL; we'll use 1, 2, 3 in references
-$sysEntraId = 1
-$sysHR = 2
-$sysOmada = 3
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-# ─── Contexts (Org Structure) ────────────────────────────────────
+if (-not $OutputPath) { $OutputPath = Join-Path $PSScriptRoot 'demo-company.json' }
 
-$ctxRoot      = New-DemoGuid 'ctx-root'
-$ctxEng       = New-DemoGuid 'ctx-engineering'
-$ctxFin       = New-DemoGuid 'ctx-finance'
-$ctxSales     = New-DemoGuid 'ctx-sales'
-$ctxOps       = New-DemoGuid 'ctx-operations'
-$ctxPlatform  = New-DemoGuid 'ctx-platform-team'
-$ctxSecurity  = New-DemoGuid 'ctx-security-team'
-$ctxAUNL      = New-DemoGuid 'ctx-au-netherlands'
-
-$contexts = @(
-    @{ id = $ctxRoot;     displayName = 'Fortigi Demo Corp';  contextType = 'Department'; targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR }
-    @{ id = $ctxEng;      displayName = 'Engineering';        contextType = 'Department'; targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR; parentContextId = $ctxRoot }
-    @{ id = $ctxFin;      displayName = 'Finance';            contextType = 'Department'; targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR; parentContextId = $ctxRoot }
-    @{ id = $ctxSales;    displayName = 'Sales';              contextType = 'Department'; targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR; parentContextId = $ctxRoot }
-    @{ id = $ctxOps;      displayName = 'Operations';         contextType = 'Department'; targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR; parentContextId = $ctxRoot }
-    @{ id = $ctxPlatform; displayName = 'Platform Team';      contextType = 'Team';       targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR; parentContextId = $ctxEng }
-    @{ id = $ctxSecurity; displayName = 'Security Team';      contextType = 'Team';       targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysHR; parentContextId = $ctxEng }
-    @{ id = $ctxAUNL;     displayName = 'AU-Netherlands';     contextType = 'AdministrativeUnit'; targetType = 'Principal'; variant = 'synced'; scopeSystemId = $sysEntraId }
-)
-
-# ─── Principals ───────────────────────────────────────────────────
-
-$employees = @(
-    # C-Level
-    @{ id = 'E0001'; name = 'Anna Bakker';      title = 'CEO';                dept = 'Management';  manager = $null;   ctx = $ctxRoot }
-    @{ id = 'E0002'; name = 'Bob Chen';          title = 'CTO';                dept = 'Engineering'; manager = 'E0001'; ctx = $ctxEng }
-    @{ id = 'E0003'; name = 'Clara Dijkstra';    title = 'CFO';                dept = 'Finance';     manager = 'E0001'; ctx = $ctxFin }
-    @{ id = 'E0004'; name = 'David El-Amin';     title = 'CSO';                dept = 'Sales';       manager = 'E0001'; ctx = $ctxSales }
-    @{ id = 'E0005'; name = 'Eva Fischer';        title = 'COO';                dept = 'Operations';  manager = 'E0001'; ctx = $ctxOps }
-    # Team Leads
-    @{ id = 'E0010'; name = 'Fatih Gunay';       title = 'Team Lead Platform'; dept = 'Engineering'; manager = 'E0002'; ctx = $ctxPlatform }
-    @{ id = 'E0011'; name = 'Grace Huang';       title = 'Team Lead Security'; dept = 'Engineering'; manager = 'E0002'; ctx = $ctxSecurity }
-    @{ id = 'E0012'; name = 'Maria Novak';       title = 'Finance Manager';    dept = 'Finance';     manager = 'E0003'; ctx = $ctxFin }
-    @{ id = 'E0013'; name = 'Paul Quinn';        title = 'Sales Manager';      dept = 'Sales';       manager = 'E0004'; ctx = $ctxSales }
-    @{ id = 'E0014'; name = 'Ursula Visser';     title = 'Ops Manager';        dept = 'Operations';  manager = 'E0005'; ctx = $ctxOps }
-    # Individual Contributors
-    @{ id = 'E0020'; name = 'Hassan Ibrahim';    title = 'Developer';           dept = 'Engineering'; manager = 'E0010'; ctx = $ctxPlatform }
-    @{ id = 'E0021'; name = 'Ingrid Jensen';     title = 'Developer';           dept = 'Engineering'; manager = 'E0010'; ctx = $ctxPlatform }
-    @{ id = 'E0022'; name = 'Jun Kobayashi';     title = 'Developer';           dept = 'Engineering'; manager = 'E0010'; ctx = $ctxPlatform }
-    @{ id = 'E0023'; name = 'Karen Lee';         title = 'Security Engineer';   dept = 'Engineering'; manager = 'E0011'; ctx = $ctxSecurity }
-    @{ id = 'E0024'; name = 'Lars Muller';       title = 'SOC Analyst';         dept = 'Engineering'; manager = 'E0011'; ctx = $ctxSecurity }
-    @{ id = 'E0025'; name = 'Niels Olsen';       title = 'Accountant';          dept = 'Finance';     manager = 'E0012'; ctx = $ctxFin }
-    @{ id = 'E0026'; name = 'Olivia Park';       title = 'Accountant';          dept = 'Finance';     manager = 'E0012'; ctx = $ctxFin }
-    @{ id = 'E0027'; name = 'Rachel Smith';      title = 'Account Executive';   dept = 'Sales';       manager = 'E0013'; ctx = $ctxSales }
-    @{ id = 'E0028'; name = 'Stefan Tanaka';     title = 'Account Executive';   dept = 'Sales';       manager = 'E0013'; ctx = $ctxSales }
-    @{ id = 'E0029'; name = 'Victor Wang';       title = 'SysAdmin';            dept = 'Operations';  manager = 'E0014'; ctx = $ctxOps }
-    @{ id = 'E0030'; name = 'Wendy Xu';          title = 'SysAdmin';            dept = 'Operations';  manager = 'E0014'; ctx = $ctxOps }
-    # Zara Intern is the deliberate "principal with zero resource assignments"
-    # edge case (a new hire not yet provisioned): noAccess excludes her from every
-    # group / business-role grant loop below, while she still exists as a principal
-    # and appears in her department context. See docs/architecture/demo-dataset.md.
-    @{ id = 'E0031'; name = 'Zara Intern';       title = 'Intern';              dept = 'Engineering'; manager = 'E0010'; ctx = $ctxEng; noAccess = $true }
-)
-
-$principals = @()
-foreach ($emp in $employees) {
-    $guid = New-DemoGuid "principal-$($emp.id)"
-    $mgrGuid = if ($emp.manager) { New-DemoGuid "principal-$($emp.manager)" } else { $null }
-    $nameParts = $emp.name -split ' ', 2
-    $principals += @{
-        id              = $guid
-        displayName     = $emp.name
-        email           = "$($nameParts[0].ToLower()).$($nameParts[1].ToLower())@fortigidemo.com"
-        accountEnabled  = $true
-        principalType   = 'User'
-        employeeId      = $emp.id
-        givenName       = $nameParts[0]
-        surname         = $nameParts[1]
-        department      = $emp.dept
-        jobTitle        = $emp.title
-        companyName     = 'Fortigi Demo Corp'
-        managerId       = $mgrGuid
-    }
+$partsDir = Join-Path $PSScriptRoot 'parts'
+foreach ($part in @(
+    'DemoState.ps1', 'DemoOrg.ps1', 'DemoEntraBase.ps1', 'DemoGovernance.ps1',
+    'DemoSalesScenario.ps1', 'DemoConsent.ps1', 'DemoSap.ps1', 'DemoAzure.ps1'
+)) {
+    . (Join-Path $partsDir $part)
 }
 
-# Edge cases
-$guidContractor = New-DemoGuid 'principal-E0040'
-$guidDisabled   = New-DemoGuid 'principal-E0041'
-$guidSvcPrinc   = New-DemoGuid 'principal-SVC-001'
-$guidAIAgent    = New-DemoGuid 'principal-AI-001'
-$guidMailbox    = New-DemoGuid 'principal-SM-001'
+$state = New-DemoState
 
-$principals += @(
-    @{ id = $guidContractor; displayName = 'Yuki Zhao'; email = 'yuki.zhao@external.com'; accountEnabled = $true;  principalType = 'ExternalUser'; employeeId = 'E0040'; department = 'Engineering'; jobTitle = 'Contractor'; companyName = 'External Inc' }
-    @{ id = $guidDisabled;   displayName = 'Alex Former'; email = 'alex.former@fortigidemo.com'; accountEnabled = $false; principalType = 'User'; employeeId = 'E0041'; department = 'Sales'; jobTitle = 'Former Employee' }
-    @{ id = $guidSvcPrinc;   displayName = 'Deploy Pipeline'; principalType = 'ServicePrincipal'; accountEnabled = $true }
-    @{ id = $guidAIAgent;    displayName = 'Copilot Assistant'; principalType = 'AIAgent'; accountEnabled = $true }
-    @{ id = $guidMailbox;    displayName = 'info@fortigidemo.com'; principalType = 'SharedMailbox'; email = 'info@fortigidemo.com'; accountEnabled = $true }
-)
+# Order matters: Org creates the systems + people every later part references,
+# and EntraBase creates the resources Governance links its business roles to.
+Add-DemoOrg           $state
+Add-DemoEntraBase     $state
+Add-DemoGovernance    $state
+Add-DemoSalesScenario $state
+Add-DemoConsent       $state
+Add-DemoSap           $state
+Add-DemoAzure         $state
 
-# ─── Resources ────────────────────────────────────────────────────
+# ─── Derive the system of each assignment / relationship from its resource ────
+# ResourceAssignments and ResourceRelationships both carry a systemId. Rather
+# than making every call site pass one (and get it wrong), derive it once here
+# from the resource the row hangs off. This is what lets the ingester post each
+# system's rows under its own envelope, so a full-sync reconcile only ever
+# deletes within the system it is syncing.
+$resourceSystem = @{}
+foreach ($r in $state.Resources) { $resourceSystem[$r.id] = $r.systemId }
 
-$resAllEmp     = New-DemoGuid 'res-sg-all-employees'
-$resEng        = New-DemoGuid 'res-sg-engineering'
-$resFin        = New-DemoGuid 'res-sg-finance'
-$resVPN        = New-DemoGuid 'res-sg-vpn-access'
-$resAdminTier0 = New-DemoGuid 'res-sg-admin-tier0'
-$resPAM        = New-DemoGuid 'res-sg-pam-users'
-$resGlobalAdmin = New-DemoGuid 'res-global-administrator'
-$resSPAdmin    = New-DemoGuid 'res-sharepoint-admin'
-$resAppFG      = New-DemoGuid 'res-app-fortigraph'
-$resAppSAP     = New-DemoGuid 'res-app-sap-finance'
-$resBRBase     = New-DemoGuid 'res-br-employee-base'
-$resBREng      = New-DemoGuid 'res-br-engineering-tools'
-$resBRFin      = New-DemoGuid 'res-br-finance-systems'
-$resBRAdmin    = New-DemoGuid 'res-br-admin-privileged'
-
-$catEmployee   = New-DemoGuid 'cat-employee-access'
-$catPrivileged = New-DemoGuid 'cat-privileged-access'
-
-$resources = @(
-    @{ id = $resAllEmp;      displayName = 'SG-AllEmployees';       resourceType = 'Group';        systemId = $sysEntraId; enabled = $true }
-    @{ id = $resEng;         displayName = 'SG-Engineering';        resourceType = 'Group';        systemId = $sysEntraId; enabled = $true }
-    @{ id = $resFin;         displayName = 'SG-Finance';            resourceType = 'Group';        systemId = $sysEntraId; enabled = $true }
-    @{ id = $resVPN;         displayName = 'SG-VPN-Access';         resourceType = 'Group';        systemId = $sysEntraId; enabled = $true }
-    @{ id = $resAdminTier0;  displayName = 'SG-Admin-Tier0';        resourceType = 'Group';        systemId = $sysEntraId; enabled = $true; description = 'Tier 0 administrative access - critical' }
-    @{ id = $resPAM;         displayName = 'SG-PAM-Users';          resourceType = 'Group';        systemId = $sysEntraId; enabled = $true }
-    @{ id = $resGlobalAdmin; displayName = 'Global Administrator';  resourceType = 'EntraDirectoryRole'; systemId = $sysEntraId; enabled = $true }
-    @{ id = $resSPAdmin;     displayName = 'SharePoint Admin';      resourceType = 'EntraDirectoryRole'; systemId = $sysEntraId; enabled = $true }
-    @{ id = $resAppFG;       displayName = 'FortigiGraph-App';      resourceType = 'AppRole';      systemId = $sysEntraId; enabled = $true }
-    @{ id = $resAppSAP;      displayName = 'SAP-Finance-Role';      resourceType = 'AppRole';      systemId = $sysEntraId; enabled = $true }
-    @{ id = $resBRBase;      displayName = 'BR-Employee-Base';      resourceType = 'BusinessRole';      systemId = $sysOmada;   enabled = $true; catalogId = $catEmployee }
-    @{ id = $resBREng;       displayName = 'BR-Engineering-Tools';  resourceType = 'BusinessRole';      systemId = $sysOmada;   enabled = $true; catalogId = $catEmployee }
-    @{ id = $resBRFin;       displayName = 'BR-Finance-Systems';    resourceType = 'BusinessRole';      systemId = $sysOmada;   enabled = $true; catalogId = $catEmployee }
-    @{ id = $resBRAdmin;     displayName = 'BR-Admin-Privileged';   resourceType = 'BusinessRole';      systemId = $sysOmada;   enabled = $true; catalogId = $catPrivileged }
-)
-
-# ─── Resource Assignments ─────────────────────────────────────────
-
-$assignments = @()
-
-# Employees who receive access grants — everyone except the noAccess edge case(s)
-# (Zara Intern), so the dataset always contains a principal with zero resource
-# assignments for the matrix's zero-assignment path to exercise.
-$provisionedEmployees = @($employees | Where-Object { -not $_.noAccess })
-
-# All employees -> SG-AllEmployees (Direct)
-foreach ($emp in $provisionedEmployees) {
-    $pGuid = New-DemoGuid "principal-$($emp.id)"
-    $assignments += @{ resourceId = $resAllEmp; principalId = $pGuid; assignmentType = 'Direct' }
+foreach ($a in $state.Assignments) {
+    $a['systemId'] = $resourceSystem[$a.resourceId]
+}
+foreach ($rel in $state.Relationships) {
+    $rel['systemId'] = $resourceSystem[$rel.parentResourceId]
 }
 
-# Engineering employees -> SG-Engineering
-foreach ($emp in ($provisionedEmployees | Where-Object { $_.dept -eq 'Engineering' })) {
-    $pGuid = New-DemoGuid "principal-$($emp.id)"
-    $assignments += @{ resourceId = $resEng; principalId = $pGuid; assignmentType = 'Direct' }
-}
+# ─── Assemble & write ─────────────────────────────────────────────────────────
 
-# Finance employees -> SG-Finance
-foreach ($emp in ($provisionedEmployees | Where-Object { $_.dept -eq 'Finance' })) {
-    $pGuid = New-DemoGuid "principal-$($emp.id)"
-    $assignments += @{ resourceId = $resFin; principalId = $pGuid; assignmentType = 'Direct' }
-}
-
-# SysAdmins -> VPN
-$assignments += @{ resourceId = $resVPN; principalId = (New-DemoGuid 'principal-E0029'); assignmentType = 'Direct' }
-$assignments += @{ resourceId = $resVPN; principalId = (New-DemoGuid 'principal-E0030'); assignmentType = 'Direct' }
-
-# Admin Tier0: CTO + SysAdmin + SP as members
-$assignments += @{ resourceId = $resAdminTier0; principalId = (New-DemoGuid 'principal-E0002'); assignmentType = 'Direct' }
-$assignments += @{ resourceId = $resAdminTier0; principalId = (New-DemoGuid 'principal-E0029'); assignmentType = 'Direct' }
-$assignments += @{ resourceId = $resAdminTier0; principalId = $guidSvcPrinc; assignmentType = 'Direct' }
-
-# CTO -> Global Admin directory role
-$assignments += @{ resourceId = $resGlobalAdmin; principalId = (New-DemoGuid 'principal-E0002'); assignmentType = 'Direct' }
-
-# Governed business-role memberships: Direct assignments flagged governed=true
-foreach ($emp in $provisionedEmployees) {
-    $pGuid = New-DemoGuid "principal-$($emp.id)"
-    $assignments += @{ resourceId = $resBRBase; principalId = $pGuid; assignmentType = 'Direct'; governed = $true }
-}
-foreach ($emp in ($provisionedEmployees | Where-Object { $_.dept -eq 'Engineering' })) {
-    $pGuid = New-DemoGuid "principal-$($emp.id)"
-    $assignments += @{ resourceId = $resBREng; principalId = $pGuid; assignmentType = 'Direct'; governed = $true }
-}
-
-# SysAdmin eligible for privileged admin
-$assignments += @{ resourceId = $resBRAdmin; principalId = (New-DemoGuid 'principal-E0029'); assignmentType = 'Eligible' }
-
-# ─── Resource Relationships ───────────────────────────────────────
-
-$relationships = @(
-    @{ parentResourceId = $resBRBase;  childResourceId = $resAllEmp;  relationshipType = 'Contains' }
-    @{ parentResourceId = $resBRBase;  childResourceId = $resAppFG;   relationshipType = 'Contains' }
-    @{ parentResourceId = $resBREng;   childResourceId = $resEng;     relationshipType = 'Contains' }
-    @{ parentResourceId = $resBREng;   childResourceId = $resVPN;     relationshipType = 'Contains' }
-    @{ parentResourceId = $resBRFin;   childResourceId = $resFin;     relationshipType = 'Contains' }
-    @{ parentResourceId = $resBRFin;   childResourceId = $resAppSAP;  relationshipType = 'Contains' }
-    @{ parentResourceId = $resBRAdmin; childResourceId = $resAdminTier0; relationshipType = 'Contains' }
-    @{ parentResourceId = $resBRAdmin; childResourceId = $resPAM;     relationshipType = 'Contains' }
-    @{ parentResourceId = $resEng;     childResourceId = $resAllEmp;  relationshipType = 'GrantsAccessTo' }
-)
-
-# ─── Group Ownership ──────────────────────────────────────────────
-# v5 models ownership as a Direct assignment on a synthetic GroupOwnership
-# resource (named after the owned group), linked to the group by a HasOwnership
-# relationship — mirroring ConvertTo-EntraGroupOwnership in the Entra crawler.
-# Without this the dataset has no ownership at all, leaving the matrix's
-# owner-badge rules (docs/architecture/matrix.md) without demo coverage (#713).
-$ownedGroups = @(
-    @{ groupId = $resEng;        name = 'SG-Engineering'; owners = @('E0010') }
-    @{ groupId = $resFin;        name = 'SG-Finance';     owners = @('E0012') }
-    @{ groupId = $resAdminTier0; name = 'SG-Admin-Tier0'; owners = @('E0002', 'E0029') }
-)
-foreach ($og in $ownedGroups) {
-    $ownId = New-DemoGuid "res-ownership-$($og.name)"
-    $resources += @{
-        id                 = $ownId
-        displayName        = $og.name
-        resourceType       = 'GroupOwnership'
-        systemId           = $sysEntraId
-        enabled            = $true
-        externalId         = "entraid-ownership:$($og.groupId)"
-        extendedAttributes = @{ ownedResourceId = $og.groupId }
-    }
-    $relationships += @{ parentResourceId = $og.groupId; childResourceId = $ownId; relationshipType = 'HasOwnership' }
-    foreach ($ownerId in $og.owners) {
-        $assignments += @{ resourceId = $ownId; principalId = (New-DemoGuid "principal-$ownerId"); assignmentType = 'Direct'; resourceType = 'GroupOwnership' }
-    }
-}
-
-# ─── Identities & IdentityMembers ────────────────────────────────
-
-$identities = @()
-$identityMembers = @()
-
-foreach ($emp in $employees) {
-    $idGuid = New-DemoGuid "identity-$($emp.id)"
-    $pGuid  = New-DemoGuid "principal-$($emp.id)"
-    $nameParts = $emp.name -split ' ', 2
-
-    $identities += @{
-        id          = $idGuid
-        displayName = $emp.name
-        email       = "$($nameParts[0].ToLower()).$($nameParts[1].ToLower())@fortigidemo.com"
-        department  = $emp.dept
-        jobTitle    = $emp.title
-        employeeId  = $emp.id
-        givenName   = $nameParts[0]
-        surname     = $nameParts[1]
-        companyName = 'Fortigi Demo Corp'
-    }
-
-    # Primary principal link
-    $identityMembers += @{
-        identityId  = $idGuid
-        principalId = $pGuid
-        displayName = $emp.name
-        accountType = 'EntraID'
-        isPrimary   = $true
-        accountEnabled = $true
-    }
-}
-
-# Disabled employee identity
-$idDisabled = New-DemoGuid 'identity-E0041'
-$identities += @{ id = $idDisabled; displayName = 'Alex Former'; email = 'alex.former@fortigidemo.com'; department = 'Sales'; employeeId = 'E0041' }
-$identityMembers += @{ identityId = $idDisabled; principalId = $guidDisabled; displayName = 'Alex Former'; accountType = 'EntraID'; isPrimary = $true; accountEnabled = $false }
-
-# Multi-system: Hassan Ibrahim has Omada account too
-$pOmadaHassan = New-DemoGuid 'principal-E0020-omada'
-$principals += @{ id = $pOmadaHassan; displayName = 'Hassan Ibrahim (Omada)'; principalType = 'User'; employeeId = 'E0020'; accountEnabled = $true; companyName = 'Fortigi Demo Corp'; department = 'Engineering' }
-$identityMembers += @{
-    identityId  = (New-DemoGuid 'identity-E0020')
-    principalId = $pOmadaHassan
-    displayName = 'Hassan Ibrahim (Omada)'
-    accountType = 'Omada'
-    isPrimary   = $false
-    accountEnabled = $true
-}
-
-# ─── Context Members (org membership) ────────────────────────────
-# Attach each principal to their department context (so a department scope in
-# the matrix resolves directly) and, for engineers, also to their team context.
-# Without these, the synced Department/Team contexts have zero members and the
-# access matrix cannot be scoped by department — the product's headline view.
-$deptCtxByName = @{
-    'Management'  = $ctxRoot
-    'Engineering' = $ctxEng
-    'Finance'     = $ctxFin
-    'Sales'       = $ctxSales
-    'Operations'  = $ctxOps
-}
-
-$contextMembers = @()
-$seenCtxMember = [System.Collections.Generic.HashSet[string]]::new()
-foreach ($emp in $employees) {
-    $pGuid = New-DemoGuid "principal-$($emp.id)"
-    foreach ($cid in @($deptCtxByName[$emp.dept], $emp.ctx)) {
-        if ($cid -and $seenCtxMember.Add("$cid|$pGuid")) {
-            $contextMembers += @{ contextId = $cid; memberId = $pGuid; memberType = 'Principal'; addedBy = 'sync' }
-        }
-    }
-}
-
-# Departmented edge cases (contractor in Engineering, former employee in Sales)
-foreach ($ec in @(@{ c = $ctxEng; g = $guidContractor }, @{ c = $ctxSales; g = $guidDisabled })) {
-    if ($seenCtxMember.Add("$($ec.c)|$($ec.g)")) {
-        $contextMembers += @{ contextId = $ec.c; memberId = $ec.g; memberType = 'Principal'; addedBy = 'sync' }
-    }
-}
-
-# ─── Governance ───────────────────────────────────────────────────
-
-$catalogs = @(
-    @{ id = $catEmployee;   displayName = 'Employee Access';   catalogType = 'userManaged'; enabled = $true; systemId = $sysOmada }
-    @{ id = $catPrivileged; displayName = 'Privileged Access'; catalogType = 'userManaged'; enabled = $true; systemId = $sysOmada }
-)
-
-$policies = @(
-    @{ id = (New-DemoGuid 'pol-auto-base');     resourceId = $resBRBase;  displayName = 'Auto-assign all employees';    allowedTargetScope = 'allMemberUsers'; systemId = $sysOmada }
-    @{ id = (New-DemoGuid 'pol-mgr-eng');       resourceId = $resBREng;   displayName = 'Manager approval required';    allowedTargetScope = 'specificDirectoryUsers'; systemId = $sysOmada }
-    @{ id = (New-DemoGuid 'pol-dual-admin');     resourceId = $resBRAdmin; displayName = 'Dual approval (mgr + security)'; allowedTargetScope = 'specificDirectoryUsers'; systemId = $sysOmada }
-)
-
-$certifications = @(
-    @{ id = (New-DemoGuid 'cert-001'); resourceId = $resBRAdmin; principalId = (New-DemoGuid 'principal-E0029'); decision = 'Approve'; reviewedBy = (New-DemoGuid 'principal-E0011'); reviewedByDisplayName = 'Grace Huang'; justification = 'Required for infrastructure maintenance'; systemId = $sysOmada }
-    @{ id = (New-DemoGuid 'cert-002'); resourceId = $resBRBase;  principalId = $guidDisabled; decision = 'Deny'; reviewedBy = (New-DemoGuid 'principal-E0013'); reviewedByDisplayName = 'Paul Quinn'; justification = 'Employee has left the organization'; systemId = $sysOmada }
-)
-
-# ─── Assemble & Write ────────────────────────────────────────────
-
-$dataset = @{
-    metadata = @{
+$dataset = [ordered]@{
+    metadata = [ordered]@{
         company     = 'Fortigi Demo Corp'
-        version     = '1.0'
+        version     = '2.0'
         generatedAt = (Get-Date).ToString('o')
-        description = 'Synthetic dataset for E2E testing — 50 employees, 3 systems, 14 resources, 4 business roles'
-        entityCounts = @{
-            systems                = $systems.Count
-            principals             = $principals.Count
-            resources              = $resources.Count
-            resourceAssignments    = $assignments.Count
-            resourceRelationships  = $relationships.Count
-            identities             = $identities.Count
-            identityMembers        = $identityMembers.Count
-            contexts               = $contexts.Count
-            contextMembers         = $contextMembers.Count
-            governanceCatalogs     = $catalogs.Count
-            assignmentPolicies     = $policies.Count
-            certificationDecisions = $certifications.Count
+        description = 'Synthetic dataset for E2E testing and the public demo (issue #705) — 5 systems, 6 departments, Capture-the-Flag scenarios.'
+        # Placeholder systemId -> system identity, in insertion order. The
+        # ingester posts Systems first, reads the real SERIAL ids back from the
+        # API response, and remaps every systemId in the payload. Never assume
+        # the placeholder is the live id.
+        systemKeys   = @($state.SystemKeys)
+        entityCounts = [ordered]@{
+            systems                = $state.Systems.Count
+            principals             = $state.Principals.Count
+            resources              = $state.Resources.Count
+            resourceAssignments    = $state.Assignments.Count
+            resourceRelationships  = $state.Relationships.Count
+            identities             = $state.Identities.Count
+            identityMembers        = $state.IdentityMembers.Count
+            contexts               = $state.Contexts.Count
+            contextMembers         = $state.ContextMembers.Count
+            governanceCatalogs     = $state.Catalogs.Count
+            assignmentPolicies     = $state.Policies.Count
+            certificationDecisions = $state.Certifications.Count
         }
     }
-    systems                = $systems
-    contexts               = $contexts
-    contextMembers         = $contextMembers
-    principals             = $principals
-    resources              = $resources
-    resourceAssignments    = $assignments
-    resourceRelationships  = $relationships
-    identities             = $identities
-    identityMembers        = $identityMembers
-    governanceCatalogs     = $catalogs
-    assignmentPolicies     = $policies
-    certificationDecisions = $certifications
+    systems                = @($state.Systems)
+    contexts               = @($state.Contexts)
+    contextMembers         = @($state.ContextMembers)
+    principals             = @($state.Principals)
+    resources              = @($state.Resources)
+    resourceAssignments    = @($state.Assignments)
+    resourceRelationships  = @($state.Relationships)
+    identities             = @($state.Identities)
+    identityMembers        = @($state.IdentityMembers)
+    governanceCatalogs     = @($state.Catalogs)
+    assignmentPolicies     = @($state.Policies)
+    certificationDecisions = @($state.Certifications)
 }
 
-$dataset | ConvertTo-Json -Depth 10 | Out-File -FilePath $outputPath -Encoding UTF8
+$dataset | ConvertTo-Json -Depth 10 | Out-File -FilePath $OutputPath -Encoding UTF8
 
-$counts = $dataset.metadata.entityCounts
-Write-Host "Demo dataset generated: $outputPath" -ForegroundColor Green
-Write-Host "  Systems:              $($counts.systems)"
-Write-Host "  Principals:           $($counts.principals)"
-Write-Host "  Resources:            $($counts.resources)"
-Write-Host "  Assignments:          $($counts.resourceAssignments)"
-Write-Host "  Relationships:        $($counts.resourceRelationships)"
-Write-Host "  Identities:           $($counts.identities)"
-Write-Host "  Identity Members:     $($counts.identityMembers)"
-Write-Host "  Contexts:             $($counts.contexts)"
-Write-Host "  Context Members:      $($counts.contextMembers)"
-Write-Host "  Governance Catalogs:  $($counts.governanceCatalogs)"
-Write-Host "  Assignment Policies:  $($counts.assignmentPolicies)"
-Write-Host "  Certifications:       $($counts.certificationDecisions)"
+Write-Host "Demo dataset generated: $OutputPath" -ForegroundColor Green
+foreach ($entry in $dataset.metadata.entityCounts.GetEnumerator()) {
+    Write-Host ("  {0,-22} {1}" -f $entry.Key, $entry.Value)
+}

--- a/test/demo-dataset/Ingest-DemoDataset.ps1
+++ b/test/demo-dataset/Ingest-DemoDataset.ps1
@@ -1,16 +1,31 @@
 <#
 .SYNOPSIS
-    Ingests the demo dataset into FortigiGraph via the Ingest API.
+    Ingests the demo dataset into Identity Atlas via the Ingest API.
 
 .DESCRIPTION
     Reads demo-company.json and POSTs each entity section to the appropriate
     Ingest API endpoint in dependency order.
 
+    SYSTEM IDS ARE RESOLVED, NOT ASSUMED. Systems.id is a SERIAL, so the ids the
+    database hands out depend on sequence state — they are only 1..N on a
+    pristine database. This script therefore posts Systems first, reads the real
+    ids back from the API response (`systemIds`, returned in record order), and
+    remaps every placeholder id in the payload before posting anything else.
+    The previous version hardcoded 1=EntraID / 2=HR / 3=Omada, which silently
+    attached rows to the wrong system on any database that had ever seen another
+    crawler.
+
+    Rows are posted PER SYSTEM. A full sync reconciles (soft-deletes) rows that
+    belong to the envelope's systemId and are absent from the batch, so each
+    system's rows must go up under their own envelope — otherwise one system's
+    full sync would be evaluated against another system's rows.
+
 .PARAMETER ApiBaseUrl
     Base URL of the Ingest API (default: http://localhost:3001/api)
 
 .PARAMETER ApiKey
-    Crawler API key (fgc_...)
+    Crawler API key (fgc_...). Must not be scoped to a subset of systems — the
+    demo dataset spans all five.
 
 .PARAMETER DatasetPath
     Path to demo-company.json (default: same directory as this script)
@@ -39,7 +54,7 @@ if (-not (Test-Path $DatasetPath)) {
 $dataset = Get-Content $DatasetPath -Raw | ConvertFrom-Json
 $headers = @{ 'Authorization' = "Bearer $ApiKey"; 'Content-Type' = 'application/json' }
 
-function Post-Ingest {
+function Invoke-IngestPost {
     param(
         [string]$Endpoint,
         [object]$Records,
@@ -69,68 +84,116 @@ function Post-Ingest {
     }
 }
 
+# Rewrite every placeholder system reference to the real id the API assigned.
+function Convert-SystemIds {
+    param([object]$Records, [hashtable]$Map)
+    foreach ($rec in $Records) {
+        foreach ($field in @('systemId', 'scopeSystemId')) {
+            if (($rec.PSObject.Properties.Name -contains $field) -and $null -ne $rec.$field) {
+                $placeholder = [int]$rec.$field
+                if (-not $Map.ContainsKey($placeholder)) {
+                    throw "Record references unknown placeholder systemId $placeholder"
+                }
+                $rec.$field = $Map[$placeholder]
+            }
+        }
+    }
+}
+
+# Post a section one batch per system, so each full sync reconciles only within
+# the system it is syncing.
+function Invoke-IngestPerSystem {
+    param([string]$Endpoint, [object]$Records, [string]$Label)
+    $groups = @($Records | Group-Object -Property systemId)
+    foreach ($g in $groups) {
+        Write-Host "  $Label — system $($g.Name): $($g.Count) record(s)" -ForegroundColor DarkGray
+        Invoke-IngestPost -Endpoint $Endpoint -Records $g.Group -SystemId ([int]$g.Name) -SyncMode 'full' | Out-Null
+    }
+}
+
 Write-Host "`n=== Ingesting Fortigi Demo Corp ===" -ForegroundColor Cyan
 Write-Host "Dataset: $DatasetPath"
 Write-Host "API:     $ApiBaseUrl"
 Write-Host ""
 
-# 1. Systems (no systemId needed)
+# 1. Systems (no systemId needed) — and resolve the real ids.
 Write-Host "[1/12] Systems ($($dataset.systems.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/systems' -Records $dataset.systems -SyncMode 'delta'
+$sysResult = Invoke-IngestPost -Endpoint 'ingest/systems' -Records $dataset.systems -SyncMode 'delta'
 
-# Get system IDs (we assume 1=EntraID, 2=HR, 3=Omada based on insertion order)
-$sysEntraId = 1
-$sysHR = 2
-$sysOmada = 3
+$realIds = @($sysResult.systemIds)
+if ($realIds.Count -ne $dataset.systems.Count) {
+    Write-Host "  Expected $($dataset.systems.Count) system ids back, got $($realIds.Count). Cannot map placeholders." -ForegroundColor Red
+    exit 1
+}
+
+# metadata.systemKeys is emitted parallel to the systems array, and the API
+# returns systemIds in record order — so index i lines up across all three.
+$systemMap = @{}
+$byKey = @{}
+for ($i = 0; $i -lt $realIds.Count; $i++) {
+    $systemMap[$i + 1] = [int]$realIds[$i]
+    $byKey[$dataset.metadata.systemKeys[$i].key] = [int]$realIds[$i]
+}
+Write-Host "  System ids: $(($byKey.GetEnumerator() | Sort-Object Key | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ', ')" -ForegroundColor DarkGray
+
+foreach ($section in @(
+    $dataset.contexts, $dataset.principals, $dataset.resources,
+    $dataset.resourceAssignments, $dataset.resourceRelationships,
+    $dataset.governanceCatalogs, $dataset.assignmentPolicies, $dataset.certificationDecisions
+)) {
+    Convert-SystemIds -Records $section -Map $systemMap
+}
+
+$sysEntra = $byKey['entra']
+$sysHR    = $byKey['hr']
+$sysIga   = $byKey['iga']
 
 # 2. Contexts
 Write-Host "[2/12] Contexts ($($dataset.contexts.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/contexts' -Records $dataset.contexts -SystemId $sysHR -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/contexts' -Records $dataset.contexts -SystemId $sysHR -SyncMode 'full' | Out-Null
 
-# 3. Principals
+# 3. Principals — span Entra, IGA and SAP.
 Write-Host "[3/12] Principals ($($dataset.principals.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/principals' -Records $dataset.principals -SystemId $sysEntraId -SyncMode 'full'
+Invoke-IngestPerSystem -Endpoint 'ingest/principals' -Records $dataset.principals -Label 'principals'
 
-# 4. Context Members (department / team membership — depends on Contexts + Principals)
+# 4. Context Members (depends on Contexts + Principals)
 Write-Host "[4/12] Context Members ($($dataset.contextMembers.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/context-members' -Records $dataset.contextMembers -SystemId $sysHR -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/context-members' -Records $dataset.contextMembers -SystemId $sysHR -SyncMode 'full' | Out-Null
 
-# 5. Resources
+# 5. Resources — span Entra, IGA, SAP and AzureRM.
 Write-Host "[5/12] Resources ($($dataset.resources.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/resources' -Records $dataset.resources -SystemId $sysEntraId -SyncMode 'full'
+Invoke-IngestPerSystem -Endpoint 'ingest/resources' -Records $dataset.resources -Label 'resources'
 
-# 6. Resource Assignments
+# 6. Resource Assignments — carry the system of the resource they hang off.
 Write-Host "[6/12] Resource Assignments ($($dataset.resourceAssignments.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/resource-assignments' -Records $dataset.resourceAssignments -SystemId $sysEntraId -SyncMode 'full'
+Invoke-IngestPerSystem -Endpoint 'ingest/resource-assignments' -Records $dataset.resourceAssignments -Label 'assignments'
 
 # 7. Resource Relationships
 Write-Host "[7/12] Resource Relationships ($($dataset.resourceRelationships.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/resource-relationships' -Records $dataset.resourceRelationships -SystemId $sysEntraId -SyncMode 'full'
+Invoke-IngestPerSystem -Endpoint 'ingest/resource-relationships' -Records $dataset.resourceRelationships -Label 'relationships'
 
 # 8. Identities
 Write-Host "[8/12] Identities ($($dataset.identities.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/identities' -Records $dataset.identities -SystemId $sysHR -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/identities' -Records $dataset.identities -SystemId $sysHR -SyncMode 'full' | Out-Null
 
-# 9. Identity Members
+# 9. Identity Members — the cross-system correlation (Entra + IGA + SAP).
 Write-Host "[9/12] Identity Members ($($dataset.identityMembers.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/identity-members' -Records $dataset.identityMembers -SystemId $sysHR -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/identity-members' -Records $dataset.identityMembers -SystemId $sysHR -SyncMode 'full' | Out-Null
 
-# 10. Governance Catalogs
+# 10-12. Governance — sourced from the IGA system.
 Write-Host "[10/12] Governance Catalogs ($($dataset.governanceCatalogs.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/governance/catalogs' -Records $dataset.governanceCatalogs -SystemId $sysOmada -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/governance/catalogs' -Records $dataset.governanceCatalogs -SystemId $sysIga -SyncMode 'full' | Out-Null
 
-# 11. Assignment Policies
 Write-Host "[11/12] Assignment Policies ($($dataset.assignmentPolicies.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/governance/policies' -Records $dataset.assignmentPolicies -SystemId $sysOmada -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/governance/policies' -Records $dataset.assignmentPolicies -SystemId $sysIga -SyncMode 'full' | Out-Null
 
-# 12. Certification Decisions
 Write-Host "[12/12] Certification Decisions ($($dataset.certificationDecisions.Count))..." -ForegroundColor Cyan
-Post-Ingest -Endpoint 'ingest/governance/certifications' -Records $dataset.certificationDecisions -SystemId $sysOmada -SyncMode 'full'
+Invoke-IngestPost -Endpoint 'ingest/governance/certifications' -Records $dataset.certificationDecisions -SystemId $sysIga -SyncMode 'full' | Out-Null
 
 # Refresh views
 Write-Host "`nRefreshing views..." -ForegroundColor Cyan
 try {
-    Invoke-RestMethod -Uri "$ApiBaseUrl/ingest/refresh-views" -Method Post -Headers $headers -Body '{}' -ContentType 'application/json' -TimeoutSec 60
+    Invoke-RestMethod -Uri "$ApiBaseUrl/ingest/refresh-views" -Method Post -Headers $headers -Body '{}' -ContentType 'application/json' -TimeoutSec 60 | Out-Null
     Write-Host "  Views refreshed" -ForegroundColor Green
 }
 catch {
@@ -158,3 +221,6 @@ catch {
 }
 
 Write-Host "`n=== Ingest Complete ===" -ForegroundColor Green
+Write-Host "Next, for the full demo experience (issue #705):" -ForegroundColor Cyan
+Write-Host "  - run the 'department-from-principal' and 'risky-consent' context plugins" -ForegroundColor DarkGray
+Write-Host "  - apply Simulate-History.sql to back-date the timeline" -ForegroundColor DarkGray

--- a/test/demo-dataset/Verify-DemoDataset.ps1
+++ b/test/demo-dataset/Verify-DemoDataset.ps1
@@ -81,18 +81,21 @@ Write-Host "`n=== Demo Dataset Verification ===" -ForegroundColor Cyan
 
 Write-Host "`n--- Row Counts ---" -ForegroundColor Yellow
 
+# The generator is deterministic, so these are exact. If one of them fails after
+# a dataset change, that is the point: re-run Generate-DemoDataset.ps1, confirm
+# the new number is intended, and update it here in the same PR.
 $counts = @{
-    'Systems'                = @{ Min = 3;  Max = 3 }
-    'Principals'             = @{ Min = 27; Max = 30 }  # 22 employees + edge cases + omada account
-    'Resources'              = @{ Min = 17; Max = 17 }  # 6 groups + 2 dir roles + 2 app roles + 4 business roles + 3 group-ownership (#713)
-    'ResourceAssignments'    = @{ Min = 50; Max = 120 }
-    'ResourceRelationships'  = @{ Min = 12; Max = 12 }  # 8 Contains + 1 GrantsAccessTo + 3 HasOwnership (#713)
-    'Identities'             = @{ Min = 20; Max = 25 }
-    'IdentityMembers'        = @{ Min = 20; Max = 40 }
+    'Systems'                = @{ Min = 5;  Max = 5 }   # EntraID + HR + IGA + SAP + AzureRM (#705)
+    'Principals'             = @{ Min = 45; Max = 45 }  # 26 employees + 5 edge cases + IGA acct + 10 SAP + 3 app SPs
+    'Resources'              = @{ Min = 39; Max = 39 }  # Entra 10 + ownership 3 + business roles 5 + Sales 4 + consent 4 + SAP 4 + Azure 9
+    'ResourceAssignments'    = @{ Min = 143; Max = 143 }
+    'ResourceRelationships'  = @{ Min = 20; Max = 20 }  # 14 Contains + 1 GrantsAccessTo + 3 HasOwnership + 2 DelegatesScope
+    'Identities'             = @{ Min = 27; Max = 27 }  # 26 employees + the leaver
+    'IdentityMembers'        = @{ Min = 38; Max = 38 }  # 27 Entra + 1 IGA + 10 SAP
     'GovernanceCatalogs'     = @{ Min = 2;  Max = 2 }
-    'AssignmentPolicies'     = @{ Min = 3;  Max = 3 }
-    'CertificationDecisions' = @{ Min = 2;  Max = 2 }
-    'Crawlers'               = @{ Min = 1;  Max = 10 }
+    'AssignmentPolicies'     = @{ Min = 4;  Max = 4 }
+    'CertificationDecisions' = @{ Min = 3;  Max = 3 }
+    'Crawlers'               = @{ Min = 1;  Max = 10 }  # runtime state, not generated
 }
 
 foreach ($table in $counts.Keys | Sort-Object) {
@@ -108,13 +111,12 @@ foreach ($table in $counts.Keys | Sort-Object) {
 }
 
 # Contexts are counted separately, filtered to the dataset's own. In the v6
-# model a Context carries a `variant`: the demo dataset ingests 8 'synced' ones
-# (1 admin unit + 5 departments + 2 teams), while the API creates 'manual' Tag
-# roots at bootstrap and the context-algorithm plugins emit 'generated' ones
-# whenever the worker runs. A bare COUNT(*) therefore drifts with runtime state —
-# it read 8 before the worker started and 9 after. Filtering by variant makes
-# this deterministic.
-Assert-Count 'RowCount-Contexts' -Min 8 -Max 8 -Query @'
+# model a Context carries a `variant`: the demo dataset ingests 9 'synced' ones
+# (1 root + 5 departments + 2 teams + 1 admin unit), while the API creates
+# 'manual' Tag roots at bootstrap and the context-algorithm plugins emit
+# 'generated' ones whenever the worker runs. A bare COUNT(*) therefore drifts
+# with runtime state. Filtering by variant makes this deterministic.
+Assert-Count 'RowCount-Contexts' -Min 9 -Max 9 -Query @'
 SELECT COUNT(*) FROM "Contexts" WHERE "variant" = 'synced'
 '@
 
@@ -174,7 +176,7 @@ SELECT COUNT(*) FROM "Principals" WHERE "accountEnabled" = false AND "deletedAt"
 '@
 
 # Resource types
-Assert-Count 'BusinessRole-Count' -Min 4 -Max 4 -Query @'
+Assert-Count 'BusinessRole-Count' -Min 5 -Max 5 -Query @'
 SELECT COUNT(*) FROM "Resources" WHERE "resourceType" = 'BusinessRole' AND "deletedAt" IS NULL
 '@
 
@@ -243,6 +245,143 @@ Assert-Count 'Has-MultiSystem-Identity' -Min 1 -Label 'identities with 2+ accoun
 SELECT COUNT(*) FROM (
   SELECT "identityId" FROM "IdentityMembers" GROUP BY "identityId" HAVING COUNT(*) > 1
 ) multi
+'@
+
+# ─── Capture-the-Flag scenarios (#705) ────────────────────────────
+# Each flag's answer, computed straight from the database. These are the
+# data-level regression layer: if a dataset change moves an answer, the flag
+# breaks here rather than in a participant's inbox. Update the published answer
+# in the same PR as any change that trips one of these.
+
+Write-Host "`n--- Capture-the-Flag scenarios ---" -ForegroundColor Yellow
+
+# Flag 1 — Sales has 6 ACTIVE identities. The 7th (the disabled leaver) is the
+# distractor, so assert both numbers: a naive count must differ from the answer.
+Assert-Count 'CTF01-SalesActiveIdentities' -Min 6 -Max 6 -Query @'
+SELECT COUNT(DISTINCT i."id") FROM "Identities" i
+JOIN "IdentityMembers" im ON im."identityId" = i."id"
+WHERE i."department" = 'Sales' AND im."accountEnabled" = true
+'@
+
+Assert-Count 'CTF01-SalesIdentitiesIncludingLeaver' -Min 7 -Max 7 -Query @'
+SELECT COUNT(DISTINCT i."id") FROM "Identities" i WHERE i."department" = 'Sales'
+'@
+
+# Flag 4 — Piet's CRM access is role-derived only. A Direct grant would make the
+# answer "because someone gave it to him", which is the wrong lesson.
+Assert-Count 'CTF04-PietCrmNotDirect' -Min 0 -Max 0 -Label '0 direct grants' -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+JOIN "Resources"  r ON r."id" = ra."resourceId"
+JOIN "Principals" p ON p."id" = ra."principalId"
+WHERE p."displayName" = 'Piet Jansen' AND r."displayName" = 'SG-CRM-Users'
+  AND ra."assignmentType" = 'Direct' AND ra."deletedAt" IS NULL
+'@
+
+Assert-Count 'CTF04-PietCrmViaRole' -Min 1 -Max 1 -Query @'
+SELECT COUNT(*) FROM "ResourceAssignments" ra
+JOIN "Resources"  r ON r."id" = ra."resourceId"
+JOIN "Principals" p ON p."id" = ra."principalId"
+WHERE p."displayName" = 'Piet Jansen' AND r."displayName" = 'SG-CRM-Users'
+  AND ra."assignmentType" = 'Indirect' AND ra."deletedAt" IS NULL
+'@
+
+# Flag 6 — the role candidate must NOT already be in BR-Sales, or there is
+# nothing to recommend.
+Assert-Count 'CTF06-SharePointNotInRole' -Min 0 -Max 0 -Label '0 Contains edges' -Query @'
+SELECT COUNT(*) FROM "ResourceRelationships" rr
+JOIN "Resources" parent ON parent."id" = rr."parentResourceId"
+JOIN "Resources" child  ON child."id"  = rr."childResourceId"
+WHERE parent."displayName" = 'BR-Sales' AND child."displayName" = 'SG-Sales-SharePoint'
+  AND rr."relationshipType" = 'Contains'
+'@
+
+# Flag 7 — the trap must cross the department boundary; that (plus its
+# sensitivity) is what distinguishes it from flag 6's clean candidate.
+Assert-Count 'CTF07-TrapIsCrossDepartment' -Min 2 -Query @'
+SELECT COUNT(DISTINCT p."department") FROM "ResourceAssignments" ra
+JOIN "Resources"  r ON r."id" = ra."resourceId"
+JOIN "Principals" p ON p."id" = ra."principalId"
+WHERE r."displayName" = 'SG-Finance-Reports' AND ra."deletedAt" IS NULL
+'@
+
+# Flag 8 — Finance has the most SAP accounts...
+Assert-Count 'CTF08-SapFinanceCount' -Min 4 -Max 4 -Query @'
+SELECT COUNT(*) FROM "Principals" p
+JOIN "Systems" s ON s."id" = p."systemId"
+JOIN "IdentityMembers" im ON im."principalId" = p."id"
+JOIN "Identities" i ON i."id" = im."identityId"
+WHERE s."systemType" = 'SAP' AND i."department" = 'Finance' AND p."deletedAt" IS NULL
+'@
+
+# ...and the flag is only hard because SAP accounts carry no department of their
+# own. If this ever becomes non-zero the answer is readable straight off the
+# account list and the flag is worthless.
+Assert-Count 'CTF08-SapAccountsHaveNoDepartment' -Min 0 -Max 0 -Label '0 with department' -Query @'
+SELECT COUNT(*) FROM "Principals" p
+JOIN "Systems" s ON s."id" = p."systemId"
+WHERE s."systemType" = 'SAP' AND p."department" IS NOT NULL AND p."deletedAt" IS NULL
+'@
+
+# Flag 9 — the never-expiring password set.
+Assert-Count 'CTF09-NeverExpiringPasswords' -Min 5 -Max 5 -Query @'
+SELECT COUNT(*) FROM "Principals"
+WHERE "extendedAttributes"->>'passwordNeverExpires' = 'true' AND "deletedAt" IS NULL
+'@
+
+# Flag 10 — everyone holding an Azure US role. The westeurope distractor must
+# also exist, or "filter by region" isn't a real step.
+Assert-Count 'CTF10-AzureUsPrincipals' -Min 3 -Max 3 -Query @'
+SELECT COUNT(DISTINCT ra."principalId") FROM "ResourceAssignments" ra
+JOIN "Resources" r ON r."id" = ra."resourceId"
+WHERE r."resourceType" = 'AzureRoleAssignment'
+  AND r."extendedAttributes"->>'azureLocation' = 'eastus' AND ra."deletedAt" IS NULL
+'@
+
+Assert-Count 'CTF10-AzureEuDistractorExists' -Min 1 -Query @'
+SELECT COUNT(*) FROM "Resources"
+WHERE "resourceType" = 'AzureRoleAssignment'
+  AND "extendedAttributes"->>'azureLocation' = 'westeurope' AND "deletedAt" IS NULL
+'@
+
+# Flag 11 — who consented to Files.ReadWrite.All.
+Assert-Count 'CTF11-FilesReadWriteConsenters' -Min 5 -Max 5 -Query @'
+SELECT COUNT(DISTINCT ra."principalId") FROM "ResourceAssignments" ra
+JOIN "Resources" r ON r."id" = ra."resourceId"
+WHERE r."resourceType" = 'DelegatedPermission'
+  AND r."extendedAttributes"->>'scope' = 'Files.ReadWrite.All' AND ra."deletedAt" IS NULL
+'@
+
+# Flag 12 — the intersection: risky consent AND a never-expiring password.
+Assert-Count 'CTF12-RiskyConsentAndNeverExpire' -Min 2 -Max 2 -Query @'
+SELECT COUNT(DISTINCT ra."principalId") FROM "ResourceAssignments" ra
+JOIN "Resources"  r ON r."id" = ra."resourceId"
+JOIN "Principals" p ON p."id" = ra."principalId"
+WHERE r."resourceType" = 'DelegatedPermission'
+  AND r."extendedAttributes"->>'scope' = 'Files.ReadWrite.All'
+  AND p."extendedAttributes"->>'passwordNeverExpires' = 'true'
+  AND ra."deletedAt" IS NULL
+'@
+
+# ...and the trap must stay bigger than the answer. If these ever match, the
+# "risky" half of the question stopped mattering.
+Assert-Count 'CTF12-TrapIsWiderThanAnswer' -Min 3 -Max 3 -Label '3 (answer is 2)' -Query @'
+SELECT COUNT(DISTINCT ra."principalId") FROM "ResourceAssignments" ra
+JOIN "Resources"  r ON r."id" = ra."resourceId"
+JOIN "Principals" p ON p."id" = ra."principalId"
+WHERE r."resourceType" = 'DelegatedPermission'
+  AND p."extendedAttributes"->>'passwordNeverExpires' = 'true'
+  AND ra."deletedAt" IS NULL
+'@
+
+# The risky-consent context plugin joins clientSpId -> Principals to read the
+# app's appId/publisher. A dangling clientSpId silently drops the grant from the
+# plugin's output (the shape of issue #719), taking flags 11-12 with it.
+Assert-Count 'CTF-ConsentGrantsResolveToClientSp' -Min 0 -Max 0 -Label '0 dangling clientSpId' -Query @'
+SELECT COUNT(*) FROM "Resources" r
+WHERE r."resourceType" = 'DelegatedPermission' AND r."deletedAt" IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "Principals" p WHERE p."id"::text = r."extendedAttributes"->>'clientSpId'
+  )
 '@
 
 # ─── API Verification ─────────────────────────────────────────────

--- a/test/demo-dataset/parts/DemoAzure.ps1
+++ b/test/demo-dataset/parts/DemoAzure.ps1
@@ -1,0 +1,136 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — the AzureRM system (CTF Track 2, flag 10).
+
+.DESCRIPTION
+    A small but structurally faithful copy of what the real Azure RM crawler
+    emits (tools/crawlers/azure-rm/AzureRMCrawler.Transform.ps1):
+
+      * Scope nodes — 'AzureScope' (root), 'AzureResourceGroup', 'AzureResource'
+        — carrying `armPath` / `scopeKind` / `scopeTypeLabel`, linked into a tree
+        by `Contains`.
+      * One synthetic 'AzureRoleAssignment' capability resource per
+        (scope, role definition), named "<Role> @ <scope>", carrying
+        `capabilityId` / `targetNodeId` / `roleName` / `isCustom` / `plane`.
+      * RBAC grants as Direct assignments from Entra principals onto those
+        capability resources — which is also the demo's cross-system case: an
+        Entra account holding access in a different system.
+
+    Region: the real crawler stores the region as `azureLocation` in the scope
+    node's extendedAttributes (AzureRMCrawler.Functions.ps1). We ALSO stamp
+    azureLocation on the capability resource. That is a deliberate
+    denormalisation: the capability is "role at scope", so the scope's region is
+    an intrinsic property of it — and it is the only way a matrix resource-filter
+    can select "everything in Azure US", since the assignments hang off the
+    capability, not the scope node. The real crawler should arguably do the same;
+    noted as a follow-up rather than fixed here.
+
+    Flag 10 answers "which users have access to a resource in Azure US" =
+    everyone assigned to an eastus capability. rg-prod-westeurope exists purely
+    as the distractor, and Victor Wang holds roles in BOTH regions so the answer
+    can't be reached by "whoever isn't in westeurope".
+#>
+
+Set-StrictMode -Version Latest
+
+$script:DemoSubId = '11111111-2222-3333-4444-555555555555'
+
+function Add-DemoAzure {
+    param([Parameter(Mandatory)]$State)
+
+    $sysAz = $State.SystemIds['azurerm']
+    $sub   = $script:DemoSubId
+
+    $rootId = New-DemoGuid 'res-az-scope-root'
+    $null = Add-DemoResource $State -Id $rootId -DisplayName 'Fortigi Demo Tenant' -ResourceType 'AzureScope' `
+        -SystemId $sysAz -ExternalId '/' `
+        -Extended @{ armPath = '/'; scopeKind = 'Root'; scopeTypeLabel = 'Root' }
+
+    $scopes = @(
+        @{ Key = 'rg-eastus';  Name = 'rg-prod-eastus';      Location = 'eastus';      Kind = 'ResourceGroup' }
+        @{ Key = 'rg-weu';     Name = 'rg-prod-westeurope';  Location = 'westeurope';  Kind = 'ResourceGroup' }
+    )
+    $scopeIds = @{}
+    foreach ($s in $scopes) {
+        $armPath = "/subscriptions/$sub/resourceGroups/$($s.Name)"
+        $id = New-DemoGuid "res-az-scope-$($s.Key)"
+        $scopeIds[$s.Key] = $id
+        $null = Add-DemoResource $State -Id $id -DisplayName $s.Name -ResourceType 'AzureResourceGroup' `
+            -SystemId $sysAz -ExternalId $armPath `
+            -Extended @{ armPath = $armPath; scopeKind = 'ResourceGroup'; scopeTypeLabel = 'RG'; azureLocation = $s.Location }
+        Add-DemoRelationship $State -ParentResourceId $rootId -ChildResourceId $id -RelationshipType 'Contains'
+    }
+
+    $storage = @(
+        @{ Key = 'st-eastus'; Name = 'stprodeastus01'; Rg = 'rg-eastus'; RgName = 'rg-prod-eastus'; Location = 'eastus' }
+        @{ Key = 'st-weu';    Name = 'stprodweu01';    Rg = 'rg-weu';    RgName = 'rg-prod-westeurope'; Location = 'westeurope' }
+    )
+    foreach ($st in $storage) {
+        $armPath = "/subscriptions/$sub/resourceGroups/$($st.RgName)/providers/Microsoft.Storage/storageAccounts/$($st.Name)"
+        $id = New-DemoGuid "res-az-scope-$($st.Key)"
+        $scopeIds[$st.Key] = $id
+        $null = Add-DemoResource $State -Id $id -DisplayName $st.Name -ResourceType 'AzureResource' `
+            -SystemId $sysAz -ExternalId $armPath `
+            -Extended @{
+                armPath = $armPath; scopeKind = 'Resource'; scopeTypeLabel = 'Res'
+                azureResourceType = 'Microsoft.Storage/storageAccounts'; azureLocation = $st.Location
+            }
+        Add-DemoRelationship $State -ParentResourceId $scopeIds[$st.Rg] -ChildResourceId $id -RelationshipType 'Contains'
+    }
+
+    Add-DemoAzureRoleAssignments $State -ScopeIds $scopeIds
+}
+
+# The synthetic "<role> @ <scope>" capability resources plus who holds them.
+function Add-DemoAzureRoleAssignments {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][hashtable]$ScopeIds
+    )
+
+    $sysAz = $State.SystemIds['azurerm']
+
+    # Well-known Azure built-in role definition ids.
+    $roleDefs = @{
+        'Contributor'                  = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+        'Reader'                       = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+        'Storage Blob Data Contributor' = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+    }
+
+    $caps = @(
+        # ── Azure US (eastus) — flag 10's answer lives here ──────────────────
+        @{ Key = 'contrib-rg-eastus'; Role = 'Contributor'; Scope = 'rg-eastus'; ScopeName = 'rg-prod-eastus'
+           Location = 'eastus'; Holders = @('E0029'); ServicePrincipals = @('SvcPrinc') }
+        @{ Key = 'blob-st-eastus'; Role = 'Storage Blob Data Contributor'; Scope = 'st-eastus'; ScopeName = 'stprodeastus01'
+           Location = 'eastus'; Holders = @('E0030'); ServicePrincipals = @() }
+        # ── EU (westeurope) — the distractor ─────────────────────────────────
+        @{ Key = 'reader-rg-weu'; Role = 'Reader'; Scope = 'rg-weu'; ScopeName = 'rg-prod-westeurope'
+           Location = 'westeurope'; Holders = @('E0020', 'E0010'); ServicePrincipals = @() }
+        # Victor holds roles in both regions, so "not in westeurope" is not a
+        # shortcut to the answer.
+        @{ Key = 'contrib-rg-weu'; Role = 'Contributor'; Scope = 'rg-weu'; ScopeName = 'rg-prod-westeurope'
+           Location = 'westeurope'; Holders = @('E0029'); ServicePrincipals = @() }
+    )
+
+    foreach ($cap in $caps) {
+        $capId = New-DemoGuid "res-az-cap-$($cap.Key)"
+        $null = Add-DemoResource $State -Id $capId -DisplayName "$($cap.Role) @ $($cap.ScopeName)" `
+            -ResourceType 'AzureRoleAssignment' -SystemId $sysAz `
+            -Extended @{
+                capabilityId  = $roleDefs[$cap.Role]
+                targetNodeId  = $ScopeIds[$cap.Scope]
+                roleName      = $cap.Role
+                isCustom      = $false
+                plane         = 'control'
+                azureLocation = $cap.Location
+            }
+
+        foreach ($e in $cap.Holders) {
+            Add-DemoAssignment $State -ResourceId $capId -PrincipalId (Get-DemoPrincipalId $e) -AssignmentType 'Direct'
+        }
+        foreach ($spKey in $cap.ServicePrincipals) {
+            Add-DemoAssignment $State -ResourceId $capId -PrincipalId $State.EdgeCaseIds[$spKey] `
+                -AssignmentType 'Direct' -ResourceType 'AzureRoleAssignment'
+        }
+    }
+}

--- a/test/demo-dataset/parts/DemoConsent.ps1
+++ b/test/demo-dataset/parts/DemoConsent.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — OAuth consent / shadow IT (CTF Track 3, flags 11-12).
+
+.DESCRIPTION
+    Two third-party enterprise apps and the delegated scopes users consented to.
+
+    THIS SHAPE IS NOT ARBITRARY — it is what the shipped `risky-consent` context
+    plugin reads (app/api/src/contexts/plugins/risky-consent.js):
+
+      * The grant is a Resource, resourceType='DelegatedPermission', whose
+        extendedAttributes carry `scope` (the permission string) and `clientSpId`
+        (the consuming app's service-principal id, as text).
+      * The plugin joins clientSpId -> Principals and reads that principal's
+        extendedAttributes `appId` + `publisherName`.
+      * Consent itself is a Direct assignment on the grant resource. (Migration
+        045 rewrote the retired OAuth2Grant type to Direct, so this matches
+        production data and shows up under "Direct Members".)
+
+    Determinism (issue #705 risk R1): no LLM is involved. 'Files.ReadWrite.All'
+    is in the plugin's curated HIGH_RISK set (riskyConsentRiskMap.js), so running
+    the plugin with defaults always puts FileSync Pro's grant in "Risky Consent —
+    High". FileSync Pro's publisher is 'Default Directory' — an unverified
+    publisher — so it also lands in "Risky App Consent — Suspicious" via the
+    offline heuristic, with no threat-feed call needed.
+
+    Contoso Timesheets is the control: 'User.Read' classifies Low (below the
+    plugin's default enabled tiers), its publisher is verified, and it has four
+    consenters so the low-prevalence heuristic doesn't fire. It exists so that
+    "which app is risky?" is a real question with a wrong answer available.
+#>
+
+Set-StrictMode -Version Latest
+
+# Flag 11's answer: who consented to Files.ReadWrite.All. Spread across
+# departments so no single department scope reveals it.
+$script:RiskyConsenters = @('E0032', 'E0027', 'E0020', 'E0030', 'E0025')
+
+# The control app's consenters. Victor Wang (E0029) is here and nowhere else:
+# he has a never-expiring password, so anyone who forgets the "risky" half of
+# flag 12 will wrongly include him. Four consenters also keeps this app above
+# the plugin's low-prevalence threshold, so it is not flagged Suspicious.
+$script:CleanConsenters = @('E0029', 'E0021', 'E0022', 'E0024')
+
+function Add-DemoConsent {
+    param([Parameter(Mandatory)]$State)
+
+    $sysEntra = $State.SystemIds['entra']
+
+    # The resource API these scopes are granted against.
+    $graphSpId = Get-DemoPrincipalId 'SP-MSGRAPH'
+    $null = Add-DemoPrincipal $State -Record @{
+        id             = $graphSpId
+        displayName    = 'Microsoft Graph'
+        principalType  = 'ServicePrincipal'
+        accountEnabled = $true
+        systemId       = $sysEntra
+        extendedAttributes = @{
+            appId         = '00000003-0000-0000-c000-000000000000'
+            publisherName = 'Microsoft Services'
+        }
+    }
+
+    $apps = @(
+        @{
+            Key = 'filesync'; Name = 'FileSync Pro'; Scope = 'Files.ReadWrite.All'
+            AppId = 'a3f1c7d4-9b2e-4c81-8e5a-6d0f2b7c1e93'
+            # An unverified publisher is what the plugin's offline heuristic
+            # keys on — this is the shadow-IT tell.
+            Publisher = 'Default Directory'
+            AppDesc = 'Third-party file synchronisation tool. Self-service consent, unverified publisher.'
+            Consenters = $script:RiskyConsenters
+        }
+        @{
+            Key = 'contoso'; Name = 'Contoso Timesheets'; Scope = 'User.Read'
+            AppId = 'd82b6a10-4f3c-4a97-b1d5-3e9c8f0a2b46'
+            Publisher = 'Contoso Ltd.'
+            AppDesc = 'Approved timesheet application. Verified publisher, sign-in scope only.'
+            Consenters = $script:CleanConsenters
+        }
+    )
+
+    foreach ($app in $apps) {
+        Add-DemoConsentApp $State -App $app -GraphSpId $graphSpId
+    }
+}
+
+# One enterprise app: its service principal, its Application resource, the
+# delegated scope it holds, and the users who consented.
+function Add-DemoConsentApp {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][hashtable]$App,
+        [Parameter(Mandatory)][string]$GraphSpId
+    )
+
+    $sysEntra = $State.SystemIds['entra']
+    $spId     = Get-DemoPrincipalId "SP-$($App.Key.ToUpper())"
+    $appResId = New-DemoGuid "res-app-$($App.Key)"
+    $grantId  = New-DemoGuid "res-scope-$($App.Key)-$($App.Scope)"
+
+    # The app's own service principal — the plugin resolves clientSpId to this
+    # to read appId + publisherName.
+    $null = Add-DemoPrincipal $State -Record @{
+        id             = $spId
+        displayName    = $App.Name
+        principalType  = 'ServicePrincipal'
+        accountEnabled = $true
+        systemId       = $sysEntra
+        extendedAttributes = @{
+            appId         = $App.AppId
+            publisherName = $App.Publisher
+        }
+    }
+
+    $null = Add-DemoResource $State -Id $appResId -DisplayName $App.Name -ResourceType 'Application' `
+        -SystemId $sysEntra -Description $App.AppDesc `
+        -Extended @{ appId = $App.AppId; publisherName = $App.Publisher; clientSpId = $spId }
+
+    # The delegated scope. `scope` + `clientSpId` are the two keys the
+    # risky-consent plugin requires — renaming either makes the grant invisible
+    # to it (see issue #719 for how that failure mode looks).
+    $null = Add-DemoResource $State -Id $grantId -DisplayName $App.Scope -ResourceType 'DelegatedPermission' `
+        -SystemId $sysEntra -Description "$($App.Scope) delegated to $($App.Name)." `
+        -Extended @{
+            scope        = $App.Scope
+            clientSpId   = $spId
+            targetApiSpId = $GraphSpId
+            consentType  = 'Principal'
+        }
+
+    Add-DemoRelationship $State -ParentResourceId $appResId -ChildResourceId $grantId -RelationshipType 'DelegatesScope'
+
+    foreach ($e in $App.Consenters) {
+        Add-DemoAssignment $State -ResourceId $grantId -PrincipalId (Get-DemoPrincipalId $e) -AssignmentType 'Direct'
+    }
+}

--- a/test/demo-dataset/parts/DemoEntraBase.ps1
+++ b/test/demo-dataset/parts/DemoEntraBase.ps1
@@ -1,0 +1,124 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — the Entra ID baseline: groups, directory roles, app
+    roles, their grants, and group ownership.
+
+.DESCRIPTION
+    The "ordinary" access every demo needs, independent of the CTF: company-wide
+    and departmental security groups, two directory roles, two app roles, and the
+    v5 ownership model (a Direct assignment on a synthetic GroupOwnership
+    resource, never the retired 'Owner' assignmentType).
+#>
+
+Set-StrictMode -Version Latest
+
+function Add-DemoEntraBase {
+    param([Parameter(Mandatory)]$State)
+
+    $sysEntra = $State.SystemIds['entra']
+
+    $res = [ordered]@{
+        AllEmp      = New-DemoGuid 'res-sg-all-employees'
+        Eng         = New-DemoGuid 'res-sg-engineering'
+        Fin         = New-DemoGuid 'res-sg-finance'
+        VPN         = New-DemoGuid 'res-sg-vpn-access'
+        AdminTier0  = New-DemoGuid 'res-sg-admin-tier0'
+        PAM         = New-DemoGuid 'res-sg-pam-users'
+        GlobalAdmin = New-DemoGuid 'res-global-administrator'
+        SPAdmin     = New-DemoGuid 'res-sharepoint-admin'
+        AppFG       = New-DemoGuid 'res-app-fortigraph'
+        AppSAP      = New-DemoGuid 'res-app-sap-finance'
+    }
+    $State['Res'] = $res
+
+    $groups = @(
+        @{ Id = $res.AllEmp;     Name = 'SG-AllEmployees' }
+        @{ Id = $res.Eng;        Name = 'SG-Engineering' }
+        @{ Id = $res.Fin;        Name = 'SG-Finance' }
+        @{ Id = $res.VPN;        Name = 'SG-VPN-Access' }
+        @{ Id = $res.AdminTier0; Name = 'SG-Admin-Tier0'; Desc = 'Tier 0 administrative access - critical' }
+        @{ Id = $res.PAM;        Name = 'SG-PAM-Users' }
+    )
+    foreach ($g in $groups) {
+        $desc = if ($g.ContainsKey('Desc')) { $g.Desc } else { '' }
+        $null = Add-DemoResource $State -Id $g.Id -DisplayName $g.Name -ResourceType 'Group' -SystemId $sysEntra -Description $desc
+    }
+
+    foreach ($dr in @(
+        @{ Id = $res.GlobalAdmin; Name = 'Global Administrator' }
+        @{ Id = $res.SPAdmin;     Name = 'SharePoint Admin' }
+    )) {
+        $null = Add-DemoResource $State -Id $dr.Id -DisplayName $dr.Name -ResourceType 'EntraDirectoryRole' -SystemId $sysEntra
+    }
+
+    foreach ($ar in @(
+        @{ Id = $res.AppFG;  Name = 'FortigiGraph-App' }
+        @{ Id = $res.AppSAP; Name = 'SAP-Finance-Role' }
+    )) {
+        $null = Add-DemoResource $State -Id $ar.Id -DisplayName $ar.Name -ResourceType 'AppRole' -SystemId $sysEntra
+    }
+
+    Add-DemoEntraBaseGrants $State
+    Add-DemoGroupOwnership  $State
+}
+
+function Add-DemoEntraBaseGrants {
+    param([Parameter(Mandatory)]$State)
+
+    $res = $State.Res
+
+    # Every provisioned employee is in SG-AllEmployees. This is also the one
+    # member of the Sales shared set that everyone holds *directly* rather than
+    # through a role — the contrast flag 5 turns on.
+    foreach ($emp in (Get-DemoProvisioned $State)) {
+        Add-DemoAssignment $State -ResourceId $res.AllEmp -PrincipalId (Get-DemoPrincipalId $emp.id) -AssignmentType 'Direct'
+    }
+
+    foreach ($pair in @(
+        @{ Res = $res.Eng; Dept = 'Engineering' }
+        @{ Res = $res.Fin; Dept = 'Finance' }
+    )) {
+        foreach ($emp in (Get-DemoProvisioned $State -Department $pair.Dept)) {
+            Add-DemoAssignment $State -ResourceId $pair.Res -PrincipalId (Get-DemoPrincipalId $emp.id) -AssignmentType 'Direct'
+        }
+    }
+
+    # SysAdmins -> VPN
+    foreach ($e in @('E0029', 'E0030')) {
+        Add-DemoAssignment $State -ResourceId $res.VPN -PrincipalId (Get-DemoPrincipalId $e) -AssignmentType 'Direct'
+    }
+
+    # Admin Tier0: CTO + SysAdmin + the deploy service principal
+    foreach ($p in @((Get-DemoPrincipalId 'E0002'), (Get-DemoPrincipalId 'E0029'), $State.EdgeCaseIds.SvcPrinc)) {
+        Add-DemoAssignment $State -ResourceId $res.AdminTier0 -PrincipalId $p -AssignmentType 'Direct'
+    }
+
+    # CTO -> Global Admin directory role
+    Add-DemoAssignment $State -ResourceId $res.GlobalAdmin -PrincipalId (Get-DemoPrincipalId 'E0002') -AssignmentType 'Direct'
+}
+
+# v5 ownership: a Direct assignment on a synthetic GroupOwnership resource
+# (named after the owned group), linked to the group by a HasOwnership
+# relationship — mirroring ConvertTo-EntraGroupOwnership in the Entra crawler.
+function Add-DemoGroupOwnership {
+    param([Parameter(Mandatory)]$State)
+
+    $res = $State.Res
+    $ownedGroups = @(
+        @{ GroupId = $res.Eng;        Name = 'SG-Engineering'; Owners = @('E0010') }
+        @{ GroupId = $res.Fin;        Name = 'SG-Finance';     Owners = @('E0012') }
+        @{ GroupId = $res.AdminTier0; Name = 'SG-Admin-Tier0'; Owners = @('E0002', 'E0029') }
+    )
+
+    foreach ($og in $ownedGroups) {
+        $ownId = New-DemoGuid "res-ownership-$($og.Name)"
+        $null = Add-DemoResource $State -Id $ownId -DisplayName $og.Name -ResourceType 'GroupOwnership' `
+            -SystemId $State.SystemIds['entra'] -ExternalId "entraid-ownership:$($og.GroupId)" `
+            -Extended @{ ownedResourceId = $og.GroupId }
+        Add-DemoRelationship $State -ParentResourceId $og.GroupId -ChildResourceId $ownId -RelationshipType 'HasOwnership'
+        foreach ($ownerId in $og.Owners) {
+            Add-DemoAssignment $State -ResourceId $ownId -PrincipalId (Get-DemoPrincipalId $ownerId) `
+                -AssignmentType 'Direct' -ResourceType 'GroupOwnership'
+        }
+    }
+}

--- a/test/demo-dataset/parts/DemoGovernance.ps1
+++ b/test/demo-dataset/parts/DemoGovernance.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — the IGA layer: catalogs, business roles, policies,
+    certifications.
+
+.DESCRIPTION
+    Vendor-neutral by design (issue #705, Rob's review): a business role is the
+    same concept whether it comes from Omada, midPoint or SailPoint, so the
+    source system is 'IGA' and nothing here names a vendor.
+
+    MODEL NOTE — how role-derived access actually works:
+      * A business role is a Resource (resourceType='BusinessRole'), which ingest
+        auto-flags governanceResource=true.
+      * Holding it is a Direct assignment with governed=true.
+      * `Contains` links the role to what it grants.
+      * The matrix matview (migration 049) DERIVES "managed by this role" from
+        Contains + holding the role — but only for cells that actually exist.
+        A Contains child with no effective assignment renders as a provisioning
+        GAP, not as access. So anything a role really grants must ALSO be emitted
+        as an explicit Indirect assignment (see DemoSalesScenario.ps1).
+
+    BR-Employee-Base deliberately Contains FortigiGraph-App without anyone
+    holding an effective assignment on it — that is the demo's provisioning-gap
+    example, visible under the matrix's Gaps toggle. Do not "fix" it.
+#>
+
+Set-StrictMode -Version Latest
+
+function Add-DemoGovernance {
+    param([Parameter(Mandatory)]$State)
+
+    $sysIga = $State.SystemIds['iga']
+    $res    = $State.Res
+
+    $catEmployee   = New-DemoGuid 'cat-employee-access'
+    $catPrivileged = New-DemoGuid 'cat-privileged-access'
+
+    $br = [ordered]@{
+        Base  = New-DemoGuid 'res-br-employee-base'
+        Eng   = New-DemoGuid 'res-br-engineering-tools'
+        Fin   = New-DemoGuid 'res-br-finance-systems'
+        Admin = New-DemoGuid 'res-br-admin-privileged'
+    }
+    $State['BR'] = $br
+
+    foreach ($cat in @(
+        @{ Id = $catEmployee;   Name = 'Employee Access' }
+        @{ Id = $catPrivileged; Name = 'Privileged Access' }
+    )) {
+        $State.Catalogs.Add(@{
+            id = $cat.Id; displayName = $cat.Name; catalogType = 'userManaged'
+            enabled = $true; systemId = $sysIga
+        })
+    }
+
+    $roles = @(
+        @{ Id = $br.Base;  Name = 'BR-Employee-Base';     Cat = $catEmployee }
+        @{ Id = $br.Eng;   Name = 'BR-Engineering-Tools'; Cat = $catEmployee }
+        @{ Id = $br.Fin;   Name = 'BR-Finance-Systems';   Cat = $catEmployee }
+        @{ Id = $br.Admin; Name = 'BR-Admin-Privileged';  Cat = $catPrivileged }
+    )
+    foreach ($r in $roles) {
+        $null = Add-DemoResource $State -Id $r.Id -DisplayName $r.Name -ResourceType 'BusinessRole' `
+            -SystemId $sysIga -CatalogId $r.Cat
+    }
+
+    foreach ($rel in @(
+        @{ P = $br.Base;  C = $res.AllEmp }
+        @{ P = $br.Base;  C = $res.AppFG }
+        @{ P = $br.Eng;   C = $res.Eng }
+        @{ P = $br.Eng;   C = $res.VPN }
+        @{ P = $br.Fin;   C = $res.Fin }
+        @{ P = $br.Fin;   C = $res.AppSAP }
+        @{ P = $br.Admin; C = $res.AdminTier0 }
+        @{ P = $br.Admin; C = $res.PAM }
+    )) {
+        Add-DemoRelationship $State -ParentResourceId $rel.P -ChildResourceId $rel.C -RelationshipType 'Contains'
+    }
+    Add-DemoRelationship $State -ParentResourceId $res.Eng -ChildResourceId $res.AllEmp -RelationshipType 'GrantsAccessTo'
+
+    # Governed role memberships.
+    foreach ($emp in (Get-DemoProvisioned $State)) {
+        Add-DemoAssignment $State -ResourceId $br.Base -PrincipalId (Get-DemoPrincipalId $emp.id) -AssignmentType 'Direct' -Governed
+    }
+    foreach ($emp in (Get-DemoProvisioned $State -Department 'Engineering')) {
+        Add-DemoAssignment $State -ResourceId $br.Eng -PrincipalId (Get-DemoPrincipalId $emp.id) -AssignmentType 'Direct' -Governed
+    }
+
+    # SysAdmin is eligible for privileged admin rather than holding it.
+    Add-DemoAssignment $State -ResourceId $br.Admin -PrincipalId (Get-DemoPrincipalId 'E0029') -AssignmentType 'Eligible'
+
+    Add-DemoGovernancePolicies $State
+}
+
+function Add-DemoGovernancePolicies {
+    param([Parameter(Mandatory)]$State)
+
+    $sysIga = $State.SystemIds['iga']
+    $br     = $State.BR
+
+    # Derived, not read from state: every demo GUID is a pure function of its
+    # seed, so referencing another part's resource needs no ordering contract.
+    $salesBR    = New-DemoGuid 'res-br-sales'
+    $finReports = New-DemoGuid 'res-sg-finance-reports'
+
+    foreach ($pol in @(
+        @{ Seed = 'pol-auto-base';  Res = $br.Base;  Name = 'Auto-assign all employees';          Scope = 'allMemberUsers' }
+        @{ Seed = 'pol-mgr-eng';    Res = $br.Eng;   Name = 'Manager approval required';          Scope = 'specificDirectoryUsers' }
+        @{ Seed = 'pol-dual-admin'; Res = $br.Admin; Name = 'Dual approval (mgr + security)';     Scope = 'specificDirectoryUsers' }
+        @{ Seed = 'pol-sales';      Res = $salesBR;  Name = 'Sales role — manager approval';      Scope = 'specificDirectoryUsers' }
+    )) {
+        $State.Policies.Add(@{
+            id = (New-DemoGuid $pol.Seed); resourceId = $pol.Res; displayName = $pol.Name
+            allowedTargetScope = $pol.Scope; systemId = $sysIga
+        })
+    }
+
+    foreach ($cert in @(
+        @{ Seed = 'cert-001'; Res = $br.Admin; Principal = (Get-DemoPrincipalId 'E0029'); Decision = 'Approve'
+           By = (Get-DemoPrincipalId 'E0011'); ByName = 'Grace Huang'
+           Why = 'Required for infrastructure maintenance' }
+        @{ Seed = 'cert-002'; Res = $br.Base; Principal = $State.EdgeCaseIds.Disabled; Decision = 'Deny'
+           By = (Get-DemoPrincipalId 'E0013'); ByName = 'Paul Quinn'
+           Why = 'Employee has left the organization' }
+        # The over-privileged trap was reviewed and approved for the Sales
+        # Manager only — the evidence a participant needs for flag 7's "why".
+        @{ Seed = 'cert-003'; Res = $finReports; Principal = (Get-DemoPrincipalId 'E0013'); Decision = 'Approve'
+           By = (Get-DemoPrincipalId 'E0012'); ByName = 'Maria Novak'
+           Why = 'Sales Manager needs pipeline revenue reporting; approved for this role only' }
+    )) {
+        $State.Certifications.Add(@{
+            id = (New-DemoGuid $cert.Seed); resourceId = $cert.Res; principalId = $cert.Principal
+            decision = $cert.Decision; reviewedBy = $cert.By; reviewedByDisplayName = $cert.ByName
+            justification = $cert.Why; systemId = $sysIga
+        })
+    }
+}

--- a/test/demo-dataset/parts/DemoOrg.ps1
+++ b/test/demo-dataset/parts/DemoOrg.ps1
@@ -1,0 +1,269 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — systems, org contexts, people, identities.
+
+.DESCRIPTION
+    The backbone every other part hangs off: the five connected systems, the
+    department/team context tree, the employee roster, and the Identities /
+    IdentityMembers that correlate accounts across systems.
+
+    VENDOR-NEUTRAL IGA: the governance system is 'IGA', not 'Omada'. A business
+    role is the same concept whether it comes from Omada, midPoint or SailPoint,
+    so the demo must not imply one vendor. (The real Omada crawler under
+    tools/crawlers/omada/ is untouched — this is demo data only.)
+#>
+
+Set-StrictMode -Version Latest
+
+function Add-DemoOrg {
+    param([Parameter(Mandatory)]$State)
+
+    # ─── Systems ──────────────────────────────────────────────────────────────
+    # Placeholder ids only — Ingest-DemoDataset.ps1 remaps them to the real
+    # SERIAL ids the API returns. See DemoState.ps1.
+    $sysEntra = Add-DemoSystem $State -Key 'entra'   -SystemType 'EntraID' -DisplayName 'Fortigi Demo EntraID' -TenantId 'demo-tenant-001'
+    $sysHR    = Add-DemoSystem $State -Key 'hr'      -SystemType 'HR'      -DisplayName 'Fortigi Demo HR'      -TenantId 'demo-hr-001'
+    $sysIga   = Add-DemoSystem $State -Key 'iga'     -SystemType 'IGA'     -DisplayName 'Fortigi Demo IGA'     -TenantId 'demo-iga-001'
+    $null     = Add-DemoSystem $State -Key 'sap'     -SystemType 'SAP'     -DisplayName 'Fortigi Demo SAP ERP' -TenantId 'demo-sap-001'
+    $null     = Add-DemoSystem $State -Key 'azurerm' -SystemType 'AzureRM' -DisplayName 'Fortigi Demo Azure'   -TenantId 'demo-azure-001'
+
+    # ─── Contexts (org structure) ─────────────────────────────────────────────
+    $ctx = [ordered]@{
+        Root      = New-DemoGuid 'ctx-root'
+        Eng       = New-DemoGuid 'ctx-engineering'
+        Fin       = New-DemoGuid 'ctx-finance'
+        Sales     = New-DemoGuid 'ctx-sales'
+        Ops       = New-DemoGuid 'ctx-operations'
+        Marketing = New-DemoGuid 'ctx-marketing'
+        Platform  = New-DemoGuid 'ctx-platform-team'
+        Security  = New-DemoGuid 'ctx-security-team'
+        AUNL      = New-DemoGuid 'ctx-au-netherlands'
+    }
+    $State['Ctx'] = $ctx
+
+    # Department attribute -> context id. The context keys are short handles,
+    # the `dept` attribute carries the display name, so the two need mapping.
+    $State['DeptCtx'] = @{
+        'Management'  = $ctx.Root
+        'Engineering' = $ctx.Eng
+        'Finance'     = $ctx.Fin
+        'Sales'       = $ctx.Sales
+        'Operations'  = $ctx.Ops
+        'Marketing'   = $ctx.Marketing
+    }
+
+    Add-DemoContext $State -Id $ctx.Root      -DisplayName 'Fortigi Demo Corp' -ContextType 'Department' -ScopeSystemId $sysHR
+    foreach ($dept in @(
+        @{ Id = $ctx.Eng;       Name = 'Engineering' }
+        @{ Id = $ctx.Fin;       Name = 'Finance' }
+        @{ Id = $ctx.Sales;     Name = 'Sales' }
+        @{ Id = $ctx.Ops;       Name = 'Operations' }
+        @{ Id = $ctx.Marketing; Name = 'Marketing' }
+    )) {
+        Add-DemoContext $State -Id $dept.Id -DisplayName $dept.Name -ContextType 'Department' -ScopeSystemId $sysHR -ParentContextId $ctx.Root
+    }
+    foreach ($team in @(
+        @{ Id = $ctx.Platform; Name = 'Platform Team' }
+        @{ Id = $ctx.Security; Name = 'Security Team' }
+    )) {
+        Add-DemoContext $State -Id $team.Id -DisplayName $team.Name -ContextType 'Team' -ScopeSystemId $sysHR -ParentContextId $ctx.Eng
+    }
+    Add-DemoContext $State -Id $ctx.AUNL -DisplayName 'AU-Netherlands' -ContextType 'AdministrativeUnit' -ScopeSystemId $sysEntra
+
+    # ─── Employees ────────────────────────────────────────────────────────────
+    # Surnames are deliberately single-word: the email local part is built as
+    # "<given>.<surname>" and a two-word surname ("de Vries") would put a space
+    # in the address.
+    $employees = @(
+        # C-Level
+        @{ id = 'E0001'; name = 'Anna Bakker';    title = 'CEO';                  dept = 'Management';  manager = $null;   ctx = $ctx.Root }
+        @{ id = 'E0002'; name = 'Bob Chen';       title = 'CTO';                  dept = 'Engineering'; manager = 'E0001'; ctx = $ctx.Eng }
+        @{ id = 'E0003'; name = 'Clara Dijkstra'; title = 'CFO';                  dept = 'Finance';     manager = 'E0001'; ctx = $ctx.Fin }
+        @{ id = 'E0004'; name = 'David El-Amin';  title = 'CSO';                  dept = 'Sales';       manager = 'E0001'; ctx = $ctx.Sales }
+        @{ id = 'E0005'; name = 'Eva Fischer';    title = 'COO';                  dept = 'Operations';  manager = 'E0001'; ctx = $ctx.Ops }
+        # Team Leads
+        @{ id = 'E0010'; name = 'Fatih Gunay';    title = 'Team Lead Platform';   dept = 'Engineering'; manager = 'E0002'; ctx = $ctx.Platform }
+        @{ id = 'E0011'; name = 'Grace Huang';    title = 'Team Lead Security';   dept = 'Engineering'; manager = 'E0002'; ctx = $ctx.Security }
+        @{ id = 'E0012'; name = 'Maria Novak';    title = 'Finance Manager';      dept = 'Finance';     manager = 'E0003'; ctx = $ctx.Fin }
+        @{ id = 'E0013'; name = 'Paul Quinn';     title = 'Sales Manager';        dept = 'Sales';       manager = 'E0004'; ctx = $ctx.Sales }
+        @{ id = 'E0014'; name = 'Ursula Visser';  title = 'Ops Manager';          dept = 'Operations';  manager = 'E0005'; ctx = $ctx.Ops }
+        # Individual Contributors
+        @{ id = 'E0020'; name = 'Hassan Ibrahim'; title = 'Developer';            dept = 'Engineering'; manager = 'E0010'; ctx = $ctx.Platform }
+        @{ id = 'E0021'; name = 'Ingrid Jensen';  title = 'Developer';            dept = 'Engineering'; manager = 'E0010'; ctx = $ctx.Platform }
+        @{ id = 'E0022'; name = 'Jun Kobayashi';  title = 'Developer';            dept = 'Engineering'; manager = 'E0010'; ctx = $ctx.Platform }
+        @{ id = 'E0023'; name = 'Karen Lee';      title = 'Security Engineer';    dept = 'Engineering'; manager = 'E0011'; ctx = $ctx.Security }
+        @{ id = 'E0024'; name = 'Lars Muller';    title = 'SOC Analyst';          dept = 'Engineering'; manager = 'E0011'; ctx = $ctx.Security }
+        @{ id = 'E0025'; name = 'Niels Olsen';    title = 'Accountant';           dept = 'Finance';     manager = 'E0012'; ctx = $ctx.Fin }
+        @{ id = 'E0026'; name = 'Olivia Park';    title = 'Accountant';           dept = 'Finance';     manager = 'E0012'; ctx = $ctx.Fin }
+        @{ id = 'E0027'; name = 'Rachel Smith';   title = 'Account Executive';    dept = 'Sales';       manager = 'E0013'; ctx = $ctx.Sales }
+        @{ id = 'E0028'; name = 'Stefan Tanaka';  title = 'Account Executive';    dept = 'Sales';       manager = 'E0013'; ctx = $ctx.Sales }
+        @{ id = 'E0029'; name = 'Victor Wang';    title = 'SysAdmin';             dept = 'Operations';  manager = 'E0014'; ctx = $ctx.Ops }
+        @{ id = 'E0030'; name = 'Wendy Xu';       title = 'SysAdmin';             dept = 'Operations';  manager = 'E0014'; ctx = $ctx.Ops }
+        # Zara Intern is the deliberate "principal with zero resource assignments"
+        # edge case (a new hire not yet provisioned): noAccess excludes her from
+        # every grant loop, while she still exists as a principal and appears in
+        # her department context. See docs/architecture/demo-dataset.md.
+        @{ id = 'E0031'; name = 'Zara Intern';    title = 'Intern';               dept = 'Engineering'; manager = 'E0010'; ctx = $ctx.Eng; noAccess = $true }
+        # ── CTF cast (issue #705) ────────────────────────────────────────────
+        # Piet Jansen is the recurring worst-case identity: role-inherited CRM
+        # access (flag 4), a never-expiring password (flag 9), and consent to a
+        # risky app (flags 11-12).
+        @{ id = 'E0032'; name = 'Piet Jansen';    title = 'Account Executive';    dept = 'Sales';       manager = 'E0013'; ctx = $ctx.Sales }
+        # Newest rep — the one Sales member WITHOUT the ad-hoc SharePoint grant,
+        # which is what makes that grant a role *candidate* (flag 6) rather than
+        # part of the shared-by-all set (flag 2).
+        @{ id = 'E0033'; name = 'Sanne Vermeer';  title = 'Sales Development Rep'; dept = 'Sales';      manager = 'E0013'; ctx = $ctx.Sales }
+        # Transferred out of Sales into Operations; his BR-Sales role assignment
+        # was never revoked. One of the two flag-3 outsiders.
+        @{ id = 'E0034'; name = 'Tom Bakker';     title = 'Logistics Coordinator'; dept = 'Operations'; manager = 'E0014'; ctx = $ctx.Ops }
+        # Marketing, holds BR-Sales for a joint campaign. The other flag-3 outsider.
+        @{ id = 'E0035'; name = 'Nadia Haddad';   title = 'Marketing Specialist';  dept = 'Marketing';  manager = 'E0001'; ctx = $ctx.Marketing }
+    )
+
+    foreach ($emp in $employees) {
+        if (-not $emp.ContainsKey('noAccess')) { $emp['noAccess'] = $false }
+        $State.EmployeesById[$emp.id] = $emp
+    }
+
+    # ─── Principals, Identities, IdentityMembers ──────────────────────────────
+    foreach ($emp in $employees) {
+        $pGuid   = Get-DemoPrincipalId $emp.id
+        $idGuid  = Get-DemoIdentityId  $emp.id
+        $parts   = $emp.name -split ' ', 2
+        $email   = "$($parts[0].ToLower()).$($parts[1].ToLower())@fortigidemo.com"
+        $mgrGuid = if ($emp.manager) { Get-DemoPrincipalId $emp.manager } else { $null }
+
+        $null = Add-DemoPrincipal $State -Record @{
+            id                 = $pGuid
+            displayName        = $emp.name
+            email              = $email
+            accountEnabled     = $true
+            principalType      = 'User'
+            employeeId         = $emp.id
+            givenName          = $parts[0]
+            surname            = $parts[1]
+            department         = $emp.dept
+            jobTitle           = $emp.title
+            companyName        = 'Fortigi Demo Corp'
+            managerId          = $mgrGuid
+            systemId           = $State.SystemIds['entra']
+            extendedAttributes = @{ passwordNeverExpires = (Test-DemoNeverExpires $emp.id) }
+        }
+
+        $null = Add-DemoIdentity $State -Record @{
+            id          = $idGuid
+            displayName = $emp.name
+            email       = $email
+            department  = $emp.dept
+            jobTitle    = $emp.title
+            employeeId  = $emp.id
+            givenName   = $parts[0]
+            surname     = $parts[1]
+            companyName = 'Fortigi Demo Corp'
+        }
+        Add-DemoIdentityMember $State -IdentityId $idGuid -PrincipalId $pGuid `
+            -DisplayName $emp.name -AccountType 'EntraID' -IsPrimary $true
+
+        # Department context, plus the team context for those who have one.
+        foreach ($cid in @($State.DeptCtx[$emp.dept], $emp.ctx)) {
+            if ($cid) { Add-DemoContextMember $State -ContextId $cid -MemberId $pGuid }
+        }
+    }
+
+    Add-DemoOrgEdgeCases $State
+}
+
+# The accounts whose password never expires (flag 9): two non-human (a service
+# principal and a shared mailbox — the plausible, defensible ones) and three
+# humans. Both SysAdmins qualify, which is realistic and gives flag 12 its trap:
+# Victor Wang has a never-expiring password AND has consented to an app — but a
+# clean one, so he is NOT part of flag 12's answer. Piet and Wendy are.
+$script:NeverExpireAccounts = @('SVC-001', 'SM-001', 'E0029', 'E0030', 'E0032')
+
+function Test-DemoNeverExpires {
+    param([Parameter(Mandatory)][string]$AccountKey)
+    return $script:NeverExpireAccounts -contains $AccountKey
+}
+
+# Non-employee principals: the contractor, the disabled leaver, and the
+# non-human accounts. These exist to exercise principalType variety and to act
+# as distractors — Alex Former is the disabled Sales account that makes flag 1
+# ("how many identities does Sales have?") non-trivial.
+function Add-DemoOrgEdgeCases {
+    param([Parameter(Mandatory)]$State)
+
+    $ctx      = $State.Ctx
+    $sysEntra = $State.SystemIds['entra']
+
+    $guidContractor = Get-DemoPrincipalId 'E0040'
+    $guidDisabled   = Get-DemoPrincipalId 'E0041'
+    $guidSvcPrinc   = Get-DemoPrincipalId 'SVC-001'
+    $guidAIAgent    = Get-DemoPrincipalId 'AI-001'
+    $guidMailbox    = Get-DemoPrincipalId 'SM-001'
+
+    $State['EdgeCaseIds'] = [ordered]@{
+        Contractor = $guidContractor
+        Disabled   = $guidDisabled
+        SvcPrinc   = $guidSvcPrinc
+        AIAgent    = $guidAIAgent
+        Mailbox    = $guidMailbox
+    }
+
+    $edgeCases = @(
+        @{ id = $guidContractor; displayName = 'Yuki Zhao'; email = 'yuki.zhao@external.com'; accountEnabled = $true
+           principalType = 'ExternalUser'; employeeId = 'E0040'; department = 'Engineering'; jobTitle = 'Contractor'
+           companyName = 'External Inc'; neverExpires = $false }
+        @{ id = $guidDisabled; displayName = 'Alex Former'; email = 'alex.former@fortigidemo.com'; accountEnabled = $false
+           principalType = 'User'; employeeId = 'E0041'; department = 'Sales'; jobTitle = 'Former Employee'
+           neverExpires = $false }
+        @{ id = $guidSvcPrinc; displayName = 'Deploy Pipeline'; principalType = 'ServicePrincipal'; accountEnabled = $true
+           neverExpires = (Test-DemoNeverExpires 'SVC-001') }
+        @{ id = $guidAIAgent; displayName = 'Copilot Assistant'; principalType = 'AIAgent'; accountEnabled = $true
+           neverExpires = $false }
+        @{ id = $guidMailbox; displayName = 'info@fortigidemo.com'; email = 'info@fortigidemo.com'
+           principalType = 'SharedMailbox'; accountEnabled = $true; neverExpires = (Test-DemoNeverExpires 'SM-001') }
+    )
+
+    foreach ($ec in $edgeCases) {
+        $rec = @{
+            id                 = $ec.id
+            displayName        = $ec.displayName
+            principalType      = $ec.principalType
+            accountEnabled     = $ec.accountEnabled
+            systemId           = $sysEntra
+            extendedAttributes = @{ passwordNeverExpires = $ec.neverExpires }
+        }
+        foreach ($opt in @('email', 'employeeId', 'department', 'jobTitle', 'companyName')) {
+            if ($ec.ContainsKey($opt)) { $rec[$opt] = $ec[$opt] }
+        }
+        $null = Add-DemoPrincipal $State -Record $rec
+    }
+
+    # The leaver keeps an identity of his own so he shows up in the Sales
+    # department alongside the six active members (flag 1's distractor).
+    $idDisabled = New-DemoGuid 'identity-E0041'
+    $null = Add-DemoIdentity $State -Record @{
+        id = $idDisabled; displayName = 'Alex Former'; email = 'alex.former@fortigidemo.com'
+        department = 'Sales'; employeeId = 'E0041'
+    }
+    Add-DemoIdentityMember $State -IdentityId $idDisabled -PrincipalId $guidDisabled `
+        -DisplayName 'Alex Former' -AccountType 'EntraID' -IsPrimary $true -AccountEnabled $false
+
+    Add-DemoContextMember $State -ContextId $ctx.Eng   -MemberId $guidContractor
+    Add-DemoContextMember $State -ContextId $ctx.Sales -MemberId $guidDisabled
+
+    # Multi-system: Hassan Ibrahim also has an account in the IGA system.
+    $pIgaHassan = New-DemoGuid 'principal-E0020-iga'
+    $null = Add-DemoPrincipal $State -Record @{
+        id             = $pIgaHassan
+        displayName    = 'Hassan Ibrahim (IGA)'
+        principalType  = 'User'
+        employeeId     = 'E0020'
+        accountEnabled = $true
+        companyName    = 'Fortigi Demo Corp'
+        department     = 'Engineering'
+        systemId       = $State.SystemIds['iga']
+    }
+    Add-DemoIdentityMember $State -IdentityId (Get-DemoIdentityId 'E0020') -PrincipalId $pIgaHassan `
+        -DisplayName 'Hassan Ibrahim (IGA)' -AccountType 'IGA'
+}

--- a/test/demo-dataset/parts/DemoSalesScenario.ps1
+++ b/test/demo-dataset/parts/DemoSalesScenario.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — the Sales role-mining scenario (CTF Track 1, flags 1-7).
+
+.DESCRIPTION
+    One department, engineered so that every flag in Track 1 has exactly one
+    defensible answer and at least one plausible wrong one.
+
+    The cast:
+      * BR-Sales           — the business role. Contains SG-Sales + SG-CRM-Users.
+      * SG-Sales-SharePoint — the ROLE CANDIDATE (flag 6): held directly by 5 of
+        the 6 Sales members, not in the role. A clean mining candidate.
+      * SG-Finance-Reports  — the TRAP (flag 7): held directly by 4 of 6 Sales, so
+        it *looks* like the same pattern — but it is sensitive cross-department
+        finance access that only the Sales Manager legitimately needs
+        (CertificationDecisions cert-003 is the evidence). Folding it into
+        BR-Sales would over-grant every rep.
+      * Tom Bakker + Nadia Haddad — the two out-of-department holders of the whole
+        shared set (flag 3), via a BR-Sales assignment that was never revoked.
+
+    WHY THE Indirect ROWS ARE EXPLICIT: the matrix matview reads declared rows.
+    Holding BR-Sales does not by itself put SG-CRM-Users in anyone's access — it
+    only makes the matview mark that cell "managed by" the role IF the cell
+    exists. So role-derived access is emitted as real Indirect assignments; the
+    Contains edge then supplies the "why". Without both, Piet's CRM access would
+    render as a provisioning gap instead of as access, and flag 4 would have no
+    answer. See migration 049 + docs/architecture/matrix.md.
+#>
+
+Set-StrictMode -Version Latest
+
+# Sales members who hold BR-Sales but do not work in Sales (flag 3). Tom
+# transferred to Operations and kept the role; Nadia holds it for a joint
+# campaign. Both are the realistic "role assignment nobody cleaned up" case.
+$script:SalesOutsiders = @('E0034', 'E0035')
+
+# The one Sales member without the ad-hoc SharePoint grant — the newest hire.
+# Keeping her out is what makes SG-Sales-SharePoint a *candidate* (held by most)
+# rather than part of the shared-by-all set.
+$script:SharePointExcluded = @('E0033')
+
+# Sales reps who picked up the finance-reports group ad hoc, plus the manager who
+# legitimately needs it. Deliberately a majority-but-not-all pattern, so it
+# mimics a mining candidate.
+$script:FinanceReportsSales = @('E0013', 'E0027', 'E0028', 'E0032')
+
+function Add-DemoSalesScenario {
+    param([Parameter(Mandatory)]$State)
+
+    $sysEntra = $State.SystemIds['entra']
+    $sysIga   = $State.SystemIds['iga']
+
+    $sales = [ordered]@{
+        BR         = New-DemoGuid 'res-br-sales'
+        Group      = New-DemoGuid 'res-sg-sales'
+        Crm        = New-DemoGuid 'res-sg-crm-users'
+        SharePoint = New-DemoGuid 'res-sg-sales-sharepoint'
+        FinReports = New-DemoGuid 'res-sg-finance-reports'
+    }
+    $State['Sales'] = $sales
+
+    $groups = @(
+        @{ Id = $sales.Group; Name = 'SG-Sales'
+           Desc = 'Sales department security group — shared drives, distribution list.' }
+        @{ Id = $sales.Crm; Name = 'SG-CRM-Users'
+           Desc = 'CRM access — customer accounts, opportunities and pipeline.' }
+        @{ Id = $sales.SharePoint; Name = 'SG-Sales-SharePoint'
+           Desc = 'Sales team SharePoint site — proposals, battlecards and templates.' }
+        # The description is the signal that separates the trap from the
+        # candidate: sensitive, cross-department, manager-only.
+        @{ Id = $sales.FinReports; Name = 'SG-Finance-Reports'
+           Desc = 'Sensitive financial reporting — quarterly revenue, margin and forecast data. Restricted to department managers and Finance.' }
+    )
+    foreach ($g in $groups) {
+        $null = Add-DemoResource $State -Id $g.Id -DisplayName $g.Name -ResourceType 'Group' `
+            -SystemId $sysEntra -Description $g.Desc
+    }
+
+    $null = Add-DemoResource $State -Id $sales.BR -DisplayName 'BR-Sales' -ResourceType 'BusinessRole' `
+        -SystemId $sysIga -CatalogId (New-DemoGuid 'cat-employee-access') `
+        -Description 'Sales business role — grants the Sales group and CRM access.'
+
+    # What the role grants. These two edges are what turn "Piet has CRM" into
+    # "Piet has CRM *because of BR-Sales*" (flag 4).
+    foreach ($child in @($sales.Group, $sales.Crm)) {
+        Add-DemoRelationship $State -ParentResourceId $sales.BR -ChildResourceId $child -RelationshipType 'Contains'
+    }
+
+    Add-DemoSalesGrants $State
+}
+
+function Add-DemoSalesGrants {
+    param([Parameter(Mandatory)]$State)
+
+    $sales = $State.Sales
+
+    $salesMembers = @(Get-DemoProvisioned $State -Department 'Sales' | ForEach-Object { $_.id })
+    $State['SalesMemberIds'] = $salesMembers
+
+    # Everyone who holds the role: the department, plus the two outsiders.
+    $roleHolders = @($salesMembers) + @($script:SalesOutsiders)
+
+    foreach ($e in $roleHolders) {
+        $p = Get-DemoPrincipalId $e
+        # The role membership itself — governed, because an IGA drives it.
+        Add-DemoAssignment $State -ResourceId $sales.BR -PrincipalId $p -AssignmentType 'Direct' -Governed
+        # ...and the access it actually confers, materialised so the matrix has
+        # cells to mark as role-managed.
+        foreach ($child in @($sales.Group, $sales.Crm)) {
+            Add-DemoAssignment $State -ResourceId $child -PrincipalId $p -AssignmentType 'Indirect'
+        }
+    }
+
+    # Flag 6 — the role candidate: ad-hoc direct grants that never made it into
+    # BR-Sales. Sales only; the outsiders don't have it.
+    foreach ($e in ($salesMembers | Where-Object { $script:SharePointExcluded -notcontains $_ })) {
+        Add-DemoAssignment $State -ResourceId $sales.SharePoint -PrincipalId (Get-DemoPrincipalId $e) -AssignmentType 'Direct'
+    }
+
+    # Flag 7 — the trap: same "most of Sales holds it directly" shape, but it
+    # crosses into Finance and only the manager (E0013) is certified for it.
+    foreach ($e in $script:FinanceReportsSales) {
+        Add-DemoAssignment $State -ResourceId $sales.FinReports -PrincipalId (Get-DemoPrincipalId $e) -AssignmentType 'Direct'
+    }
+    # Finance holds it legitimately — this is what makes it cross-department
+    # rather than a Sales-shaped pattern.
+    foreach ($emp in (Get-DemoProvisioned $State -Department 'Finance')) {
+        Add-DemoAssignment $State -ResourceId $sales.FinReports -PrincipalId (Get-DemoPrincipalId $emp.id) -AssignmentType 'Direct'
+    }
+}

--- a/test/demo-dataset/parts/DemoSap.ps1
+++ b/test/demo-dataset/parts/DemoSap.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Fortigi Demo Corp — the SAP ERP system (CTF Track 2, flag 8).
+
+.DESCRIPTION
+    A second account source with its own namespace and its own roles.
+
+    THE POINT OF THIS PART: SAP accounts deliberately carry NO `department`
+    attribute and NO recognisable display name — just an SAP user id like
+    'CDIJKSTRA'. That is what real ERP account lists look like, and it is what
+    makes flag 8 ("which department has the most users in SAP ERP?") genuinely
+    hard from a raw export: the export has no department column, so you would
+    have to map every SAP account to a person and then to an HR department by
+    hand.
+
+    In Identity Atlas the same question is a join that is already done —
+    IdentityMembers correlates each SAP account to its identity, and the identity
+    carries the department. Because these accounts have no department of their
+    own, they never join a department context directly; the answer is only
+    reachable through the identity, which is exactly the lesson.
+
+    Distribution is Finance 4 > Sales 3 > Operations 2 > Engineering 1, so the
+    answer is Finance but the runner-up is close enough to require counting.
+#>
+
+Set-StrictMode -Version Latest
+
+# Who has an SAP account, and which SAP role they hold. Skewed to Finance —
+# an ERP's heaviest users are the finance back office.
+$script:SapAccounts = @(
+    @{ Emp = 'E0003'; Role = 'FI' }   # Clara Dijkstra  — CFO
+    @{ Emp = 'E0012'; Role = 'FI' }   # Maria Novak     — Finance Manager
+    @{ Emp = 'E0025'; Role = 'FI' }   # Niels Olsen     — Accountant
+    @{ Emp = 'E0026'; Role = 'FI' }   # Olivia Park     — Accountant
+    @{ Emp = 'E0013'; Role = 'SD' }   # Paul Quinn      — Sales Manager
+    @{ Emp = 'E0027'; Role = 'SD' }   # Rachel Smith    — Account Executive
+    @{ Emp = 'E0032'; Role = 'SD' }   # Piet Jansen     — Account Executive
+    @{ Emp = 'E0014'; Role = 'MM' }   # Ursula Visser   — Ops Manager
+    @{ Emp = 'E0029'; Role = 'BASIS' }# Victor Wang     — SysAdmin
+    @{ Emp = 'E0020'; Role = 'MM' }   # Hassan Ibrahim  — Developer
+)
+
+function Add-DemoSap {
+    param([Parameter(Mandatory)]$State)
+
+    $sysSap = $State.SystemIds['sap']
+
+    $roles = @(
+        @{ Key = 'FI';    Name = 'SAP_FI_ACCOUNTANT'; Desc = 'Financial Accounting — post journal entries, close periods.' }
+        @{ Key = 'SD';    Name = 'SAP_SD_SALES';      Desc = 'Sales & Distribution — quotations, orders, billing.' }
+        @{ Key = 'MM';    Name = 'SAP_MM_VIEWER';     Desc = 'Materials Management — read-only stock and purchasing.' }
+        @{ Key = 'BASIS'; Name = 'SAP_BASIS_ADMIN';   Desc = 'SAP Basis administration — transports, users, system config.' }
+    )
+
+    $roleIds = @{}
+    foreach ($r in $roles) {
+        $rid = New-DemoGuid "res-sap-role-$($r.Key)"
+        $roleIds[$r.Key] = $rid
+        $null = Add-DemoResource $State -Id $rid -DisplayName $r.Name -ResourceType 'SAPRole' `
+            -SystemId $sysSap -Description $r.Desc
+    }
+
+    foreach ($acct in $script:SapAccounts) {
+        Add-DemoSapAccount $State -EmployeeId $acct.Emp -RoleId $roleIds[$acct.Role]
+    }
+}
+
+# One SAP account: a bare principal in the SAP namespace, correlated to the
+# person's identity. No department, no email, no friendly name — the correlation
+# is the only route from this account back to a department.
+function Add-DemoSapAccount {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$EmployeeId,
+        [Parameter(Mandatory)][string]$RoleId
+    )
+
+    $emp   = $State.EmployeesById[$EmployeeId]
+    $parts = $emp.name -split ' ', 2
+    # SAP user id convention: first initial + surname, uppercased.
+    $sapUser = "$($parts[0].Substring(0,1))$($parts[1])".ToUpper() -replace '[^A-Z0-9]', ''
+    # NB: not $pId — PowerShell variable names are case-insensitive and $PID is
+    # a read-only automatic variable.
+    $sapPrincipalId = New-DemoGuid "principal-$EmployeeId-sap"
+
+    $null = Add-DemoPrincipal $State -Record @{
+        id             = $sapPrincipalId
+        displayName    = $sapUser
+        principalType  = 'User'
+        accountEnabled = $true
+        employeeId     = $EmployeeId
+        systemId       = $State.SystemIds['sap']
+        extendedAttributes = @{ sapUserName = $sapUser; sapClient = '100' }
+    }
+
+    Add-DemoIdentityMember $State -IdentityId (Get-DemoIdentityId $EmployeeId) -PrincipalId $sapPrincipalId `
+        -DisplayName $sapUser -AccountType 'SAP'
+
+    Add-DemoAssignment $State -ResourceId $RoleId -PrincipalId $sapPrincipalId -AssignmentType 'Direct'
+}

--- a/test/demo-dataset/parts/DemoState.ps1
+++ b/test/demo-dataset/parts/DemoState.ps1
@@ -1,0 +1,260 @@
+<#
+.SYNOPSIS
+    Shared state + record builders for the Fortigi Demo Corp dataset generator.
+
+.DESCRIPTION
+    Dot-sourced by Generate-DemoDataset.ps1 before every other part. Owns:
+
+      * New-DemoGuid       — the deterministic GUID function (MD5 of a seed).
+      * New-DemoState      — the accumulator every part appends into.
+      * Add-Demo*          — one builder per entity section.
+
+    Every part file appends through these builders rather than emitting literal
+    hashtables, so the shape of a record is defined once. That keeps the parts
+    readable and keeps near-identical table blocks out of the repo (the jscpd
+    duplication gate fails a PR on any new clone — see .jscpd.json).
+
+    SYSTEM IDS ARE PLACEHOLDERS. Add-DemoSystem hands out 1..N in insertion
+    order and records the key→placeholder map in State.SystemKeys. The real ids
+    are assigned by postgres (Systems.id is SERIAL), so Ingest-DemoDataset.ps1
+    remaps every placeholder to the id the API reports back. Never assume a
+    placeholder equals a live systemId.
+#>
+
+Set-StrictMode -Version Latest
+
+# Deterministic GUID from a seed string (same input always produces same GUID).
+# The 'fortigi-demo:' namespace keeps these from colliding with any other
+# generator that hashes the same seeds.
+function New-DemoGuid {
+    param([Parameter(Mandatory)][string]$Seed)
+    $md5 = [System.Security.Cryptography.MD5]::Create()
+    try {
+        $bytes = $md5.ComputeHash([System.Text.Encoding]::UTF8.GetBytes("fortigi-demo:$Seed"))
+        return [Guid]::new($bytes).ToString()
+    }
+    finally { $md5.Dispose() }
+}
+
+# The accumulator. Every part dot-sourced after this one appends into it; the
+# orchestrator reads it back out to assemble demo-company.json.
+function New-DemoState {
+    # Each list is constructed inline rather than via a shared factory
+    # scriptblock: PowerShell unrolls a collection returned from a scriptblock
+    # into the pipeline, so an empty List comes back as $null.
+    return [ordered]@{
+        Systems                = [System.Collections.Generic.List[object]]::new()
+        Contexts               = [System.Collections.Generic.List[object]]::new()
+        ContextMembers         = [System.Collections.Generic.List[object]]::new()
+        Principals             = [System.Collections.Generic.List[object]]::new()
+        Resources              = [System.Collections.Generic.List[object]]::new()
+        Assignments            = [System.Collections.Generic.List[object]]::new()
+        Relationships          = [System.Collections.Generic.List[object]]::new()
+        Identities             = [System.Collections.Generic.List[object]]::new()
+        IdentityMembers        = [System.Collections.Generic.List[object]]::new()
+        Catalogs               = [System.Collections.Generic.List[object]]::new()
+        Policies               = [System.Collections.Generic.List[object]]::new()
+        Certifications         = [System.Collections.Generic.List[object]]::new()
+
+        # key -> placeholder systemId (1-based, insertion order)
+        SystemIds              = @{}
+        # ordered list of keys, parallel to Systems — the ingester's remap index
+        SystemKeys             = [System.Collections.Generic.List[object]]::new()
+        # guards against duplicate (context, member) pairs
+        SeenContextMembers     = [System.Collections.Generic.HashSet[string]]::new()
+        # employeeId -> employee record, for cross-part lookups
+        EmployeesById          = [ordered]@{}
+    }
+}
+
+function Add-DemoSystem {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$Key,
+        [Parameter(Mandatory)][string]$SystemType,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [Parameter(Mandatory)][string]$TenantId
+    )
+    $placeholder = $State.Systems.Count + 1
+    $State.Systems.Add(@{
+        systemType  = $SystemType
+        displayName = $DisplayName
+        tenantId    = $TenantId
+        enabled     = $true
+        syncEnabled = $true
+    })
+    $State.SystemIds[$Key] = $placeholder
+    $State.SystemKeys.Add(@{ key = $Key; systemType = $SystemType; tenantId = $TenantId })
+    return $placeholder
+}
+
+function Add-DemoContext {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [Parameter(Mandatory)][string]$ContextType,
+        [Parameter(Mandatory)][int]$ScopeSystemId,
+        [string]$ParentContextId,
+        [string]$TargetType = 'Principal'
+    )
+    $rec = @{
+        id            = $Id
+        displayName   = $DisplayName
+        contextType   = $ContextType
+        targetType    = $TargetType
+        variant       = 'synced'
+        scopeSystemId = $ScopeSystemId
+    }
+    if ($ParentContextId) { $rec['parentContextId'] = $ParentContextId }
+    $State.Contexts.Add($rec)
+}
+
+# De-duplicating: a principal in both a department and a team context must not
+# produce two rows for the same pair (ContextMembers is keyed on contextId+memberId).
+function Add-DemoContextMember {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$ContextId,
+        [Parameter(Mandatory)][string]$MemberId,
+        [string]$MemberType = 'Principal'
+    )
+    if (-not $State.SeenContextMembers.Add("$ContextId|$MemberId")) { return }
+    $State.ContextMembers.Add(@{
+        contextId  = $ContextId
+        memberId   = $MemberId
+        memberType = $MemberType
+        addedBy    = 'sync'
+    })
+}
+
+function Add-DemoPrincipal {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][hashtable]$Record
+    )
+    $State.Principals.Add($Record)
+    return $Record.id
+}
+
+function Add-DemoResource {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [Parameter(Mandatory)][string]$ResourceType,
+        [Parameter(Mandatory)][int]$SystemId,
+        [string]$Description,
+        [string]$ExternalId,
+        [string]$CatalogId,
+        [hashtable]$Extended
+    )
+    $rec = @{
+        id           = $Id
+        displayName  = $DisplayName
+        resourceType = $ResourceType
+        systemId     = $SystemId
+        enabled      = $true
+    }
+    if ($Description) { $rec['description']        = $Description }
+    if ($ExternalId)  { $rec['externalId']         = $ExternalId }
+    if ($CatalogId)   { $rec['catalogId']          = $CatalogId }
+    if ($Extended)    { $rec['extendedAttributes'] = $Extended }
+    $State.Resources.Add($rec)
+    return $Id
+}
+
+# assignmentType is constrained to Direct | Indirect | Eligible — the only three
+# the model accepts (ck_RA_assignmentType + ingest validation + the static guard
+# in app/api/src/ingest/assignmentTypes.guard.test.js, which scans this folder).
+# `governed` marks IGA-driven access, it is NOT a fourth assignment type.
+function Add-DemoAssignment {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$ResourceId,
+        [Parameter(Mandatory)][string]$PrincipalId,
+        [Parameter(Mandatory)][ValidateSet('Direct', 'Indirect', 'Eligible')][string]$AssignmentType,
+        [switch]$Governed,
+        [string]$ResourceType,
+        [hashtable]$Extended
+    )
+    $rec = @{
+        resourceId     = $ResourceId
+        principalId    = $PrincipalId
+        assignmentType = $AssignmentType
+    }
+    if ($Governed)     { $rec['governed']           = $true }
+    if ($ResourceType) { $rec['resourceType']       = $ResourceType }
+    if ($Extended)     { $rec['extendedAttributes'] = $Extended }
+    $State.Assignments.Add($rec)
+}
+
+function Add-DemoRelationship {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$ParentResourceId,
+        [Parameter(Mandatory)][string]$ChildResourceId,
+        [Parameter(Mandatory)]
+        [ValidateSet('Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole',
+                     'HasOwnership', 'HasAppOwnership', 'HasApplicationPermission')]
+        [string]$RelationshipType
+    )
+    $State.Relationships.Add(@{
+        parentResourceId = $ParentResourceId
+        childResourceId  = $ChildResourceId
+        relationshipType = $RelationshipType
+    })
+}
+
+function Add-DemoIdentity {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][hashtable]$Record
+    )
+    $State.Identities.Add($Record)
+    return $Record.id
+}
+
+function Add-DemoIdentityMember {
+    param(
+        [Parameter(Mandatory)]$State,
+        [Parameter(Mandatory)][string]$IdentityId,
+        [Parameter(Mandatory)][string]$PrincipalId,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [Parameter(Mandatory)][string]$AccountType,
+        [bool]$IsPrimary = $false,
+        [bool]$AccountEnabled = $true
+    )
+    $State.IdentityMembers.Add(@{
+        identityId     = $IdentityId
+        principalId    = $PrincipalId
+        displayName    = $DisplayName
+        accountType    = $AccountType
+        isPrimary      = $IsPrimary
+        accountEnabled = $AccountEnabled
+    })
+}
+
+# ─── Convenience lookups shared across parts ──────────────────────────────────
+
+function Get-DemoPrincipalId {
+    param([Parameter(Mandatory)][string]$EmployeeId)
+    return New-DemoGuid "principal-$EmployeeId"
+}
+
+function Get-DemoIdentityId {
+    param([Parameter(Mandatory)][string]$EmployeeId)
+    return New-DemoGuid "identity-$EmployeeId"
+}
+
+# Employees in a department who receive access grants (excludes the deliberate
+# zero-assignment edge case). Used by every grant loop.
+function Get-DemoProvisioned {
+    param(
+        [Parameter(Mandatory)]$State,
+        [string]$Department
+    )
+    $all = @($State.EmployeesById.Values | Where-Object { -not $_.noAccess })
+    if ($Department) { $all = @($all | Where-Object { $_.dept -eq $Department }) }
+    return $all
+}

--- a/test/unit/DemoDataset.Tests.ps1
+++ b/test/unit/DemoDataset.Tests.ps1
@@ -72,7 +72,7 @@ BeforeAll {
     $script:badShape     = @($script:data.contextMembers | Where-Object { $_.memberType -ne 'Principal' -or $_.addedBy -ne 'sync' })
     $script:pairs        = @($script:data.contextMembers | ForEach-Object { "$($_.contextId)|$($_.memberId)" })
     $script:deepCount    = @{}
-    foreach ($name in @('Engineering', 'Finance', 'Sales', 'Operations')) {
+    foreach ($name in @('Engineering', 'Finance', 'Sales', 'Operations', 'Marketing')) {
         $script:deepCount[$name] = @(Get-CtxMembersDeep -CtxId $script:ctxIdByName[$name]).Count
     }
     $script:platformCount = @(Get-CtxMembersDeep -CtxId $script:ctxIdByName['Platform Team']).Count
@@ -100,8 +100,10 @@ Describe 'Demo dataset — context membership' {
         ($script:pairs | Sort-Object -Unique).Count | Should -Be $script:pairs.Count
     }
 
-    It 'resolves the Sales department to its 5 members' {
-        $script:deepCount['Sales'] | Should -Be 5
+    It 'resolves the Sales department to its 7 members' {
+        # 6 active (CTF flag 1's answer) + Alex Former, the disabled leaver who
+        # is the deliberate distractor. See DemoSalesScenario.ps1.
+        $script:deepCount['Sales'] | Should -Be 7
     }
 
     It 'resolves the Engineering department to include its team members' {
@@ -111,7 +113,7 @@ Describe 'Demo dataset — context membership' {
     }
 
     It 'gives every department at least one member' {
-        foreach ($name in @('Engineering', 'Finance', 'Sales', 'Operations')) {
+        foreach ($name in @('Engineering', 'Finance', 'Sales', 'Operations', 'Marketing')) {
             $script:deepCount[$name] | Should -BeGreaterThan 0
         }
     }
@@ -188,5 +190,241 @@ Describe 'Demo dataset — group ownership (#713)' {
 
     It 'never emits the retired Owner assignmentType' {
         @($script:data.resourceAssignments | Where-Object { $_.assignmentType -eq 'Owner' }).Count | Should -Be 0
+    }
+}
+
+Describe 'Demo dataset — Capture-the-Flag scenarios (#705)' {
+
+    BeforeAll {
+        $script:resByName = @{}
+        foreach ($r in $script:data.resources) { $script:resByName[$r.displayName] = $r }
+        $script:princByName = @{}
+        foreach ($p in $script:data.principals) { $script:princByName[$p.displayName] = $p }
+
+        # principalId -> resourceId -> assignmentType
+        $script:heldBy = @{}
+        foreach ($a in $script:data.resourceAssignments) {
+            if (-not $script:heldBy.ContainsKey($a.principalId)) { $script:heldBy[$a.principalId] = @{} }
+            $script:heldBy[$a.principalId][$a.resourceId] = $a.assignmentType
+        }
+
+        # The six active Sales principals (flag 1's answer).
+        $script:salesPrincipals = @(
+            $script:data.principals |
+                Where-Object { $_.department -eq 'Sales' -and $_.accountEnabled -and $_.principalType -eq 'User' } |
+                ForEach-Object { $_.id }
+        )
+
+        # Resources every active Sales member holds (flag 2's answer).
+        $script:sharedSet = $null
+        foreach ($p in $script:salesPrincipals) {
+            $set = @($script:heldBy[$p].Keys)
+            if ($null -eq $script:sharedSet) { $script:sharedSet = $set }
+            else { $script:sharedSet = @($script:sharedSet | Where-Object { $set -contains $_ }) }
+        }
+    }
+
+    It 'gives Sales exactly 6 active members, with a disabled leaver as the distractor (flag 1)' {
+        $script:salesPrincipals.Count | Should -Be 6
+        $script:princByName['Alex Former'].accountEnabled | Should -BeFalse
+        $script:princByName['Alex Former'].department | Should -Be 'Sales'
+    }
+
+    It 'shares exactly 5 resources across all of Sales (flag 2)' {
+        $script:sharedSet.Count | Should -Be 5
+    }
+
+    It 'gives exactly two out-of-department users the whole shared set (flag 3)' {
+        $outsiders = @()
+        foreach ($p in $script:heldBy.Keys) {
+            if ($script:salesPrincipals -contains $p) { continue }
+            $set = @($script:heldBy[$p].Keys)
+            $hasAll = $true
+            foreach ($s in $script:sharedSet) { if ($set -notcontains $s) { $hasAll = $false; break } }
+            if ($hasAll) { $outsiders += $p }
+        }
+        $outsiders.Count | Should -Be 2
+        $names = @($script:data.principals | Where-Object { $outsiders -contains $_.id } | ForEach-Object { $_.displayName } | Sort-Object)
+        $names | Should -Be @('Nadia Haddad', 'Tom Bakker')
+    }
+
+    It 'gives Piet his CRM access only through BR-Sales, never directly (flag 4)' {
+        $piet = $script:princByName['Piet Jansen'].id
+        $crm  = $script:resByName['SG-CRM-Users'].id
+        $mine = @($script:data.resourceAssignments | Where-Object { $_.principalId -eq $piet -and $_.resourceId -eq $crm })
+        $mine.Count | Should -Be 1
+        $mine[0].assignmentType | Should -Be 'Indirect'
+
+        # ...and the Contains edge that explains WHY must exist, otherwise the
+        # matrix has no path to show and the flag has no answer.
+        $brSales = $script:resByName['BR-Sales'].id
+        @($script:data.resourceRelationships | Where-Object {
+            $_.parentResourceId -eq $brSales -and $_.childResourceId -eq $crm -and $_.relationshipType -eq 'Contains'
+        }).Count | Should -Be 1
+    }
+
+    It 'makes exactly the two role-granted resources the role-based part of the shared set (flag 5)' {
+        $brSales  = $script:resByName['BR-Sales'].id
+        $contains = @($script:data.resourceRelationships |
+            Where-Object { $_.parentResourceId -eq $brSales -and $_.relationshipType -eq 'Contains' } |
+            ForEach-Object { $_.childResourceId })
+        $names = @($script:sharedSet | Where-Object { $contains -contains $_ } |
+            ForEach-Object { $rid = $_; ($script:data.resources | Where-Object { $_.id -eq $rid }).displayName } | Sort-Object)
+        $names | Should -Be @('SG-CRM-Users', 'SG-Sales')
+    }
+
+    It 'holds the role candidate directly, by most of Sales, and keeps it out of the role (flag 6)' {
+        $sp = $script:resByName['SG-Sales-SharePoint'].id
+        $holders = @($script:data.resourceAssignments |
+            Where-Object { $_.resourceId -eq $sp -and $_.assignmentType -eq 'Direct' })
+        # Most, but not all — otherwise it would be part of the flag-2 shared set
+        # rather than a mining candidate.
+        $holders.Count | Should -Be 5
+        $script:sharedSet | Should -Not -Contain $sp
+
+        $brSales = $script:resByName['BR-Sales'].id
+        @($script:data.resourceRelationships | Where-Object {
+            $_.parentResourceId -eq $brSales -and $_.childResourceId -eq $sp
+        }).Count | Should -Be 0
+    }
+
+    It 'makes the trap look like the candidate but cross the department boundary (flag 7)' {
+        $trap = $script:resByName['SG-Finance-Reports'].id
+        $holders = @($script:data.resourceAssignments | Where-Object { $_.resourceId -eq $trap })
+        $depts = @($holders | ForEach-Object { $pid2 = $_.principalId
+            ($script:data.principals | Where-Object { $_.id -eq $pid2 }).department } | Sort-Object -Unique)
+        # It spans Sales AND Finance — that is the tell that separates it from
+        # flag 6's clean, Sales-only candidate.
+        $depts | Should -Contain 'Sales'
+        $depts | Should -Contain 'Finance'
+        # Not in the role, so it genuinely looks mineable.
+        $brSales = $script:resByName['BR-Sales'].id
+        @($script:data.resourceRelationships | Where-Object {
+            $_.parentResourceId -eq $brSales -and $_.childResourceId -eq $trap
+        }).Count | Should -Be 0
+    }
+
+    It 'skews SAP accounts to Finance and gives them no department of their own (flag 8)' {
+        $sapSysId = ([array]::IndexOf(@($script:data.metadata.systemKeys.key), 'sap')) + 1
+        $sapPrincipals = @($script:data.principals | Where-Object { $_.systemId -eq $sapSysId })
+        $sapPrincipals.Count | Should -Be 10
+
+        # The whole point of the flag: no department on the account, so the
+        # answer is only reachable through identity correlation.
+        @($sapPrincipals | Where-Object { $_.PSObject.Properties.Name -contains 'department' }).Count | Should -Be 0
+
+        $identOf = @{}
+        foreach ($m in $script:data.identityMembers) { $identOf[$m.principalId] = $m.identityId }
+        $byDept = @{}
+        foreach ($sp in $sapPrincipals) {
+            $dept = ($script:data.identities | Where-Object { $_.id -eq $identOf[$sp.id] }).department
+            if (-not $byDept.ContainsKey($dept)) { $byDept[$dept] = 0 }
+            $byDept[$dept]++
+        }
+        $byDept['Finance'] | Should -Be 4
+        # Close enough that you have to count, not guess.
+        $byDept['Sales'] | Should -Be 3
+        $byDept['Finance'] | Should -BeGreaterThan $byDept['Sales']
+    }
+
+    It 'marks exactly five accounts as never-expiring (flag 9)' {
+        $ne = @($script:data.principals |
+            Where-Object { $_.extendedAttributes -and $_.extendedAttributes.passwordNeverExpires -eq $true })
+        $ne.Count | Should -Be 5
+        @($ne | ForEach-Object { $_.displayName }) | Should -Contain 'Piet Jansen'
+    }
+
+    It 'puts three principals in Azure US and keeps an EU distractor (flag 10)' {
+        $east = @($script:data.resources | Where-Object {
+            $_.resourceType -eq 'AzureRoleAssignment' -and $_.extendedAttributes.azureLocation -eq 'eastus' })
+        $west = @($script:data.resources | Where-Object {
+            $_.resourceType -eq 'AzureRoleAssignment' -and $_.extendedAttributes.azureLocation -eq 'westeurope' })
+        $east.Count | Should -BeGreaterThan 0
+        $west.Count | Should -BeGreaterThan 0
+
+        $eastIds = @($east | ForEach-Object { $_.id })
+        $users = @($script:data.resourceAssignments |
+            Where-Object { $eastIds -contains $_.resourceId } |
+            ForEach-Object { $_.principalId } | Sort-Object -Unique)
+        $users.Count | Should -Be 3
+    }
+
+    It 'shapes the consent grants the way the risky-consent plugin reads them (flags 11-12)' {
+        $grants = @($script:data.resources | Where-Object { $_.resourceType -eq 'DelegatedPermission' })
+        $grants.Count | Should -Be 2
+
+        foreach ($g in $grants) {
+            # The plugin reads ext.scope and joins ext.clientSpId -> Principals.
+            # Either being absent silently drops the grant (issue #719's shape).
+            $g.extendedAttributes.scope | Should -Not -BeNullOrEmpty
+            $g.extendedAttributes.clientSpId | Should -Not -BeNullOrEmpty
+            @($script:data.principals | Where-Object { $_.id -eq $g.extendedAttributes.clientSpId }).Count | Should -Be 1
+        }
+
+        # Files.ReadWrite.All is in the plugin's curated HIGH_RISK set, which is
+        # what makes FileSync Pro deterministically risky with no LLM involved.
+        $risky = @($grants | Where-Object { $_.extendedAttributes.scope -eq 'Files.ReadWrite.All' })
+        $risky.Count | Should -Be 1
+    }
+
+    It 'answers flag 11 with five consenters and flag 12 with two — the trap being wider' {
+        $risky = ($script:data.resources | Where-Object {
+            $_.resourceType -eq 'DelegatedPermission' -and $_.extendedAttributes.scope -eq 'Files.ReadWrite.All' })
+        $consenterIds = @($script:data.resourceAssignments |
+            Where-Object { $_.resourceId -eq $risky.id } | ForEach-Object { $_.principalId })
+        $consenterIds.Count | Should -Be 5
+
+        $consenters = @($script:data.principals | Where-Object { $consenterIds -contains $_.id })
+        $flag12 = @($consenters | Where-Object { $_.extendedAttributes.passwordNeverExpires -eq $true })
+        @($flag12 | ForEach-Object { $_.displayName } | Sort-Object) | Should -Be @('Piet Jansen', 'Wendy Xu')
+
+        # Anyone who ignores the "risky" half gets a bigger, wrong set — that is
+        # what makes flag 12 a Pro flag rather than a filter.
+        $allGrantIds = @($script:data.resources |
+            Where-Object { $_.resourceType -eq 'DelegatedPermission' } | ForEach-Object { $_.id })
+        $anyConsenterIds = @($script:data.resourceAssignments |
+            Where-Object { $allGrantIds -contains $_.resourceId } | ForEach-Object { $_.principalId } | Sort-Object -Unique)
+        $trap = @($script:data.principals |
+            Where-Object { $anyConsenterIds -contains $_.id -and $_.extendedAttributes.passwordNeverExpires -eq $true })
+        $trap.Count | Should -BeGreaterThan $flag12.Count
+    }
+}
+
+Describe 'Demo dataset — vendor-neutral IGA (#705)' {
+
+    It 'names the governance system generically, not after a vendor' {
+        # A business role is the same concept from Omada, midPoint or SailPoint,
+        # so the demo must not imply one vendor. (The real Omada crawler under
+        # tools/crawlers/omada/ is a separate thing and is unaffected.)
+        @($script:data.systems | Where-Object { $_.systemType -eq 'IGA' }).Count | Should -Be 1
+        @($script:data.systems | Where-Object { $_.systemType -eq 'Omada' }).Count | Should -Be 0
+        @($script:data.identityMembers | Where-Object { $_.accountType -eq 'Omada' }).Count | Should -Be 0
+    }
+
+    It 'sources every business role from the IGA system' {
+        $igaSysId = ([array]::IndexOf(@($script:data.metadata.systemKeys.key), 'iga')) + 1
+        $roles = @($script:data.resources | Where-Object { $_.resourceType -eq 'BusinessRole' })
+        $roles.Count | Should -Be 5
+        foreach ($r in $roles) { $r.systemId | Should -Be $igaSysId }
+    }
+}
+
+Describe 'Demo dataset — system id remapping (#705)' {
+
+    It 'publishes a systemKeys index parallel to the systems array' {
+        # Systems.id is SERIAL, so the generator emits placeholders and
+        # Ingest-DemoDataset.ps1 remaps them to the ids the API hands back.
+        # The index must line up with the systems array for that remap to work.
+        @($script:data.metadata.systemKeys).Count | Should -Be @($script:data.systems).Count
+        for ($i = 0; $i -lt @($script:data.systems).Count; $i++) {
+            $script:data.metadata.systemKeys[$i].systemType | Should -Be $script:data.systems[$i].systemType
+            $script:data.metadata.systemKeys[$i].tenantId   | Should -Be $script:data.systems[$i].tenantId
+        }
+    }
+
+    It 'references only placeholder system ids that exist' {
+        $valid = 1..(@($script:data.systems).Count)
+        foreach ($r in $script:data.resources)  { $valid | Should -Contain $r.systemId }
+        foreach ($p in $script:data.principals) { $valid | Should -Contain $p.systemId }
     }
 }


### PR DESCRIPTION
Extends the Fortigi Demo Corp dataset so all twelve Capture-the-Flag scenarios from #705 are answerable, and publishes the player-facing flag list. Build-plan **B + H**; the answer key, history back-dating and per-flag CI reachability specs stay as follow-ups.

Every flag has exactly one defensible answer and at least one plausible wrong one — a flag that's easy from a raw export is a bad flag.

## What's in the data

- **3 systems → 5.** Alongside Entra ID and HR: an **IGA** system, an **SAP ERP** system and an **AzureRM** system, with accounts correlated across all of them.
- **Vendor-neutral IGA** (Rob's review, amendment #1): the governance system is `IGA`, not `Omada` — a business role is the same concept from Omada, midPoint or SailPoint. **The real Omada crawler is untouched**; this is demo data only.
- **A Marketing department and four new people**, including **Piet Jansen** — the deliberately worst-case identity, threading through flags 4, 9, 11 and 12.
- **A Sales role-mining scenario**: `BR-Sales`, an ad-hoc role candidate, and an over-privileged cross-department trap — so the demo shows what a role grants, what it *should probably* grant, and what it must not.
- **OAuth consent**: two third-party apps, one risky and one clean, shaped exactly as the shipped `risky-consent` plugin reads them.
- **`passwordNeverExpires`** on every Entra account, and **region-tagged** Azure resources.

## Two latent bugs fixed on the way

- **`Ingest-DemoDataset.ps1` hardcoded `1=EntraID, 2=HR, 3=Omada`.** `Systems.id` is a `SERIAL`, so those ids only hold on a pristine database — anywhere else the demo silently attached rows to the **wrong system**. It now posts Systems first and remaps every placeholder from the ids the API returns.
- **Rows now post per system.** A full sync reconciles against the envelope's `systemId`, so one system's sync could previously be evaluated against another system's rows.

## Structure

The generator was split before it sprawled (per the spec): `Generate-DemoDataset.ps1` is now a thin orchestrator over `parts/`, one file per domain, appending into a shared state object through record builders. Literal hashtable tables are gone — each record's shape is defined once. Deterministic GUIDs mean any part can reference another's records with no ordering contract.

## Verified, not assumed

Ingested through the real demo crawler on a live stack. **All 12 answers hold in the database**, and the matrix renders flag 4 correctly (`Indirect` + `managedByAccessPackage`). The `risky-consent` plugin was run against it and produced "Risky Consent — High" and "Risky App Consent — Suspicious", correctly ignoring the control app.

Gates checked: Pester **32/32**; both static guards (`assignmentTypes` / `resourceTypes`) pass against the new files; **jscpd finds zero clones** in them.

## Product gaps this exposes

Per Rob's amendment #5, which regime each flag is in:

| Flag | Status |
|---|---|
| 1, 4, 5, 7, 8, 9, 10, 11, 12 | **Follows the product** — answerable today, verified |
| 6 | Answerable via the Non-governed toggle on a Sales scope. No mining *recommendation* engine exists, but the question resolves by eye |
| **2, 3** | **Steers the product** — data-complete, but there is **no shared-by-all scope statistic**. `/api/matrix/scope-stats` returns governed/non-governed, not universality. The published flag says so rather than sending players after a button that doesn't exist |

Two claims in the design doc turned out stale and are corrected here:
- **`Verify-DemoDataset.ps1` is not SQL-Server-era** — it was rewritten for Postgres in #707 and runs on every PR.
- **Risk R1 is closed and R4 is wrong.** Risk scoring's engine is pure rule-based regex (the LLM only authors classifiers), and `Files.ReadWrite.All` is already in the `risky-consent` plugin's curated `HIGH_RISK` set — so flags 11–12 are deterministic and offline with **no LLM and no risk-classifier seeding**. Flag 12 resolves on a single matrix screen.

## Docs

- **`docs/demo/capture-the-flag.md`** — the player-facing page: three tracks, twelve flags, questions and hints only, written for a newcomer (amendment #3). The answer key sits at the end behind a collapsed spoiler (verified to leak nothing into the visible page).
- **`docs/architecture/demo-dataset.md`** — brought back in line with reality; it still described the 3-system, 22-employee, Omada-flavoured dataset. Its answer key and trap table are collapsed, and it carries a spoiler warning at the top since it's in the site nav.

## Notes for the reviewer

- ⚠️ **`test/demo-dataset/**` is in no CI path filter**, so this PR does **not** run `Verify-DemoDataset.ps1` or the guards that scan it. It only runs Pester because it touches `test/unit/**`. Worth fixing separately.
- ⚠️ **Re-seeding over an existing demo database leaves orphans.** Systems ingest with `syncMode: 'delta'` and upsert on `(systemType, tenantId)`, so the old `Omada` system and its business roles survive alongside the new `IGA` ones. **The demo environment must be re-seeded from a clean database**, not layered on top.
- Found while writing the docs: `NewContextWizard.jsx:473` says *"nothing is written until you press Run"*, but the button is **Create tree**. Stale UI copy, unrelated to this branch.

Closes #705 is **not** claimed — this is build-plan B + H of a larger plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)