### PR TITLE
docs: Definition of Ready v3.3 — tracking issue as durable spine + demo-data validation

### DIFF
--- a/docs/process/definition-of-ready.md
+++ b/docs/process/definition-of-ready.md
@@ -1,6 +1,6 @@
-# Definition of Ready v3.2 — the "ready-to-build" process
+# Definition of Ready v3.3 — the "ready-to-build" process
 
-**Purpose.** Produce a spec complete enough that building, testing and documenting run with **zero *functional* human decisions and zero silent *functional* assumptions** — while spending the fewest possible **human round-trips** getting there. Non-functional decisions (architecture, design/UX, product fit) are **routed to the role that owns them**, *batched*, and resolved in as few interactions as possible. *Form* is expected to need a **feedback loop**, because taste is a see-it reaction that can't be fully pre-specified.
+**Purpose.** Produce a spec complete enough that building, testing and documenting run with **zero *functional* human decisions and zero silent *functional* assumptions** — while spending the fewest possible **human round-trips**. Non-functional decisions (architecture, design/UX, product fit) are **routed to the role that owns them**, *batched*, and resolved in as few interactions as possible. *Form* is expected to need a **feedback loop**. Every feature is tracked by a **GitHub issue** that is its durable spine from intent to close.
 
 **The realistic bar.** "One perfect spec → build once" is reachable for **function**, not **form**. Front-load every *functional* decision; route every *architectural / design / product* decision to its owner; keep round-trips minimal; treat post-build feedback as a normal, cheap loop.
 
@@ -17,23 +17,22 @@ flowchart TD
 
   start([Feature idea]):::req --> pre{PO pre-screen}:::po
   pre -->|no| drop([Park / drop]):::po
-  pre -->|yes| intv[Phase A — Intent interview<br/>ONE sitting · GENERATIVE · scope battery · time-travel]:::ai
-  intv --> probe[Phase B — probe · adversarial · CI dry-run]:::ai
+  pre -->|yes| issue[/Create tracking issue<br/>label needs-clarification · seed intent/]:::ai
+  issue --> intv[Phase A — Intent interview<br/>GENERATIVE · scope battery · time-travel]:::ai
+  intv --> probe[Phase B — probe · adversarial · CI dry-run<br/>decisions register + ACs recorded in the issue]:::ai
   probe -->|re-probe until nothing new — AI only, no human| probe
   probe --> collate[Collate ONCE: decisions to ratify +<br/>blocking questions grouped by role]:::ai
   collate --> packet[[Single consolidated packet<br/>batched per role · one packet if one person]]:::ai
-  packet --> c1[Requestor: answer + confirm]:::req
+  packet --> c1[Requestor: answer + confirm → label ready-to-build]:::req
   packet --> c2[Architect: answer + sign off]:::arch
