### PR TITLE
ci(deps): bump codeql-action to 4.37.3 (init + autobuild + analyze together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,17 +42,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: /language:javascript-typescript
 
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: python
           queries: security-and-quality
@@ -80,6 +80,6 @@ jobs:
 
       # Python is interpreted — no build step; CodeQL extracts straight from source.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: /language:python

--- a/changes/codeql-action-4-37-3.md
+++ b/changes/codeql-action-4-37-3.md
@@ -1,0 +1,1 @@
+- Updated the CodeQL analysis workflow to codeql-action 4.37.3 across the init, autobuild, and analyze steps together (they must stay on a single version).


### PR DESCRIPTION
## Why

Dependabot split the `codeql-action` 4.36.3 → 4.37.3 bump into **three separate PRs** — #847 (`init`), #850 (`autobuild`), #854 (`analyze`). CodeQL requires `init`, `autobuild`, and `analyze` to run the **same** version, so each PR on its own fails the Analyze job:

```
##[error] Loaded a configuration file for version '4.37.3', but running version '4.36.3'
```

This is the genuine interdependency — the three only work applied **together**.

## What

- Bumps all **5** `github/codeql-action/*` references in `.github/workflows/codeql.yml` (init ×2, autobuild ×1, analyze ×2) from `54f647b…` to `e4fba868…` (v4 / bundle 4.37.3) in one commit.

## Supersedes

Closing #847, #850, #854 in favour of this consolidated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)