### PR TITLE
fix(ui): render tagged entity-list rows (isDark not defined crash)

### DIFF
--- a/app/ui/src/components/EntityListPage.jsx
+++ b/app/ui/src/components/EntityListPage.jsx
@@ -251,6 +251,7 @@ export default function EntityListPage({
         renderEntityCell={renderEntityCell}
         renderDataCells={renderDataCells}
         onOpenDetail={onOpenDetail}
+        isDark={isDark}
       />
 
       {/* Pagination */}
@@ -284,7 +285,7 @@ export default function EntityListPage({
 
 // The list body's four states (loading / error / empty / table) are their
 // own component so EntityListPage's render stays under the complexity ceiling.
-function EntityListTable({ ep, label, tableColumns, renderEntityCell, renderDataCells, onOpenDetail }) {
+function EntityListTable({ ep, label, tableColumns, renderEntityCell, renderDataCells, onOpenDetail, isDark }) {
   return (
     ep.loading ? (
         <div className="text-center text-gray-500 dark:text-gray-400 py-12">Loading {label}...</div>

--- a/app/ui/src/components/EntityListPage.mount.test.jsx
+++ b/app/ui/src/components/EntityListPage.mount.test.jsx
@@ -88,6 +88,36 @@ describe('EntityListPage pagination', () => {
     // tagPillStyle emits a solid tint + an AA-safe text colour instead.
     expect(style).not.toContain('#1d4ed820');
   });
+
+  it('renders a row whose entity carries tags without crashing (#762)', async () => {
+    // Regression guard: the extracted EntityListTable renders per-row tag pills via
+    // tagPillStyle(t.color, isDark). isDark was declared only in the parent and was
+    // not threaded into the child, so rendering any *tagged row* threw
+    // `ReferenceError: isDark is not defined`. The other tests never tripped it
+    // because their list items had no `tags`; this one gives the item a tag.
+    const af = makeAuthFetch((url) => {
+      const s = String(url);
+      if (s.includes(COLUMNS)) return [];
+      if (s.includes('/api/tags')) return [];
+      if (s.includes(LIST)) {
+        return {
+          data: [{ id: '1', displayName: 'Bob', tags: [{ id: 'r1', name: 'Prod', color: '#1d4ed8' }] }],
+          total: 1,
+        };
+      }
+      return undefined;
+    });
+
+    renderPage(af);
+
+    // The row renders (pre-fix this threw during render and hit the error boundary).
+    expect(await screen.findByText('Bob')).toBeInTheDocument();
+    // The per-row tag pill is styled via tagPillStyle — solid tint, not the alpha hack.
+    const rowPill = screen.getByText('Prod');
+    const style = rowPill.getAttribute('style') || '';
+    expect(style).toMatch(/background-color/);
+    expect(style).not.toContain('#1d4ed820');
+  });
 });
 
 describe('EntityListPage error state (audit H6)', () => {

--- a/changes/fix-entity-list-isdark-tag-pill.md
+++ b/changes/fix-entity-list-isdark-tag-pill.md
@@ -1,0 +1,1 @@
+- Fixed a crash ("Something went wrong — isDark is not defined") when opening the Resources list, or any entity list containing tagged rows, in either light or dark mode. Tagged rows now render with correctly themed tag pills.


### PR DESCRIPTION
## Summary
The Resources list — and any entity list containing **tagged** rows — crashed into the app error boundary with **"Something went wrong — isDark is not defined"** (client-side `ReferenceError`, thrown during render).

## Root cause
`EntityListTable` was extracted out of `EntityListPage` to keep the parent render under the complexity ceiling. The extraction dropped `isDark` from the child's props, but its per-row tag pill still calls `tagPillStyle(t.color, isDark)`. `isDark` is only declared in the parent (`const isDark = useIsDark()`), so it's undeclared in `EntityListTable` → `ReferenceError`, thrown the moment a tagged row renders. Untagged lists never trip it, which is why it looked Resources-specific.

Regression window: introduced between v5.465 and v5.501 (the extraction), matching the reported broken/working builds.

## Fix
Thread `isDark` from `EntityListPage` into `EntityListTable`. Audited every other `tagPillStyle` call site (`UserDetailPage`, `ResourceDetailPage`, `AccessPackageDetailPage`, `AccessPackagesPage`) — all correctly obtain `isDark` from `useIsDark()`; only the extracted child was missing it.

## Test
Added a mount test that renders a row whose entity carries a tag and asserts it renders without throwing. Verified it **fails** (throws) without the fix and **passes** with it. The pre-existing tag-pill test only exercised the filter-bar pill in the parent (where `isDark` was in scope), which is why the bug shipped past backend-only nightly verification.

## Notes
- The customer release line (v5.465) predates the regression, so they're **not affected** — but any upgrade past the regressed commit would hit it. This fix should reach that line before they upgrade.
- Once merged, `:edge` advances past v5.501 and the public demo picks it up on its next nightly reseed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)