-  packet --> c3[Designer confirm + PO GO]:::po
-  c1 --> rtb([READY-TO-BUILD + APPROVED]):::po
-  c2 --> rtb
-  c3 --> rtb
-  rtb --> build[Autonomous build on SK3<br/>implement · fixture-AC tests · SEED validation data · docs · PR · CI green · deploy]:::ai
-  build --> bd([BUILD-DONE · report ACs + green run]):::ai
-  bd --> val{Requestor functional validation<br/>vs ACs + time-travel criteria}:::req
-  val -->|disappointed / form| fb[Feedback = new intent]:::req
+  packet --> c3[Designer confirm + PO GO → label approved]:::po
+  c1 --> build
+  c2 --> build
+  c3 --> build[Autonomous build on SK3 · impl · fixture-AC tests ·<br/>load demo data if runtime · docs · PR Closes #N · CI green · deploy → build-done]:::ai
+  build --> val{Requestor functional validation<br/>vs ACs + time-travel criteria}:::req
+  val -->|disappointed / form / missed scope| fb[Feedback = new intent · comment on issue]:::req
   fb --> intv
-  val -->|happy| appr[Approve PR → merge → Shipped]:::req
+  val -->|happy| appr[Approve PR → merge → close issue with outcome comment]:::req
 ```
 
 ## Roles (lanes)
@@ -48,85 +47,85 @@ One human may wear several hats. The point is not headcount; it's that **each qu
 | **Product Owner** | Desirability / product coherence — the GO | does this move the product forward or just add complexity/bloat |
 | **Builder (AI)** | Runs Phases A/B, then builds/tests/documents autonomously | — |
 
+## Tracking issue — the durable spine
+
+Every feature that passes the PO pre-screen gets a **GitHub issue**, created *before* Phase A and closed *after* merge + validation. It is the one artifact that outlives the session and the (squash-merged) PR, carries the gate labels, and gives end-to-end traceability. Maintaining it is the **Builder's** job — it adds **no human touchpoints**.
+
+- **Created at pre-screen "yes"**, labelled `needs-clarification`, seeded with the Phase-A intent.
+- **Body = current-state spec:** pinned scope (A8), time-travel criteria (A7), the **decisions register** (each entry tagged by role, ratify/blocking + how it resolved), the **fixture ACs**, and the form artifact. Updated as Phase B produces them.
+- **Comments = the trail:** material changes and every feedback-loop iteration ("decisions along the way").
+- **Labels ride the gates:** `needs-clarification` → `ready-to-build` (C1) → `approved` (C3) → `build-done` (D1).
+- **PR references `Closes #N`** so issue ↔ PR link both ways.
+- **Closed on merge + functional validation**, with an **outcome comment**: what shipped vs. what was consciously de-scoped. The outcome comment is a required closing step, not an afterthought.
+
 ## Minimise human round-trips — batch, don't ping-pong
 
-Every *return* to a human costs real time. Routing to the right role is worthless if it produces *more* interactions. So:
-
-- **Efficiency = few round-trips, not few questions.** This discipline limits how often you *return* to a human — it does **not** thin out the first interview. A *complete* spec reached in two touchpoints beats a *thin* one reached in two touchpoints. Ask freely in the one sitting; batch your *returns*.
-- **Exhaust the AI-resolvable work before touching any human.** The Phase-B probe, adversarial passes and CI dry-run are an **AI-internal loop** — never a reason to go back to a person.
-- **Prefer a proposed decision over a question.** If the AI can pick a defensible default from the code/model, record it for **bulk ratification**. Only escalate as a **blocking question** what genuinely needs a human's judgment. *(But scope-ambition is the requestor's call — surface it, don't default it away; see A8.)*
-- **Batch by role, ask once.** Group all blocking questions + decisions-to-ratify by owning role in a **single async packet**; fold a role's questions into its **sign-off**.
-- **One person, one packet.** When one human wears several hats, present a single consolidated packet, not separate meetings.
-- **Target: two human touchpoints** — the Phase-A interview, and one consolidated sign-off/GO packet.
-
-**Optionality rule.** Only pose a question to a role if a genuine question is *owned* by that role. Skip hats with no open questions.
+- **Efficiency = few round-trips, not few questions.** The discipline limits *returns* to a human — it does **not** thin the first interview. A *complete* spec in two touchpoints beats a *thin* one in two touchpoints.
+- **Exhaust the AI-resolvable work before touching any human.** The Phase-B probe/adversarial/CI-dry-run loop is AI-internal — never a reason to return to a person.
+- **Prefer a proposed decision over a question** (bulk-ratify) — *except scope-ambition, which is the requestor's to choose (surface it, don't default it away).*
+- **Batch by role, ask once**, folding a role's questions into its sign-off. **One person, one packet.**
+- **Target: two human touchpoints** — the Phase-A interview and one consolidated sign-off/GO packet.
+- **Optionality rule.** Only pose a question to a role that owns it; skip hats with no open question.
 
 ---
 
 ## Phase A — Intent interview (GENERATIVE, one sitting)
-**Generative, not extractive.** Do not just transcribe the opening description — actively help the requestor find the *best and most complete* version of the feature. An open brain-dump alone tends to **under-scope**; start with the open description, then run the **scope-elicitation battery** below as explicit choices. All of this is touchpoint #1 — no round-trips.
-
+**Generative, not extractive.** Actively help the requestor find the *best and most complete* version. An open brain-dump alone under-scopes; start with the open description, then run the scope battery as explicit choices. All touchpoint #1 — no round-trips.
 - **A1 Problem & value** — a user/governance question, not a solution; who for; why now.
 - **A2 Scope boundaries** — what it deliberately does NOT do.
 - **A3 Backlog context** — related/precondition/duplicate issues; weighed against the whole backlog.
 - **A4 External dependencies** — known and secured, or N/A.
-- **A5 Architecture fit** — fits the existing architecture, or *raises* an architectural question → tag for the architect, don't resolve with the requestor.
+- **A5 Architecture fit** — fits the existing architecture, or *raises* an architectural question → tag for the architect.
 - **A6 Documentation needs.**
