### PR TITLE
docs: Definition of Ready v3.2 — generative interview + scope battery, validation-data seeding

### DIFF
--- a/docs/process/definition-of-ready.md
+++ b/docs/process/definition-of-ready.md
@@ -1,8 +1,8 @@
-# Definition of Ready v3.1 — the "ready-to-build" process
+# Definition of Ready v3.2 — the "ready-to-build" process
 
-**Purpose.** Produce a spec complete enough that building, testing and documenting run with **zero *functional* human decisions and zero silent *functional* assumptions** — while spending the fewest possible **human touchpoints** getting there. Non-functional decisions (architecture, design/UX, product fit) are not eliminated — they are **routed to the role that owns them**, *batched*, and resolved in as few interactions as possible. *Form* is expected to need a **feedback loop**, because taste is a see-it reaction that can't be fully pre-specified.
+**Purpose.** Produce a spec complete enough that building, testing and documenting run with **zero *functional* human decisions and zero silent *functional* assumptions** — while spending the fewest possible **human round-trips** getting there. Non-functional decisions (architecture, design/UX, product fit) are **routed to the role that owns them**, *batched*, and resolved in as few interactions as possible. *Form* is expected to need a **feedback loop**, because taste is a see-it reaction that can't be fully pre-specified.
 
-**The realistic bar.** "One perfect spec → build once" is reachable for **function**, not **form**. Front-load every *functional* decision; route every *architectural / design / product* decision to its owner; keep human round-trips minimal; treat post-build feedback as a normal, cheap loop.
+**The realistic bar.** "One perfect spec → build once" is reachable for **function**, not **form**. Front-load every *functional* decision; route every *architectural / design / product* decision to its owner; keep round-trips minimal; treat post-build feedback as a normal, cheap loop.
 
 ---
 
@@ -17,7 +17,7 @@ flowchart TD
 
   start([Feature idea]):::req --> pre{PO pre-screen}:::po
   pre -->|no| drop([Park / drop]):::po
-  pre -->|yes| intv[Phase A — Intent interview<br/>ONE sitting incl. time-travel]:::ai
+  pre -->|yes| intv[Phase A — Intent interview<br/>ONE sitting · GENERATIVE · scope battery · time-travel]:::ai
   intv --> probe[Phase B — probe · adversarial · CI dry-run]:::ai
   probe -->|re-probe until nothing new — AI only, no human| probe
   probe --> collate[Collate ONCE: decisions to ratify +<br/>blocking questions grouped by role]:::ai
@@ -28,9 +28,9 @@ flowchart TD
   c1 --> rtb([READY-TO-BUILD + APPROVED]):::po
   c2 --> rtb
   c3 --> rtb
-  rtb --> build[Autonomous build on SK3 → CI green → deploy]:::ai
-  build --> bd([BUILD-DONE]):::ai
-  bd --> val{Functional validation<br/>vs ACs + time-travel criteria}:::req
+  rtb --> build[Autonomous build on SK3<br/>implement · fixture-AC tests · SEED validation data · docs · PR · CI green · deploy]:::ai
+  build --> bd([BUILD-DONE · report ACs + green run]):::ai
+  bd --> val{Requestor functional validation<br/>vs ACs + time-travel criteria}:::req
   val -->|disappointed / form| fb[Feedback = new intent]:::req
   fb --> intv
   val -->|happy| appr[Approve PR → merge → Shipped]:::req
@@ -38,69 +38,78 @@ flowchart TD
 
 ## Roles (lanes)
 
-One human may wear several hats — on a small team the same person is requestor, architect and PO. The point is not headcount; it's that **each question is answered by the right *hat*, a hat with no open question is not consulted, and a hat is touched as few times as possible.**
+One human may wear several hats. The point is not headcount; it's that **each question is answered by the right *hat*, a hat with no open question is not consulted, and a hat is touched as few times as possible.**
 
 | Role | Owns | Answers questions about |
 |------|------|-------------------------|
