### PR TITLE
docs(audit): recompute audit-doc status roll-ups from their detail rows

### DIFF
--- a/docs/security/maintenance-audit-2026-06.md
+++ b/docs/security/maintenance-audit-2026-06.md
@@ -63,12 +63,12 @@ Status legend: ✅ **Fixed** (merged) · 🟦 **By design** (intended/supported,
 
 | Phase | Tracked | ✅ Fixed | 🟦 By design | 🟨 Partial | 🔧 Open |
 |-------|--------:|--------:|------------:|----------:|--------:|
-| Design / UX | 21 | 10 | 0 | 0 | 11 |
+| Design / UX | 21 | 11 | 0 | 0 | 10 |
 | Security | 22 | 11 | 3 | 0 | 8 |
-| Perf & Quality | 16 | 8 | 2 | 1 | 5 |
-| CI / Test Harness | 11 | 6 | 0 | 3 | 2 |
+| Perf & Quality | 16 | 10 | 2 | 1 | 3 |
+| CI / Test Harness | 11 | 9 | 0 | 2 | 0 |
 | Documentation | 11 | 11 | 0 | 0 | 0 |
-| **Total** | **81** | **46** | **5** | **4** | **26** |
+| **Total** | **81** | **52** | **5** | **3** | **21** |
 
 _(Row groups P6–P10, Q9–Q10, F10–F13, D10–D12 and the Codex net-new bullets are tracked as single rows here; the audit's raw sub-finding count is 85.)_
 

--- a/docs/ux/assessment.md
+++ b/docs/ux/assessment.md
@@ -23,7 +23,7 @@ This page is a **public, sanitized summary**: it records what was assessed, the 
 
 | Severity | Found | Remediated / in progress | Open |
 |---|---|---|---|
-| Critical | 4 | 3 | 1 |
+| Critical | 4 | 4 | 0 |
 | High | 21 | 17 | 4 |
 | Medium | ~35 | several | most |
 | Low / Informational | ~30 | several | most |


### PR DESCRIPTION
The summary/glance tables in the audit docs had drifted **below** their own detail rows (fixes shipped but the roll-ups weren't recomputed). Recounted every glance/summary table from its detail rows and corrected the mismatches.

### maintenance-audit-2026-06.md — phase table
| Phase | Was | Now | Why |
|---|---|---|---|
| Design / UX | `21·10·0·0·11` | `21·11·0·0·10` | L1 (EmptyState, #760) shipped in #831 → Fixed |
| Perf & Quality | `16·8·2·1·5` | `16·10·2·1·3` | summary undercounted Fixed by 2 |
| CI / Test Harness | `11·6·0·3·2` | `11·9·0·2·0` | F1–F9 all Fixed; F10–F13 + Codex CI are the 2 partials; 0 open |
| **Total** | `81·46·5·4·26` | `81·52·5·3·21` | rolls up the above (Tracked 81 unchanged) |

Security (`22·11·3·0·8`) and Documentation (`11·11·0·0·0`) were already correct.

### ux/assessment.md — Critical glance
`4 │ 3 │ 1` → `4 │ 4 │ 0`. C-01/C-02 are Fixed, C-03/C-04 "Partially addressed"; the column is **"Remediated / in progress"**, which counts partials as in-progress (as the High row already does: 14 fixed + 3 partial = 17), so 0 are fully open.

### Deliberately left unchanged
- **security/assessment.md Medium `12 │ 6 │ 6`** — its column is "Remediated / **accepted**" (not "in progress"), under which the two partials (M-01, M-12) count as not-yet-done. `12│6│6` is self-consistent with that reading (and with the Critical/High rows, which have no partials to disambiguate). Changing it would import the ux doc's different semantics.
- The Medium/Low ux rows are prose-only (`~35`/`~30`) with no per-item detail — not numerically verifiable.
- Stale-candidate rows flagged by link type (ux C-04/H-01/H-05/H-11, security M-12) were checked: each is genuinely partial, with the merged PR covering the done portion and the remainder tracked in an open issue. No status flips.

Docs-only; no functional code touched.