-- **A7 Time-travel pre-mortem (Rob's question).** *"We fast-forward to the moment I show you the finished feature. You're delighted because…? You're disappointed because…?"* The "disappointed because" answers become explicit accept/reject criteria — where *form* preferences surface before code.
-- **A8 Scope-elicitation battery (ask as explicit choices).** These dimensions most change what gets built; surface each and let the requestor include or *consciously* defer it — never default it away silently:
-  - **Generality** — a specific case, or a general capability? (Name the first case as the example, but pin the scope the requestor actually wants — build the general version if that's the intent.)
-  - **Operation completeness** — beyond the minimal operation, the full set? (e.g. existence → count/threshold → range; view → edit; single → bulk.)
-  - **Symmetry & variants** — inverse directions, related entities, adjacent cases the same mechanism naturally covers.
-  - **Surface / reach** — one page, or everywhere the pattern exists?
-  - **Adjacent / phase-2 opportunity** — a natural bigger or reusable version (persist / save / reuse) worth acknowledging, even if deferred to a follow-up.
-  - **Driver & priority** — what's pushing it now (frames the issue and the cut line).
+- **A7 Time-travel pre-mortem.** *"We fast-forward to the moment I show you the finished feature. You're delighted because…? You're disappointed because…?"* The "disappointed because" answers become explicit accept/reject criteria.
+- **A8 Scope-elicitation battery (ask as explicit choices; include or consciously defer each — never default away):** **generality** (specific case vs general capability) · **operation completeness** (existence → count/threshold → range; view → edit; single → bulk) · **symmetry & variants** (inverse directions, adjacent cases) · **surface / reach** (one page vs everywhere) · **adjacent / phase-2** (a bigger/reusable version) · **driver & priority**.
 
-**Pin the chosen scope explicitly** (feeds B4). A minimal cut is fine — but as a *conscious choice*, never a silent default.
+**Pin the chosen scope explicitly** (feeds B4). A minimal cut is fine — but as a *conscious choice*.
 
 ## Phase B — Build-readiness probe (AI-internal; no human until it's exhausted)
-Intent is fixed. **Draft the actual implementation against the real code and schema — far enough to hit the walls.** A dry-run, not a re-read.
-- **B1 Trace every value to its real storage** — write the real query; multi-hop → write the join path; not modelled as assumed → raise it.
+Draft the actual implementation against the real code and schema — far enough to hit the walls. A dry-run, not a re-read.
+- **B1 Trace every value to its real storage** — write the real query; multi-hop → the join path; not modelled as assumed → raise it.
 - **B2 Enumerate consumers** of every shared contract/function/wire-format/table/component touched.
-- **B3 Resolve every choice to one option** — no "A or B", no "TBD". Includes **UX-shaping words** ("alongside / integrated / inline").
-- **B4 Pin the exact scope set** — the concrete list, matching the scope chosen in A8.
+- **B3 Resolve every choice to one option** — no "A or B", no "TBD"; includes UX-shaping words.
+- **B4 Pin the exact scope set** — matching the scope chosen in A8.
 - **B5 Delivery decomposition** — one PR or a required stack, and the order.
-- **B6 Adversarial pass (independent)** — *"find where this spec contradicts the real code/schema — hidden hop, unlisted consumer, unhandled empty/edge case, ambiguous UX word."*
+- **B6 Adversarial pass (independent)** — find where the spec contradicts the real code/schema (hidden hop, unlisted consumer, unhandled empty/edge, ambiguous UX word).
 - **B7 Dry-run the CI / Definition of Done** (appendix) — not just the schema.
-- **B8 Classify each open item** as a **proposed decision** (ratify in bulk) or a **blocking question**; tag each by owning role.
-- **B9 Outputs:** **decisions register** (decision + reason + owning role, ratify/blocking) · **fixture-backed ACs** (input → expected output vs the REAL model; incl. empty/zero/error) · **validation-data plan** (what representative data — instances *with* and *without* the condition — must be seeded so the requestor can actually exercise the feature) · **form artifact** for UI · **test plan** · **docs + changelog targets.**
-- **B10 Loop** the probe + adversarial pass until a pass surfaces nothing new — all AI, no human.
+- **B8 Classify each open item** — proposed decision (ratify) vs blocking question; tag by role.
+- **B9 Outputs (recorded in the tracking issue):** decisions register · fixture-backed ACs (input → expected output vs the REAL model; incl. empty/zero/error) · validation-data plan · form artifact for UI · test plan · docs + changelog targets.
+- **B10 Loop** until a pass surfaces nothing new — all AI, no human.
 
 ## Phase C — Consolidated sign-off (batched; one packet if one person)
-Present the collated output as a **single packet**, batched per role. Answering a role's questions and taking its sign-off are the **same touch**.
-- **C1 Requestor** — answers batched functional questions, confirms the functional summary + scope + time-travel criteria ⇒ *functional* `ready-to-build`.
-- **C2 Architect** — answers batched architectural questions, signs off the technical approach ⇒ *technical* ready.
-- **C3 Product Owner** — GO ⇒ `approved`. Only now may autonomous build start. (Designer confirms the form artifact here too.)
+- **C1 Requestor** — answers batched functional questions, confirms summary + scope + time-travel criteria ⇒ label `ready-to-build`.
+- **C2 Architect** — answers batched architectural questions, signs off the technical approach.
+- **C3 Product Owner** — GO ⇒ label `approved`; only now may autonomous build start. (Designer confirms the form artifact here too.)
 
 ## Phase D — Build, validate, and the feedback loop (first-class)
-- **D1 Autonomous build** on SK3: implement, run the fixture-AC tests, **seed the representative validation data** (instances with and without the condition, per the B9 plan) so the feature can actually be exercised, docs, changelog, PR, CI green, deploy ⇒ `build-done`. The build-done handoff **reports the acceptance criteria and their green test run** (the fixture-AC contract test file + result), so real testing is visible and distinct from manual validation.
-- **D2 Functional validation** by the requestor against the fixture ACs **and the time-travel criteria** — check the numbers and the "disappointed because" list, using the seeded data.
-- **D3 Feedback loop.** Disappointment (usually *form*, sometimes *missed scope*) is captured as **new intent** and re-enters at Phase A. Expected and cheap. Happy ⇒ approve PR ⇒ merge.
+- **D1 Autonomous build** on SK3: implement, run the fixture-AC tests, and — **for a feature with a runtime surface** — **load the full demo dataset** (baseline realistic volume; it includes ownership/sponsor/member data) and top up any feature-specific gap, so functional validation runs against real data, not a hand-seeded sliver. Then docs, changelog, PR (`Closes #N`), CI green, deploy ⇒ label `build-done`. The handoff **reports the ACs + their green test run** so real testing is visible and distinct from manual validation. *(A change with no runtime surface — e.g. docs — skips the demo-data load; note that in the issue rather than forcing it.)*
+- **D2 Functional validation** by the requestor against the fixture ACs **and** the time-travel criteria, using the loaded data.
+- **D3 Feedback loop.** Disappointment (form, or missed scope) is captured as **new intent** (a comment on the issue) and re-enters at Phase A. Expected and cheap. Happy ⇒ approve PR ⇒ merge ⇒ close the issue with the outcome comment.
 
 ---
 
 ## Appendix — Definition of Done the probe must design against
 - **Coverage** — aggregate + per-file ratchet (only up) + diff-coverage. New code ships with tests.
 - **File size** — >1000 lines must split; >600 is a smell.
-- **Complexity** — per-unit cyclomatic + cognitive ratchets; new/touched units under the per-language threshold.
+- **Complexity** — per-unit cyclomatic + cognitive ratchets; under the per-language threshold.
 - **Duplication** — jscpd gate; reuse before creating.
-- **Contract tests** — real PostgreSQL; each test **DELETEs its own rows** (never DROP/TRUNCATE, never assume a clean shared DB).
+- **Contract tests** — real PostgreSQL; each test **DELETEs its own rows**.
 - **OpenAPI** — a new router must be documented in `openapi.yaml` or allowlisted.
-- **UI** — dark mode from the start; WCAG AA contrast (no bare `text-*-300/400`); real accessible names; no native `alert/confirm/prompt`; `@ui/` alias (no relative traversal); nothing crawler-specific under `app/ui/`.
-- **Changelog** — a fragment under `changes/` for functional changes (never edit `CHANGES.md`; docs-only needs none).
+- **UI** — dark mode; WCAG AA contrast (no bare `text-*-300/400`); real accessible names; no native `alert/confirm/prompt`; `@ui/` alias; nothing crawler-specific under `app/ui/`.
+- **Changelog** — a fragment under `changes/` for functional changes (docs-only needs none).
 - **Merge** — 1 approval; never admin-merge.
 
-**Baseline precondition.** Verify `main` (and the target Sidekick) is green *before* starting. A pre-existing failure is repo debt, not a feature defect — fix it as a disclosed separate chore.
+**Baseline precondition.** Verify `main` (and the target Sidekick) is green *before* starting. Pre-existing failure = repo debt, fixed as a disclosed separate chore.
 
 ## The bar
-A fresh builder given ONLY the spec builds, tests and documents it with **zero functional decisions and zero silent functional assumptions**, reached with **≈two human touchpoints** — and the spec is the **complete** version the requestor actually wanted, not the floor. End-validation is mechanical against the fixture ACs + time-travel criteria, using seeded data. Residual *form* gaps go through the D3 feedback loop.
+A fresh builder given ONLY the spec (via its tracking issue) builds, tests and documents it with **zero functional decisions and zero silent functional assumptions**, in **≈two human touchpoints**, to the **complete** scope the requestor chose. End-validation is mechanical against the fixture ACs + time-travel criteria on real data. Residual *form* gaps go through the D3 feedback loop. The issue carries the whole trail and closes with an outcome comment.
 
 ## Version history (generalized lessons)
-- **v1 → v2:** "no open design questions" was satisfiable by *review*; v2 requires an *executed* build-readiness probe. Added consumer-enumeration, no-A-or-B, pinned scope, adversarial pass, fixture ACs.
-- **v2 → v3:** v2 collapsed a product team into "the requestor." Added role-routing, the time-travel pre-mortem, a form artifact for UI, CI/DoD dry-run, and a first-class feedback loop.
-- **v3 → v3.1:** role-routing without batching risks *human ping-pong*. Added the round-trip discipline — exhaust AI work first, prefer proposed-decisions, batch per role, one packet, ≈two touchpoints.
-- **v3.1 → v3.2:** the efficiency discipline *starved the interview* — a from-scratch run built a thin feature (2 edges, existence-only) because Phase A was extractive. Clarified **efficiency = few round-trips, not few questions**; made Phase A **generative** with a **scope-elicitation battery** (generality / operation-completeness / symmetry / surface / phase-2 / driver); required **validation-data seeding** on the Sidekick so the requestor can actually test; and **AC-result transparency** at build-done.
+- **v1 → v2:** review didn't satisfy "no open questions" — added the executed build-readiness probe, consumer-enumeration, no-A-or-B, pinned scope, adversarial pass, fixture ACs.
+- **v2 → v3:** stopped collapsing a product team into "the requestor" — role-routing, time-travel pre-mortem, form artifact, CI/DoD dry-run, first-class feedback loop.
+- **v3 → v3.1:** round-trip discipline — exhaust AI work first, prefer proposed-decisions, batch per role, ≈two touchpoints.
+- **v3.1 → v3.2:** efficiency had starved the interview — made Phase A generative with the scope battery; validation-data seeding; AC-result transparency.
+- **v3.2 → v3.3:** the gate labels had no home and the decisions trail died with the session — added the **tracking issue** as the durable spine (created at pre-screen, decisions in the body, trail in comments, labels ride it, `Closes #N`, closed with an outcome comment). Made the validation-data load use the **full demo dataset** and scoped it to features with a runtime surface.


### PR DESCRIPTION
Follow-up to #864. Two gaps the recent from-scratch runs exposed:

1. **The gate labels had no home.** We designed `ready-to-build` → `approved` → `build-done` but the from-scratch runs created no issue to hang them on, and the decisions register + ACs died in a scratchpad and a squash-merged PR. v3.3 adds a **tracking issue** as the durable spine: created at PO pre-screen, body = current-state spec (pinned scope, time-travel criteria, decisions register, fixture ACs), comments = the decisions/feedback trail, labels ride the gates, PR uses `Closes #N`, closed after merge + validation with a required **outcome comment** (shipped vs. de-scoped). No extra human touchpoints — the Builder maintains it.
2. **Functional testing ran on a sliver.** D1 now loads the **full demo dataset** (realistic volume, incl. ownership/sponsor/member data) for any feature with a runtime surface, topping up feature-specific gaps; a no-runtime change (docs) skips it.

Deliberately *not* adding non-code adaptations yet — the next run (a docs feature) is how we learn where the code-shaped steps misfit. Docs-only, no changelog fragment. Related: #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)