-| **Requestor** | Intent + functional decisions; the time-travel success/failure criteria | what it should do, for whom, which cases matter, "just another attribute vs. a new surface" |
+| **Requestor** | Intent + functional decisions; scope; the time-travel success/failure criteria | what it should do, for whom, how *complete/general* it should be, "just another attribute vs. a new surface" |
 | **Architect / tech lead** | Technical approach; coherence of the codebase | registry vs engine, additive vs mutate-shared-contract, matview vs query-time, migrations |
 | **Designer** | Form: interaction model, information architecture | how it looks/feels, integrate with an existing control or stand alone |
 | **Product Owner** | Desirability / product coherence — the GO | does this move the product forward or just add complexity/bloat |
 | **Builder (AI)** | Runs Phases A/B, then builds/tests/documents autonomously | — |
 
-## Minimise human round-trips — batch, don't ping-pong  ← the scheduling discipline
+## Minimise human round-trips — batch, don't ping-pong
 
-Every return to a human costs real time (a message, a meeting, a wait). Routing questions to the right role is worthless if it produces *more* interactions. So:
+Every *return* to a human costs real time. Routing to the right role is worthless if it produces *more* interactions. So:
 
-- **Exhaust the AI-resolvable work before touching any human.** The Phase-B probe, adversarial passes and CI dry-run are an **AI-internal loop** (B10) — they are *never* a reason to go back to a person. Iterate them fully first.
-- **Prefer a proposed decision over a question.** If the AI can pick a defensible default from the code/model, record it in the decisions register as *"decided: X (because Y)"* for the owning role to **ratify in bulk**. Only escalate as a **blocking question** what genuinely needs a human's judgment *before* building. Most items should be proposed-decisions, not questions.
-- **Batch by role, ask once.** Group all blocking questions + all decisions-to-ratify by owning role and put them to that role in a **single async packet** — never a trickle of one-at-a-time asks. Fold a role's questions into that role's **sign-off** so answering and signing off are one touch.
-- **One person, one packet.** When the same human wears several hats, do **not** simulate separate meetings — present a single consolidated packet: decisions to ratify + the few must-ask questions (each tagged by hat) + all sign-offs, handled in one sitting.
-- **Async by default.** A human touch is a written packet the person answers on their own time, not a scheduled meeting. Reserve synchronous time only when a decision genuinely needs discussion.
-- **Target: two human touchpoints** — the Phase-A interview, and one consolidated sign-off/GO packet. A second interview round happens only when a genuine cross-role dependency forces it — and even then, present options **with their implications** ("if you pick X, that means Y for you") so the chain resolves in one pass.
+- **Efficiency = few round-trips, not few questions.** This discipline limits how often you *return* to a human — it does **not** thin out the first interview. A *complete* spec reached in two touchpoints beats a *thin* one reached in two touchpoints. Ask freely in the one sitting; batch your *returns*.
+- **Exhaust the AI-resolvable work before touching any human.** The Phase-B probe, adversarial passes and CI dry-run are an **AI-internal loop** — never a reason to go back to a person.
+- **Prefer a proposed decision over a question.** If the AI can pick a defensible default from the code/model, record it for **bulk ratification**. Only escalate as a **blocking question** what genuinely needs a human's judgment. *(But scope-ambition is the requestor's call — surface it, don't default it away; see A8.)*
+- **Batch by role, ask once.** Group all blocking questions + decisions-to-ratify by owning role in a **single async packet**; fold a role's questions into its **sign-off**.
+- **One person, one packet.** When one human wears several hats, present a single consolidated packet, not separate meetings.
+- **Target: two human touchpoints** — the Phase-A interview, and one consolidated sign-off/GO packet.
 
-**Optionality rule.** Only pose a question to a role if a genuine question is *owned* by that role. Do not ask the requestor an architectural question, or any hat for an opinion it doesn't own. Skip hats with no open questions.
+**Optionality rule.** Only pose a question to a role if a genuine question is *owned* by that role. Skip hats with no open questions.
 
 ---
 
