### PR TITLE
fix(dor): board-status helper mis-reads owner-qualified repo name

### DIFF
--- a/.github/scripts/dor_reconcile.sh
+++ b/.github/scripts/dor_reconcile.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 
 OWNER="${OWNER:-Fortigi}"
 REPO="${REPO:-IdentityAtlas}"
+# Accept an owner-qualified REPO (github.repository = "owner/name"); split so `--repo "$OWNER/$REPO"`
+# below doesn't become "owner/owner/name". Same guard as dor_set_status.sh.
+if [[ "$REPO" == */* ]]; then OWNER="${REPO%%/*}"; REPO="${REPO##*/}"; fi
 PROJECT_ID="${PROJECT_ID:-PVT_kwDOAhfTz84Bern-}"
 UNROUTED_HOURS="${UNROUTED_HOURS:-6}"
 STALE_FLAG_DAYS="${STALE_FLAG_DAYS:-14}"

--- a/.github/scripts/dor_set_status.sh
+++ b/.github/scripts/dor_set_status.sh
@@ -15,6 +15,10 @@ ISSUE="${1:?usage: dor_set_status.sh <issue-number> <state-label>}"
 LABEL="${2:?usage: dor_set_status.sh <issue-number> <state-label>}"
 OWNER="${OWNER:-Fortigi}"
 REPO="${REPO:-IdentityAtlas}"
+# Accept an owner-qualified REPO (GitHub Actions' github.repository is "owner/name"). Callers that
+# also `gh --repo "$REPO"` pass the qualified form, so split it — otherwise the GraphQL
+# repository(owner,name) lookup below gets name="owner/name" and 404s ("owner/owner/name").
+if [[ "$REPO" == */* ]]; then OWNER="${REPO%%/*}"; REPO="${REPO##*/}"; fi
 PROJECT_ID="${PROJECT_ID:-PVT_kwDOAhfTz84Bern-}"
 STATUS_FIELD_ID="${STATUS_FIELD_ID:-PVTSSF_lADOAhfTz84Bern-zhZEAac}"
 REQ_FIELD_ID="${REQ_FIELD_ID:-PVTSSF_lADOAhfTz84Bern-zhZEFTM}"

--- a/.github/workflows/dor-agent.yml
+++ b/.github/workflows/dor-agent.yml
@@ -8,9 +8,9 @@ name: DoR agent (interview + probe)
 # EXECUTION MODEL — a deterministic split, to contain prompt injection on a PUBLIC repo where
 # issue/comment content is attacker-controllable:
 #   1. FETCH  (deterministic)  — read the issue thread + backlog into files.
-#   2. REASON (LLM, sandboxed) — claude-code-action with Read/Grep/Glob/Write ONLY: no shell, no
-#      gh, no network. The model reads those files + the repo and WRITES its decision to output
-#      files. Without a shell it cannot curl/gh to exfiltrate the subscription token in its env.
+#   2. REASON (LLM, sandboxed) — claude-code-action with Read/Grep/Glob + Edit(.dor/out/**) ONLY:
+#      no shell, no gh, no network. The model reads those files + the repo and writes its decision
+#      to output files. Without a shell it cannot curl/gh to exfiltrate the subscription token in its env.
 #   3. POST   (deterministic)  — validate the chosen label against a fixed allow-list, scan the
 #      output for the token (egress filter), then post the comment + set the one label.
 # Documented residual: the model's Read tool could in principle reach /proc/self/environ; the
@@ -94,7 +94,7 @@ jobs:
           gh issue list --repo "$REPO" --state open --limit 100 \
             --json number,title,labels > .dor/in/backlog.json
 
-      # 2. REASON (LLM, sandboxed) — Read/Grep/Glob/Write ONLY. No GH_TOKEN in this step's env;
+      # 2. REASON (LLM, sandboxed) — Read/Grep/Glob + Edit(.dor/out/**) ONLY. No GH_TOKEN in this step's env;
       #    no shell/gh/network tool, so untrusted issue content cannot shell out or exfiltrate the
       #    subscription token. The model's only outputs are the two files it writes.
       - name: DoR interview + probe (reasoning only)

--- a/changes/dor-board-status-repo.md
+++ b/changes/dor-board-status-repo.md
@@ -1,0 +1,1 @@
+- Fixed the opt-in Definition-of-Ready automation so an issue's Feature Pipeline board status updates correctly after the review agent runs (the board-sync helper was mis-reading the repository name and failing the update).


### PR DESCRIPTION
## What

Second (and final) finding from the DoR smoke test on issue #883. After the `Edit`-scope fix (#884), the agent now runs its full review and **posts its comment + sets the `state:*` label correctly** — but the job still ended **red** because the last sub-step (board Status sync) failed:

```
gh: Could not resolve to a Repository with the name 'Fortigi/Fortigi/IdentityAtlas'.
```

## Root cause

`dor-agent.yml`'s post step exports `REPO: ${{ github.repository }}` = `Fortigi/IdentityAtlas` (it needs the owner-qualified form for its own `gh issue comment/edit --repo "$REPO"` calls). `dor_set_status.sh` inherited that `REPO` but expected a **bare** repo name, so its GraphQL `repository(owner:"Fortigi", name:"Fortigi/IdentityAtlas")` lookup 404'd — GitHub formats the not-found message as `owner/name`, hence the doubled `Fortigi/Fortigi/IdentityAtlas`.

Confirmed with a read-only repro: `name:"IdentityAtlas"` resolves the issue node; `name:"Fortigi/IdentityAtlas"` reproduces the exact error. Triage and board-sync were unaffected only because those steps don't export `REPO` (the script's `IdentityAtlas` default applied) — which is why triage's board write succeeded in the same smoke test.

## Fix (at the source)

Both `dor_set_status.sh` and `dor_reconcile.sh` now split an owner-qualified `REPO`, so they accept **either** `owner/name` (the natural `github.repository` form callers already have) **or** a bare name:

```bash
if [[ "$REPO" == */* ]]; then OWNER="${REPO%%/*}"; REPO="${REPO##*/}"; fi
```

`dor_reconcile.sh` isn't currently broken (its workflow passes no `REPO`), but gets the same guard so a future owner-qualified caller can't reintroduce the bug.

Also refreshes two `dor-agent.yml` header comments still saying "Write ONLY" after #884 (cosmetic).

## Notes
- Workflow/script-only change — coverage ratchet N/A; `jscpd` ignores `.github/workflows/**`.
- Security containment unchanged.
- Feature stays **off by default** (`DOR_ENABLED`).

Follow-up to #881 / #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)