### PR TITLE
feat: filter entity lists by references (relationships)

### DIFF
--- a/app/api/contract-tests/referenceFilters.contract.test.js
+++ b/app/api/contract-tests/referenceFilters.contract.test.js
@@ -1,0 +1,312 @@
+// Contract test — reference-field (relationship) filters against a real
+// PostgreSQL schema, end-to-end through the live route handlers.
+//
+// Covers the 12 acceptance criteria agreed in the Definition-of-Ready packet:
+// existence/threshold operators, single-valued (manager) cardinality, all-type
+// member counting, 2-hop group owners, inverse directions, sponsors, dynamic
+// per-sub-tab discovery, soft-delete exclusion, bulk-tag parity, and fail-closed
+// handling of unknown keys/values.
+//
+// Isolation on the shared contract DB: every row this test asserts on carries a
+// unique search marker M and a unique principalType/resourceType, so list
+// queries (search=M + type) and scoped discovery see ONLY this test's rows.
+// beforeAll seeds; afterAll deletes everything it created.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'crypto';
+import { bootContractApp } from '../test-utils/contractApp.js';
+
+let agent;
+let pool;
+let systemId;
+let tagId;
+
+const S = randomUUID().slice(0, 8);
+const M = `REF-${S}`;                 // display-name search marker
+const AGENT = `AIAgent-${S}`;         // unique principalType for agents
+const USER = `User-${S}`;             // unique principalType for users
+const GROUP = `Group-${S}`;           // unique resourceType for groups
+
+const ids = {};
+
+async function addPrincipal(name, { type = USER, managerId = null, deleted = false } = {}) {
+  const r = await pool.query(
+    `INSERT INTO "Principals" ("systemId","displayName","email","principalType","managerId","deletedAt")
+     VALUES ($1,$2,$3,$4,$5,$6) RETURNING id`,
+    [systemId, `${M} ${name}`, `${name}-${S}@example.test`, type, managerId, deleted ? new Date() : null],
+  );
+  return r.rows[0].id;
+}
+async function addRel(subjectId, relatedId, relationshipType) {
+  await pool.query(
+    `INSERT INTO "PrincipalRelationships" ("principalId","relatedPrincipalId","relationshipType","systemId")
+     VALUES ($1,$2,$3,$4)`,
+    [subjectId, relatedId, relationshipType, systemId],
+  );
+}
+async function addResource(name, { type = GROUP, marker = true } = {}) {
+  const r = await pool.query(
+    `INSERT INTO "Resources" ("systemId","displayName","resourceType") VALUES ($1,$2,$3) RETURNING id`,
+    [systemId, marker ? `${M} ${name}` : name, type],
+  );
+  return r.rows[0].id;
+}
+async function addAssignment(resourceId, principalId, type, { deleted = false } = {}) {
+  await pool.query(
+    `INSERT INTO "ResourceAssignments" ("resourceId","principalId","assignmentType","systemId","deletedAt")
+     VALUES ($1,$2,$3,$4,$5)`,
+    [resourceId, principalId, type, systemId, deleted ? new Date() : null],
+  );
+}
+async function addOwnership(groupId, ownerPrincipalId) {
+  const ow = await addResource('ownership', { type: `${GROUP}-own`, marker: false });
+  await pool.query(
+    `INSERT INTO "ResourceRelationships" ("parentResourceId","childResourceId","relationshipType","systemId")
+     VALUES ($1,$2,'HasOwnership',$3)`,
+    [groupId, ow, systemId],
+  );
+  await addAssignment(ow, ownerPrincipalId, 'Direct');
+}
+
+// GET the id set for a filtered list, scoped to this test's rows via search=M.
+async function userIds(filters) {
+  const res = await agent.get('/api/users')
+    .query({ search: M, filters: JSON.stringify(filters), limit: 1000 });
+  expect(res.status).toBe(200);
+  return new Set(res.body.data.map((r) => r.id));
+}
+async function resourceIds(filters) {
+  const res = await agent.get('/api/resources')
+    .query({ search: M, filters: JSON.stringify(filters), limit: 1000 });
+  expect(res.status).toBe(200);
+  return new Set(res.body.data.map((r) => r.id));
+}
+
+beforeAll(async () => {
+  ({ agent, pool } = await bootContractApp());
+  const sys = await pool.query(
+    `INSERT INTO "Systems" ("systemType","displayName") VALUES ('test',$1) RETURNING id`,
+    [`contract-reffilters-${S}`],
+  );
+  systemId = sys.rows[0].id;
+
+  // Owners / manager targets (users)
+  ids.owner1 = await addPrincipal('owner1');
+  ids.owner2 = await addPrincipal('owner2');
+  ids.owner3 = await addPrincipal('owner3');
+  ids.ownerDeleted = await addPrincipal('ownerDeleted', { deleted: true });
+
+  // Agents with 0/1/2/3 owners (+ one whose sole owner is soft-deleted)
+  ids.A1 = await addPrincipal('agentA1', { type: AGENT });   // 1 owner
+  ids.A2 = await addPrincipal('agentA2', { type: AGENT });   // 0 owners
+  ids.A3 = await addPrincipal('agentA3', { type: AGENT });   // 2 owners
+  ids.A4 = await addPrincipal('agentA4', { type: AGENT });   // 3 owners
+  ids.A5 = await addPrincipal('agentA5', { type: AGENT });   // 1 owner, but deleted
+  await addRel(ids.A1, ids.owner1, 'Owner');
+  await addRel(ids.A3, ids.owner1, 'Owner');
+  await addRel(ids.A3, ids.owner2, 'Owner');
+  await addRel(ids.A4, ids.owner1, 'Owner');
+  await addRel(ids.A4, ids.owner2, 'Owner');
+  await addRel(ids.A4, ids.owner3, 'Owner');
+  await addRel(ids.A5, ids.ownerDeleted, 'Owner');           // owner tombstoned → counts as 0
+
+  // Users: manager present/absent, a manager with a report, an agent owner
+  ids.M1 = await addPrincipal('managerM1');                        // manages U1
+  ids.U1 = await addPrincipal('userU1', { managerId: ids.M1 });    // has manager
+  ids.U2 = await addPrincipal('userU2');                           // no manager
+  // owner1 also "owns agents" (A1/A3/A4) → inverse direction
+
+  // Guests with/without a sponsor
+  ids.GST1 = await addPrincipal('guest1');
+  ids.GST2 = await addPrincipal('guest2');
+  await addRel(ids.GST1, ids.owner1, 'Sponsor');
+
+  // Groups: members via Direct / Indirect / empty, + soft-deleted assignment
+  ids.G1 = await addResource('groupG1');
+  ids.G2 = await addResource('groupG2');
+  ids.G3 = await addResource('groupG3');
+  ids.GDEL = await addResource('groupGDEL');
+  await addAssignment(ids.G1, ids.U1, 'Direct');
+  await addAssignment(ids.G2, ids.U1, 'Indirect');
+  await addAssignment(ids.G2, ids.U2, 'Indirect');
+  await addAssignment(ids.GDEL, ids.U1, 'Direct', { deleted: true });
+
+  // Groups with / without an owner (2-hop via GroupOwnership)
+  ids.GO1 = await addResource('groupGO1');
+  ids.GO2 = await addResource('groupGO2');
+  await addOwnership(ids.GO1, ids.owner1);
+}, 60000);
+
+afterAll(async () => {
+  if (tagId) {
+    await pool.query(`DELETE FROM "ContextMembers" WHERE "contextId" = $1`, [tagId]);
+    await pool.query(`DELETE FROM "Contexts" WHERE id = $1`, [tagId]);
+  }
+  if (systemId) {
+    await pool.query(`DELETE FROM "PrincipalRelationships" WHERE "systemId" = $1`, [systemId]);
+    await pool.query(`DELETE FROM "ResourceRelationships" WHERE "systemId" = $1`, [systemId]);
+    await pool.query(`DELETE FROM "ResourceAssignments" WHERE "systemId" = $1`, [systemId]);
+    await pool.query(`DELETE FROM "Resources" WHERE "systemId" = $1`, [systemId]);
+    await pool.query(`DELETE FROM "Principals" WHERE "systemId" = $1`, [systemId]);
+    await pool.query(`DELETE FROM "Systems" WHERE id = $1`, [systemId]);
+  }
+  await pool.end();
+  delete process.env.USE_SQL;
+});
+
+describe('AC1/AC2 — owners existence + thresholds (agents)', () => {
+  it('None (0) returns the ownerless agent, not the owned one', async () => {
+    const none = await userIds({ principalType: AGENT, 'rel.owners': 'None (0)' });
+    expect(none.has(ids.A2)).toBe(true);
+    expect(none.has(ids.A1)).toBe(false);
+  });
+  it('Any (1 or more) returns owned agents, not the ownerless one', async () => {
+    const any = await userIds({ principalType: AGENT, 'rel.owners': 'Any (1 or more)' });
+    expect(any.has(ids.A1)).toBe(true);
+    expect(any.has(ids.A2)).toBe(false);
+  });
+  it('Exactly 1 / 2 or more / 3 or more partition by owner count', async () => {
+    const one = await userIds({ principalType: AGENT, 'rel.owners': 'Exactly 1' });
+    expect(one.has(ids.A1)).toBe(true);
+    expect(one.has(ids.A3)).toBe(false);
+    expect(one.has(ids.A4)).toBe(false);
+    const two = await userIds({ principalType: AGENT, 'rel.owners': '2 or more' });
+    expect(two.has(ids.A3)).toBe(true);
+    expect(two.has(ids.A4)).toBe(true);
+    expect(two.has(ids.A1)).toBe(false);
+    const three = await userIds({ principalType: AGENT, 'rel.owners': '3 or more' });
+    expect(three.has(ids.A4)).toBe(true);
+    expect(three.has(ids.A3)).toBe(false);
+  });
+});
+
+describe('AC3 — manager (single-valued)', () => {
+  it('None → users without a manager; Any → users with one', async () => {
+    const none = await userIds({ principalType: USER, 'rel.manager': 'None (0)' });
+    expect(none.has(ids.U2)).toBe(true);
+    expect(none.has(ids.U1)).toBe(false);
+    const any = await userIds({ principalType: USER, 'rel.manager': 'Any (1 or more)' });
+    expect(any.has(ids.U1)).toBe(true);
+    expect(any.has(ids.U2)).toBe(false);
+  });
+});
+
+describe('AC4 — members count ALL assignment types', () => {
+  it('None returns only the truly empty group (Indirect-only is NOT empty)', async () => {
+    const none = await resourceIds({ 'rel.members': 'None (0)' });
+    expect(none.has(ids.G3)).toBe(true);
+    expect(none.has(ids.G1)).toBe(false);
+    expect(none.has(ids.G2)).toBe(false); // 2 Indirect members ⇒ not "None"
+  });
+});
+
+describe('AC5 — group owners (2-hop via GroupOwnership)', () => {
+  it('None returns the ownerless group, not the owned one', async () => {
+    const none = await resourceIds({ 'rel.owners': 'None (0)' });
+    expect(none.has(ids.GO2)).toBe(true);
+    expect(none.has(ids.GO1)).toBe(false);
+  });
+});
+
+describe('AC6/AC7 — inverse directions', () => {
+  it('ownsAgents: the owner shows as owning ≥1 agent', async () => {
+    const owns = await userIds({ principalType: USER, 'rel.ownsAgents': 'Any (1 or more)' });
+    expect(owns.has(ids.owner1)).toBe(true);
+    expect(owns.has(ids.U2)).toBe(false);
+  });
+  it('directReports: the manager shows as having ≥1 report', async () => {
+    const mgrs = await userIds({ principalType: USER, 'rel.directReports': 'Any (1 or more)' });
+    expect(mgrs.has(ids.M1)).toBe(true);
+    expect(mgrs.has(ids.U1)).toBe(false);
+  });
+});
+
+describe('AC8 — guest sponsors', () => {
+  it('None returns the unsponsored guest, not the sponsored one', async () => {
+    const none = await userIds({ principalType: USER, 'rel.sponsors': 'None (0)' });
+    expect(none.has(ids.GST2)).toBe(true);
+    expect(none.has(ids.GST1)).toBe(false);
+  });
+});
+
+describe('AC9 — dynamic discovery scoped to the sub-tab', () => {
+  it('Agents tab offers owners (multi picklist) but not manager/directReports', async () => {
+    const res = await agent.get('/api/user-columns-page').query({ principalType: AGENT });
+    expect(res.status).toBe(200);
+    const byCol = Object.fromEntries(res.body.map((c) => [c.column, c]));
+    expect(byCol['rel.owners']).toBeTruthy();
+    expect(byCol['rel.owners'].values).toEqual(
+      ['None (0)', 'Any (1 or more)', 'Exactly 1', '2 or more', '3 or more'],
+    );
+    expect(byCol['rel.owners'].label).toBe('Owners');
+    expect(byCol['rel.manager']).toBeFalsy();
+    expect(byCol['rel.directReports']).toBeFalsy();
+  });
+  it('Users tab offers manager (single picklist) + directReports, not owners', async () => {
+    const res = await agent.get('/api/user-columns-page').query({ principalType: USER });
+    expect(res.status).toBe(200);
+    const byCol = Object.fromEntries(res.body.map((c) => [c.column, c]));
+    expect(byCol['rel.manager']).toBeTruthy();
+    expect(byCol['rel.manager'].values).toEqual(['None (0)', 'Any (1 or more)']);
+    expect(byCol['rel.directReports']).toBeTruthy();
+    expect(byCol['rel.owners']).toBeFalsy();
+  });
+  it('Resource columns expose members and owners reference fields', async () => {
+    const res = await agent.get('/api/resource-columns');
+    expect(res.status).toBe(200);
+    const cols = new Set(res.body.map((c) => c.column));
+    expect(cols.has('rel.members')).toBe(true);
+    expect(cols.has('rel.owners')).toBe(true);
+  });
+});
+
+describe('AC10 — soft-deleted related rows are not counted', () => {
+  it('agent whose only owner is tombstoned reads as None, not Any', async () => {
+    const none = await userIds({ principalType: AGENT, 'rel.owners': 'None (0)' });
+    const any = await userIds({ principalType: AGENT, 'rel.owners': 'Any (1 or more)' });
+    expect(none.has(ids.A5)).toBe(true);
+    expect(any.has(ids.A5)).toBe(false);
+  });
+  it('group whose only member assignment is soft-deleted reads as None', async () => {
+    const none = await resourceIds({ 'rel.members': 'None (0)' });
+    expect(none.has(ids.GDEL)).toBe(true);
+  });
+});
+
+describe('AC11 — bulk tag-by-filter applies the same rel constraint (no over-tag)', () => {
+  it('tags exactly the ownerless agents, not the whole set', async () => {
+    const created = await agent.post('/api/tags')
+      .send({ name: `reffilter-${S}`, color: '#3b82f6', entityType: 'user' });
+    expect(created.status).toBeLessThan(300);
+    tagId = created.body.id;
+
+    const res = await agent.post(`/api/tags/${tagId}/assign-by-filter`).send({
+      entityType: 'user',
+      search: M,
+      filters: { principalType: AGENT, 'rel.owners': 'None (0)' },
+    });
+    expect(res.status).toBe(200);
+
+    const tagged = new Set(
+      (await pool.query(`SELECT "memberId" FROM "ContextMembers" WHERE "contextId" = $1`, [tagId]))
+        .rows.map((r) => r.memberId),
+    );
+    // ownerless agents (A2, and A5 whose owner is deleted) — NOT the owned ones
+    expect(tagged.has(ids.A2)).toBe(true);
+    expect(tagged.has(ids.A5)).toBe(true);
+    expect(tagged.has(ids.A1)).toBe(false);
+    expect(tagged.has(ids.A3)).toBe(false);
+    expect(tagged.has(ids.A4)).toBe(false);
+  });
+});
+
+describe('AC12 — fail closed on unknown key / value', () => {
+  it('unknown rel key matches nothing (never widens)', async () => {
+    const r = await userIds({ principalType: AGENT, 'rel.bogus': 'None (0)' });
+    for (const id of [ids.A1, ids.A2, ids.A3, ids.A4, ids.A5]) expect(r.has(id)).toBe(false);
+  });
+  it('unrecognised value matches nothing (no SQL error)', async () => {
+    const r = await userIds({ principalType: AGENT, 'rel.owners': "'; DROP TABLE x --" });
+    expect(r.size).toBe(0);
+  });
+});

