### PR TITLE
feat(#840): filter entities by relationship presence/absence/count

### DIFF
--- a/app/api/contract-tests/relationshipFilter.contract.test.js
+++ b/app/api/contract-tests/relationshipFilter.contract.test.js
@@ -1,0 +1,222 @@
+// Contract test — the #840 relationship filter against the real PostgreSQL 16
+// schema, end-to-end through the list endpoints (supertest) so the resolver SQL,
+// the route wiring, and the availability endpoint are all exercised against real
+// tables. These are the fixture-backed acceptance criteria (AC1–AC11).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+import { findUncoveredRelationshipTypes } from '../src/relationships/edgeCatalog.js';
+
+let agent, pool;
+const ids = {};
+
+// Insert helpers ------------------------------------------------------------
+async function newResource(systemId, name, type) {
+  return (await pool.query(
+    `INSERT INTO "Resources" ("id","systemId","displayName","resourceType","enabled")
+     VALUES (gen_random_uuid(),$1,$2,$3,true) RETURNING "id"`,
+    [systemId, name, type],
+  )).rows[0].id;
+}
+async function newPrincipal(systemId, name, type, ext = null) {
+  return (await pool.query(
+    `INSERT INTO "Principals" ("id","systemId","displayName","email","principalType","extendedAttributes")
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,$5) RETURNING "id"`,
+    [systemId, name, `${name}@x.test`, type, ext],
+  )).rows[0].id;
+}
+async function assign(systemId, resourceId, principalId) {
+  await pool.query(
+    `INSERT INTO "ResourceAssignments" ("resourceId","principalId","assignmentType","systemId")
+     VALUES ($1,$2,'Direct',$3)`,
+    [resourceId, principalId, systemId],
+  );
+}
+async function ownership(systemId, ownedId, ownershipType, relType, owners) {
+  const ownId = await newResource(systemId, `own-${ownedId}`, ownershipType);
+  await pool.query(
+    `INSERT INTO "ResourceRelationships" ("parentResourceId","childResourceId","relationshipType","systemId")
+     VALUES ($1,$2,$3,$4)`,
+    [ownedId, ownId, relType, systemId],
+  );
+  for (const o of owners) await assign(systemId, ownId, o);
+}
+async function principalRel(systemId, subjectId, relatedId, relType) {
+  await pool.query(
+    `INSERT INTO "PrincipalRelationships" ("principalId","relatedPrincipalId","relationshipType","systemId")
+     VALUES ($1,$2,$3,$4)`,
+    [subjectId, relatedId, relType, systemId],
+  );
+}
+
+// GET /api/resources|users, returning the set of matching ids ---------------
+async function listIds(path, { filters, relFilters }) {
+  const q = new URLSearchParams();
+  if (filters) q.set('filters', JSON.stringify(filters));
+  if (relFilters) q.set('relFilters', JSON.stringify(relFilters));
+  q.set('limit', '1000');
+  const res = await agent.get(`${path}?${q}`);
+  expect(res.status).toBe(200);
+  return new Set(res.body.data.map((r) => r.id));
+}
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+  const systemId = (await pool.query(
+    `INSERT INTO "Systems" ("systemType","displayName") VALUES ('test','rel-filter') RETURNING "id"`,
+  )).rows[0].id;
+  ids.systemId = systemId;
+
+  // Groups + one application.
+  ids.G1 = await newResource(systemId, 'G1', 'Group');
+  ids.G2 = await newResource(systemId, 'G2', 'Group');
+  ids.G3 = await newResource(systemId, 'G3', 'Group');
+  ids.APP1 = await newResource(systemId, 'APP1', 'Application');
+
+  // Owners/members pool.
+  const P = {};
+  for (const n of ['PM1', 'PM2', 'PO1', 'PO2', 'PO3']) P[n] = await newPrincipal(systemId, n, 'User');
+
+  // G1: 2 members, 2 owners. G2: 0 members, 1 owner. G3: 0 members, 0 owners.
+  await assign(systemId, ids.G1, P.PM1);
+  await assign(systemId, ids.G1, P.PM2);
+  await ownership(systemId, ids.G1, 'GroupOwnership', 'HasOwnership', [P.PO1, P.PO2]);
+  await ownership(systemId, ids.G2, 'GroupOwnership', 'HasOwnership', [P.PO1]);
+  // APP1: 1 owner via app ownership (proves the HasAppOwnership arm).
+  await ownership(systemId, ids.APP1, 'ApplicationOwnership', 'HasAppOwnership', [P.PO3]);
+
+  // AI agents: A1 has an owner, A2 does not.
+  ids.A1 = await newPrincipal(systemId, 'A1', 'AIAgent');
+  ids.A2 = await newPrincipal(systemId, 'A2', 'AIAgent');
+  await principalRel(systemId, ids.A1, P.PO1, 'Owner');
+
+  // Guests: U1 has a sponsor, U2 does not (both userType=Guest in extendedAttributes).
+  ids.U1 = await newPrincipal(systemId, 'U1', 'User', { userType: 'Guest' });
+  ids.U2 = await newPrincipal(systemId, 'U2', 'User', { userType: 'Guest' });
+  await principalRel(systemId, ids.U1, P.PO1, 'Sponsor');
+});
+
+afterAll(async () => {
+  // Contract tests share ONE Postgres DB, so this file must remove everything it
+  // seeded — otherwise its extra principals/resources leak into other suites
+  // (e.g. the export-paging contract) and break their row-count assertions.
+  const sid = ids.systemId;
+  await pool.query(`DELETE FROM "PrincipalRelationships" WHERE "systemId" = $1`, [sid]);
+  await pool.query(`DELETE FROM "ResourceAssignments"  WHERE "systemId" = $1`, [sid]);
+  await pool.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [sid]);
+  if (ids.tagId) {
+    await pool.query(`DELETE FROM "ContextMembers" WHERE "contextId" = $1`, [ids.tagId]);
+    await pool.query(`DELETE FROM "Contexts" WHERE "id" = $1`, [ids.tagId]);
+  }
+  await pool.query(`DELETE FROM "Resources"  WHERE "systemId" = $1`, [sid]);
+  await pool.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [sid]);
+  await pool.query(`DELETE FROM "Systems"    WHERE "id" = $1`, [sid]);
+  await pool.end();
+  delete process.env.USE_SQL;
+});
+
+describe('resource edges (Resources list)', () => {
+  it('AC1 — groups with no owners', async () => {
+    const got = await listIds('/api/resources', { filters: { resourceType: 'Group' }, relFilters: [{ edge: 'resource.owners', op: 'absent' }] });
+    expect(got).toEqual(new Set([ids.G3]));
+  });
+
+  it('AC2 — groups with fewer than 2 owners', async () => {
+    const got = await listIds('/api/resources', { filters: { resourceType: 'Group' }, relFilters: [{ edge: 'resource.owners', op: 'lt', n: 2 }] });
+    expect(got).toEqual(new Set([ids.G2, ids.G3]));
+  });
+
+  it('AC3 — groups with no members', async () => {
+    const got = await listIds('/api/resources', { filters: { resourceType: 'Group' }, relFilters: [{ edge: 'resource.members', op: 'absent' }] });
+    expect(got).toEqual(new Set([ids.G2, ids.G3]));
+  });
+
+  it('AC3b — applications with no owners (app-ownership arm)', async () => {
+    const got = await listIds('/api/resources', { filters: { resourceType: 'Application' }, relFilters: [{ edge: 'resource.owners', op: 'absent' }] });
+    expect(got).toEqual(new Set()); // APP1 has an owner via HasAppOwnership
+  });
+});
+
+describe('principal edges (Users list)', () => {
+  it('AC4 — AI agents with no owner', async () => {
+    const got = await listIds('/api/users', { filters: { principalType: 'AIAgent' }, relFilters: [{ edge: 'principal.owner', op: 'absent' }] });
+    expect(got).toEqual(new Set([ids.A2]));
+  });
+
+  it('AC5 — guests with no sponsor', async () => {
+    const got = await listIds('/api/users', { filters: { 'ext.userType': 'Guest' }, relFilters: [{ edge: 'principal.sponsor', op: 'absent' }] });
+    expect(got).toEqual(new Set([ids.U2]));
+  });
+
+  it('AC6 — guests with a sponsor (exists is the inverse of absent)', async () => {
+    const got = await listIds('/api/users', { filters: { 'ext.userType': 'Guest' }, relFilters: [{ edge: 'principal.sponsor', op: 'exists' }] });
+    expect(got).toEqual(new Set([ids.U1]));
+  });
+});
+
+describe('AC7/AC8/AC9 — empty + error handling', () => {
+  it('AC7 — empty relFilters behaves like no relFilters', async () => {
+    const withEmpty = await listIds('/api/resources', { filters: { resourceType: 'Group' }, relFilters: [] });
+    const without = await listIds('/api/resources', { filters: { resourceType: 'Group' } });
+    expect(withEmpty).toEqual(without);
+    expect(without.size).toBe(3);
+  });
+
+  it('AC8 — unknown edge id returns 400', async () => {
+    const res = await agent.get(`/api/resources?relFilters=${encodeURIComponent(JSON.stringify([{ edge: 'bogus', op: 'absent' }]))}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('AC9 — negative n returns 400', async () => {
+    const res = await agent.get(`/api/resources?relFilters=${encodeURIComponent(JSON.stringify([{ edge: 'resource.owners', op: 'lt', n: -1 }]))}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a principal edge on the resource list (400)', async () => {
+    const res = await agent.get(`/api/resources?relFilters=${encodeURIComponent(JSON.stringify([{ edge: 'principal.owner', op: 'absent' }]))}`);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('AC10 — availability endpoint', () => {
+  it('lists Principal edges with availability true where data exists', async () => {
+    const res = await agent.get('/api/relationship-edges?entity=Principal');
+    expect(res.status).toBe(200);
+    const byId = Object.fromEntries(res.body.edges.map((e) => [e.id, e]));
+    expect(byId['principal.sponsor'].available).toBe(true); // U1 has a sponsor
+    expect(byId['principal.owner'].available).toBe(true);   // A1 has an owner
+    expect(byId['principal.sponsor'].ops).toContain('absent');
+  });
+
+  it('accepts the list entityType alias and rejects an unknown entity', async () => {
+    expect((await agent.get('/api/relationship-edges?entity=resource')).status).toBe(200);
+    expect((await agent.get('/api/relationship-edges?entity=Nonsense')).status).toBe(400);
+  });
+});
+
+describe('AC11 — assign-by-filter honours relFilters', () => {
+  it('tags only the entities matching the relationship condition', async () => {
+    const tagId = (await pool.query(
+      `INSERT INTO "Contexts" ("id","variant","targetType","contextType","displayName")
+       VALUES (gen_random_uuid(),'manual','Principal','Tag','rel-tag') RETURNING "id"`,
+    )).rows[0].id;
+    ids.tagId = tagId; // recorded so afterAll can clean it up
+
+    const res = await agent
+      .post(`/api/tags/${tagId}/assign-by-filter`)
+      .send({ entityType: 'user', filters: { 'ext.userType': 'Guest' }, relFilters: [{ edge: 'principal.sponsor', op: 'absent' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.inserted).toBe(1); // only U2 (no sponsor), not U1
+
+    const members = (await pool.query(`SELECT "memberId" FROM "ContextMembers" WHERE "contextId" = $1`, [tagId])).rows;
+    expect(members.map((m) => m.memberId)).toEqual([ids.U2]);
+  });
+});
+
+describe('coverage guard — catalog covers the data', () => {
+  it('every relationship type in the seeded data is catalogued or ignored', async () => {
+    const rr = (await pool.query(`SELECT DISTINCT "relationshipType" FROM "ResourceRelationships"`)).rows.map((r) => r.relationshipType);
+    const pr = (await pool.query(`SELECT DISTINCT "relationshipType" FROM "PrincipalRelationships"`)).rows.map((r) => r.relationshipType);
+    expect(findUncoveredRelationshipTypes({ resourceRelTypes: rr, principalRelTypes: pr })).toEqual([]);
+  });
+});

--- a/app/api/package-lock.json
+++ b/app/api/package-lock.json
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2257,21 +2257,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2332,23 +2345,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3408,9 +3408,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3766,9 +3766,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -6108,9 +6108,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -6246,9 +6246,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6952,9 +6952,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -7084,9 +7084,9 @@
       }
     },
     "node_modules/testcontainers/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/app/api/src/app.js
+++ b/app/api/src/app.js
@@ -33,6 +33,7 @@ import identitiesRouter from './routes/identities.js';
 import preferencesRouter from './routes/preferences.js';
 import systemsRouter from './routes/systems.js';
 import resourcesRouter from './routes/resources.js';
+import relationshipEdgesRouter from './routes/relationshipEdges.js';
 import contextsRouter from './routes/contexts.js';
 import contextPluginsRouter from './routes/contextPlugins.js';
 import adminRouter from './routes/admin.js';
@@ -336,6 +337,7 @@ export function createApp() {
   app.use('/api', authMiddleware, preferencesRouter);
   app.use('/api', authMiddleware, systemsRouter);
   app.use('/api', authMiddleware, resourcesRouter);
+  app.use('/api', authMiddleware, relationshipEdgesRouter);
   app.use('/api', authMiddleware, contextsRouter);
   // Context plugins (Admin → Contexts) — admin-only across the board.
   // Permission gates are applied PER ROUTE inside each router (not on the /api

--- a/app/api/src/openapi.yaml
+++ b/app/api/src/openapi.yaml
@@ -33,6 +33,8 @@ tags:
     description: Crawler management (requires Entra ID auth)
   - name: Effective Access
     description: On-demand effective-access resolution — computed per request, never stored
+  - name: Relationship Filter
+    description: Relationship-presence/absence/count filter edges for the entity lists
 
 paths:
   # ─── Ingest Endpoints ──────────────────────────────────────────
@@ -473,6 +475,30 @@ paths:
           description: Per-capability effective access at the node
         '400':
           description: Missing node, or unknown resolution policy
+
+  /relationship-edges:
+    get:
+      tags: [Relationship Filter]
+      summary: List relationship-filter edges available for an entity
+      operationId: listRelationshipEdges
+      description: >
+        Returns the relationship edges (e.g. has owners, has a sponsor) offered on the
+        Resources or Users list filter, each with a live `available` flag indicating whether
+        any data of that edge's mechanism exists — so edges from opt-in crawler phases are
+        hidden/annotated until that data is present. Backs the #840 relationship filter.
+      security:
+        - EntraIdBearer: []
+      parameters:
+        - name: entity
+          in: query
+          required: true
+          description: Resource or Principal (also accepts the list entityType resource/user).
+          schema: { type: string }
+      responses:
+        '200':
+          description: The edges for the entity, each with id, label, ops and availability
+        '400':
+          description: entity must be Resource or Principal
 
 components:
   securitySchemes:

--- a/app/api/src/relationships/edgeCatalog.js
+++ b/app/api/src/relationships/edgeCatalog.js
@@ -1,0 +1,153 @@
+// Relationship-edge catalog — the single source of truth for the ad-hoc
+// "filter entities by relationship presence/absence/count" feature (#840, Phase 1).
+//
+// Each edge's SQL traversal is IRREDUCIBLY bespoke (ownership is a 3-hop walk
+// through a synthetic *Ownership resource; membership is a ResourceAssignments
+// row; owner/sponsor is a PrincipalRelationships row), so the catalog is code,
+// not data. What keeps it from silently drifting is (a) availability is computed
+// live from these same probes and (b) the coverage guard below fails when the
+// data contains a relationship type this catalog neither consumes nor ignores.
+//
+// An edge entry:
+//   id            stable id, `<entity>.<name>` (also the wire value)
+//   label         user-facing text ("has members")
+//   fromEntity    'Resource' | 'Principal' — the list this edge is offered on
+//   inverseOf     (optional) the id this edge is the reverse direction of
+//   fromWhere(a)  correlated `FROM … WHERE …=a."id" …` fragment (a = outer alias)
+//   countCol      the COUNT(...) expression for count operators
+//   availableProbe a non-correlated `SELECT 1 …` used to decide `available`
+//
+// `fromWhere` and `countCol` are composed by relationshipSql.js into EXISTS /
+// NOT EXISTS / scalar-count predicates — kept apart here so the join text is
+// written once per edge (no exists-vs-count duplication).
+
+// Ownership is modelled as a Direct assignment on a synthetic ownership resource
+// (migration 046 + the app-owners crawler). These are the resourceTypes and the
+// relationshipTypes that carry it.
+const OWNERSHIP_RESOURCE_TYPES = "('GroupOwnership','ServicePrincipalOwnership','ApplicationOwnership')";
+const OWNERSHIP_REL_TYPES = "('HasOwnership','HasAppOwnership')";
+
+export const EDGES = {
+  // ─── Resource-anchored (offered on the Resources list) ───────────────
+  'resource.members': {
+    id: 'resource.members',
+    label: 'has members',
+    fromEntity: 'Resource',
+    fromWhere: (a) => `FROM "ResourceAssignments" ra WHERE ra."resourceId" = ${a}."id" AND ra."deletedAt" IS NULL`,
+    countCol: 'count(DISTINCT ra."principalId")',
+    availableProbe: 'SELECT 1 FROM "ResourceAssignments" WHERE "deletedAt" IS NULL',
+  },
+  'resource.owners': {
+    id: 'resource.owners',
+    label: 'has owners',
+    fromEntity: 'Resource',
+    fromWhere: (a) => `FROM "ResourceRelationships" rr
+      JOIN "Resources" own ON own."id" = rr."childResourceId" AND own."deletedAt" IS NULL
+      JOIN "ResourceAssignments" ra ON ra."resourceId" = own."id" AND ra."assignmentType" = 'Direct' AND ra."deletedAt" IS NULL
+     WHERE rr."parentResourceId" = ${a}."id" AND rr."relationshipType" IN ${OWNERSHIP_REL_TYPES}`,
+    countCol: 'count(DISTINCT ra."principalId")',
+    availableProbe: `SELECT 1 FROM "ResourceRelationships" WHERE "relationshipType" IN ${OWNERSHIP_REL_TYPES}`,
+  },
+
+  // ─── Principal-anchored (offered on the Users list) ──────────────────
+  'principal.memberOf': {
+    id: 'principal.memberOf',
+    label: 'is a member of a resource',
+    fromEntity: 'Principal',
+    inverseOf: 'resource.members',
+    fromWhere: (a) => `FROM "ResourceAssignments" ra WHERE ra."principalId" = ${a}."id" AND ra."deletedAt" IS NULL`,
+    countCol: 'count(DISTINCT ra."resourceId")',
+    availableProbe: 'SELECT 1 FROM "ResourceAssignments" WHERE "deletedAt" IS NULL',
+  },
+  'principal.owns': {
+    id: 'principal.owns',
+    label: 'owns a resource',
+    fromEntity: 'Principal',
+    inverseOf: 'resource.owners',
+    fromWhere: (a) => `FROM "ResourceAssignments" ra
+      JOIN "Resources" own ON own."id" = ra."resourceId" AND own."resourceType" IN ${OWNERSHIP_RESOURCE_TYPES} AND own."deletedAt" IS NULL
+     WHERE ra."principalId" = ${a}."id" AND ra."assignmentType" = 'Direct' AND ra."deletedAt" IS NULL`,
+    countCol: 'count(DISTINCT ra."resourceId")',
+    availableProbe: `SELECT 1 FROM "Resources" WHERE "resourceType" IN ${OWNERSHIP_RESOURCE_TYPES} AND "deletedAt" IS NULL`,
+  },
+  'principal.owner': {
+    id: 'principal.owner',
+    label: 'has an owner',
+    fromEntity: 'Principal',
+    fromWhere: (a) => `FROM "PrincipalRelationships" prx WHERE prx."principalId" = ${a}."id" AND prx."relationshipType" = 'Owner'`,
+    countCol: 'count(*)',
+    availableProbe: `SELECT 1 FROM "PrincipalRelationships" WHERE "relationshipType" = 'Owner'`,
+  },
+  'principal.sponsor': {
+    id: 'principal.sponsor',
+    label: 'has a sponsor',
+    fromEntity: 'Principal',
+    fromWhere: (a) => `FROM "PrincipalRelationships" prx WHERE prx."principalId" = ${a}."id" AND prx."relationshipType" = 'Sponsor'`,
+    countCol: 'count(*)',
+    availableProbe: `SELECT 1 FROM "PrincipalRelationships" WHERE "relationshipType" = 'Sponsor'`,
+  },
+  'principal.ownsPrincipals': {
+    id: 'principal.ownsPrincipals',
+    label: 'is an owner of a principal',
+    fromEntity: 'Principal',
+    inverseOf: 'principal.owner',
+    fromWhere: (a) => `FROM "PrincipalRelationships" prx WHERE prx."relatedPrincipalId" = ${a}."id" AND prx."relationshipType" = 'Owner'`,
+    countCol: 'count(*)',
+    availableProbe: `SELECT 1 FROM "PrincipalRelationships" WHERE "relationshipType" = 'Owner'`,
+  },
+  'principal.sponsorsPrincipals': {
+    id: 'principal.sponsorsPrincipals',
+    label: 'sponsors a guest',
+    fromEntity: 'Principal',
+    inverseOf: 'principal.sponsor',
+    fromWhere: (a) => `FROM "PrincipalRelationships" prx WHERE prx."relatedPrincipalId" = ${a}."id" AND prx."relationshipType" = 'Sponsor'`,
+    countCol: 'count(*)',
+    availableProbe: `SELECT 1 FROM "PrincipalRelationships" WHERE "relationshipType" = 'Sponsor'`,
+  },
+};
+
+// The operators every edge supports. `exists`/`absent` are existence; `eq`/`lt`/
+// `gt` are count comparisons and require an integer `n >= 0`.
+export const OPS = ['exists', 'absent', 'eq', 'lt', 'gt'];
+export const COUNT_OPS = ['eq', 'lt', 'gt'];
+export const OP_SYMBOL = { eq: '=', lt: '<', gt: '>' };
+
+// Return the catalogue entries offered for a given entity target, as the shape
+// the /relationship-edges endpoint and the UI consume (no SQL leaked).
+export function edgesForEntity(entity) {
+  return Object.values(EDGES)
+    .filter((e) => e.fromEntity === entity)
+    .map((e) => ({ id: e.id, label: e.label, fromEntity: e.fromEntity, inverseOf: e.inverseOf || null, ops: OPS }));
+}
+
+// ─── Coverage guard (closes the "static catalog silently drifts" loose end) ──
+//
+// The relationship types the catalog actually consumes as filter edges, and the
+// ones it deliberately ignores (they exist but aren't relationship-presence
+// filters). Any distinct relationshipType found in the data that is in NEITHER
+// set is drift — a new mechanism nobody taught the catalog about — and
+// assertCatalogCoversData() flags it so a human adds an edge (or ignores it).
+export const CONSUMED_RESOURCE_REL_TYPES = new Set(['HasOwnership', 'HasAppOwnership']);
+export const IGNORED_RESOURCE_REL_TYPES = new Set([
+  'Contains', 'GrantsAccessTo', 'DelegatesScope', 'HasAppRole', 'HasApplicationPermission',
+]);
+export const CONSUMED_PRINCIPAL_REL_TYPES = new Set(['Owner', 'Sponsor']);
+
+// Given the distinct relationshipType values present in each relationship-bearing
+// table, return the list of uncovered (drifted) types. Empty ⇒ catalog is complete.
+// Pure function so it is unit-testable without a DB; the contract test feeds it
+// values read from the live schema.
+export function findUncoveredRelationshipTypes({ resourceRelTypes = [], principalRelTypes = [] }) {
+  const uncovered = [];
+  for (const t of resourceRelTypes) {
+    if (!CONSUMED_RESOURCE_REL_TYPES.has(t) && !IGNORED_RESOURCE_REL_TYPES.has(t)) {
+      uncovered.push({ table: 'ResourceRelationships', relationshipType: t });
+    }
+  }
+  for (const t of principalRelTypes) {
+    if (!CONSUMED_PRINCIPAL_REL_TYPES.has(t)) {
+      uncovered.push({ table: 'PrincipalRelationships', relationshipType: t });
+    }
+  }
+  return uncovered;
+}

--- a/app/api/src/relationships/relationshipSql.js
+++ b/app/api/src/relationships/relationshipSql.js
@@ -1,0 +1,103 @@
+// Turn a validated list of relationship conditions into a parameterised SQL
+// WHERE fragment, and compute per-edge availability. Companion to edgeCatalog.js.
+//
+// A relationship condition (wire shape, from the `relFilters` query param or the
+// assign-by-filter body):
+//   { edge: 'resource.owners', op: 'absent' }              // existence
+//   { edge: 'resource.owners', op: 'lt', n: 2 }            // count
+//
+// Parsing + validation live in `relFilterGuard` (an Express middleware) so the
+// (already complex) list handlers gain no branching — they just call
+// `relFiltersToSql` on the pre-validated `req.relFilters`. A relationship filter
+// fails loud (400) rather than warn-and-drop like the matrix filter, because it
+// is an explicit typed param and a silently-dropped condition would quietly
+// widen a governance query.
+
+import { EDGES, OPS, COUNT_OPS, OP_SYMBOL, edgesForEntity } from './edgeCatalog.js';
+
+const MAX_CONDITIONS = 20;
+
+// Parse the raw `relFilters` value (a JSON string, or already-parsed array) into
+// an array. Returns { relFilters, error }.
+export function parseRelFilters(raw) {
+  if (raw == null || raw === '') return { relFilters: [], error: null };
+  let arr = raw;
+  if (typeof raw === 'string') {
+    try { arr = JSON.parse(raw); } catch { return { relFilters: null, error: 'relFilters is not valid JSON' }; }
+  }
+  if (!Array.isArray(arr)) return { relFilters: null, error: 'relFilters must be an array' };
+  if (arr.length > MAX_CONDITIONS) return { relFilters: null, error: `too many relationship conditions (max ${MAX_CONDITIONS})` };
+  return { relFilters: arr, error: null };
+}
+
+// Validate one condition against the catalog + the entity being filtered.
+// Returns an error string, or null if valid.
+function validateCondition(cond, entity) {
+  if (!cond || typeof cond !== 'object') return 'each relationship condition must be an object';
+  const edge = EDGES[cond.edge];
+  if (!edge) return `unknown relationship edge: ${cond.edge}`;
+  if (edge.fromEntity !== entity) return `edge ${cond.edge} is not valid for ${entity} entities`;
+  if (!OPS.includes(cond.op)) return `unknown operator: ${cond.op}`;
+  if (COUNT_OPS.includes(cond.op) && (!Number.isInteger(cond.n) || cond.n < 0)) {
+    return `operator ${cond.op} requires an integer n >= 0`;
+  }
+  return null;
+}
+
+// Validate every condition. Returns the first error string, or null.
+export function validateRelFilters(relFilters, entity) {
+  for (const cond of relFilters) {
+    const err = validateCondition(cond, entity);
+    if (err) return err;
+  }
+  return null;
+}
+
+// Express middleware: parse + validate the relFilters on a list/tag request and
+// stash the validated array on req.relFilters, or respond 400. Keeps the heavy
+// list handlers branch-free. `entityOf` is the relationship target ('Resource' /
+// 'Principal') or a (req)=>target function (assign-by-filter derives it from the
+// request body's entityType).
+export function relFilterGuard(entityOf) {
+  return (req, res, next) => {
+    const raw = (req.query && req.query.relFilters) ?? (req.body && req.body.relFilters);
+    const { relFilters, error: parseErr } = parseRelFilters(raw);
+    if (parseErr) return res.status(400).json({ error: parseErr });
+    const entity = typeof entityOf === 'function' ? entityOf(req) : entityOf;
+    const validationErr = validateRelFilters(relFilters, entity);
+    if (validationErr) return res.status(400).json({ error: validationErr });
+    req.relFilters = relFilters;
+    next();
+  };
+}
+
+// Build the AND-ed WHERE fragment (leading ' AND …', like buildFilterWhere) from
+// PRE-VALIDATED conditions (relFilterGuard has run). `alias` is the outer table
+// alias (r / u / e); `bind` is the shared positional binder.
+export function relFiltersToSql(relFilters, { alias, bind }) {
+  let sql = '';
+  for (const cond of relFilters) {
+    const edge = EDGES[cond.edge];
+    const body = edge.fromWhere(alias);
+    if (cond.op === 'exists') {
+      sql += ` AND EXISTS (SELECT 1 ${body})`;
+    } else if (cond.op === 'absent') {
+      sql += ` AND NOT EXISTS (SELECT 1 ${body})`;
+    } else {
+      sql += ` AND (SELECT ${edge.countCol} ${body}) ${OP_SYMBOL[cond.op]} ${bind(cond.n)}`;
+    }
+  }
+  return sql;
+}
+
+// Compute `available` for every edge of an entity, in one round-trip: each edge's
+// non-correlated existence probe becomes one boolean column. Returns the edge
+// descriptors with `available` set. `runQuery(sql)` is `pool.query`-like.
+export async function computeAvailability(entity, runQuery) {
+  const edges = edgesForEntity(entity);
+  if (edges.length === 0) return [];
+  const cols = edges.map((e, i) => `EXISTS (${EDGES[e.id].availableProbe}) AS "a${i}"`);
+  const { rows } = await runQuery(`SELECT ${cols.join(', ')}`);
+  const row = rows[0] || {};
+  return edges.map((e, i) => ({ ...e, available: !!row[`a${i}`] }));
+}

--- a/app/api/src/relationships/relationshipSql.test.js
+++ b/app/api/src/relationships/relationshipSql.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseRelFilters,
+  validateRelFilters,
+  relFiltersToSql,
+  relFilterGuard,
+  computeAvailability,
+} from './relationshipSql.js';
+import {
+  EDGES,
+  OPS,
+  edgesForEntity,
+  findUncoveredRelationshipTypes,
+} from './edgeCatalog.js';
+
+// A stand-in for createParams().bind — records bound values, returns $N.
+function fakeBinder() {
+  const params = [];
+  const bind = (v) => `$${params.push(v)}`;
+  return { params, bind };
+}
+
+describe('parseRelFilters', () => {
+  it('returns [] for empty/absent input', () => {
+    expect(parseRelFilters(undefined)).toEqual({ relFilters: [], error: null });
+    expect(parseRelFilters('')).toEqual({ relFilters: [], error: null });
+  });
+
+  it('parses a JSON string', () => {
+    const { relFilters, error } = parseRelFilters('[{"edge":"resource.owners","op":"absent"}]');
+    expect(error).toBeNull();
+    expect(relFilters).toEqual([{ edge: 'resource.owners', op: 'absent' }]);
+  });
+
+  it('passes an already-parsed array through', () => {
+    const arr = [{ edge: 'principal.owner', op: 'exists' }];
+    expect(parseRelFilters(arr)).toEqual({ relFilters: arr, error: null });
+  });
+
+  it('errors on invalid JSON', () => {
+    expect(parseRelFilters('{not json').error).toMatch(/not valid JSON/);
+  });
+
+  it('errors on a non-array', () => {
+    expect(parseRelFilters('{"edge":"x"}').error).toMatch(/must be an array/);
+  });
+
+  it('errors when over the condition cap', () => {
+    const many = JSON.stringify(Array.from({ length: 21 }, () => ({ edge: 'resource.members', op: 'exists' })));
+    expect(parseRelFilters(many).error).toMatch(/too many/);
+  });
+});
+
+describe('relFiltersToSql — existence operators', () => {
+  it('emits EXISTS for exists', () => {
+    const { bind } = fakeBinder();
+    const sql = relFiltersToSql([{ edge: 'resource.members', op: 'exists' }], { alias: 'r', bind });
+    expect(sql).toContain('AND EXISTS (SELECT 1 FROM "ResourceAssignments" ra');
+    expect(sql).toContain('ra."resourceId" = r."id"');
+    expect(sql).toContain('ra."deletedAt" IS NULL');
+  });
+
+  it('emits NOT EXISTS for absent', () => {
+    const { bind } = fakeBinder();
+    const sql = relFiltersToSql([{ edge: 'resource.owners', op: 'absent' }], { alias: 'r', bind });
+    expect(sql).toContain('AND NOT EXISTS (SELECT 1 FROM "ResourceRelationships" rr');
+    expect(sql).toContain(`rr."relationshipType" IN ('HasOwnership','HasAppOwnership')`);
+    expect(sql).toContain('rr."parentResourceId" = r."id"');
+  });
+
+  it('anchors principal edges on the given alias', () => {
+    const { bind } = fakeBinder();
+    const sql = relFiltersToSql([{ edge: 'principal.sponsor', op: 'exists' }], { alias: 'u', bind });
+    expect(sql).toContain(`prx."principalId" = u."id" AND prx."relationshipType" = 'Sponsor'`);
+  });
+});
+
+describe('relFiltersToSql — count operators', () => {
+  it('emits a scalar count subquery with a bound n and the right symbol', () => {
+    const { params, bind } = fakeBinder();
+    const sql = relFiltersToSql([{ edge: 'resource.owners', op: 'lt', n: 2 }], { alias: 'r', bind });
+    expect(sql).toContain('AND (SELECT count(DISTINCT ra."principalId")');
+    expect(sql).toMatch(/\) < \$1$/);
+    expect(params).toEqual([2]);
+  });
+
+  it('maps eq/gt to = and >', () => {
+    const eq = relFiltersToSql([{ edge: 'principal.owner', op: 'eq', n: 0 }], { alias: 'u', bind: fakeBinder().bind });
+    expect(eq).toContain('count(*)');
+    expect(eq).toMatch(/= \$1$/);
+    const gt = relFiltersToSql([{ edge: 'principal.owner', op: 'gt', n: 1 }], { alias: 'u', bind: fakeBinder().bind });
+    expect(gt).toMatch(/> \$1$/);
+  });
+
+  it('AND-s multiple conditions together', () => {
+    const { bind } = fakeBinder();
+    const sql = relFiltersToSql(
+      [{ edge: 'resource.members', op: 'absent' }, { edge: 'resource.owners', op: 'lt', n: 2 }],
+      { alias: 'r', bind },
+    );
+    expect(sql.match(/ AND /g).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns empty sql for no conditions', () => {
+    expect(relFiltersToSql([], { alias: 'r', bind: fakeBinder().bind })).toBe('');
+  });
+});
+
+describe('validateRelFilters — fail loud', () => {
+  const v = (conds, entity = 'Resource') => validateRelFilters(conds, entity);
+
+  it('accepts valid conditions', () => {
+    expect(v([{ edge: 'resource.owners', op: 'absent' }])).toBeNull();
+    expect(v([{ edge: 'principal.owner', op: 'lt', n: 2 }], 'Principal')).toBeNull();
+  });
+
+  it('rejects an unknown edge', () => {
+    expect(v([{ edge: 'bogus', op: 'absent' }])).toMatch(/unknown relationship edge/);
+  });
+
+  it('rejects an edge not valid for the entity', () => {
+    expect(v([{ edge: 'principal.owner', op: 'absent' }], 'Resource')).toMatch(/not valid for Resource/);
+  });
+
+  it('rejects an unknown operator', () => {
+    expect(v([{ edge: 'resource.owners', op: 'between' }])).toMatch(/unknown operator/);
+  });
+
+  it('rejects a count op with a missing/negative/non-integer n', () => {
+    expect(v([{ edge: 'resource.owners', op: 'lt' }])).toMatch(/integer n >= 0/);
+    expect(v([{ edge: 'resource.owners', op: 'lt', n: -1 }])).toMatch(/integer n >= 0/);
+    expect(v([{ edge: 'resource.owners', op: 'lt', n: 1.5 }])).toMatch(/integer n >= 0/);
+  });
+
+  it('rejects a non-object condition', () => {
+    expect(v([null])).toMatch(/must be an object/);
+  });
+});
+
+describe('relFilterGuard middleware', () => {
+  const mkRes = () => {
+    const res = { statusCode: 200, body: null };
+    res.status = (c) => { res.statusCode = c; return res; };
+    res.json = (b) => { res.body = b; return res; };
+    return res;
+  };
+
+  it('sets req.relFilters and calls next for valid input', () => {
+    const req = { query: { relFilters: JSON.stringify([{ edge: 'resource.owners', op: 'absent' }]) } };
+    const res = mkRes();
+    const next = vi.fn();
+    relFilterGuard('Resource')(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.relFilters).toEqual([{ edge: 'resource.owners', op: 'absent' }]);
+  });
+
+  it('400s on a parse error without calling next', () => {
+    const req = { query: { relFilters: '{bad' } };
+    const res = mkRes();
+    const next = vi.fn();
+    relFilterGuard('Resource')(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400s on a validation error and resolves entity from a function', () => {
+    const req = { body: { entityType: 'user', relFilters: [{ edge: 'resource.owners', op: 'absent' }] } };
+    const res = mkRes();
+    const next = vi.fn();
+    // resource.owners is not valid for Principal (user → Principal)
+    relFilterGuard((r) => (r.body.entityType === 'user' ? 'Principal' : 'Resource'))(req, res, next);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/not valid for Principal/);
+  });
+});
+
+describe('computeAvailability', () => {
+  it('maps each edge to its EXISTS probe result', async () => {
+    const seen = [];
+    const runQuery = async (sql) => {
+      seen.push(sql);
+      // Two resource edges → a0 (members) true, a1 (owners) false.
+      return { rows: [{ a0: true, a1: false }] };
+    };
+    const edges = await computeAvailability('Resource', runQuery);
+    expect(edges.map((e) => e.id)).toEqual(['resource.members', 'resource.owners']);
+    expect(edges[0].available).toBe(true);
+    expect(edges[1].available).toBe(false);
+    expect(seen[0]).toContain('EXISTS (');
+  });
+
+  it('returns [] for an entity with no edges without querying', async () => {
+    let called = false;
+    const edges = await computeAvailability('Identity', async () => { called = true; return { rows: [] }; });
+    expect(edges).toEqual([]);
+    expect(called).toBe(false);
+  });
+});
+
+describe('edgeCatalog', () => {
+  it('offers exactly the resource edges on Resource and the principal edges on Principal', () => {
+    expect(edgesForEntity('Resource').map((e) => e.id).sort()).toEqual(['resource.members', 'resource.owners']);
+    expect(edgesForEntity('Principal').map((e) => e.id)).toContain('principal.sponsor');
+    expect(edgesForEntity('Identity')).toEqual([]);
+  });
+
+  it('every edge exposes the full operator set', () => {
+    for (const e of Object.values(EDGES)) expect(e.ops ?? OPS).toEqual(OPS);
+    expect(edgesForEntity('Resource')[0].ops).toEqual(OPS);
+  });
+
+  it('coverage guard: passes for known types, flags an unknown one', () => {
+    expect(findUncoveredRelationshipTypes({
+      resourceRelTypes: ['HasOwnership', 'Contains', 'HasAppRole'],
+      principalRelTypes: ['Owner', 'Sponsor'],
+    })).toEqual([]);
+
+    const drift = findUncoveredRelationshipTypes({
+      resourceRelTypes: ['HasFutureThing'],
+      principalRelTypes: ['Delegate'],
+    });
+    expect(drift).toEqual([
+      { table: 'ResourceRelationships', relationshipType: 'HasFutureThing' },
+      { table: 'PrincipalRelationships', relationshipType: 'Delegate' },
+    ]);
+  });
+});

--- a/app/api/src/routes/relationshipEdges.js
+++ b/app/api/src/routes/relationshipEdges.js
@@ -1,0 +1,52 @@
+// GET /api/relationship-edges?entity=Resource|Principal
+//
+// Lists the relationship-filter edges offered for an entity, each with a live
+// `available` flag (whether any data of that edge's mechanism exists). The UI
+// uses `available` to hide/annotate edges from opt-in crawler phases (e.g. the
+// Sponsor edge is unavailable until the Principal Relationships phase has run).
+//
+// Availability is computed from the code catalog's probes at request time — the
+// catalog is the single source of truth (no DB view to drift). A short TTL cache
+// keeps it cheap under the list page's edge-picker traffic.
+
+import { Router } from 'express';
+import { computeAvailability } from '../relationships/relationshipSql.js';
+import { ENTITY_TO_TARGET } from './tags.js';
+
+const router = Router();
+const useSql = process.env.USE_SQL === 'true';
+
+let db = null;
+if (useSql) {
+  db = await import('../db/connection.js');
+}
+
+const VALID_ENTITIES = new Set(['Resource', 'Principal']);
+const TTL_MS = 5 * 60 * 1000; // mirror columnCache's 5-minute TTL
+const cache = new Map(); // entity -> { at, edges }
+
+router.get('/relationship-edges', async (req, res) => {
+  try {
+    // Accept either the target name (Resource/Principal) or a list entityType
+    // (resource/user) so both the UI and internal callers can ask naturally.
+    const raw = String(req.query.entity || '').trim();
+    const entity = VALID_ENTITIES.has(raw) ? raw : ENTITY_TO_TARGET[raw];
+    if (!VALID_ENTITIES.has(entity)) {
+      return res.status(400).json({ error: 'entity must be Resource or Principal' });
+    }
+    if (!useSql) return res.json({ edges: [] });
+
+    const hit = cache.get(entity);
+    if (hit && Date.now() - hit.at < TTL_MS) {
+      return res.json({ edges: hit.edges });
+    }
+    const edges = await computeAvailability(entity, (sql) => db.query(sql));
+    cache.set(entity, { at: Date.now(), edges });
+    res.json({ edges });
+  } catch (err) {
+    console.error('GET /relationship-edges failed:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -5,6 +5,7 @@ import { parseJsonbColumn } from '../lib/jsonb.js';
 import { buildOrderBy } from '../lib/listSort.js';
 import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
 import { ensureTagTables, buildFilterWhere, parseTags } from './tags.js';
+import { relFilterGuard, relFiltersToSql } from '../relationships/relationshipSql.js';
 import { UUID_RE, cleanRow, getPermissionTable } from './details/shared.js';
 import { isMissingSchema } from '../db/schemaErrors.js';
 
@@ -27,7 +28,7 @@ if (useSql) {
 
 // ─── GET /api/resources ─────────────────────────────────────────
 // List resources with pagination, filtering, and search
-router.get('/resources', async (req, res) => {
+router.get('/resources', relFilterGuard('Resource'), async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0 });
 
@@ -103,6 +104,11 @@ router.get('/resources', async (req, res) => {
         INNER JOIN "GraphTags" _rt ON _rta."tagId" = _rt.id AND _rt."name" = ${bind(resourceTagFilter)} AND _rt."entityType" IN ('resource', 'group')`;
     }
     where += buildFilterWhere(attrFilters, colNames, 'r', bind);
+
+    // Relationship filters (#840): presence/absence/count over graph edges.
+    // Validated by relFilterGuard; bound through the same `bind` before the
+    // countParams snapshot so the COUNT query gets the same placeholders.
+    where += relFiltersToSql(req.relFilters || [], { alias: 'r', bind });
 
     // Returns every Resources column so the same endpoint feeds the UI grid
     // AND the Power Query Excel export (which auto-expands extendedAttributes

--- a/app/api/src/routes/tags/crud.js
+++ b/app/api/src/routes/tags/crud.js
@@ -15,6 +15,7 @@ import { recalcMemberCountsForChain } from '../../contexts/memberCounts.js';
 import { requirePermission } from '../../middleware/auth.js';
 import { createParams } from '../../db/sqlParams.js';
 import { useSql, db, ensureTagTables, buildFilterWhere, ENTITY_TO_TARGET, UUID_RE } from './shared.js';
+import { relFilterGuard, relFiltersToSql } from '../../relationships/relationshipSql.js';
 
 const router = Router();
 const writeTags = requirePermission('data.write.tags');
@@ -226,7 +227,7 @@ router.post('/tags/:id/unassign', writeTags, async (req, res) => {
 
 // ─── POST /api/tags/:id/assign-by-filter ──────────────────────────
 // Bulk-assign: tags ALL entities matching a search filter (server-side)
-router.post('/tags/:id/assign-by-filter', writeTags, async (req, res) => {
+router.post('/tags/:id/assign-by-filter', writeTags, relFilterGuard((req) => ENTITY_TO_TARGET[req.body.entityType]), async (req, res) => {
   try {
     if (!useSql) return res.status(400).json({ error: 'SQL mode required' });
     const { entityType, search: rawSearch, filters } = req.body;
@@ -278,6 +279,12 @@ router.post('/tags/:id/assign-by-filter', writeTags, async (req, res) => {
       const colNames = new Set(cols.map(c => c.name));
       where += buildFilterWhere(filters, colNames, alias, bind);
     }
+
+    // Apply relationship filters (#840) so "Tag all matching" respects the same
+    // relationship conditions the list is narrowed by — otherwise a relationship-
+    // filtered list would tag the broader attribute-only set. Validated by
+    // relFilterGuard (entity derived from the body's entityType).
+    where += relFiltersToSql(req.relFilters || [], { alias, bind });
 
     // Tags now live in Contexts — write directly to ContextMembers, skipping
     // dupes via ON CONFLICT. INSERT count comes back as pg's rowCount.

--- a/app/api/src/routes/tags/entities.js
+++ b/app/api/src/routes/tags/entities.js
@@ -12,6 +12,7 @@ import { createParams } from '../../db/sqlParams.js';
 import { parseJsonbColumn } from '../../lib/jsonb.js';
 import { buildOrderBy } from '../../lib/listSort.js';
 import { useSql, db, ensureTagTables, buildFilterWhere, UUID_RE, parseTags } from './shared.js';
+import { relFilterGuard, relFiltersToSql } from '../../relationships/relationshipSql.js';
 
 const router = Router();
 
@@ -103,7 +104,7 @@ async function groupColumnsHandler(req, res) {
 }
 
 // ─── GET /api/users ───────────────────────────────────────────────
-router.get('/users', async (req, res) => {
+router.get('/users', relFilterGuard('Principal'), async (req, res) => {
   try {
     if (!useSql) return res.json({ data: [], total: 0 });
 
@@ -150,6 +151,10 @@ router.get('/users', async (req, res) => {
         INNER JOIN "GraphTags" _ut ON _uta."tagId" = _ut.id AND _ut."name" = ${bind(userTagFilter)} AND _ut."entityType" = 'user'`;
     }
     where += buildFilterWhere(attrFilters, colNames, 'u', bind);
+
+    // Relationship filters (#840). Validated by relFilterGuard; bound through the
+    // same `bind` before the countParams snapshot.
+    where += relFiltersToSql(req.relFilters || [], { alias: 'u', bind });
 
     // Paginate FIRST (cheap), then resolve the per-row tag string only for the
     // page's rows. The tagString subquery used to sit in the top-level SELECT, so

--- a/app/ui/package-lock.json
+++ b/app/ui/package-lock.json
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2254,9 +2254,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2913,9 +2913,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4554,9 +4554,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/app/ui/src/components/EntityListPage.jsx
+++ b/app/ui/src/components/EntityListPage.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useAuth } from '@ui/auth/AuthGate';
 import useEntityPage from '@ui/hooks/useEntityPage';
 import FilterBar from './FilterBar';
+import RelationshipFilterBar from './RelationshipFilterBar';
 import EmptyState from './EmptyState';
 import { TAG_COLORS, tagPillStyle } from '@ui/utils/colors';
 import { useIsDark } from '@ui/contexts/ThemeContext';
@@ -157,6 +158,21 @@ export default function EntityListPage({
           onRemoveFilter={ep.removeFilter}
           loading={ep.columnsLoading}
         />
+
+        {/* Relationship filters (#840) — only for entities with a relationship
+            target (Resources / Users); the Identities list maps to neither. */}
+        {ep.relTargetType && (
+          <>
+            <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
+            <RelationshipFilterBar
+              entity={ep.relTargetType}
+              authFetch={authFetch}
+              relFilters={ep.relFilters}
+              onAdd={ep.addRelFilter}
+              onRemove={ep.removeRelFilter}
+            />
+          </>
+        )}
 
         <div className="border-l border-gray-300 dark:border-gray-600 h-5 mx-1" />
 

--- a/app/ui/src/components/RelationshipFilterBar.jsx
+++ b/app/ui/src/components/RelationshipFilterBar.jsx
@@ -1,0 +1,139 @@
+import { useState, useMemo } from 'react';
+import { useFetch } from '@ui/hooks/useFetch';
+
+// Relationship filter control (#840). Sibling of FilterBar — lets you filter a
+// list by the presence / absence / count of a graph edge (e.g. "groups with no
+// owners", "guests with no sponsor"). Renders inline elements (Fragment); place
+// inside a flex container next to FilterBar.
+//
+// Props:
+//   entity       'Resource' | 'Principal' — the relationship target for this list
+//   authFetch    authenticated fetch (from useAuth)
+//   relFilters   [{edge, op, n?}] active relationship conditions
+//   onAdd(cond)  add/replace a condition
+//   onRemove(edgeId)
+
+const OP_LABEL = { exists: 'has value', absent: 'has no value', eq: 'count =', lt: 'count <', gt: 'count >' };
+const COUNT_OPS = ['eq', 'lt', 'gt'];
+
+export default function RelationshipFilterBar({ entity, authFetch, relFilters, onAdd, onRemove }) {
+  const { data: edges } = useFetch(`/api/relationship-edges?entity=${entity}`, {
+    authFetch,
+    enabled: !!entity,
+    initialData: [],
+    transform: (json) => json.edges || [],
+  });
+
+  const [adding, setAdding] = useState(false);
+  const [edge, setEdge] = useState('');
+  const [op, setOp] = useState('absent');
+  const [n, setN] = useState('0');
+
+  const edgeById = useMemo(() => Object.fromEntries(edges.map((e) => [e.id, e])), [edges]);
+  const activeEdges = useMemo(() => new Set(relFilters.map((f) => f.edge)), [relFilters]);
+  // Offer edges not already used. Unavailable edges (no data yet — e.g. an
+  // un-run opt-in phase) stay listed but disabled with a hint.
+  const selectable = edges.filter((e) => !activeEdges.has(e.id));
+
+  const reset = () => { setAdding(false); setEdge(''); setOp('absent'); setN('0'); };
+
+  const confirm = () => {
+    if (!edge) return;
+    const cond = { edge, op };
+    if (COUNT_OPS.includes(op)) cond.n = Math.max(0, parseInt(n, 10) || 0);
+    onAdd(cond);
+    reset();
+  };
+
+  const describe = (f) => {
+    const label = edgeById[f.edge]?.label || f.edge;
+    const opText = COUNT_OPS.includes(f.op) ? `${OP_LABEL[f.op]} ${f.n}` : OP_LABEL[f.op];
+    return `${label}: ${opText}`;
+  };
+
+  return (
+    <>
+      <span className="font-medium text-gray-700 dark:text-gray-300">Relationships:</span>
+
+      {relFilters.map((f) => (
+        <span
+          key={f.edge}
+          className="inline-flex items-center gap-1 px-2 py-1 bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-700 rounded text-xs"
+        >
+          <span className="font-medium text-indigo-700 dark:text-indigo-300">{describe(f)}</span>
+          <button
+            onClick={() => onRemove(f.edge)}
+            className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 font-bold ml-0.5"
+            title="Remove relationship filter"
+          >
+            &times;
+          </button>
+        </span>
+      ))}
+
+      {adding ? (
+        <span className="inline-flex items-center gap-1 px-2 py-1 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-xs">
+          <select
+            autoFocus
+            aria-label="Relationship edge"
+            value={edge}
+            onChange={(e) => setEdge(e.target.value)}
+            className="bg-transparent border-none text-xs dark:text-gray-200 p-0 pr-4"
+          >
+            <option value="">Select relationship...</option>
+            {selectable.map((e) => (
+              <option key={e.id} value={e.id} disabled={!e.available}>
+                {e.label}{e.available ? '' : ' (no data yet)'}
+              </option>
+            ))}
+          </select>
+          {edge && (
+            <>
+              <select
+                aria-label="Relationship operator"
+                value={op}
+                onChange={(e) => setOp(e.target.value)}
+                className="bg-transparent border-none text-xs dark:text-gray-200 p-0 pr-4"
+              >
+                {Object.entries(OP_LABEL).map(([v, l]) => (
+                  <option key={v} value={v}>{l}</option>
+                ))}
+              </select>
+              {COUNT_OPS.includes(op) && (
+                <input
+                  type="number"
+                  min="0"
+                  aria-label="Relationship count"
+                  value={n}
+                  onChange={(e) => setN(e.target.value)}
+                  className="w-14 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded text-xs px-1 dark:text-gray-200"
+                />
+              )}
+              <button
+                onClick={confirm}
+                className="text-indigo-700 dark:text-indigo-300 font-semibold hover:underline"
+              >
+                Add
+              </button>
+            </>
+          )}
+          <button
+            onClick={reset}
+            className="text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 font-bold"
+          >
+            &times;
+          </button>
+        </span>
+      ) : (
+        selectable.length > 0 && (
+          <button
+            onClick={() => setAdding(true)}
+            className="px-2 py-1 rounded text-xs text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-700 border-dashed"
+          >
+            + Add relationship
+          </button>
+        )
+      )}
+    </>
+  );
+}

--- a/app/ui/src/components/RelationshipFilterBar.test.jsx
+++ b/app/ui/src/components/RelationshipFilterBar.test.jsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import {
+  renderWithProviders,
+  makeAuthFetch,
+  screen,
+  userEvent,
+} from '@ui/test-utils/renderWithProviders';
+import RelationshipFilterBar from '@ui/components/RelationshipFilterBar';
+
+const EDGES = {
+  '/api/relationship-edges': {
+    edges: [
+      { id: 'principal.owner', label: 'has an owner', ops: ['exists', 'absent', 'eq', 'lt', 'gt'], available: true },
+      { id: 'principal.sponsor', label: 'has a sponsor', ops: ['exists', 'absent', 'eq', 'lt', 'gt'], available: false },
+    ],
+  },
+};
+
+function setup(relFilters = []) {
+  const onAdd = vi.fn();
+  const onRemove = vi.fn();
+  const af = makeAuthFetch(EDGES);
+  renderWithProviders(
+    <RelationshipFilterBar entity="Principal" authFetch={af} relFilters={relFilters} onAdd={onAdd} onRemove={onRemove} />,
+    { auth: { authFetch: af } },
+  );
+  return { onAdd, onRemove };
+}
+
+// The "+ Add relationship" button only appears once the edge list has loaded
+// (useFetch resolves async), so open the picker via findBy.
+async function openPicker(user) {
+  await user.click(await screen.findByText('+ Add relationship'));
+  return screen.findByLabelText('Relationship edge');
+}
+
+describe('RelationshipFilterBar', () => {
+  it('renders active relationship conditions as readable pills (label resolves once edges load)', async () => {
+    setup([{ edge: 'principal.owner', op: 'lt', n: 2 }]);
+    expect(await screen.findByText('has an owner: count < 2')).toBeInTheDocument();
+  });
+
+  it('adds an existence condition via the picker', async () => {
+    const user = userEvent.setup();
+    const { onAdd } = setup();
+    await openPicker(user);
+
+    await user.selectOptions(screen.getByLabelText('Relationship edge'), 'principal.owner');
+    await user.selectOptions(screen.getByLabelText('Relationship operator'), 'absent');
+    await user.click(screen.getByText('Add'));
+
+    expect(onAdd).toHaveBeenCalledWith({ edge: 'principal.owner', op: 'absent' });
+  });
+
+  it('reveals a count input for count operators and passes n', async () => {
+    const user = userEvent.setup();
+    const { onAdd } = setup();
+    await openPicker(user);
+    await user.selectOptions(screen.getByLabelText('Relationship edge'), 'principal.owner');
+    await user.selectOptions(screen.getByLabelText('Relationship operator'), 'lt');
+
+    const nInput = screen.getByLabelText('Relationship count');
+    await user.clear(nInput);
+    await user.type(nInput, '2');
+    await user.click(screen.getByText('Add'));
+
+    expect(onAdd).toHaveBeenCalledWith({ edge: 'principal.owner', op: 'lt', n: 2 });
+  });
+
+  it('disables an unavailable edge (opt-in phase not run)', async () => {
+    const user = userEvent.setup();
+    setup();
+    await openPicker(user);
+    const opt = screen.getByRole('option', { name: /has a sponsor \(no data yet\)/ });
+    expect(opt).toBeDisabled();
+  });
+
+  it('removes an active condition', async () => {
+    const user = userEvent.setup();
+    const { onRemove } = setup([{ edge: 'principal.owner', op: 'absent' }]);
+    await user.click(screen.getByTitle('Remove relationship filter'));
+    expect(onRemove).toHaveBeenCalledWith('principal.owner');
+  });
+});

--- a/app/ui/src/hooks/useEntityPage.js
+++ b/app/ui/src/hooks/useEntityPage.js
@@ -44,6 +44,13 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
   const [availableColumns, setAvailableColumns] = useState([]);
   const [columnsLoading, setColumnsLoading] = useState(true);
   const [activeFilters, setActiveFilters] = usePersistedState(skey('filters'), []);
+  // Relationship filters (#840): [{edge, op, n?}] — presence/absence/count over
+  // graph edges. Only meaningful for entities that map to a relationship target
+  // (Resource / Principal); the Identities list maps to neither and never shows
+  // the control. Persisted alongside the attribute filters.
+  const [relFilters, setRelFilters] = usePersistedState(skey('relFilters'), []);
+  const REL_TARGET = { user: 'Principal', resource: 'Resource', group: 'Resource' };
+  const relTargetType = REL_TARGET[entityType] || null;
 
   // Filter state
   const [search, setSearch] = usePersistedState(skey('search'), '');
@@ -74,7 +81,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
 
   // Reset page & selection when filters change — during render via a
   // value-signature compare, so no synchronous setState lives in an effect.
-  const filterResetSig = JSON.stringify({ debouncedSearch, activeFilters, baseFilters, includeDeleted, sortCol, sortDir });
+  const filterResetSig = JSON.stringify({ debouncedSearch, activeFilters, relFilters, baseFilters, includeDeleted, sortCol, sortDir });
   const [seenFilterResetSig, setSeenFilterResetSig] = useState(filterResetSig);
   if (filterResetSig !== seenFilterResetSig) {
     setSeenFilterResetSig(filterResetSig);
@@ -123,6 +130,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
     const params = new URLSearchParams({ limit: PAGE_SIZE, offset: page * PAGE_SIZE });
     if (debouncedSearch) params.set('search', debouncedSearch);
     if (filtersObj) params.set('filters', JSON.stringify(filtersObj));
+    if (relFilters.length) params.set('relFilters', JSON.stringify(relFilters));
     if (includeDeleted) params.set('includeDeleted', 'true');
     // Sort is applied server-side over the full result set — a column header
     // sorts every match, not just the rows already on this page (audit H-14).
@@ -150,7 +158,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
         if (version === fetchVersion.current) setError(err);
       })
       .finally(() => { if (version === fetchVersion.current) setLoading(false); });
-  }, [page, debouncedSearch, filtersObj, authFetch, listEndpoint, includeDeleted, entityType, sortCol, sortDir]);
+  }, [page, debouncedSearch, filtersObj, relFilters, authFetch, listEndpoint, includeDeleted, entityType, sortCol, sortDir]);
 
   useEffect(() => { fetchItems(); }, [fetchItems]);
 
@@ -197,8 +205,19 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
 
   const clearAllFilters = () => {
     setActiveFilters([]);
+    setRelFilters([]);
     setSearch('');
   };
+
+  // Relationship-filter helpers (#840). Conditions are keyed by edge id, so
+  // adding an edge that's already active replaces its operator/count.
+  const addRelFilter = useCallback((cond) => {
+    setRelFilters(prev => [...prev.filter(f => f.edge !== cond.edge), cond]);
+  }, [setRelFilters]);
+
+  const removeRelFilter = useCallback((edge) => {
+    setRelFilters(prev => prev.filter(f => f.edge !== edge));
+  }, [setRelFilters]);
 
   // Active tag filter
   const activeTagFilter = activeFilters.find(f => f.field === tagFilterKey)?.value || '';
@@ -249,6 +268,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
           entityType,
           search: debouncedSearch || undefined,
           filters: filtersObj || undefined,
+          relFilters: relFilters.length ? relFilters : undefined,
         }),
       });
       if (res.ok) {
@@ -289,7 +309,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
   const allOnPageSelected = items.length > 0 && selected.size === items.length;
-  const hasAnyFilter = activeFilters.length > 0 || debouncedSearch;
+  const hasAnyFilter = activeFilters.length > 0 || relFilters.length > 0 || debouncedSearch;
 
   // Build filterFields from availableColumns. Keys that start with `ext.`
   // are extended-attribute filters (see api columnCache.js / buildFilterWhere)
@@ -324,6 +344,7 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
     search, setSearch, debouncedSearch,
     includeDeleted, setIncludeDeleted,
     activeFilters, addFilter, removeFilter, clearAllFilters,
+    relFilters, addRelFilter, removeRelFilter, relTargetType,
     hasAnyFilter, activeTagFilter, filtersObj,
     columnsLoading, getFilterFields, getOptionsForField,
     // Selection

--- a/app/ui/src/hooks/useEntityPage.relFilters.test.jsx
+++ b/app/ui/src/hooks/useEntityPage.relFilters.test.jsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  renderHook,
+  act,
+  waitFor,
+  makeWrapper,
+  makeAuthFetch,
+} from '@ui/test-utils/renderWithProviders';
+import useEntityPage from '@ui/hooks/useEntityPage';
+
+const LIST = '/api/users';
+const COLUMNS = '/api/users/columns';
+
+beforeEach(() => sessionStorage.clear());
+
+function setup(entityType = 'user') {
+  const af = makeAuthFetch({
+    [COLUMNS]: [{ column: 'department', values: ['Sales'] }],
+    [LIST]: { data: [{ id: '1', displayName: 'Bob' }], total: 1 },
+    '/api/tags': [],
+  });
+  const { wrapper } = makeWrapper({ auth: { authFetch: af } });
+  const { result } = renderHook(
+    () => useEntityPage({ authFetch: af, entityType, listEndpoint: LIST, columnsEndpoint: COLUMNS, tagFilterKey: '__userTag' }),
+    { wrapper },
+  );
+  return { af, result };
+}
+
+function lastListUrl(af) {
+  const calls = af.mock.calls.map((c) => String(c[0]));
+  return [...calls].reverse().find((u) => u.startsWith(LIST + '?'));
+}
+
+describe('useEntityPage — relationship filters (#840)', () => {
+  it('maps entityType to a relationship target (user → Principal)', async () => {
+    const { result } = setup('user');
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.relTargetType).toBe('Principal');
+  });
+
+  it('gates out entities with no relationship target (identity → null)', async () => {
+    const { result } = setup('identity');
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.relTargetType).toBeNull();
+  });
+
+  it('serializes relFilters into the list request and flags hasAnyFilter', async () => {
+    const { af, result } = setup('user');
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.addRelFilter({ edge: 'principal.sponsor', op: 'absent' }));
+    await waitFor(() => {
+      const url = lastListUrl(af);
+      expect(url).toContain('relFilters=');
+      expect(decodeURIComponent(url)).toContain('"edge":"principal.sponsor"');
+    });
+    expect(result.current.hasAnyFilter).toBe(true);
+    expect(result.current.relFilters).toEqual([{ edge: 'principal.sponsor', op: 'absent' }]);
+  });
+
+  it('replaces a condition when the same edge is re-added, and removes it', async () => {
+    const { af, result } = setup('user');
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.addRelFilter({ edge: 'principal.owner', op: 'lt', n: 2 }));
+    act(() => result.current.addRelFilter({ edge: 'principal.owner', op: 'absent' }));
+    expect(result.current.relFilters).toEqual([{ edge: 'principal.owner', op: 'absent' }]);
+
+    act(() => result.current.removeRelFilter('principal.owner'));
+    await waitFor(() => expect(result.current.relFilters).toEqual([]));
+    const url = lastListUrl(af);
+    expect(url).not.toContain('relFilters=');
+  });
+
+  it('clearAllFilters clears relationship filters too', async () => {
+    const { result } = setup('user');
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.addRelFilter({ edge: 'principal.sponsor', op: 'exists' }));
+    act(() => result.current.clearAllFilters());
+    expect(result.current.relFilters).toEqual([]);
+  });
+});