-## Phase A — Intent interview (what & why) — one sitting, exhaust it
-Get maximum detail in a single interview so you rarely need to return.
+## Phase A — Intent interview (GENERATIVE, one sitting)
+**Generative, not extractive.** Do not just transcribe the opening description — actively help the requestor find the *best and most complete* version of the feature. An open brain-dump alone tends to **under-scope**; start with the open description, then run the **scope-elicitation battery** below as explicit choices. All of this is touchpoint #1 — no round-trips.
+
 - **A1 Problem & value** — a user/governance question, not a solution; who for; why now.
 - **A2 Scope boundaries** — what it deliberately does NOT do.
 - **A3 Backlog context** — related/precondition/duplicate issues; weighed against the whole backlog.
 - **A4 External dependencies** — known and secured, or N/A.
-- **A5 Architecture fit** — fits the existing architecture, or *raises* an architectural question → tag it for the architect, don't resolve it with the requestor.
+- **A5 Architecture fit** — fits the existing architecture, or *raises* an architectural question → tag for the architect, don't resolve with the requestor.
 - **A6 Documentation needs.**
-- **A7 Time-travel pre-mortem (Rob's question).** *"We fast-forward to the moment I show you the finished feature. You're delighted because…? You're disappointed because…?"* The "disappointed because" answers become explicit acceptance/rejection criteria — this is where *form* preferences surface before code.
+- **A7 Time-travel pre-mortem (Rob's question).** *"We fast-forward to the moment I show you the finished feature. You're delighted because…? You're disappointed because…?"* The "disappointed because" answers become explicit accept/reject criteria — where *form* preferences surface before code.
+- **A8 Scope-elicitation battery (ask as explicit choices).** These dimensions most change what gets built; surface each and let the requestor include or *consciously* defer it — never default it away silently:
+  - **Generality** — a specific case, or a general capability? (Name the first case as the example, but pin the scope the requestor actually wants — build the general version if that's the intent.)
+  - **Operation completeness** — beyond the minimal operation, the full set? (e.g. existence → count/threshold → range; view → edit; single → bulk.)
+  - **Symmetry & variants** — inverse directions, related entities, adjacent cases the same mechanism naturally covers.
+  - **Surface / reach** — one page, or everywhere the pattern exists?
+  - **Adjacent / phase-2 opportunity** — a natural bigger or reusable version (persist / save / reuse) worth acknowledging, even if deferred to a follow-up.
+  - **Driver & priority** — what's pushing it now (frames the issue and the cut line).
+
+**Pin the chosen scope explicitly** (feeds B4). A minimal cut is fine — but as a *conscious choice*, never a silent default.
 
 ## Phase B — Build-readiness probe (AI-internal; no human until it's exhausted)
-Intent is fixed. **Draft the actual implementation against the real code and schema — far enough to hit the walls.** An implementation dry-run, not a re-read.
-- **B1 Trace every value to its real storage** — write the real query; multi-hop → write the join path; not modelled as assumed (derived / blob / N hops / premise self-refuted) → raise it.
-- **B2 Enumerate consumers** of every shared contract/function/wire-format/table/component touched, with the compatibility approach for each.
-- **B3 Resolve every choice to one option** — no "A or B", no "TBD". Includes **UX-shaping words** ("alongside / integrated / shared / inline") — resolve them explicitly.
-- **B4 Pin the exact scope set** — the concrete list.
+Intent is fixed. **Draft the actual implementation against the real code and schema — far enough to hit the walls.** A dry-run, not a re-read.
+- **B1 Trace every value to its real storage** — write the real query; multi-hop → write the join path; not modelled as assumed → raise it.
+- **B2 Enumerate consumers** of every shared contract/function/wire-format/table/component touched.
+- **B3 Resolve every choice to one option** — no "A or B", no "TBD". Includes **UX-shaping words** ("alongside / integrated / inline").
+- **B4 Pin the exact scope set** — the concrete list, matching the scope chosen in A8.
 - **B5 Delivery decomposition** — one PR or a required stack, and the order.
-- **B6 Adversarial pass (independent)** — *"find where this spec contradicts the real code/schema — assume a hidden hop, an unlisted consumer, an unhandled empty/edge case, or an ambiguous UX word."*
+- **B6 Adversarial pass (independent)** — *"find where this spec contradicts the real code/schema — hidden hop, unlisted consumer, unhandled empty/edge case, ambiguous UX word."*
 - **B7 Dry-run the CI / Definition of Done** (appendix) — not just the schema.
-- **B8 Classify each open item** as a **proposed decision** (AI default → ratify in bulk) or a **blocking question** (needs human judgment). Tag each by owning role. Minimise blocking questions.
-- **B9 Outputs:** **decisions register** (each entry: decision + reason + owning role, marked ratify/blocking) · **fixture-backed ACs** (input → expected output vs the REAL model; incl. empty/zero/error) · **form artifact** for UI (interaction spec / mock) · **test plan** that keeps the ratchets green · **docs + changelog targets.**
-- **B10 Loop** the probe + adversarial pass until a pass surfaces nothing new — **all AI, no human.**
+- **B8 Classify each open item** as a **proposed decision** (ratify in bulk) or a **blocking question**; tag each by owning role.
+- **B9 Outputs:** **decisions register** (decision + reason + owning role, ratify/blocking) · **fixture-backed ACs** (input → expected output vs the REAL model; incl. empty/zero/error) · **validation-data plan** (what representative data — instances *with* and *without* the condition — must be seeded so the requestor can actually exercise the feature) · **form artifact** for UI · **test plan** · **docs + changelog targets.**
+- **B10 Loop** the probe + adversarial pass until a pass surfaces nothing new — all AI, no human.
 
 ## Phase C — Consolidated sign-off (batched; one packet if one person)
-Present the collated output as a **single packet**, batched per role. Answering a role's batched questions and taking its sign-off are the **same touch**.
-- **C1 Requestor** — answers any batched functional questions, confirms the functional summary + time-travel criteria ⇒ *functional* `ready-to-build`.
-- **C2 Architect** — answers batched architectural questions, signs off the technical approach ⇒ *technical* ready. The technical-coherence gate against spaghetti.
-- **C3 Product Owner** — GO: moves the product forward vs. adds bloat ⇒ `approved`. Only now may autonomous build start. (Designer confirms the form artifact here too.)
+Present the collated output as a **single packet**, batched per role. Answering a role's questions and taking its sign-off are the **same touch**.
+- **C1 Requestor** — answers batched functional questions, confirms the functional summary + scope + time-travel criteria ⇒ *functional* `ready-to-build`.
+- **C2 Architect** — answers batched architectural questions, signs off the technical approach ⇒ *technical* ready.
+- **C3 Product Owner** — GO ⇒ `approved`. Only now may autonomous build start. (Designer confirms the form artifact here too.)
 
 ## Phase D — Build, validate, and the feedback loop (first-class)
-- **D1 Autonomous build** on SK3: implement, fixture-AC tests, docs, changelog, PR, CI green, deploy ⇒ `build-done`.
-- **D2 Functional validation** by the requestor against the fixture ACs **and the time-travel criteria** — check the numbers and the "disappointed because" list, not just "does it run."
-- **D3 Feedback loop.** Disappointment (usually *form*) is captured as **new intent** and re-enters at Phase A. Expected and cheap — the point of cheap building. Happy ⇒ approve PR ⇒ merge.
+- **D1 Autonomous build** on SK3: implement, run the fixture-AC tests, **seed the representative validation data** (instances with and without the condition, per the B9 plan) so the feature can actually be exercised, docs, changelog, PR, CI green, deploy ⇒ `build-done`. The build-done handoff **reports the acceptance criteria and their green test run** (the fixture-AC contract test file + result), so real testing is visible and distinct from manual validation.
+- **D2 Functional validation** by the requestor against the fixture ACs **and the time-travel criteria** — check the numbers and the "disappointed because" list, using the seeded data.
+- **D3 Feedback loop.** Disappointment (usually *form*, sometimes *missed scope*) is captured as **new intent** and re-enters at Phase A. Expected and cheap. Happy ⇒ approve PR ⇒ merge.
 
 ---
 
 ## Appendix — Definition of Done the probe must design against
-Standing repo gates (design against these in B7; they are knowable, so must not be mid-build surprises):
 - **Coverage** — aggregate + per-file ratchet (only up) + diff-coverage. New code ships with tests.
 - **File size** — >1000 lines must split; >600 is a smell.
 - **Complexity** — per-unit cyclomatic + cognitive ratchets; new/touched units under the per-language threshold.
@@ -111,12 +120,13 @@ Standing repo gates (design against these in B7; they are knowable, so must not 
 - **Changelog** — a fragment under `changes/` for functional changes (never edit `CHANGES.md`; docs-only needs none).
 - **Merge** — 1 approval; never admin-merge.
 
-**Baseline precondition.** Verify `main` (and the target Sidekick) is green *before* starting. A pre-existing failure (e.g. a transitive npm-audit advisory) is repo debt, not a feature defect — fix it as a disclosed separate chore.
+**Baseline precondition.** Verify `main` (and the target Sidekick) is green *before* starting. A pre-existing failure is repo debt, not a feature defect — fix it as a disclosed separate chore.
 
 ## The bar
-A fresh builder given ONLY the spec builds, tests and documents it with **zero functional decisions and zero silent functional assumptions**, reached with **≈two human touchpoints**; end-validation is mechanical against the fixture ACs + time-travel criteria. Architectural/design/product decisions were made by their owners, batched. Residual *form* gaps go through the D3 feedback loop.
+A fresh builder given ONLY the spec builds, tests and documents it with **zero functional decisions and zero silent functional assumptions**, reached with **≈two human touchpoints** — and the spec is the **complete** version the requestor actually wanted, not the floor. End-validation is mechanical against the fixture ACs + time-travel criteria, using seeded data. Residual *form* gaps go through the D3 feedback loop.
 
 ## Version history (generalized lessons)
 - **v1 → v2:** "no open design questions" was satisfiable by *review*; v2 requires an *executed* build-readiness probe. Added consumer-enumeration, no-A-or-B, pinned scope, adversarial pass, fixture ACs.
 - **v2 → v3:** v2 collapsed a product team into "the requestor." Added role-routing, the time-travel pre-mortem, a form artifact for UI, CI/DoD dry-run, and a first-class feedback loop.
-- **v3 → v3.1:** role-routing without batching risks *human ping-pong*. Added the **round-trip discipline** — exhaust AI-internal work first; prefer proposed-decisions over questions; batch per role; one consolidated packet (one packet when one person wears the hats); target ≈two human touchpoints.
+- **v3 → v3.1:** role-routing without batching risks *human ping-pong*. Added the round-trip discipline — exhaust AI work first, prefer proposed-decisions, batch per role, one packet, ≈two touchpoints.
+- **v3.1 → v3.2:** the efficiency discipline *starved the interview* — a from-scratch run built a thin feature (2 edges, existence-only) because Phase A was extractive. Clarified **efficiency = few round-trips, not few questions**; made Phase A **generative** with a **scope-elicitation battery** (generality / operation-completeness / symmetry / surface / phase-2 / driver); required **validation-data seeding** on the Sidekick so the requestor can actually test; and **AC-result transparency** at build-done.


### PR DESCRIPTION
Follow-up to #860. A from-scratch round-3 run exposed that v3.1's round-trip discipline had over-corrected: Phase A became *extractive* (record the ask, default the rest) and shipped a thin feature — 2 relationships, existence-only — where the original richer interview had produced generality + count + both-directions + a phase-2. Efficiency starved scope.

**v3.2 changes**
- **Efficiency = few round-trips, not few questions.** The discipline limits *returns* to humans; it must not thin the first interview.
- **Generative Phase A + scope-elicitation battery** — generality / operation-completeness / symmetry / surface-reach / phase-2 / driver — asked as explicit choices; scope is pinned *consciously*, never silently defaulted to the floor.
- **Validation-data seeding** — the build seeds representative data (instances with and without the condition) so the requestor can actually exercise the feature (fixes "nothing to test against").
- **AC transparency at build-done** — report the acceptance criteria + their green run, so real (self-seeding contract) testing is visible and distinct from manual validation.

Docs-only, no changelog fragment. Related: #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)