--- a/app/api/src/lib/referenceFilters.js
+++ b/app/api/src/lib/referenceFilters.js
@@ -1,0 +1,178 @@
+// Reference-field (relationship) filters for the entity list pages.
+//
+// The Users/Resources filter bars let an analyst filter on scalar columns
+// (`buildFilterWhere` in routes/tags/shared.js). This module adds the SAME
+// dropdown experience for *reference* fields — "how many owners / members /
+// direct reports does this row have" — WITHOUT a new UI control. A reference
+// field is surfaced as a pseudo-column keyed `rel.<name>` whose value list is a
+// small fixed count picklist, so it renders through the existing FilterBar
+// unchanged (see app/ui/src/hooks/useEntityPage.js).
+//
+// Three heterogeneous stores back these relationships, unified behind one
+// registry so a route never has to know the difference:
+//   * PrincipalRelationships (Owner / Sponsor)      — principal → principal
+//   * Principals.managerId                          — single-valued column
+//   * ResourceAssignments / ResourceRelationships   — principal → resource
+//
+// SAFETY: the picklist strings are defined HERE and echoed by the columns
+// endpoints to the UI, which posts the chosen one back verbatim; this module is
+// the sole definer AND parser, so the two sides can't drift. An unknown `rel`
+// key or an unrecognised value FAILS CLOSED (`AND 1=0`) — it never widens the
+// result set (which, on the bulk tag-by-filter path, would over-tag).
+
+import * as db from '../db/connection.js';
+
+// ─── Operator picklist (server-owned contract) ──────────────────
+// Value string → { op, n } for a count comparison. Many-valued relations offer
+// the full set; single-valued ones (a managerId) only None/Any.
+export const MULTI_OPTIONS = ['None (0)', 'Any (1 or more)', 'Exactly 1', '2 or more', '3 or more'];
+export const SINGLE_OPTIONS = ['None (0)', 'Any (1 or more)'];
+
+const VALUE_TO_OPN = {
+  'None (0)': { op: '=', n: 0 },
+  'Any (1 or more)': { op: '>=', n: 1 },
+  'Exactly 1': { op: '=', n: 1 },
+  '2 or more': { op: '>=', n: 2 },
+  '3 or more': { op: '>=', n: 3 },
+};
+
+// Only these two shapes reach SQL, so op is never attacker-controlled.
+const SAFE_ALIAS_RE = /^[a-z][a-z0-9]*$/;
+
+// ─── Registry ───────────────────────────────────────────────────
+// Each entry: a correlated scalar-count expression over the subject row `<a>`.
+// countSql already filters soft-deleted counted rows so the count matches the
+// live-only list the routes render (the outer query hides `deletedAt IS NOT
+// NULL`; an owner/member whose account is tombstoned must not keep a row
+// "owned"). `card:'one'` relations use a CASE so the same count machinery and
+// emitter cover a single-valued column with no special path.
+const REGISTRY = [
+  // Principals ----------------------------------------------------
+  {
+    key: 'owners', label: 'Owners', table: 'principals', card: 'many',
+    countSql: (a) => `(SELECT count(*) FROM "PrincipalRelationships" pr
+       JOIN "Principals" rp ON rp.id = pr."relatedPrincipalId" AND rp."deletedAt" IS NULL
+      WHERE pr."principalId" = ${a}.id AND pr."relationshipType" = 'Owner')`,
+  },
+  {
+    key: 'sponsors', label: 'Sponsors', table: 'principals', card: 'many',
+    countSql: (a) => `(SELECT count(*) FROM "PrincipalRelationships" pr
+       JOIN "Principals" rp ON rp.id = pr."relatedPrincipalId" AND rp."deletedAt" IS NULL
+      WHERE pr."principalId" = ${a}.id AND pr."relationshipType" = 'Sponsor')`,
+  },
+  {
+    key: 'manager', label: 'Manager', table: 'principals', card: 'one',
+    countSql: (a) => `(CASE WHEN ${a}."managerId" IS NOT NULL THEN 1 ELSE 0 END)`,
+  },
+  {
+    key: 'ownsAgents', label: 'Owns agents', table: 'principals', card: 'many',
+    countSql: (a) => `(SELECT count(*) FROM "PrincipalRelationships" pr
+       JOIN "Principals" sp ON sp.id = pr."principalId" AND sp."deletedAt" IS NULL
+      WHERE pr."relatedPrincipalId" = ${a}.id AND pr."relationshipType" = 'Owner')`,
+  },
+  {
+    key: 'directReports', label: 'Direct reports', table: 'principals', card: 'many',
+    countSql: (a) => `(SELECT count(*) FROM "Principals" m
+      WHERE m."managerId" = ${a}.id AND m."deletedAt" IS NULL)`,
+  },
+  // Resources -----------------------------------------------------
+  {
+    // All assignment types (Direct/Indirect/Eligible) to match the resource
+    // detail page's memberCount — one definition of "member".
+    key: 'members', label: 'Members', table: 'resources', card: 'many',
+    countSql: (a) => `(SELECT count(*) FROM "ResourceAssignments" ra
+      WHERE ra."resourceId" = ${a}.id AND ra."deletedAt" IS NULL)`,
+  },
+  {
+    key: 'owners', label: 'Owners', table: 'resources', card: 'many',
+    countSql: (a) => `(SELECT count(*) FROM "ResourceRelationships" rr
+       JOIN "ResourceAssignments" ra ON ra."resourceId" = rr."childResourceId"
+            AND ra."assignmentType" = 'Direct' AND ra."deletedAt" IS NULL
+      WHERE rr."parentResourceId" = ${a}.id AND rr."relationshipType" = 'HasOwnership')`,
+  },
+];
+
+const TABLES = { principals: 'Principals', resources: 'Resources' };
+const SCOPE_COL = { principals: 'principalType', resources: 'resourceType' };
+
+function entriesFor(table) {
+  return REGISTRY.filter((e) => e.table === table);
+}
+
+function optionsFor(entry) {
+  return entry.card === 'one' ? SINGLE_OPTIONS : MULTI_OPTIONS;
+}
+
+// Pull `rel.*` keys out of the attribute-filters object (mutating it, like the
+// routes already do for `__*Tag` virtual keys) and return them separately.
+export function extractRelFilters(attrFilters) {
+  const rel = {};
+  for (const k of Object.keys(attrFilters)) {
+    if (k.startsWith('rel.')) {
+      rel[k] = attrFilters[k];
+      delete attrFilters[k];
+    }
+  }
+  return rel;
+}
+
+// Build the WHERE fragment for a set of `rel.*` filters. No positional params
+// are emitted — the operator is one of two whitelisted shapes and the threshold
+// is a validated small integer — so callers need no `bind`, and the fragment is
+// safe to append after `buildFilterWhere` (before the COUNT snapshot).
+export function buildRelationshipWhere(relFilters, table, alias) {
+  if (!relFilters || !SAFE_ALIAS_RE.test(alias) || !TABLES[table]) {
+    return relFilters && Object.keys(relFilters).length ? ' AND 1=0' : '';
+  }
+  let where = '';
+  for (const [field, value] of Object.entries(relFilters)) {
+    const key = field.slice(4); // strip 'rel.'
+    const entry = REGISTRY.find((e) => e.table === table && e.key === key);
+    const opn = VALUE_TO_OPN[value];
+    // Fail closed: unknown field, unknown value, or a count operator on a
+    // single-valued relation (which never offers >1) matches nothing.
+    if (!entry || !opn || (entry.card === 'one' && opn.n > 1)) {
+      where += ' AND 1=0';
+      continue;
+    }
+    where += ` AND (${entry.countSql(alias)}) ${opn.op} ${opn.n}`;
+  }
+  return where;
+}
+
+// Discover which reference fields have data in the CURRENT sub-view and should
+// therefore appear in the filter dropdown. `scope` carries the page's active
+// sub-tab (principalType for the Users page, resourceType for Resources) so a
+// field only shows where it actually applies — e.g. `manager` never appears on
+// the AI-Agents tab, `owners` never on the ordinary Users tab. Returns rows
+// shaped like the columns endpoint's `{ column, values }`, plus a `label` the
+// UI uses directly (so it needn't hardcode a name per page).
+export async function discoverReferenceFields(table, scope = {}, conn = db) {
+  const entries = entriesFor(table);
+  if (!entries.length || !TABLES[table]) return [];
+  const t = TABLES[table];
+
+  const params = [];
+  let scopeWhere = 'X."deletedAt" IS NULL';
+  const scopeVal = scope?.[SCOPE_COL[table]];
+  if (scopeVal != null && String(scopeVal).trim() !== '') {
+    params.push(String(scopeVal));
+    scopeWhere += ` AND X."${SCOPE_COL[table]}" = $${params.length}`;
+  }
+
+  const cols = entries.map(
+    (e, i) => `EXISTS(SELECT 1 FROM "${t}" X WHERE ${scopeWhere} AND (${e.countSql('X')}) >= 1) AS c${i}`,
+  );
+  const r = await conn.query(`SELECT ${cols.join(', ')}`, params);
+  const row = r.rows[0] || {};
+  return entries
+    .filter((_, i) => row[`c${i}`])
+    .map((e) => ({ column: `rel.${e.key}`, label: e.label, values: optionsFor(e) }));
+}
+
+// Map an assign-by-filter entityType to the registry's table discriminator.
+export function storeForEntityType(entityType) {
+  if (entityType === 'user') return 'principals';
+  if (entityType === 'resource' || entityType === 'group') return 'resources';
+  return null; // identities have no reference fields (accountCount already filters them)
+}

