### PR TITLE
fix(demo): regenerate the demo dataset on every crawler run (fresh Docker)

### DIFF
--- a/changes/demo-crawler-fresh-docker.md
+++ b/changes/demo-crawler-fresh-docker.md
@@ -1,0 +1,1 @@
+- Fixed the built-in demo crawler failing on a fresh Docker install — it now regenerates the demo dataset on every run instead of trusting a possibly-stale bundled copy, so the full demo company (systems, principals, resources, assignments, identities, governance) loads reliably rather than stopping after the first few systems.

--- a/test/unit/DemoDataset.Tests.ps1
+++ b/test/unit/DemoDataset.Tests.ps1
@@ -428,3 +428,25 @@ Describe 'Demo dataset — system id remapping (#705)' {
         foreach ($p in $script:data.principals) { $valid | Should -Contain $p.systemId }
     }
 }
+
+Describe 'Demo dataset — always regenerated for the built-in demo crawler (fresh Docker)' {
+
+    # Start-DemoCrawler.ps1 regenerates the dataset on every run via
+    # `Generate-DemoDataset.ps1 -OutputPath <datasetPath>` instead of trusting a
+    # possibly-stale on-disk copy. A bundled demo-company.json predating
+    # metadata.systemKeys crashed Ingest-DemoDataset.ps1 ("Cannot index into a
+    # null array") and left fresh Docker installs with only a few systems loaded.
+    # This pins the exact mechanism the crawler now relies on.
+    It 'writes a complete, ingest-ready dataset to an explicit -OutputPath' {
+        $out = Join-Path $TestDrive 'demo-regen.json'
+        & $script:genScript -OutputPath $out | Out-Null
+
+        Test-Path $out | Should -BeTrue
+        $fresh = Get-Content $out -Raw | ConvertFrom-Json
+
+        # The section whose absence broke the ingest: one systemKeys entry per
+        # system, each carrying the `key` the ingest indexes to map system ids.
+        @($fresh.metadata.systemKeys).Count | Should -Be @($fresh.systems).Count
+        foreach ($sk in $fresh.metadata.systemKeys) { $sk.key | Should -Not -BeNullOrEmpty }
+    }
+}

--- a/tools/crawlers/demo/Start-DemoCrawler.ps1
+++ b/tools/crawlers/demo/Start-DemoCrawler.ps1
@@ -41,14 +41,20 @@ function Update-DemoProgress {
 
 Update-DemoProgress -Step 'Loading demo dataset' -Pct 10
 
-if (-not (Test-Path $datasetPath)) {
+# The demo dataset is a gitignored build artifact whose shape tracks the ingest
+# script (e.g. metadata.systemKeys, which Ingest-DemoDataset.ps1 indexes to map
+# placeholder system ids). A bundled or older on-disk copy can therefore be
+# STALE — present but in an out-of-date format — which crashes the ingest with
+# "Cannot index into a null array" and leaves a fresh Docker install with only a
+# handful of systems loaded. So always regenerate from the deterministic
+# generator (same GUIDs every run) so the dataset matches this build's ingest
+# format; only fall back to an existing file when the generator isn't shipped.
+$genScript = "$appRoot/test/demo-dataset/Generate-DemoDataset.ps1"
+if (Test-Path $genScript) {
     Update-DemoProgress -Step 'Generating demo dataset' -Pct 5
-    $genScript = "$appRoot/test/demo-dataset/Generate-DemoDataset.ps1"
-    if (Test-Path $genScript) {
-        & $genScript
-    } else {
-        throw "Demo dataset not found at $datasetPath and generator not available"
-    }
+    & $genScript -OutputPath $datasetPath
+} elseif (-not (Test-Path $datasetPath)) {
+    throw "Demo dataset not found at $datasetPath and generator not available"
 }
 
 Update-DemoProgress -Step 'Ingesting demo data' -Pct 30


### PR DESCRIPTION
### The bug
On a fresh `docker compose up`, the built-in **demo crawler crashes** — it loads the 3 Systems, then dies with `Cannot index into a null array` at `Ingest-DemoDataset.ps1:135` (`$dataset.metadata.systemKeys[$i]`), leaving a new install with almost no demo data.

### Root cause
`demo-company.json` is a **gitignored build artifact** whose shape tracks the ingest script (the ingest indexes `metadata.systemKeys` to map placeholder system ids). But `Start-DemoCrawler.ps1` only regenerated it **when the file was missing** (`if (-not (Test-Path $datasetPath))`). The worker image bundles whatever copy is on disk at build time, which can be **stale but present** — an older dataset predating `metadata.systemKeys`. The guard passed, the stale file was ingested, and it crashed.

### Fix
Always regenerate from the deterministic generator (`Generate-DemoDataset.ps1 -OutputPath`) before ingesting, so the dataset always matches this build's ingest format. Only fall back to an existing file when the generator isn't shipped. Regeneration is deterministic (same GUIDs every run) and fast.

### Verification (local)
- Recreated the exact failure: dropped the stale bundled `demo-company.json` (no `systemKeys`) into the running worker, then ran the **fixed** crawler → it regenerated the dataset (`systemKeys: entra,hr,iga,sap,azurerm`) and ingested all 12 sections ("Demo data loaded successfully", exit 0), **no null-array crash**.
- `Invoke-Pester test/unit/DemoDataset.Tests.ps1` → 33 passed. New test pins that a fresh `-OutputPath` regeneration carries one `systemKeys` entry per system (the section whose absence broke the ingest).
- Cyclomatic + cognitive complexity ratchets pass.

No tracked schema/version files touched. `demo-company.json` remains a gitignored build artifact.
