### PR TITLE
ci(ui): enable no-undef lint + e2e for tagged list rows (catch #762 class)

### DIFF
--- a/app/ui/e2e/groups-page.spec.js
+++ b/app/ui/e2e/groups-page.spec.js
@@ -51,3 +51,54 @@ test.describe('Groups Page', () => {
     }
   });
 });
+
+// Renders the resources list with a *tagged* row in a real browser. Regression
+// guard for #762: the per-row tag pill lives in the extracted EntityListTable
+// and calls tagPillStyle(t.color, isDark); when `isDark` wasn't threaded into
+// that child it threw `ReferenceError: isDark is not defined` during render,
+// collapsing the whole page into the "Something went wrong" error boundary.
+// The tag-lifecycle suite (tags.spec.js) is API-only and never rendered a row,
+// so nothing in CI exercised this path.
+test.describe('Resources list — tagged row rendering (#762)', () => {
+  const API = 'http://localhost:3001/api';
+  const TAG_NAME = 'e2e-tagged-row-render';
+
+  test('a resource carrying a tag renders its pill without hitting the error boundary', async ({ page, request }) => {
+    // Seed: create a tag and assign it to a real resource via the API.
+    const createRes = await request.post(`${API}/tags`, {
+      data: { name: TAG_NAME, entityType: 'resource', color: '#1d4ed8' },
+    });
+    if (!createRes.ok()) test.skip(true, 'tag API unavailable');
+    const tag = await createRes.json();
+    const tagId = tag.id;
+
+    try {
+      const resRes = await request.get(`${API}/resources?limit=1`);
+      const resBody = await resRes.json();
+      const resources = Array.isArray(resBody) ? resBody : (resBody.data ?? []);
+      if (resources.length === 0) test.skip(true, 'no resources seeded');
+      const resource = resources[0];
+      const resourceName = resource.name || resource.displayName;
+
+      const assignRes = await request.post(`${API}/tags/${tagId}/assign`, {
+        data: { entityIds: [resource.id] },
+      });
+      expect(assignRes.ok()).toBeTruthy();
+
+      // Render the list and narrow to the tagged resource by name.
+      await page.goto('/#groups');
+      await page.getByPlaceholder(/Search by resource name/i).fill(resourceName);
+      await page.waitForTimeout(600); // debounced search
+
+      const table = page.locator('table').first();
+      await expect(table).toBeVisible({ timeout: 5000 });
+      // The row's tag pill (scoped to the table so we don't match the filter-bar
+      // pill, which lives in the parent where isDark was always in scope).
+      await expect(table.getByText(TAG_NAME).first()).toBeVisible({ timeout: 5000 });
+      // The page did NOT fall into the error boundary.
+      await expect(page.getByText('Something went wrong')).toHaveCount(0);
+    } finally {
+      await request.delete(`${API}/tags/${tagId}`);
+    }
+  });
+});

--- a/app/ui/eslint.config.js
+++ b/app/ui/eslint.config.js
@@ -60,6 +60,16 @@ export default [
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      // Core correctness rule: flag references to identifiers that aren't
+      // declared in scope. This is the cheapest gate against a whole class of
+      // bugs — a typo'd variable, or a value used inside an extracted child
+      // component without being threaded in as a prop. A dropped `isDark` prop
+      // in EntityListPage's extracted table row (#762) reached production
+      // precisely because this rule was off; it renders as a client-side
+      // `ReferenceError` the moment the affected branch is hit. Kept as an
+      // explicit rule rather than pulling in all of `@eslint/js` recommended,
+      // so the ruleset stays intentional.
+      'no-undef': 'error',
       'local/no-low-contrast-text': 'error',
       // Flags two plain dark: utilities setting the same color property (the
       // audit's C1/C2/M6 class — the later one silently wins). The missing-hover
@@ -101,6 +111,23 @@ export default [
     // banned terms (as patterns / assertions / test names) — don't flag them.
     files: ['eslint-rules/**', '**/*.test.{js,jsx}', 'e2e/**'],
     rules: { 'local/no-legacy-jargon': 'off' },
+  },
+  {
+    // Vitest/jsdom unit + mount tests reference Node globals: `global` (jsdom
+    // env shims) and `Buffer` (byte assertions in the Excel-export tests).
+    // Merge Node globals on top of the browser set so `no-undef` doesn't flag
+    // them. (Flat config merges languageOptions across matching blocks.)
+    files: ['**/*.test.{js,jsx}', 'src/__tests__/**/*.{js,jsx}', 'src/test-utils/**/*.{js,jsx}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+  {
+    // Build/test tooling configs run in Node (`process`, `__dirname`, …).
+    files: ['*.config.{js,ts}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
   },
   {
     // Playwright E2E tests run in Node.js, not the browser

--- a/changes/lint-no-undef.md
+++ b/changes/lint-no-undef.md
@@ -1,0 +1,2 @@
+- Hardened the UI build so undefined-variable bugs (like a value used in a component without being passed in) now fail linting in CI instead of shipping as a runtime crash.
+- Added an end-to-end test that renders a resource list containing a tagged row, guarding against the tag-pill render crash from reaching production again.


### PR DESCRIPTION
Stacked on #865. Closes the CI gaps that let the `isDark is not defined` crash (#762) reach production. **Base = `bugfixes/entity-list-isdark`; retarget to `main` once #865 merges.**

## Why it wasn't caught
Traced the crash to commit `6cedefcb5` (PR #821 / #759, "contrast-safe tag/category pills"): a mechanical swap of the `color + '20'` alpha hack → `tagPillStyle(hex, isDark)` at all 7 pill sites. Six sites had `isDark` in scope; the 7th — the per-row pill inside the extracted `EntityListTable` child — did not, and the prop wasn't threaded in. Three gates all missed it:

1. **`no-undef` was disabled.** The flat ESLint config never loads `@eslint/js` recommended, so an undeclared identifier was invisible to lint.
2. **No unit test rendered a tagged row.** Every mount-test item had no `tags`, so the row-pill `.map` never ran.
3. **The e2e safety net doesn't render a tagged row.** `tags.spec.js` is API-only.

## Changes
- **Enable `no-undef`** in `app/ui/eslint.config.js`, with Node-globals overrides for vitest/jsdom tests (`global`, `Buffer`) and build/tooling configs (`process`, `__dirname`). The only *real* violation the rule surfaces is the bug itself. Verified `npm run lint` **fails** on the bug shape (`'isDark' is not defined`) and is otherwise **green**.
- **New e2e** in `groups-page.spec.js`: seeds a tag, assigns it to a resource, renders `#groups`, and asserts the row tag pill shows without hitting the "Something went wrong" boundary.
- (Gap #2 — a mount test that renders a tagged row — is in the base branch #865.)

## Scope note
Enabled `no-undef` specifically rather than all of `@eslint/js` recommended, to keep the ruleset intentional and the fallout bounded. Adopting the full recommended set could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)