--- a/app/api/src/lib/referenceFilters.js
+++ b/app/api/src/lib/referenceFilters.js
@@ -28,13 +28,16 @@ import * as db from '../db/connection.js';
 export const MULTI_OPTIONS = ['None (0)', 'Any (1 or more)', 'Exactly 1', '2 or more', '3 or more'];
 export const SINGLE_OPTIONS = ['None (0)', 'Any (1 or more)'];
 
-const VALUE_TO_OPN = {
+// Null-prototype so a user-supplied value that happens to name an inherited
+// member (e.g. 'constructor', 'toString') resolves to undefined and fails
+// closed, rather than returning a truthy Object.prototype member.
+const VALUE_TO_OPN = Object.assign(Object.create(null), {
   'None (0)': { op: '=', n: 0 },
   'Any (1 or more)': { op: '>=', n: 1 },
   'Exactly 1': { op: '=', n: 1 },
   '2 or more': { op: '>=', n: 2 },
   '3 or more': { op: '>=', n: 3 },
-};
+});
 
 // Only these two shapes reach SQL, so op is never attacker-controlled.
 const SAFE_ALIAS_RE = /^[a-z][a-z0-9]*$/;
@@ -103,15 +106,16 @@ function optionsFor(entry) {
   return entry.card === 'one' ? SINGLE_OPTIONS : MULTI_OPTIONS;
 }
 
