### PR TITLE
fix(matrix): stop multi-header column headers leaving a grey gap on scroll

### DIFF
--- a/app/ui/src/components/matrix/MatrixColumnHeaders.jsx
+++ b/app/ui/src/components/matrix/MatrixColumnHeaders.jsx
@@ -3,6 +3,10 @@ import { useIsDark } from '@ui/contexts/ThemeContext';
 import { computeAttributeSpans } from './sortUsers';
 import { friendlyLabel } from '@ui/utils/formatters';
 
+// Height (px) of each attribute grouping row. Drives both the cell height and
+// the sticky `top` offset of the <thead>, so the two can never drift apart.
+export const GROUP_ROW_H = 120;
+
 export default function MatrixColumnHeaders({
   users,
   infoColumnCount,
@@ -31,11 +35,22 @@ export default function MatrixColumnHeaders({
     ? Math.min(maxHeaderDepth, attrs.length) : attrs.length;
   const attrRows = attrs.slice(0, shown).map((attribute, index) => ({ attribute, spans: computeAttributeSpans(users, index) }));
 
-  // Only the final (names) row is sticky on vertical scroll — the attribute
+  // Keep only the final (names) row pinned on vertical scroll — the attribute
   // grouping rows above it scroll away, so many sort attributes don't bury the
-  // grid. (Matches the aggregated layered view.)
+  // grid. We do this by making the whole <thead> sticky with a NEGATIVE `top`
+  // equal to the combined height of the grouping rows: as you scroll, those
+  // rows slide up out of view and the names row comes to rest at top:0.
+  //
+  // This must be done on the <thead> — not on the individual last-row cells.
+  // A sticky table *cell* is constrained to its section's box, so once the
+  // <thead> scrolls past by more than the grouping-rows' height the pinned
+  // cell escapes upward and leaves a blank (grey) band where the header was
+  // (issue: multi-header matrix "grey area" on scroll). A sticky <thead> is
+  // constrained to the whole table instead, so it stays pinned through the
+  // entire body scroll.
+  const groupingOffset = attrRows.length * GROUP_ROW_H;
   return (
-    <thead>
+    <thead className="sticky z-30" style={{ top: `-${groupingOffset}px` }}>
       {/* One merged row per sort attribute */}
       {attrRows.map((row, rowIdx) => (
         <tr key={row.attribute + rowIdx}>
@@ -82,7 +97,7 @@ export default function MatrixColumnHeaders({
                 className={`border-b border-r border-gray-300 dark:border-gray-600 px-0 py-0 text-center ${
                   aggHere || memberOwn ? 'bg-indigo-50 dark:bg-indigo-900/20' : 'bg-gray-100 dark:bg-gray-800'
                 } ${onClick ? 'cursor-pointer hover:bg-blue-50 dark:hover:bg-blue-900/30' : ''}`}
-                style={{ height: '120px', minWidth: `${span.span * 24}px` }}
+                style={{ height: `${GROUP_ROW_H}px`, minWidth: `${span.span * 24}px` }}
               >
                 {showChildCount ? (
                   <span className="text-[11px] font-semibold text-indigo-700 dark:text-indigo-300">{col.childCounts?.[rowIdx] ?? 0}</span>

--- a/app/ui/src/components/matrix/MatrixColumnHeaders.mount.test.jsx
+++ b/app/ui/src/components/matrix/MatrixColumnHeaders.mount.test.jsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createElement as h } from 'react';
+import MatrixColumnHeaders, { GROUP_ROW_H } from './MatrixColumnHeaders';
+import { renderWithProviders } from '@ui/test-utils/renderWithProviders';
+
+// Build subjects whose sortKeys line up with `sortAttributes`, so the header
+// renders one grouping row per attribute.
+function makeUsers() {
+  return [
+    { id: 'u1', displayName: 'Alice', sortKeys: ['Finance', 'Payroll', 'Analyst'] },
+    { id: 'u2', displayName: 'Bob', sortKeys: ['Finance', 'Payroll', 'Manager'] },
+    { id: 'u3', displayName: 'Carol', sortKeys: ['Ops', 'Logistics', 'Planner'] },
+  ];
+}
+
+function renderHeaders(sortAttributes) {
+  return renderWithProviders(
+    h('table', null,
+      h(MatrixColumnHeaders, {
+        users: makeUsers(),
+        infoColumnCount: 3,
+        sortAttributes,
+      })),
+  );
+}
+
+describe('MatrixColumnHeaders sticky header', () => {
+  it('pins the whole <thead> with a negative top so grouping rows scroll away without leaving a grey gap', () => {
+    const attrs = [{ attribute: 'businessUnit' }, { attribute: 'division' }, { attribute: 'department' }];
+    const { container } = renderHeaders(attrs);
+
+    const thead = container.querySelector('thead');
+    expect(thead).toBeTruthy();
+    // The whole section is sticky — not just the last row's cells — so the
+    // header can never escape its section box and leave a blank band.
+    expect(thead.className).toContain('sticky');
+    // Negative offset equals the combined grouping-row height; the names row
+    // therefore comes to rest at top:0 and stays pinned through the body.
+    expect(thead.style.top).toBe(`-${attrs.length * GROUP_ROW_H}px`);
+  });
+
+  it('scales the offset with the number of grouping rows', () => {
+    const one = renderHeaders([{ attribute: 'department' }]);
+    expect(one.container.querySelector('thead').style.top).toBe(`-${GROUP_ROW_H}px`);
+
+    const two = renderHeaders([{ attribute: 'businessUnit' }, { attribute: 'department' }]);
+    expect(two.container.querySelector('thead').style.top).toBe(`-${2 * GROUP_ROW_H}px`);
+  });
+});

--- a/changes/matrix-sticky-header-gap.md
+++ b/changes/matrix-sticky-header-gap.md
@@ -1,0 +1,1 @@
+- Fixed a grey empty band that appeared in the Matrix when several column-header rows were shown and you scrolled down — the pinned header row no longer detaches and leaves a gap once it locks to the top.


### PR DESCRIPTION
## Problem

In the **Matrix**, when several column-header rows are shown (e.g. Business Unit → Division → Department → Team → Job Title grouping rows above the resource/user-name row) and you scroll down, a **grey empty band with no data** appears — right when the header "locks" onto the last header row. The more header rows are loaded, the more pronounced it is.

## Root cause

`app/ui/src/components/matrix/MatrixColumnHeaders.jsx` pinned **only the final (names) row** on vertical scroll, via per-cell `position: sticky; top: 0` — the `<thead>` itself was not sticky.

A sticky **table cell** is constrained to its section's (`<thead>`) box. The pinned last-row cells sit flush at the bottom of the `<thead>`, so they can only stay at `top:0` for as long as the grouping rows above them (each 120px) remain within the section. Once you scroll past by more than the grouping rows' combined height, the section's bottom edge pushes the pinned cells up and off screen — leaving the grey band where the header used to be. With N grouping rows the header survives only `N × 120px` of scroll before vanishing, which is why "multiple headers" makes it obvious.

The two sibling matrix views already avoid this by making the whole `<thead>` sticky (`RotatedMatrixView.jsx:213`, `RollupMatrixView.jsx:570`) rather than pinning individual cells.

## Fix

Make the whole `<thead>` sticky with a **negative `top`** equal to the combined grouping-row height (`attrRows.length × GROUP_ROW_H`):

- The grouping rows still slide up and out of view as you scroll — the deliberate "don't bury the grid with many sort attributes" behaviour is unchanged.
- The names row comes to rest at `top:0` and, because a sticky **section** is constrained to the whole table (not just its own box), stays pinned through the entire body scroll. No more escape, no more grey band.

Also extracted the `120px` grouping-row height into an exported `GROUP_ROW_H` constant so the cell height and the sticky offset can't drift apart.

## Tests

- New `MatrixColumnHeaders.mount.test.jsx` asserts the `<thead>` is sticky and its `top` offset scales with the number of grouping rows.
- Full `src/components/matrix/` suite green (41 tests); lint clean.

## Reviewer note

Verified via reasoning + unit test + sibling-view precedent. A visual sanity-check against a matrix with several sort-attribute header rows (scroll down, confirm the header stays pinned with no grey band, and the grouping rows still scroll away) is recommended, as sticky-in-table behaviour is browser-nuanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)