--- a/changes/relationship-filter.md
+++ b/changes/relationship-filter.md
@@ -1,0 +1,4 @@
+- Added a relationship filter to the Resources and Users lists: filter entities by whether they **have** or **have no** a related edge, or by a **count** (`= / < / > N`) of it. Answers hygiene questions like "groups with no owners", "groups with fewer than 2 owners", "AI agents with no owner", and "guests with no sponsor" directly from the list — compose it with the existing attribute filters (e.g. Resource Type = Group).
+- Relationship edges cover group/app **owners**, resource **members**, principal **owner** and **sponsor**, and their inverses.
+- The relationship picker only offers edges that actually have data, with a "no data yet" hint for edges that come from an opt-in crawler phase that hasn't run.
+- "Tag all matching" now respects an active relationship filter, so it tags the same set the list shows.

--- a/docs/architecture/relationship-filter.md
+++ b/docs/architecture/relationship-filter.md
@@ -1,0 +1,78 @@
+# Relationship filter (#840, Phase 1)
+
+Filter entities by the **presence, absence, or count** of a graph edge — the
+"find-the-needle" governance questions attribute filters can't ask ("groups with
+no owners", "AI agents with no owner", "guests with no sponsor", "groups with
+fewer than 2 owners").
+
+## Surface
+An **additive** capability on the existing list-page filters, not a new page and
+not a change to the equality filter. The list endpoints accept an optional
+`relFilters` query param alongside `filters`; when absent, behaviour is
+unchanged. Offered on:
+
+- **Resources list** (`GET /api/resources`) — Resource-anchored edges.
+- **Users list** (`GET /api/users`) — Principal-anchored edges.
+
+The Identities list maps to neither relationship target and shows no control.
+The motivating "groups" cases are expressed by composing the existing
+`resourceType=Group` attribute filter with a relationship condition — the
+relationship filter never self-scopes to a resourceType.
+
+`relFilters` is a JSON array of `{ edge, op, n? }`:
+
+| op | meaning |
+|----|---------|
+| `exists` / `absent` | the entity has / has no edge of this kind |
+| `eq` / `lt` / `gt` (+ integer `n >= 0`) | the count of the edge compared to `n` |
+
+Unknown edge, wrong entity, bad operator, or bad `n` → **HTTP 400** (fail loud —
+a silently-dropped condition would quietly widen a governance query).
+
+## Edge catalog — the single source of truth
+`app/api/src/relationships/edgeCatalog.js`. Each edge's SQL traversal is
+irreducibly bespoke (ownership is a 3-hop walk through a synthetic `*Ownership`
+resource; membership is a `ResourceAssignments` row; owner/sponsor is a
+`PrincipalRelationships` row), so the catalog is **code**, not a data table.
+
+| edge | on | mechanism |
+|------|----|-----------|
+| `resource.members` | Resources | `ResourceAssignments` (all live types) on the resource |
+| `resource.owners` | Resources | `HasOwnership`/`HasAppOwnership` → ownership resource → `Direct` assignment |
+| `principal.memberOf` | Users | inverse of `resource.members` |
+| `principal.owns` | Users | inverse of `resource.owners` (the owner-holder side) |
+| `principal.owner` | Users | `PrincipalRelationships` `Owner`, subject = principal |
+| `principal.sponsor` | Users | `PrincipalRelationships` `Sponsor`, subject = principal |
+| `principal.ownsPrincipals` | Users | inverse of `principal.owner` |
+| `principal.sponsorsPrincipals` | Users | inverse of `principal.sponsor` |
+
+"Members" counts **all live assignment types** (Direct + Indirect + Eligible,
+`deletedAt IS NULL`) so "no members" agrees with the member count shown on the
+detail page — an indirect-only group is not falsely flagged empty.
+
+`relationshipSql.js` composes each edge into an `EXISTS` / `NOT EXISTS` /
+scalar-count predicate, bound through the list route's shared positional binder
+so it AND-s onto the equality WHERE with consistent `$N` numbering (including the
+COUNT query). No new matview or migration — the predicates are index-supported by
+the existing primary keys.
+
+## Availability (self-maintaining, no drift)
+`GET /api/relationship-edges?entity=Resource|Principal` returns the edges for an
+entity, each with a live `available` flag computed from the catalog's own
+existence probe (single source of truth — no DB view to drift), behind a 5-minute
+TTL cache. The UI disables an unavailable edge with a "no data yet" hint — so an
+edge from an opt-in crawler phase (Principal Relationships: owner/sponsor) isn't
+offered as a filter that would flag every entity until that phase has run.
+
+## Coverage guard (closes the "static catalog silently drifts" loose end)
+`findUncoveredRelationshipTypes()` compares the distinct relationship types
+present in the data against the set the catalog consumes or explicitly ignores.
+A new mechanism nobody taught the catalog about (a new `relationshipType` in
+`ResourceRelationships`/`PrincipalRelationships`) is flagged so a human adds an
+edge — or ignores it. Exercised by `relationshipFilter.contract.test.js` against
+the real schema. (Wiring it as a live post-crawl diagnostic against tenant data
+is a future enhancement; in CI it validates the detector against seeded data.)
+
+## Out of scope (Phase 2 / later)
+"Save as Context" wizard, the matrix surface, global search, the Identities list,
+and per-system availability.