-// Pull `rel.*` keys out of the attribute-filters object (mutating it, like the
-// routes already do for `__*Tag` virtual keys) and return them separately.
+// Collect the `rel.*` reference-field filters as a list of {field, value}
+// pairs. The user-supplied key is carried as a VALUE, never used as a property
+// name (no dynamic property write → no prototype-pollution surface). We don't
+// strip them from attrFilters: buildFilterWhere only matches `ext.*` and real
+// column names, so a leftover `rel.*` key is already ignored there.
+const REL_PREFIX = 'rel.';
 export function extractRelFilters(attrFilters) {
-  const rel = {};
-  for (const k of Object.keys(attrFilters)) {
-    if (k.startsWith('rel.')) {
-      rel[k] = attrFilters[k];
-      delete attrFilters[k];
-    }
+  const rel = [];
+  for (const k of Object.keys(attrFilters || {})) {
+    if (k.startsWith(REL_PREFIX)) rel.push({ field: k, value: attrFilters[k] });
   }
   return rel;
 }
@@ -121,12 +125,12 @@ export function extractRelFilters(attrFilters) {
 // is a validated small integer — so callers need no `bind`, and the fragment is
 // safe to append after `buildFilterWhere` (before the COUNT snapshot).
 export function buildRelationshipWhere(relFilters, table, alias) {
-  if (!relFilters || !SAFE_ALIAS_RE.test(alias) || !TABLES[table]) {
-    return relFilters && Object.keys(relFilters).length ? ' AND 1=0' : '';
-  }
+  const list = Array.isArray(relFilters) ? relFilters : [];
+  if (list.length === 0) return '';
+  if (!SAFE_ALIAS_RE.test(alias) || !TABLES[table]) return ' AND 1=0';
   let where = '';
-  for (const [field, value] of Object.entries(relFilters)) {
-    const key = field.slice(4); // strip 'rel.'
+  for (const { field, value } of list) {
+    const key = String(field).slice(REL_PREFIX.length); // strip 'rel.'
     const entry = REGISTRY.find((e) => e.table === table && e.key === key);
     const opn = VALUE_TO_OPN[value];
     // Fail closed: unknown field, unknown value, or a count operator on a

--- a/app/api/src/lib/referenceFilters.test.js
+++ b/app/api/src/lib/referenceFilters.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildRelationshipWhere,
+  extractRelFilters,
+  storeForEntityType,
+  MULTI_OPTIONS,
+  SINGLE_OPTIONS,
+} from './referenceFilters.js';
+
+describe('extractRelFilters', () => {
+  it('pulls rel.* keys out and mutates the source object', () => {
+    const attr = { department: 'IT', 'rel.owners': 'None (0)', 'ext.userType': 'Member' };
+    const rel = extractRelFilters(attr);
+    expect(rel).toEqual({ 'rel.owners': 'None (0)' });
+    expect(attr).toEqual({ department: 'IT', 'ext.userType': 'Member' });
+  });
+
+  it('returns {} when there are no rel keys', () => {
+    const attr = { department: 'IT' };
+    expect(extractRelFilters(attr)).toEqual({});
+    expect(attr).toEqual({ department: 'IT' });
+  });
+});
+
+describe('buildRelationshipWhere — operator emission', () => {
+  const cases = [
+    ['None (0)', '= 0'],
+    ['Any (1 or more)', '>= 1'],
+    ['Exactly 1', '= 1'],
+    ['2 or more', '>= 2'],
+    ['3 or more', '>= 3'],
+  ];
+  for (const [value, expected] of cases) {
+    it(`maps "${value}" to a count ${expected}`, () => {
+      const sql = buildRelationshipWhere({ 'rel.owners': value }, 'principals', 'u');
+      expect(sql).toContain('PrincipalRelationships');
+      expect(sql.trim().endsWith(expected)).toBe(true);
+    });
+  }
+
+  it('references the subject alias in the correlated subquery', () => {
+    const sql = buildRelationshipWhere({ 'rel.members': 'Any (1 or more)' }, 'resources', 'r');
+    expect(sql).toContain('ResourceAssignments');
+    expect(sql).toContain('r.id');
+  });
+
+  it('composes multiple rel filters', () => {
+    const sql = buildRelationshipWhere(
+      { 'rel.owners': 'None (0)', 'rel.directReports': '2 or more' },
+      'principals', 'u',
+    );
+    expect(sql).toContain('= 0');
+    expect(sql).toContain('>= 2');
+  });
+});
+
+describe('buildRelationshipWhere — fail closed', () => {
+  it('unknown rel key → AND 1=0 (never widens results)', () => {
+    expect(buildRelationshipWhere({ 'rel.bogus': 'None (0)' }, 'principals', 'u')).toBe(' AND 1=0');
+  });
+
+  it('unrecognised value → AND 1=0', () => {
+    expect(buildRelationshipWhere({ 'rel.owners': "'; DROP TABLE" }, 'principals', 'u')).toBe(' AND 1=0');
+  });
+
+  it('count operator on a single-valued relation (manager) → AND 1=0', () => {
+    expect(buildRelationshipWhere({ 'rel.manager': '2 or more' }, 'principals', 'u')).toBe(' AND 1=0');
+  });
+
+  it('single-valued None/Any are allowed', () => {
+    expect(buildRelationshipWhere({ 'rel.manager': 'None (0)' }, 'principals', 'u')).toContain('= 0');
+    expect(buildRelationshipWhere({ 'rel.manager': 'Any (1 or more)' }, 'principals', 'u')).toContain('>= 1');
+  });
+
+  it('unknown table with rel filters → AND 1=0', () => {
+    expect(buildRelationshipWhere({ 'rel.owners': 'None (0)' }, 'widgets', 'w')).toBe(' AND 1=0');
+  });
+
+  it('unsafe alias with rel filters → AND 1=0', () => {
+    expect(buildRelationshipWhere({ 'rel.owners': 'None (0)' }, 'principals', 'u; --')).toBe(' AND 1=0');
+  });
+
+  it('empty rel filters → empty string (no clause)', () => {
+    expect(buildRelationshipWhere({}, 'principals', 'u')).toBe('');
+    expect(buildRelationshipWhere(null, 'principals', 'u')).toBe('');
+  });
+
+  it('a field from the wrong table is rejected (rel.members on principals)', () => {
+    expect(buildRelationshipWhere({ 'rel.members': 'Any (1 or more)' }, 'principals', 'u')).toBe(' AND 1=0');
+  });
+});
+
+describe('storeForEntityType', () => {
+  it('maps user→principals, resource/group→resources, identity→null', () => {
+    expect(storeForEntityType('user')).toBe('principals');
+    expect(storeForEntityType('resource')).toBe('resources');
+    expect(storeForEntityType('group')).toBe('resources');
+    expect(storeForEntityType('identity')).toBe(null);
+  });
+});
+
+describe('picklists', () => {
+  it('single-valued relations only offer None/Any', () => {
+    expect(SINGLE_OPTIONS).toEqual(['None (0)', 'Any (1 or more)']);
+    expect(MULTI_OPTIONS).toContain('Exactly 1');
+    expect(MULTI_OPTIONS).toContain('3 or more');
+  });
+});

--- a/app/api/src/lib/referenceFilters.test.js
+++ b/app/api/src/lib/referenceFilters.test.js
@@ -7,18 +7,26 @@ import {
   SINGLE_OPTIONS,
 } from './referenceFilters.js';
 
+// Test helper: build the {field,value}[] shape extractRelFilters produces.
+const R = (...pairs) => pairs.map(([field, value]) => ({ field, value }));
+
 describe('extractRelFilters', () => {
-  it('pulls rel.* keys out and mutates the source object', () => {
+  it('collects rel.* keys as {field,value} pairs, leaving the source intact', () => {
     const attr = { department: 'IT', 'rel.owners': 'None (0)', 'ext.userType': 'Member' };
-    const rel = extractRelFilters(attr);
-    expect(rel).toEqual({ 'rel.owners': 'None (0)' });
-    expect(attr).toEqual({ department: 'IT', 'ext.userType': 'Member' });
+    expect(extractRelFilters(attr)).toEqual([{ field: 'rel.owners', value: 'None (0)' }]);
+    // Not mutated — buildFilterWhere ignores rel.* keys anyway.
+    expect(attr).toEqual({ department: 'IT', 'rel.owners': 'None (0)', 'ext.userType': 'Member' });
   });
 
-  it('returns {} when there are no rel keys', () => {
-    const attr = { department: 'IT' };
-    expect(extractRelFilters(attr)).toEqual({});
-    expect(attr).toEqual({ department: 'IT' });
+  it('returns [] when there are no rel keys', () => {
+    expect(extractRelFilters({ department: 'IT' })).toEqual([]);
+    expect(extractRelFilters(null)).toEqual([]);
+  });
+
+  it('does not use the user key as a property name (carries it as data)', () => {
+    const rel = extractRelFilters({ 'rel.__proto__': 'None (0)' });
+    expect(rel).toEqual([{ field: 'rel.__proto__', value: 'None (0)' }]);
+    expect(({}).polluted).toBeUndefined();
   });
 });
 
@@ -32,21 +40,21 @@ describe('buildRelationshipWhere — operator emission', () => {
   ];
   for (const [value, expected] of cases) {
     it(`maps "${value}" to a count ${expected}`, () => {
-      const sql = buildRelationshipWhere({ 'rel.owners': value }, 'principals', 'u');
+      const sql = buildRelationshipWhere(R(['rel.owners', value]), 'principals', 'u');
       expect(sql).toContain('PrincipalRelationships');
       expect(sql.trim().endsWith(expected)).toBe(true);
     });
   }
 
   it('references the subject alias in the correlated subquery', () => {
-    const sql = buildRelationshipWhere({ 'rel.members': 'Any (1 or more)' }, 'resources', 'r');
+    const sql = buildRelationshipWhere(R(['rel.members', 'Any (1 or more)']), 'resources', 'r');
     expect(sql).toContain('ResourceAssignments');
     expect(sql).toContain('r.id');
   });
 
   it('composes multiple rel filters', () => {
     const sql = buildRelationshipWhere(
-      { 'rel.owners': 'None (0)', 'rel.directReports': '2 or more' },
+      R(['rel.owners', 'None (0)'], ['rel.directReports', '2 or more']),
       'principals', 'u',
     );
     expect(sql).toContain('= 0');
@@ -56,37 +64,41 @@ describe('buildRelationshipWhere — operator emission', () => {
 
 describe('buildRelationshipWhere — fail closed', () => {
   it('unknown rel key → AND 1=0 (never widens results)', () => {
-    expect(buildRelationshipWhere({ 'rel.bogus': 'None (0)' }, 'principals', 'u')).toBe(' AND 1=0');
+    expect(buildRelationshipWhere(R(['rel.bogus', 'None (0)']), 'principals', 'u')).toBe(' AND 1=0');
   });
 
   it('unrecognised value → AND 1=0', () => {
-    expect(buildRelationshipWhere({ 'rel.owners': "'; DROP TABLE" }, 'principals', 'u')).toBe(' AND 1=0');
+    expect(buildRelationshipWhere(R(['rel.owners', "'; DROP TABLE"]), 'principals', 'u')).toBe(' AND 1=0');
+  });
+
+  it('an inherited-property value (constructor) → AND 1=0, not a truthy match', () => {
+    expect(buildRelationshipWhere(R(['rel.owners', 'constructor']), 'principals', 'u')).toBe(' AND 1=0');
   });
 
   it('count operator on a single-valued relation (manager) → AND 1=0', () => {
-    expect(buildRelationshipWhere({ 'rel.manager': '2 or more' }, 'principals', 'u')).toBe(' AND 1=0');
+    expect(buildRelationshipWhere(R(['rel.manager', '2 or more']), 'principals', 'u')).toBe(' AND 1=0');
   });
 
   it('single-valued None/Any are allowed', () => {
-    expect(buildRelationshipWhere({ 'rel.manager': 'None (0)' }, 'principals', 'u')).toContain('= 0');
-    expect(buildRelationshipWhere({ 'rel.manager': 'Any (1 or more)' }, 'principals', 'u')).toContain('>= 1');
+    expect(buildRelationshipWhere(R(['rel.manager', 'None (0)']), 'principals', 'u')).toContain('= 0');
+    expect(buildRelationshipWhere(R(['rel.manager', 'Any (1 or more)']), 'principals', 'u')).toContain('>= 1');
   });
 
   it('unknown table with rel filters → AND 1=0', () => {
-    expect(buildRelationshipWhere({ 'rel.owners': 'None (0)' }, 'widgets', 'w')).toBe(' AND 1=0');
+    expect(buildRelationshipWhere(R(['rel.owners', 'None (0)']), 'widgets', 'w')).toBe(' AND 1=0');
   });
 
   it('unsafe alias with rel filters → AND 1=0', () => {
-    expect(buildRelationshipWhere({ 'rel.owners': 'None (0)' }, 'principals', 'u; --')).toBe(' AND 1=0');
+    expect(buildRelationshipWhere(R(['rel.owners', 'None (0)']), 'principals', 'u; --')).toBe(' AND 1=0');
   });
 
   it('empty rel filters → empty string (no clause)', () => {
-    expect(buildRelationshipWhere({}, 'principals', 'u')).toBe('');
+    expect(buildRelationshipWhere([], 'principals', 'u')).toBe('');
     expect(buildRelationshipWhere(null, 'principals', 'u')).toBe('');
   });
 
   it('a field from the wrong table is rejected (rel.members on principals)', () => {
-    expect(buildRelationshipWhere({ 'rel.members': 'Any (1 or more)' }, 'principals', 'u')).toBe(' AND 1=0');
+    expect(buildRelationshipWhere(R(['rel.members', 'Any (1 or more)']), 'principals', 'u')).toBe(' AND 1=0');
   });
 });
 

--- a/app/api/src/routes/resources.js
+++ b/app/api/src/routes/resources.js
@@ -5,6 +5,7 @@ import { parseJsonbColumn } from '../lib/jsonb.js';
 import { buildOrderBy } from '../lib/listSort.js';
 import { getResourceColumns, getResourceColumnValues } from '../db/columnCache.js';
 import { ensureTagTables, buildFilterWhere, parseTags } from './tags.js';
+import { extractRelFilters, buildRelationshipWhere, discoverReferenceFields } from '../lib/referenceFilters.js';
 import { UUID_RE, cleanRow, getPermissionTable } from './details/shared.js';
 import { isMissingSchema } from '../db/schemaErrors.js';
 
@@ -57,6 +58,8 @@ router.get('/resources', async (req, res) => {
       resourceTagFilter = String(attrFilters['__groupTag']);
       delete attrFilters['__groupTag'];
     }
+    // Reference-field (rel.*) filters — applied as correlated count subqueries.
+    const relFilters = extractRelFilters(attrFilters);
 
     const p = await db.getPool();
     await ensureTagTables(p);
@@ -103,6 +106,7 @@ router.get('/resources', async (req, res) => {
         INNER JOIN "GraphTags" _rt ON _rta."tagId" = _rt.id AND _rt."name" = ${bind(resourceTagFilter)} AND _rt."entityType" IN ('resource', 'group')`;
     }
     where += buildFilterWhere(attrFilters, colNames, 'r', bind);
+    where += buildRelationshipWhere(relFilters, 'resources', 'r');
 
     // Returns every Resources column so the same endpoint feeds the UI grid
     // AND the Power Query Excel export (which auto-expands extendedAttributes
@@ -485,7 +489,18 @@ router.get('/resource-columns', async (req, res) => {
       grouped['__resourceTag'] = schemaOnly ? [] : resourceTags;
     } catch (e) { if (!isMissingSchema(e)) throw e; /* tag tables may not exist yet */ }
 
-    return res.json(Object.entries(grouped).map(([column, values]) => ({ column, values })));
+    const columns = Object.entries(grouped).map(([column, values]) => ({ column, values }));
+
+    // Reference-field (relationship) filters for resources — only offered where
+    // data exists. Skipped on the schema-only fast path (no values needed).
+    if (!schemaOnly) {
+      try {
+        const relFields = await discoverReferenceFields('resources', { resourceType: req.query.resourceType });
+        columns.push(...relFields);
+      } catch (e) { console.error('resource reference-field discovery failed:', e.message); }
+    }
+
+    return res.json(columns);
   } catch (err) {
     console.error('resource-columns query failed:', err.message);
     return res.json([]);

--- a/app/api/src/routes/tags/crud.js
+++ b/app/api/src/routes/tags/crud.js
@@ -15,6 +15,7 @@ import { recalcMemberCountsForChain } from '../../contexts/memberCounts.js';
 import { requirePermission } from '../../middleware/auth.js';
 import { createParams } from '../../db/sqlParams.js';
 import { useSql, db, ensureTagTables, buildFilterWhere, ENTITY_TO_TARGET, UUID_RE } from './shared.js';
+import { extractRelFilters, buildRelationshipWhere, storeForEntityType } from '../../lib/referenceFilters.js';
 
 const router = Router();
 const writeTags = requirePermission('data.write.tags');
@@ -272,11 +273,17 @@ router.post('/tags/:id/assign-by-filter', writeTags, async (req, res) => {
     // (v5: temporal tables / `ValidTo` were dropped during the postgres
     // migration — no version-filtering clause needed here anymore.)
 
-    // Apply attribute filters
+    // Apply attribute filters. Reference-field (rel.*) filters MUST be applied
+    // here too: bulk-tag re-runs the same filter set the list showed, so a
+    // dropped rel.* constraint would tag every row instead of the matching
+    // subset (silent over-tag). extractRelFilters pulls them out first so
+    // buildFilterWhere sees only real columns.
     if (filters && typeof filters === 'object') {
+      const relFilters = extractRelFilters(filters);
       const cols = entityType === 'user' ? await getPrincipalOrUserColumns(p) : (entityType === 'resource' ? await getResourceCols(p) : await getGroupCols(p));
       const colNames = new Set(cols.map(c => c.name));
       where += buildFilterWhere(filters, colNames, alias, bind);
+      where += buildRelationshipWhere(relFilters, storeForEntityType(entityType), alias);
     }
 
     // Tags now live in Contexts — write directly to ContextMembers, skipping

--- a/app/api/src/routes/tags/entities.js
+++ b/app/api/src/routes/tags/entities.js
@@ -12,6 +12,7 @@ import { createParams } from '../../db/sqlParams.js';
 import { parseJsonbColumn } from '../../lib/jsonb.js';
 import { buildOrderBy } from '../../lib/listSort.js';
 import { useSql, db, ensureTagTables, buildFilterWhere, UUID_RE, parseTags } from './shared.js';
+import { extractRelFilters, buildRelationshipWhere, discoverReferenceFields } from '../../lib/referenceFilters.js';
 
 const router = Router();
 
@@ -48,7 +49,16 @@ router.get('/user-columns-page', async (req, res) => {
       if (userTags.length > 0) grouped['__userTag'] = userTags;
     } catch { /* tag tables may not exist yet */ }
 
-    return res.json(Object.entries(grouped).map(([column, values]) => ({ column, values })));
+    const columns = Object.entries(grouped).map(([column, values]) => ({ column, values }));
+
+    // Reference-field (relationship) filters, scoped to the active principalType
+    // sub-tab so only relationships with data in THIS view are offered.
+    try {
+      const relFields = await discoverReferenceFields('principals', { principalType: req.query.principalType });
+      columns.push(...relFields);
+    } catch (e) { console.error('user reference-field discovery failed:', e.message); }
+
+    return res.json(columns);
   } catch (err) {
     console.error('user-columns-page query failed:', err.message);
     return res.json([]);
@@ -124,6 +134,9 @@ router.get('/users', async (req, res) => {
       userTagFilter = String(attrFilters['__userTag']);
       delete attrFilters['__userTag'];
     }
+    // Pull reference-field (rel.*) filters out before column validation — they
+    // are applied as correlated count subqueries, not scalar column matches.
+    const relFilters = extractRelFilters(attrFilters);
 
     const p = await db.getPool();
     await ensureTagTables(p);
@@ -150,6 +163,7 @@ router.get('/users', async (req, res) => {
         INNER JOIN "GraphTags" _ut ON _uta."tagId" = _ut.id AND _ut."name" = ${bind(userTagFilter)} AND _ut."entityType" = 'user'`;
     }
     where += buildFilterWhere(attrFilters, colNames, 'u', bind);
+    where += buildRelationshipWhere(relFilters, 'principals', 'u');
 
     // Paginate FIRST (cheap), then resolve the per-row tag string only for the
     // page's rows. The tagString subquery used to sit in the top-level SELECT, so

--- a/app/ui/src/hooks/useEntityPage.js
+++ b/app/ui/src/hooks/useEntityPage.js
@@ -82,16 +82,24 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
     setSelected(new Set());
   }
 
-  // Fetch available columns for filter dropdowns
+  // Fetch available columns for filter dropdowns. The page's active sub-view
+  // (baseFilters — e.g. the Users principalType tab) is passed through so the
+  // API scopes reference-field discovery to it: a relationship only appears in
+  // the dropdown when rows in THIS view actually have it. Refetches on tab change.
   useEffect(() => {
     (async () => {
       try {
-        const res = await authFetch(columnsEndpoint);
+        const qs = new URLSearchParams();
+        for (const [k, v] of Object.entries(baseFilters || {})) {
+          if (v != null && v !== '') qs.set(k, v);
+        }
+        const url = qs.toString() ? `${columnsEndpoint}?${qs}` : columnsEndpoint;
+        const res = await authFetch(url);
         if (res.ok) setAvailableColumns(await res.json());
       } catch (err) { console.error('Failed to fetch columns:', err); }
       setColumnsLoading(false);
     })();
-  }, [authFetch, columnsEndpoint]);
+  }, [authFetch, columnsEndpoint, baseFilters]);
 
   // Fetch tags
   const fetchTags = useCallback(() => {
@@ -291,15 +299,20 @@ export default function useEntityPage({ authFetch, entityType, listEndpoint, col
   const allOnPageSelected = items.length > 0 && selected.size === items.length;
   const hasAnyFilter = activeFilters.length > 0 || debouncedSearch;
 
-  // Build filterFields from availableColumns. Keys that start with `ext.`
-  // are extended-attribute filters (see api columnCache.js / buildFilterWhere)
-  // — we strip the prefix for display and tag the label with "(ext)" so
-  // they're visually distinct from real columns in the dropdown.
+  // Build filterFields from availableColumns. Reference-field (relationship)
+  // columns arrive with an API-supplied `label` and a `rel.` key, and otherwise
+  // look exactly like a normal column (a `values` picklist) — so they render as
+  // an ordinary filter with no special UI. Keys that start with `ext.` are
+  // extended-attribute filters — we strip the prefix and tag "(ext)". Real
+  // columns fall through to a humanised label.
   const getFilterFields = useCallback((fieldLabels) => {
     const humanize = (s) => s.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase()).trim();
     return availableColumns
       .filter(col => col.values && col.values.length >= 1 && col.values.length <= 500)
       .map(col => {
+        if (col.label) {
+          return { key: col.column, label: col.label };
+        }
         if (fieldLabels[col.column]) {
           return { key: col.column, label: fieldLabels[col.column] };
         }

--- a/changes/reference-field-filters.md
+++ b/changes/reference-field-filters.md
@@ -1,0 +1,5 @@
+- Added reference-field (relationship) filters to the Users and Resources list pages: filter on a row's relationships — Owners, Sponsors, Manager, Direct reports, Owns agents, Members — using the same "Add filter" dropdown as attribute filters, with no separate control.
+- Reference filters use count values, so you can find "how many": None (0), Any (1 or more), Exactly 1, 2 or more, or 3 or more (single-valued references like Manager offer only None/Any). For example, filter AI Agents by Owners = None (0) to find agents with no accountable owner, or Groups by Members = None (0) to find empty groups.
+- Reference fields appear in the dropdown only when rows in the current view actually have that relationship — the same dynamic behaviour as attribute filters, scoped to the active sub-tab.
+- Reference filters combine with attribute filters and with "tag all matching by filter", so a bulk tag applies to exactly the filtered set.
+- Member counts include direct, indirect and eligible assignments, and removed (soft-deleted) accounts are excluded from all reference counts.

--- a/docs/ui/overview.md
+++ b/docs/ui/overview.md
@@ -142,6 +142,32 @@ Browse all synced resources (groups, directory roles, app roles, etc.) with pagi
 
 ---
 
+### Filtering by references (relationships)
+
+The **Add filter** dropdown on the Users and Resources pages lists reference
+fields — a row's relationships — alongside its ordinary attribute columns, and
+you filter them exactly the same way: pick the field, pick a value. No separate
+control.
+
+- **Reference fields** include *Owners* and *Sponsors* (on AI agents / service
+  principals / guests), *Manager* and *Direct reports* (on users), *Owns agents*
+  (the inverse of ownership), and *Members* and *Owners* (on groups/resources).
+- **Values are counts**, so you can answer "how many": **None (0)**, **Any (1 or
+  more)**, **Exactly 1**, **2 or more**, **3 or more**. Single-valued references
+  (a manager) offer only *None*/*Any*. For example, filter AI Agents by
+  *Owners = None (0)* to find every agent with no accountable owner, or Groups by
+  *Members = None (0)* to find empty groups.
+- **Only relationships that actually have data in the current view are listed** —
+  the same dynamic behaviour as attribute filters. *Manager* won't appear on the
+  AI-Agents sub-tab, and *Owners* won't appear on the ordinary Users tab.
+- Reference filters combine with attribute filters and with **bulk-tag by
+  filter**, so you can tag every matching row in one action.
+
+Member counts include all assignment types (direct, indirect and eligible), and
+accounts that have been removed (soft-deleted) are not counted.
+
+---
+
 ### Systems Page
 
 Card-based view of all connected authorization systems.


### PR DESCRIPTION
Built via Definition of Ready v3.2 (generative Phase A + Phase B probe/adversarial + fixture ACs). Two human touchpoints: intent interview + one consolidated sign-off.

## What
Filter the Users and Resources list pages by a row's **relationships** (references) — Owners, Sponsors, Manager, Direct reports, Owns agents, Members — using the **identical** field+value dropdown as attribute filters. No new UI control. A relationship is a `rel.<name>` pseudo-column whose value list is a fixed count picklist: **None (0) · Any (1 or more) · Exactly 1 · 2 or more · 3 or more** (single-valued relations like Manager offer only None/Any).

## How
- `app/api/src/lib/referenceFilters.js` — a shared **registry** unifying three stores behind one mechanism: `PrincipalRelationships` (Owner/Sponsor), `Principals.managerId` (column), `ResourceAssignments`/`ResourceRelationships` (members, 2-hop group owners). `buildRelationshipWhere` emits correlated count subqueries; unknown key/value **fails closed**.
- Discovery (`discoverReferenceFields`) is **scoped to the active sub-tab** (principalType/resourceType), so a field only appears where rows actually have that relationship.
- Wired into `/users`, `/resources`, and **`assign-by-filter`** (so a filtered bulk-tag can't silently over-tag).
- Frontend: one `rel.`/`label` branch in `useEntityPage.getFilterFields` + the column fetch now passes the sub-tab. No new component.
- **No schema change / no migration.** Member counts include all assignment types; soft-deleted related rows are excluded.

## Decisions ratified (DoR packet)
No new control (count picklist) · members = all assignment types (matches `memberCount`) · Identities reuse existing `accountCount`/`minAccounts` (no duplicate field) · query-time subqueries (no matview) · discovery scoped to sub-tab · fail-closed.

## Tests
- `app/api/src/lib/referenceFilters.test.js` — unit (emission, extraction, fail-closed, single-valued guard).
- `app/api/contract-tests/referenceFilters.contract.test.js` — **12 acceptance criteria** end-to-end against real PostgreSQL (existence/thresholds, single-valued manager, all-type members, 2-hop owners, inverse directions, sponsors, scoped discovery, soft-delete exclusion, bulk-tag parity, fail-closed).

## Changelog
`changes/reference-field-filters.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)