### PR TITLE
feat(lists): filter entity lists by relationship existence

### DIFF
--- a/app/api/contract-tests/relationshipFilters.contract.test.js
+++ b/app/api/contract-tests/relationshipFilters.contract.test.js
@@ -1,0 +1,187 @@
+// Contract test — relationship/reference list filters against a real PostgreSQL
+// schema. Verifies "AI agents without an owner", "groups without members" and
+// "groups without an owner" resolve to exactly the right rows, plus the filter
+// fields are advertised on the column-discovery endpoints.
+//
+// Fixtures (from the DoR sign-off packet):
+//   Principals: AgentA (AIAgent, NO owner), AgentB (AIAgent, has an Owner row),
+//               OwnerU (User, is AgentB's owner).
+//   Groups:     G1 (a Direct member), G2 (empty), G3 (an owner, no members),
+//               G4 (a soft-deleted member), G5 (only an Eligible assignment).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+let agent;
+let pool;
+let systemId;
+const groups = {};
+
+const q = (obj) => encodeURIComponent(JSON.stringify(obj));
+const names = (res) => res.body.data.map((r) => r.displayName).sort();
+
+async function insResource(displayName, resourceType) {
+  const r = await pool.query(
+    `INSERT INTO "Resources" ("systemId", "displayName", "resourceType", "enabled")
+     VALUES ($1, $2, $3, true) RETURNING "id"`,
+    [systemId, displayName, resourceType],
+  );
+  return r.rows[0].id;
+}
+
+async function insPrincipal(displayName, principalType) {
+  const r = await pool.query(
+    `INSERT INTO "Principals" ("systemId", "displayName", "principalType")
+     VALUES ($1, $2, $3) RETURNING "id"`,
+    [systemId, displayName, principalType],
+  );
+  return r.rows[0].id;
+}
+
+async function insAssignment(resourceId, assignmentType, { resourceType = null, deleted = false } = {}) {
+  await pool.query(
+    `INSERT INTO "ResourceAssignments"
+       ("resourceId", "principalId", "assignmentType", "systemId", "principalType", "resourceType", "deletedAt")
+     VALUES ($1, gen_random_uuid(), $2, $3, 'User', $4, $5)`,
+    [resourceId, assignmentType, systemId, resourceType, deleted ? new Date() : null],
+  );
+}
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType", "displayName") VALUES ('test', 'contract-relfilter') RETURNING "id"`,
+  );
+  systemId = sys.rows[0].id;
+
+  // ── Principals ──
+  const agentA = await insPrincipal('ZZRELFILT-AgentA', 'AIAgent'); // no owner
+  const agentB = await insPrincipal('ZZRELFILT-AgentB', 'AIAgent'); // has owner
+  const ownerU = await insPrincipal('ZZRELFILT-OwnerU', 'User');
+  void agentA;
+  await pool.query(
+    `INSERT INTO "PrincipalRelationships" ("principalId", "relatedPrincipalId", "relationshipType", "systemId")
+     VALUES ($1, $2, 'Owner', $3)`,
+    [agentB, ownerU, systemId],
+  );
+
+  // ── Groups ──
+  groups.G1 = await insResource('ZZRELFILT-G1-member', 'Group');
+  groups.G2 = await insResource('ZZRELFILT-G2-empty', 'Group');
+  groups.G3 = await insResource('ZZRELFILT-G3-ownerOnly', 'Group');
+  groups.G4 = await insResource('ZZRELFILT-G4-deletedMember', 'Group');
+  groups.G5 = await insResource('ZZRELFILT-G5-eligibleOnly', 'Group');
+
+  // G1: a live Direct member (resourceType NULL = plain group membership).
+  await insAssignment(groups.G1, 'Direct');
+  // G4: a soft-deleted Direct member → must NOT count.
+  await insAssignment(groups.G4, 'Direct', { deleted: true });
+  // G5: only an Eligible assignment → not active membership.
+  await insAssignment(groups.G5, 'Eligible');
+
+  // G3: an owner, no members. Ownership = a synthetic GroupOwnership resource
+  // linked via HasOwnership, with a Direct assignment on THAT resource.
+  const own3 = await insResource('ZZRELFILT-G3-owner', 'GroupOwnership');
+  await pool.query(
+    `INSERT INTO "ResourceRelationships" ("parentResourceId", "childResourceId", "relationshipType", "systemId")
+     VALUES ($1, $2, 'HasOwnership', $3)`,
+    [groups.G3, own3, systemId],
+  );
+  await insAssignment(own3, 'Direct', { resourceType: 'GroupOwnership' });
+});
+
+afterAll(async () => {
+  await pool.query(`DELETE FROM "ResourceAssignments" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "PrincipalRelationships" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
+  await pool.query(`DELETE FROM "Systems" WHERE "id" = $1`, [systemId]);
+  await pool.end();
+  delete process.env.USE_SQL; // singleFork — env mutations leak across files
+});
+
+describe('relationship filters — AI agent owners (/api/users)', () => {
+  const base = { principalType: 'AIAgent' };
+
+  it('hasOwner=No returns only the ownerless agent (AC1)', async () => {
+    const res = await agent.get(`/api/users?search=ZZRELFILT&filters=${q({ ...base, hasOwner: 'No' })}`);
+    expect(res.status).toBe(200);
+    expect(names(res)).toEqual(['ZZRELFILT-AgentA']);
+  });
+
+  it('hasOwner=Yes returns only the owned agent (AC2)', async () => {
+    const res = await agent.get(`/api/users?search=ZZRELFILT&filters=${q({ ...base, hasOwner: 'Yes' })}`);
+    expect(res.status).toBe(200);
+    expect(names(res)).toEqual(['ZZRELFILT-AgentB']);
+  });
+
+  it('an invalid value is ignored → both agents returned (AC3)', async () => {
+    const res = await agent.get(`/api/users?search=ZZRELFILT&filters=${q({ ...base, hasOwner: 'Maybe' })}`);
+    expect(res.status).toBe(200);
+    expect(names(res)).toEqual(['ZZRELFILT-AgentA', 'ZZRELFILT-AgentB']);
+  });
+});
+
+describe('relationship filters — group members & owners (/api/resources)', () => {
+  const url = (extra) => `/api/resources?systemId=${systemId}&filters=${q({ resourceType: 'Group', ...extra })}`;
+
+  it('hasMembers=No returns empty/owner-only/deleted-member/eligible-only groups (AC5)', async () => {
+    const res = await agent.get(url({ hasMembers: 'No' }));
+    expect(res.status).toBe(200);
+    expect(names(res)).toEqual([
+      'ZZRELFILT-G2-empty',
+      'ZZRELFILT-G3-ownerOnly',
+      'ZZRELFILT-G4-deletedMember',
+      'ZZRELFILT-G5-eligibleOnly',
+    ]);
+  });
+
+  it('hasMembers=Yes returns only the group with a live Direct member (AC6)', async () => {
+    const res = await agent.get(url({ hasMembers: 'Yes' }));
+    expect(names(res)).toEqual(['ZZRELFILT-G1-member']);
+  });
+
+  it('hasOwner=Yes returns only the owned group (AC7)', async () => {
+    const res = await agent.get(url({ hasOwner: 'Yes' }));
+    expect(names(res)).toEqual(['ZZRELFILT-G3-ownerOnly']);
+  });
+
+  it('hasOwner=No excludes the owned group (AC7)', async () => {
+    const res = await agent.get(url({ hasOwner: 'No' }));
+    expect(names(res)).toEqual([
+      'ZZRELFILT-G1-member',
+      'ZZRELFILT-G2-empty',
+      'ZZRELFILT-G4-deletedMember',
+      'ZZRELFILT-G5-eligibleOnly',
+    ]);
+  });
+
+  it('combining hasMembers=No AND hasOwner=No narrows to the truly orphaned groups', async () => {
+    const res = await agent.get(url({ hasMembers: 'No', hasOwner: 'No' }));
+    expect(names(res)).toEqual([
+      'ZZRELFILT-G2-empty',
+      'ZZRELFILT-G4-deletedMember',
+      'ZZRELFILT-G5-eligibleOnly',
+    ]);
+  });
+});
+
+describe('relationship filters — advertised on column-discovery endpoints', () => {
+  it('/api/user-columns-page advertises hasOwner with Yes/No values', async () => {
+    const res = await agent.get('/api/user-columns-page');
+    expect(res.status).toBe(200);
+    const col = res.body.find((c) => c.column === 'hasOwner');
+    expect(col).toBeTruthy();
+    expect(col.values).toEqual(['Yes', 'No']);
+  });
+
+  it('/api/resource-columns advertises hasOwner and hasMembers', async () => {
+    const res = await agent.get('/api/resource-columns');
+    expect(res.status).toBe(200);
+    const cols = res.body.map((c) => c.column);
+    expect(cols).toContain('hasOwner');
+    expect(cols).toContain('hasMembers');
+  });
+});

--- a/app/api/src/lib/relationshipFilters.js
+++ b/app/api/src/lib/relationshipFilters.js
@@ -1,0 +1,145 @@
+// Relationship/reference list filters — filter an entity list by whether the
+// object HAS (or lacks) a given relationship, not just by an attribute on the
+// object itself. E.g. "AI agents without an owner", "groups without members",
+// "groups without an owner".
+//
+// This is the single source of truth for the feature. The list route handlers
+// (/api/users, /api/resources) call `applyRelationshipFilters` to append the
+// WHERE fragment, and the column-discovery routes (/api/user-columns-page,
+// /api/resource-columns) call `advertiseRelationshipColumns` to surface the
+// filter fields in the UI filter bar. Keeping the SQL + advertisement here (a)
+// avoids a jscpd clone across the two route files and (b) keeps the route
+// handlers to a single call-statement each so they don't cross the per-function
+// complexity ratchet.
+//
+// Design notes:
+//   - Filter keys are plain (`hasOwner`, `hasMembers`), NOT `__`-prefixed like
+//     the tag virtual keys. The UI filter bar humanizes an unknown column key
+//     for its label (`hasOwner` -> "Has Owner"), so plain keys give a clean
+//     label with ZERO UI code — no per-page FIELD_LABELS entry needed. The keys
+//     are still safe against buildFilterWhere: they are not real columns and not
+//     `ext.`-prefixed, so buildFilterWhere ignores them even if not stripped.
+//   - The value is "Yes"/"No" (equality picker in the existing FilterBar);
+//     "Yes" -> EXISTS, "No" -> NOT EXISTS. Any other value is ignored (no-op).
+//   - The EXISTS/NOT EXISTS operator is chosen from a fixed whitelist and every
+//     other token in the fragment is a literal — no user value reaches the SQL,
+//     so the fragment is injection-safe and binds NO params (leaving each
+//     handler's countParams snapshot untouched).
+//   - Existence-guarded: a filter that reads a table which may be absent on an
+//     older deployment (PrincipalRelationships, migration 057) is skipped rather
+//     than 500ing the whole list — this matters because active filters are
+//     persisted in the browser's localStorage and re-sent after a rollback.
+
+const OP_BY_VALUE = { Yes: 'EXISTS', No: 'NOT EXISTS' };
+
+// Per-domain relationship filter specs.
+//   sql(alias, op) -> the `<op> ( SELECT 1 ... )` predicate for the WHERE clause
+//   probe          -> a `SELECT EXISTS(...) AS e` used to decide whether to
+//                     advertise the field (only show it when the tenant has the
+//                     relevant relationship data — same idea as the tag filters)
+//   requires       -> tables that must exist for the predicate to be runnable
+export const RELATIONSHIP_FILTERS = {
+  principal: {
+    hasOwner: {
+      label: 'Has owner',
+      requires: ['PrincipalRelationships'],
+      // An AI agent / guest "has an owner" when a PrincipalRelationships row
+      // (migration 057) points at it with relationshipType='Owner'.
+      sql: (a, op) => `${op} (SELECT 1 FROM "PrincipalRelationships" pr`
+        + ` WHERE pr."principalId" = ${a}.id AND pr."relationshipType" = 'Owner')`,
+      probe: `SELECT EXISTS (SELECT 1 FROM "PrincipalRelationships" WHERE "relationshipType" = 'Owner') AS e`,
+    },
+  },
+  resource: {
+    hasOwner: {
+      label: 'Has owner',
+      requires: ['ResourceRelationships', 'ResourceAssignments'],
+      // A resource "has an owner" when a Direct assignment sits on its synthetic
+      // ownership resource (GroupOwnership / ServicePrincipalOwnership /
+      // ApplicationOwnership) linked via HasOwnership / HasAppOwnership. Covers
+      // both group ownership (migration 046) and app/SP ownership.
+      sql: (a, op) => `${op} (SELECT 1 FROM "ResourceRelationships" rr`
+        + ` JOIN "ResourceAssignments" ra ON ra."resourceId" = rr."childResourceId"`
+        + ` AND ra."deletedAt" IS NULL AND ra."assignmentType" = 'Direct'`
+        + ` AND ra."resourceType" IN ('GroupOwnership','ServicePrincipalOwnership','ApplicationOwnership')`
+        + ` WHERE rr."parentResourceId" = ${a}.id`
+        + ` AND rr."relationshipType" IN ('HasOwnership','HasAppOwnership'))`,
+      probe: `SELECT EXISTS (SELECT 1 FROM "ResourceRelationships" WHERE "relationshipType" IN ('HasOwnership','HasAppOwnership')) AS e`,
+    },
+    hasMembers: {
+      label: 'Has members',
+      requires: ['ResourceAssignments'],
+      // A resource "has members" when it has a Direct assignment that is not the
+      // ownership assignment. Mirrors the existing member-count source
+      // (resources.js / riskscoring engine): Direct only, GroupOwnership
+      // excluded (an owner is not a member), soft-deleted excluded. A nested
+      // subgroup counts — it is itself a Direct member — so a group whose only
+      // members arrive via nesting is correctly NOT "memberless".
+      sql: (a, op) => `${op} (SELECT 1 FROM "ResourceAssignments" ra`
+        + ` WHERE ra."resourceId" = ${a}.id AND ra."deletedAt" IS NULL`
+        + ` AND ra."assignmentType" = 'Direct'`
+        + ` AND ra."resourceType" IS DISTINCT FROM 'GroupOwnership')`,
+      probe: `SELECT EXISTS (SELECT 1 FROM "ResourceAssignments" WHERE "assignmentType" = 'Direct' AND "resourceType" IS DISTINCT FROM 'GroupOwnership') AS e`,
+    },
+  },
+};
+
+// Module-level cache of table existence (feature tables never disappear within a
+// process lifetime once present). Keyed by unquoted table name.
+const _tableExists = new Map();
+
+async function tableExists(pool, name) {
+  if (_tableExists.has(name)) return _tableExists.get(name);
+  const r = await pool.query('SELECT to_regclass($1) AS t', [`"${name}"`]);
+  const exists = r.rows[0]?.t != null;
+  _tableExists.set(name, exists);
+  return exists;
+}
+
+async function allTablesExist(pool, names) {
+  for (const n of names) {
+    if (!(await tableExists(pool, n))) return false;
+  }
+  return true;
+}
+
+// Resolve the WHERE fragment for the relationship filters present in `filters`.
+// Consumes (deletes) the keys it handles so a later buildFilterWhere never sees
+// them. Returns '' when nothing applies. Never throws — a catalog/probe error
+// degrades to "skip this filter" rather than failing the list request.
+export async function applyRelationshipFilters(pool, domain, filters, alias) {
+  const specs = RELATIONSHIP_FILTERS[domain];
+  if (!specs || !filters) return '';
+  let frag = '';
+  for (const [key, spec] of Object.entries(specs)) {
+    const op = OP_BY_VALUE[filters[key]];
+    delete filters[key];
+    if (!op) continue;
+    try {
+      if (await allTablesExist(pool, spec.requires)) frag += ` AND ${spec.sql(alias, op)}`;
+    } catch { /* skip filter on any schema/catalog error */ }
+  }
+  return frag;
+}
+
+// Build the `{ column: ['Yes','No'] }` map of relationship filter fields to
+// advertise for a domain, including only fields whose relationship data exists.
+// Returned map is merged into the column-discovery response. Never throws.
+export async function advertiseRelationshipColumns(pool, domain) {
+  const specs = RELATIONSHIP_FILTERS[domain];
+  if (!specs) return {};
+  const out = {};
+  for (const [key, spec] of Object.entries(specs)) {
+    try {
+      if (!(await allTablesExist(pool, spec.requires))) continue;
+      const r = await pool.query(spec.probe);
+      if (r.rows[0]?.e) out[key] = ['Yes', 'No'];
+    } catch { /* skip advertisement on any schema/probe error */ }
+  }
+  return out;
+}
+
+// Exposed for tests: reset the table-existence cache between cases.
+export function _resetTableExistsCache() {
+  _tableExists.clear();
+}

--- a/app/api/src/lib/relationshipFilters.test.js
+++ b/app/api/src/lib/relationshipFilters.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  RELATIONSHIP_FILTERS,
+  applyRelationshipFilters,
+  advertiseRelationshipColumns,
+  _resetTableExistsCache,
+} from './relationshipFilters.js';
+
+// A stub pool. `tables` is the set of existing (unquoted) table names;
+// `probe` is what a spec.probe query returns for its `e` column; `throwOn`
+// forces query() to reject when the SQL matches the substring.
+function makePool({ tables = new Set(), probe = true, throwOn = null } = {}) {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, args) {
+      calls.push({ sql, args });
+      if (throwOn && sql.includes(throwOn)) throw new Error('boom');
+      if (sql.includes('to_regclass')) {
+        const quoted = args[0]; // e.g. "PrincipalRelationships"
+        const name = quoted.replace(/"/g, '');
+        return { rows: [{ t: tables.has(name) ? 1234 : null }] };
+      }
+      // a spec.probe (SELECT EXISTS(...) AS e)
+      return { rows: [{ e: probe }] };
+    },
+  };
+}
+
+const PRINCIPAL_TABLES = new Set(['PrincipalRelationships']);
+const RESOURCE_TABLES = new Set(['ResourceRelationships', 'ResourceAssignments']);
+
+beforeEach(() => _resetTableExistsCache());
+
+describe('RELATIONSHIP_FILTERS spec', () => {
+  it('exposes principal.hasOwner and resource.hasOwner/hasMembers with sql+probe+requires', () => {
+    expect(Object.keys(RELATIONSHIP_FILTERS.principal)).toEqual(['hasOwner']);
+    expect(Object.keys(RELATIONSHIP_FILTERS.resource).sort()).toEqual(['hasMembers', 'hasOwner']);
+    for (const domain of Object.values(RELATIONSHIP_FILTERS)) {
+      for (const spec of Object.values(domain)) {
+        expect(typeof spec.sql('x', 'EXISTS')).toBe('string');
+        expect(spec.probe).toMatch(/EXISTS/);
+        expect(Array.isArray(spec.requires)).toBe(true);
+      }
+    }
+  });
+
+  it('interpolates the alias and operator into the predicate', () => {
+    const sql = RELATIONSHIP_FILTERS.principal.hasOwner.sql('u', 'NOT EXISTS');
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('pr."principalId" = u.id');
+    expect(sql).toContain("'Owner'");
+  });
+});
+
+describe('applyRelationshipFilters', () => {
+  it('returns "" for an unknown domain', async () => {
+    expect(await applyRelationshipFilters(makePool(), 'nope', { hasOwner: 'Yes' }, 'u')).toBe('');
+  });
+
+  it('returns "" when filters is null', async () => {
+    expect(await applyRelationshipFilters(makePool(), 'principal', null, 'u')).toBe('');
+  });
+
+  it('maps Yes -> EXISTS and deletes the consumed key', async () => {
+    const filters = { hasOwner: 'Yes', department: 'IT' };
+    const frag = await applyRelationshipFilters(makePool({ tables: PRINCIPAL_TABLES }), 'principal', filters, 'u');
+    expect(frag).toBe(` AND ${RELATIONSHIP_FILTERS.principal.hasOwner.sql('u', 'EXISTS')}`);
+    expect(filters).toEqual({ department: 'IT' }); // hasOwner consumed, other key untouched
+  });
+
+  it('maps No -> NOT EXISTS', async () => {
+    const frag = await applyRelationshipFilters(makePool({ tables: PRINCIPAL_TABLES }), 'principal', { hasOwner: 'No' }, 'u');
+    expect(frag).toContain('NOT EXISTS');
+  });
+
+  it('ignores an invalid value but still consumes the key', async () => {
+    const filters = { hasOwner: 'Maybe' };
+    const frag = await applyRelationshipFilters(makePool({ tables: PRINCIPAL_TABLES }), 'principal', filters, 'u');
+    expect(frag).toBe('');
+    expect(filters).toEqual({});
+  });
+
+  it('skips the filter (no 500) when a required table is absent', async () => {
+    const frag = await applyRelationshipFilters(makePool({ tables: new Set() }), 'principal', { hasOwner: 'No' }, 'u');
+    expect(frag).toBe('');
+  });
+
+  it('skips the filter when the catalog query throws', async () => {
+    const frag = await applyRelationshipFilters(makePool({ throwOn: 'to_regclass' }), 'principal', { hasOwner: 'Yes' }, 'u');
+    expect(frag).toBe('');
+  });
+
+  it('combines both resource filters with AND', async () => {
+    const filters = { hasOwner: 'No', hasMembers: 'No' };
+    const frag = await applyRelationshipFilters(makePool({ tables: RESOURCE_TABLES }), 'resource', filters, 'r');
+    expect(frag).toContain('rr."relationshipType" IN (\'HasOwnership\',\'HasAppOwnership\')');
+    expect(frag).toContain('ra."resourceType" IS DISTINCT FROM \'GroupOwnership\'');
+    expect((frag.match(/ AND NOT EXISTS \(/g) || []).length).toBe(2);
+    expect(filters).toEqual({});
+  });
+});
+
+describe('advertiseRelationshipColumns', () => {
+  it('returns {} for an unknown domain', async () => {
+    expect(await advertiseRelationshipColumns(makePool(), 'nope')).toEqual({});
+  });
+
+  it('advertises a field with Yes/No when the data exists', async () => {
+    const out = await advertiseRelationshipColumns(makePool({ tables: PRINCIPAL_TABLES, probe: true }), 'principal');
+    expect(out).toEqual({ hasOwner: ['Yes', 'No'] });
+  });
+
+  it('omits a field when the probe finds no data', async () => {
+    const out = await advertiseRelationshipColumns(makePool({ tables: PRINCIPAL_TABLES, probe: false }), 'principal');
+    expect(out).toEqual({});
+  });
+
+  it('omits a field when the required table is absent', async () => {
+    const out = await advertiseRelationshipColumns(makePool({ tables: new Set() }), 'principal');
+    expect(out).toEqual({});
+  });
+
+  it('omits a field when the probe throws', async () => {
+    const out = await advertiseRelationshipColumns(makePool({ tables: RESOURCE_TABLES, throwOn: 'SELECT EXISTS' }), 'resource');
+    expect(out).toEqual({});
+  });
+});

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -3,6 +3,7 @@ import { timedQuery } from '../perf/sqlTimer.js';
 import { createParams } from '../db/sqlParams.js';
 import { parseJsonbColumn } from '../lib/jsonb.js';
 import { buildOrderBy } from '../lib/listSort.js';
+import { applyRelationshipFilters, advertiseRelationshipColumns } from '../lib/relationshipFilters.js';
 import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
 import { ensureTagTables, buildFilterWhere, parseTags } from './tags.js';
 import { UUID_RE, cleanRow, getPermissionTable } from './details/shared.js';
@@ -102,6 +103,11 @@ router.get('/resources', async (req, res) => {
         INNER JOIN "GraphTagAssignments" _rta ON _rta."entityId" = UPPER(r.id::text)
         INNER JOIN "GraphTags" _rt ON _rta."tagId" = _rt.id AND _rt."name" = ${bind(resourceTagFilter)} AND _rt."entityType" IN ('resource', 'group')`;
     }
+    // Relationship filters (hasOwner / hasMembers) consume their own keys first,
+    // then the remaining attribute filters go through buildFilterWhere. The
+    // relationship fragment binds no params, so the countParams snapshot below
+    // stays correct.
+    where += await applyRelationshipFilters(p, 'resource', attrFilters, 'r');
     where += buildFilterWhere(attrFilters, colNames, 'r', bind);
 
     // Returns every Resources column so the same endpoint feeds the UI grid
@@ -484,6 +490,10 @@ router.get('/resource-columns', async (req, res) => {
       const resourceTags = tagResult.rows.map(r => r.name);
       grouped['__resourceTag'] = schemaOnly ? [] : resourceTags;
     } catch (e) { if (!isMissingSchema(e)) throw e; /* tag tables may not exist yet */ }
+
+    // Advertise relationship filters ("Has owner" / "Has members") when the data
+    // exists. Static Yes/No values, so they surface even in schema-only mode.
+    Object.assign(grouped, await advertiseRelationshipColumns(p, 'resource'));
 
     return res.json(Object.entries(grouped).map(([column, values]) => ({ column, values })));
   } catch (err) {

--- a/app/api/src/routes/tags/entities.js
+++ b/app/api/src/routes/tags/entities.js
@@ -11,6 +11,7 @@ import { getResourceColumns as getResourceCols, getPrincipalOrUserColumns, getPr
 import { createParams } from '../../db/sqlParams.js';
 import { parseJsonbColumn } from '../../lib/jsonb.js';
 import { buildOrderBy } from '../../lib/listSort.js';
+import { applyRelationshipFilters, advertiseRelationshipColumns } from '../../lib/relationshipFilters.js';
 import { useSql, db, ensureTagTables, buildFilterWhere, UUID_RE, parseTags } from './shared.js';
 
 const router = Router();
@@ -47,6 +48,9 @@ router.get('/user-columns-page', async (req, res) => {
       const userTags = tagResult.rows.map(r => r.name);
       if (userTags.length > 0) grouped['__userTag'] = userTags;
     } catch { /* tag tables may not exist yet */ }
+
+    // Advertise relationship filters (e.g. "Has owner") when the data exists.
+    Object.assign(grouped, await advertiseRelationshipColumns(p, 'principal'));
 
     return res.json(Object.entries(grouped).map(([column, values]) => ({ column, values })));
   } catch (err) {
@@ -149,6 +153,11 @@ router.get('/users', async (req, res) => {
         INNER JOIN "GraphTagAssignments" _uta ON _uta."entityId" = UPPER(u.id::text)
         INNER JOIN "GraphTags" _ut ON _uta."tagId" = _ut.id AND _ut."name" = ${bind(userTagFilter)} AND _ut."entityType" = 'user'`;
     }
+    // Relationship filters (e.g. hasOwner=No) consume their own keys, then the
+    // remaining attribute filters go through buildFilterWhere. Both append to
+    // `where` before the countParams snapshot; the relationship fragment binds
+    // no params so the COUNT query stays correct.
+    where += await applyRelationshipFilters(p, 'principal', attrFilters, 'u');
     where += buildFilterWhere(attrFilters, colNames, 'u', bind);
 
     // Paginate FIRST (cheap), then resolve the per-row tag string only for the

--- a/changes/feature-relationship-filters.md
+++ b/changes/feature-relationship-filters.md
@@ -1,0 +1,4 @@
+- Added relationship filters to the entity lists: you can now filter by whether an object **has** or **lacks** a relationship, not just by attributes on the object itself.
+- On the **AI Agents** (and other principal) list, a new **"Has owner"** filter finds agents that do — or do not — have an owner.
+- On the **Resources / groups** list, new **"Has owner"** and **"Has members"** filters find, for example, groups without an owner or groups without any members.
+- The filters appear in the normal **"+ Add filter"** control (values **Yes** / **No**) and combine with your other filters; they only show up when the underlying relationship data exists.

--- a/docs/architecture/relationship-filters.md
+++ b/docs/architecture/relationship-filters.md
@@ -1,0 +1,63 @@
+# Relationship Filters
+
+The entity list pages (Principals / AI Agents, Resources / Groups) let you filter
+not only by **attributes on the object** (name, department, resource type, …) but
+also by whether the object **has or lacks a relationship** to something else —
+for example "AI agents without an owner", "groups without an owner", or "groups
+without any members".
+
+## Using it
+
+In the list's **"+ Add filter"** control, alongside the attribute fields you'll
+see relationship fields:
+
+| List | Field | Meaning |
+|------|-------|---------|
+| Principals / **AI Agents** | **Has owner** | The principal has (Yes) / lacks (No) an owner |
+| Resources / **Groups** | **Has owner** | The resource has (Yes) / lacks (No) an owner |
+| Resources / **Groups** | **Has members** | The resource has (Yes) / lacks (No) members |
+
+Pick the field, choose **Yes** or **No**, and it combines (AND) with your other
+filters. A relationship field only appears when the underlying data exists in the
+tenant (e.g. "Has owner" shows once any owner relationships have been crawled).
+
+To find ownerless AI agents: open **AI Agents**, add **Has owner = No**.
+
+## How it maps to the data model
+
+Relationship filters are a **read/query-layer** feature — no schema change. Each
+filter is translated to an `EXISTS` (Yes) / `NOT EXISTS` (No) subquery over the
+relationship tables that already hold the data:
+
+- **Principal "Has owner"** → `PrincipalRelationships` with
+  `relationshipType = 'Owner'` (the AI-agent / guest owner link, migration 057).
+- **Resource "Has owner"** → a `Direct` assignment on the object's synthetic
+  ownership resource (`GroupOwnership` / `ServicePrincipalOwnership` /
+  `ApplicationOwnership`) reached via a `HasOwnership` / `HasAppOwnership`
+  relationship. Covers both group ownership and app / service-principal
+  ownership.
+- **Resource "Has members"** → a live `Direct` `ResourceAssignments` row on the
+  resource, excluding the ownership assignment (an owner is not a member) and
+  soft-deleted rows. This mirrors the existing member-count definition. A nested
+  subgroup counts as a member (it is itself a `Direct` member), so a group whose
+  members arrive only via nesting is correctly **not** reported as memberless.
+
+The mechanism is generic: new relationship filters are added by extending the
+spec in `app/api/src/lib/relationshipFilters.js` (a domain entry with a
+predicate, an existence probe, and the tables it needs). The filter fields are
+advertised to the UI from the column-discovery endpoints, so no UI code changes
+are needed to surface a new one.
+
+### Wire format
+
+Relationship filters travel in the same `?filters=<json>` query parameter as
+attribute filters, as plain keys with a `Yes` / `No` value, e.g.
+
+```
+GET /api/users?filters={"principalType":"AIAgent","hasOwner":"No"}
+GET /api/resources?filters={"resourceType":"Group","hasMembers":"No"}
+```
+
+An unrecognised value is ignored (the filter becomes a no-op), and a filter whose
+backing table is absent on an older deployment is skipped rather than failing the
+request.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
           - Portable Windows Launcher: architecture/desktop-portable.md
           - Release & Branching Strategy: architecture/branching-strategy.md
           - Ingest API: architecture/ingest-api.md
+          - Relationship Filters: architecture/relationship-filters.md
           - Audit History: architecture/audit-history.md
           - Soft-Delete & Tombstones: architecture/soft-delete.md
           - Matrix Scope Statistics: architecture/matrix-scope-statistics.md


### PR DESCRIPTION
## What

Adds **relationship / reference filters** to the entity list pages — filter by whether an object *has* or *lacks* a relationship, not just by an attribute on the object itself.

- **AI Agents / Principals** — new **Has owner** filter → find agents that do / don't have an owner.
- **Resources / Groups** — new **Has owner** and **Has members** filters → e.g. groups without an owner, groups without members.
- Filters appear in the normal **"+ Add filter"** control (values **Yes** / **No**), combine with other filters, and only show when the underlying data exists.

## How

Pure **query-layer** feature — **no schema change, no migration, no UI code**:

- Single source of truth in `app/api/src/lib/relationshipFilters.js`: a per-domain spec → `EXISTS` / `NOT EXISTS` predicate, mirroring the existing virtual-key (`__*Tag`) pattern. Route handlers gain one call each (keeps them under the complexity ratchet; SQL lives in the helper to avoid a jscpd clone).
- Filter fields are **advertised from the column-discovery endpoints** and humanize to clean labels ("Has owner"), so the data-driven filter bar surfaces them with zero React changes.
- **Existence-guarded**: a filter whose backing table is absent on an older deployment is skipped, so a browser-persisted filter never 500s the list.

Definitions (ratified in the DoR sign-off): agent owner = `PrincipalRelationships` Owner; resource owner = Direct assignment on the synthetic ownership resource via `HasOwnership`/`HasAppOwnership`; member = live `Direct` `ResourceAssignments`, ownership + soft-deleted excluded (mirrors the existing member-count).

## Tests

- Unit (`relationshipFilters.test.js`): every branch — Yes/No/invalid, missing-table & error guards, advertisement, both domains.
- Contract (`relationshipFilters.contract.test.js`, real Postgres): ownerless vs owned agents; empty / owner-only / deleted-member / eligible-only groups; combined filters; field advertisement.

Docs: `docs/architecture/relationship-filters.md` (+ nav). Changelog fragment added.