### PR DESCRIPTION
Closes #840 (Phase 1 — the ad-hoc relationship filter; Phase 2 "Save as Context" deferred).

## What
Adds an **additive** relationship filter to the Resources and Users lists: filter entities by whether they **have** / **have no** a related edge, or by a **count** (`= / < / > N`). Compose it with the existing attribute filters (e.g. Resource Type = Group) to answer:
- groups with no owners / fewer than 2 owners
- AI agents with no owner
- guests with no sponsor
- (bonus) apps/service principals with no owner

## How
- `edgeCatalog.js` — the single source of truth: each edge's id, direction, inverse, and bespoke resolver (ownership is a 3-hop walk, membership a `ResourceAssignments` row, owner/sponsor a `PrincipalRelationships` row). Plus a **coverage guard** that flags a relationship type present in the data the catalog doesn't model.
- `relationshipSql.js` — `relFilterGuard` middleware (parse + validate, fail-loud 400) keeps the heavy list handlers branch-free; `relFiltersToSql` emits `EXISTS`/`NOT EXISTS`/count bound through the routes' shared positional binder. The equality path (`buildFilterWhere`) is untouched.
- `GET /api/relationship-edges` — live per-edge availability computed from the catalog probes (TTL-cached), so edges from opt-in crawler phases are annotated "no data yet" instead of silently flagging every entity.
- `assign-by-filter` honours `relFilters` so "Tag all matching" tags the shown set.
- UI: `RelationshipFilterBar` sibling control + `useEntityPage` wiring, gated to entities with a relationship target (Identities list shows nothing).

No DB migration, no crawler change (sponsor is already a first-class edge).

## Tests (fixture-backed ACs)
- Contract (`relationshipFilter.contract.test.js`, real PostgreSQL): AC1–AC11 — the motivating queries, app-ownership arm, empty/400 cases, availability, and assign-by-filter honouring relFilters.
- Unit: SQL builder, validation, middleware, availability mapping, coverage guard.
- UI: `RelationshipFilterBar` component + `useEntityPage` serialization/gating.
- Docs: `docs/architecture/relationship-filter.md` + changelog fragment + OpenAPI entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)